### PR TITLE
RVS: rvs_test_level argument is moved under rvs config option.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,13 +9,3 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 def pytest_addoption(parser):
     parser.addoption( "--cluster_file", action="store", required=True, help="Input file with all the details of the cluster, nodes, switches in JSON format" )
     parser.addoption( "--config_file", action="store", required=True, help="Input file with all configurations and parameters for tests in JSON format" )
-    parser.addoption(
-        "--rvs_test_level",
-        action="store",
-        default=4,
-        type=int,
-        help="RVS test level configuration (0-5). "
-             "0: Run individual tests (skip level test), "
-             "1-5: Run LEVEL test if RVS >= 1.3.0, else run individual tests. "
-             "Default is 4."
-    )

--- a/input/config_file/health/mi300_health_config.json
+++ b/input/config_file/health/mi300_health_config.json
@@ -91,6 +91,8 @@
         "nfs_install": "True",
         "config_path_mi300x": "/opt/rocm/share/rocm-validation-suite/conf/MI300X",
         "config_path_default": "/opt/rocm/share/rocm-validation-suite/conf",
+        "_comment_rvs_test_level": "RVS test level configuration (0-5). 0: Run individual tests (skip level test), 1-5: Run LEVEL config test if RVS >= 1.3.0, else run individual tests. Default is 4.",
+        "rvs_test_level": 4,
         "tests": [
             {
                 "name": "level_config",

--- a/tests/health/rvs_cvs.py
+++ b/tests/health/rvs_cvs.py
@@ -36,25 +36,6 @@ def cluster_file(pytestconfig):
 def config_file(pytestconfig):
     return pytestconfig.getoption("config_file")
 
-@pytest.fixture(scope="module")
-def rvs_test_level(pytestconfig):
-    """Get RVS test level from command line, default to 4 if not provided or invalid"""
-    level = pytestconfig.getoption("rvs_test_level", default=4)
-
-    # Validate level is between 0 and 5
-    # Level 0 is special: run all individual tests regardless of RVS version
-    try:
-        level_int = int(level)
-        if 0 <= level_int <= 5:
-            return level_int
-        else:
-            log.warning(f'Invalid RVS test level: {level}. Using default level 4')
-            return 4
-    except (ValueError, TypeError):
-        log.warning(f'Invalid RVS test level format: {level}. Using default level 4')
-        return 4
-
-
 # Importing the cluster and cofig files to script to access node, switch, test config params
 @pytest.fixture(scope="module")
 def cluster_dict(cluster_file):
@@ -79,6 +60,26 @@ def phdl(cluster_dict):
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh( log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'] )
     return phdl
+
+
+@pytest.fixture(scope="module")
+def rvs_test_level(config_dict):
+    """Get RVS test level from config file, default to 4 if not provided or invalid"""
+    level = config_dict.get('rvs_test_level', 4)
+
+    # Validate level is between 0 and 5
+    # Level 0 is special: run all individual tests regardless of RVS version
+    try:
+        level_int = int(level)
+        if 0 <= level_int <= 5:
+            log.info(f'Using RVS test level from config file: {level_int}')
+            return level_int
+        else:
+            log.warning(f'Invalid RVS test level in config: {level}. Using default level 4')
+            return 4
+    except (ValueError, TypeError):
+        log.warning(f'Invalid RVS test level format in config: {level}. Using default level 4')
+        return 4
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
command line arg rvs_test_level is removed in order to keep the uniformity for all the other pytest scripts.
Any test specific argument/paramter should be provided through its config json.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

    RVS: rvs_test_level argument is moved under rvs config option.

    command line arg rvs_test_level is removed in order to keep the
    uniformity for all the other pytest scripts.
    Any test specific argument/paramter should be provided through its
    config json.


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
