### PR TITLE
Add RCCL_P2P_BATCH_ENABLE parameter to multinode

### DIFF
--- a/input/config_file/rccl/rccl_config.json
+++ b/input/config_file/rccl/rccl_config.json
@@ -41,6 +41,7 @@
        "nccl_ib_tc": "0",
        "nccl_ib_split_data_on_qps": "0",
        "nccl_pxn_disable": [ "0", "1" ],
+       "nccl_p2p_batch_enable": [ "0", "1" ],
        "nccl_net_plugin": "none",
        "verify_bus_bw": "False",
        "verify_bw_dip": "True",

--- a/lib/html_lib.py
+++ b/lib/html_lib.py
@@ -1100,6 +1100,7 @@ def build_rccl_result_table( filename, res_dict ):
   <th>Protocol</th>
   <th>QP_count</th>
   <th>PXN_DISABLE</th>
+  <th>P2P_BATCH_ENABLE</th>
   <th>Msg Size</th>
   <th>Algo BW GB/s</th>
   <th>Bus BW GB/s</th>
@@ -1108,7 +1109,7 @@ def build_rccl_result_table( filename, res_dict ):
   </thead>'''
          fp.write(html_lines)
          for key_nam in res_dict.keys():
-             (collective,algo,protocol,qp_count,pxn_disable) = key_nam.split("-")
+             (collective,algo,protocol,qp_count,pxn_disable,p2p_batch_enable) = key_nam.split("-")
              last_bw = 0.0
              last_time = 0
              for msg_size in res_dict[key_nam].keys():
@@ -1121,6 +1122,7 @@ def build_rccl_result_table( filename, res_dict ):
      <td>{protocol}</td>
      <td>{qp_count}</td>
      <td>{pxn_disable}</td>
+     <td>{p2p_batch_enable}</td>
      <td>{msg_size}</td>
      <td>{res_dict[key_nam][msg_size]['alg_bw']}</td>
                  '''

--- a/lib/rccl_lib.py
+++ b/lib/rccl_lib.py
@@ -312,7 +312,7 @@ def rccl_cluster_test( phdl, shdl, test_name, cluster_node_list, vpc_node_list, 
         ib_rx_queue_len=8192, ucx_tls='tcp', hcoll_enable_mcast_all=0, \
         nccl_cumem_enable=0, nccl_ib_timeout=30, nccl_ib_sl=0, \
         nccl_ib_tc=41, nccl_ib_split_data_on_qps=0, nccl_pxn_disable=1, \
-        nccl_net_plugin=None, user_password=None, \
+        nccl_p2p_batch_enable=1, nccl_net_plugin=None, user_password=None, \
         min_channels=64, max_channels=64, \
         data_type="float", \
         user_key_file=None, verify_bus_bw=False, \
@@ -418,6 +418,7 @@ def rccl_cluster_test( phdl, shdl, test_name, cluster_node_list, vpc_node_list, 
         -x NCCL_IB_TC={nccl_ib_tc} \
         -x NCCL_IB_SPLIT_DATA_ON_QPS={nccl_ib_split_data_on_qps} \
         -x NCCL_PXN_DISABLE={nccl_pxn_disable} \
+        -x RCCL_P2P_BATCH_ENABLE={nccl_p2p_batch_enable} \
         -x NCCL_NET_PLUGIN={nccl_net_plugin} \
         {RCCL_TESTS_INSTALL_DIR}/{test_name} -b {start_msg_size} -e {end_msg_size} -f {step_function} \
         -g {threads_per_gpu} -c {check_iteration_count} -w {warmup_iterations} \
@@ -482,7 +483,7 @@ def rccl_cluster_test_default( phdl, shdl, test_name, cluster_node_list, vpc_nod
         ib_rx_queue_len=8192, ucx_tls='tcp', hcoll_enable_mcast_all=0, \
         nccl_cumem_enable=0, nccl_ib_timeout=30, nccl_ib_sl=0, \
         nccl_ib_tc=41, nccl_ib_split_data_on_qps=0, nccl_pxn_disable=1, \
-        nccl_net_plugin=None, user_password=None, \
+        nccl_p2p_batch_enable=1, nccl_net_plugin=None, user_password=None, \
         min_channels=64, max_channels=64, \
         user_key_file=None, verify_bus_bw=False, \
         verify_bw_dip=True, verify_lat_dip=True, exp_results_dict=None ):
@@ -584,6 +585,7 @@ def rccl_cluster_test_default( phdl, shdl, test_name, cluster_node_list, vpc_nod
         --mca btl_tcp_if_exclude lo,docker0,usb0 \
         -x UCX_NET_DEVICES={net_dev_list} \
         -x UCX_TLS={ucx_tls} \
+        -x RCCL_P2P_BATCH_ENABLE={nccl_p2p_batch_enable} \
         -x NCCL_NET_PLUGIN={nccl_net_plugin} \
         {RCCL_TESTS_INSTALL_DIR}/{test_name} -b {start_msg_size} -e {end_msg_size} -f {step_function} \
         -g {threads_per_gpu} -c {check_iteration_count} -w {warmup_iterations} \

--- a/tests/rccl/README.md
+++ b/tests/rccl/README.md
@@ -11,3 +11,8 @@ This Pytest script can be run in the following fashion (for the details on argum
 (myenv) [user@host]~/cvs:(main)$pytest -vvv --log-file=/tmp/test.log -s ./tests/rccl/rccl_multinode_cvs.py --cluster_file input/cluster_file/cluster.json  --config_file input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl.html --capture=tee-sys --self-contained-html
 
 ```
+
+## P2P Batching Restrictions
+
+- `RCCL_P2P_BATCH_ENABLE=1` is only tested on clusters with ≤32 nodes to avoid hangs observed with alltoall/alltoallv operations in larger clusters.
+- For clusters >32 nodes, only `RCCL_P2P_BATCH_ENABLE=0` is tested.


### PR DESCRIPTION

## Motivation

Add RCCL_P2P_BATCH_ENABLE parameter to multinode

## Technical Details

- Added nccl_p2p_batch_enable test parameter with values ["0", "1"] to rccl_multinode_cvs.py
- Updated rccl_lib.py to include the parameter in MPI command execution
- Added parameter to rccl_config.json configuration file
- Doubles test combinations to cover P2P batching enable/disable cases.

## Test Plan

Execute all combination of rccl multinode tests

## Test Result

WIP

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
