### PR TITLE
TransferBench: change the INSTALL path in config.

### DIFF
--- a/input/config_file/health/mi300_health_config.json
+++ b/input/config_file/health/mi300_health_config.json
@@ -10,15 +10,15 @@
     },
     "transferbench":
     {
-       "path": "/opt/amd/transferbench",
-       "example_tests_path": "/root/cache/INSTALL/TransferBench/examples",
-       "git_install_path": "/root/cache/INSTALL/",
+       "path": "/tmp/cvs/INSTALL/TransferBench",
+       "example_tests_path": "/tmp/cvs/INSTALL/TransferBench/examples",
+       "git_install_path": "/tmp/cvs/INSTALL/",
        "git_url": "https://github.com/ROCm/TransferBench.git",
        "nfs_install": "True",
        "results":
        {
            "bytes_to_transfer": "268435456",
-           "path": "/opt/amd/transferbench",
+           "path": "/tmp/cvs/INSTALL/TransferBench",
            "gpu_to_gpu_a2a_rtotal": "320.0",
            "avg_gpu_to_gpu_p2p_unidir_bw": "33.9",
            "avg_gpu_to_gpu_p2p_bidir_bw": "43.9",

--- a/tests/health/install/install_transferbench.py
+++ b/tests/health/install/install_transferbench.py
@@ -207,7 +207,7 @@ def test_install_transferbench(phdl, shdl, config_dict ):
     out_dict = hdl.exec(f'cd {git_install_path}/TransferBench;CC=hipcc make', timeout=500 )
 
     # Verify installation happened fine on all nodes
-    out_dict = phdl.exec(f'ls -l /opt/amd/transferbench')
+    out_dict = phdl.exec(f'ls -l {git_install_path}/TransferBench')
     for node in out_dict.keys():
         if not re.search( 'TransferBench', out_dict[node] ):
             fail_test(f'Transfer bench installation failed on node {node}')


### PR DESCRIPTION
TransferBench bin path and install path was different. This patch makes it to same path.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

    TransferBench: change the INSTALL path in config.

    TransferBench bin path and install path was different.
    So it was always picking up the binary from /opt/amd/transferbench, but the build & INSTALL path is different.
    This patch makes it to same path.

    /root/cache/INSTALL/  ==> This path needs sudo permission.
    So it is changed to 
    /tmp/cvs/INSTALL/


<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
