### PR TITLE
[Cherry-pick] RVS: Removed unwanted rvs tests (#25)

### DIFF
--- a/docs/how-to/run-cvs-tests.rst
+++ b/docs/how-to/run-cvs-tests.rst
@@ -137,15 +137,11 @@ See the `ROCm Validation Suite (RVS) <https://rocm.docs.amd.com/projects/ROCmVal
 
 These are the test cases for RVS:
 
-- ``gpup_single``
 - ``mem_test``
 - ``gst_single``
-- ``iet_single``
+- ``iet_stress``
 - ``pebb_single``
 - ``pbqt_single``
-- ``peqt_single``
-- ``rcqt_single``
-- ``tst_single``
 - ``babel_stream``
 
 Use these scripts to start the test:

--- a/docs/reference/configuration-files/health.rst
+++ b/docs/reference/configuration-files/health.rst
@@ -92,14 +92,6 @@ Here's a code snippet of the ``mi300_health_config.json`` file for reference:
                     ]
                 },
                 {
-                    "name": "gpup_single",
-                    "config_file": "gpup_single.conf",
-                    "description": "GPU Properties Test",
-                    "timeout": 1800,
-                    "expected_pass": true,
-                    "fail_regex_pattern": "FAIL|ERROR|RVS-ERROR"
-                },
-                {
                     "name": "mem_test",
                     "config_file": "mem.conf",
                     "description": "Memory Test",
@@ -116,9 +108,9 @@ Here's a code snippet of the ``mi300_health_config.json`` file for reference:
                     "fail_regex_pattern": "met:\\s*FALSE|RVS-ERROR"
                 },
                 {
-                    "name": "iet_single",
-                    "config_file": "iet_single.conf",
-                    "description": "Input EDPp Test",
+                    "name": "iet_stress",
+                    "config_file": "iet_stress.conf",
+                    "description": "Peak Power Test",
                     "timeout": 3600,
                     "expected_pass": true,
                     "fail_regex_pattern": "pass:\\s*FALSE|RVS-ERROR"
@@ -138,30 +130,6 @@ Here's a code snippet of the ``mi300_health_config.json`` file for reference:
                     "timeout": 3600,
                     "expected_pass": true,
                     "fail_regex_pattern": "FAIL|ERROR:|RVS-ERROR"
-                },
-                {
-                    "name": "peqt_single",
-                    "config_file": "peqt_single.conf",
-                    "description": "PCI Express Qualification Tool",
-                    "timeout": 1800,
-                    "expected_pass": true,
-                    "fail_regex_pattern": "peqt false|RVS-ERROR"
-                },
-                {
-                    "name": "rcqt_single",
-                    "config_file": "rcqt_single.conf",
-                    "description": "ROCm Configuration Qualification Tool",
-                    "timeout": 1800,
-                    "expected_pass": "true",
-                    "fail_regex_pattern": "\\[ERROR\\s*\\]|RVS-ERROR|Missing packages\\s*:\\s*([1-9]\\d*)|Version mismatch packages\\s*:\\s*([1-9]\\d*)"
-                },
-                {
-                    "name": "tst_single",
-                    "config_file": "tst_single.conf",
-                    "description": "Thermal Stress Test",
-                    "timeout": 1800,
-                    "expected_pass": true,
-                    "fail_regex_pattern": "pass: FLASE|RVS-ERROR"
                 },
                 {
                     "name": "babel_stream",
@@ -354,24 +322,6 @@ ROCm Validation Suite (RVS)
         - ``"Version mismatch packages\\s*:\\s*([1-9]\\d*)"``
      - Regular expressions
    * - ``name``
-     - ``gpup_single``
-     - Test name
-   * - ``config_file``
-     - ``gpup_single.conf``
-     - Test config file
-   * - ``description``
-     - GPU Properties Test
-     - Test description
-   * - ``timeout``
-     - 1800
-     - Timeout in secs
-   * - ``expected_pass``
-     - True
-     - Result
-   * - ``fail_regex_pattern``
-     - ``FAIL|ERROR|RVS-ERROR``
-     - Failure expression
-   * - ``name``
      - ``mem_test``
      - Test name
    * - ``config_file``
@@ -408,13 +358,13 @@ ROCm Validation Suite (RVS)
      - ``met:\\s*FALSE|RVS-ERROR``
      - Failure expression
    * - ``name``
-     - ``iet_single``
+     - ``iet_stress``
      - Test name
    * - ``config_file``
-     - ``iet_single.conf``
+     - ``iet_stress.conf``
      - Test config file
    * - ``description``
-     - Input EDPp Test
+     - Peak Power Test
      - Test description
    * - ``timeout``
      - 3600
@@ -442,60 +392,6 @@ ROCm Validation Suite (RVS)
      - Result
    * - ``fail_regex_pattern``
      - ``FAIL|ERROR:|RVS-ERROR``
-     - Failure expression
-   * - ``name``
-     - ``peqt_single``
-     - Test name
-   * - ``config_file``
-     - ``peqt_single.conf``
-     - Test config file
-   * - ``description``
-     - PCI Express Qualification Tool
-     - Test description
-   * - ``timeout``
-     - 1800
-     - Timeout in secs
-   * - ``expected_pass``
-     - True
-     - Result
-   * - ``fail_regex_pattern``
-     - ``peqt false|RVS-ERROR``
-     - Failure expression
-   * - ``name``
-     - ``rcqt_single``
-     - Test name
-   * - ``config_file``
-     - ``rcqt_single.conf``
-     - Test config file
-   * - ``description``
-     - ROCm Configuration Qualification Tool
-     - Test description
-   * - ``timeout``
-     - 1800
-     - Timeout in secs
-   * - ``expected_pass``
-     - True
-     - Result
-   * - ``fail_regex_pattern``
-     - ``\\[ERROR\\s*\\]|RVS-ERROR|`` |br| ``Missing packages\\s*:`` |br| ``\\s*([1-9]\\d*)|Version`` |br| ``mismatch packages`` |br| ``\\s*:\\s*([1-9]\\d*)``
-     - Failure expression
-   * - ``name``
-     - ``tst_single``
-     - Test name
-   * - ``config_file``
-     - ``tst_single.conf``
-     - Test config file
-   * - ``description``
-     - Thermal Stress Test
-     - Test description
-   * - ``timeout``
-     - 1800
-     - Timeout in secs
-   * - ``expected_pass``
-     - True
-     - Result
-   * - ``fail_regex_pattern``
-     - ``pass: FLASE|RVS-ERROR``
      - Failure expression
    * - ``name``
      - ``babel_stream``

--- a/input/config_file/health/mi300_health_config.json
+++ b/input/config_file/health/mi300_health_config.json
@@ -72,14 +72,6 @@
                 ]
             },
             {
-                "name": "gpup_single",
-                "config_file": "gpup_single.conf",
-                "description": "GPU Properties Test",
-                "timeout": 1800,
-                "expected_pass": true,
-                "fail_regex_pattern": "FAIL|ERROR|RVS-ERROR"
-            },
-            {
                 "name": "mem_test",
                 "config_file": "mem.conf",
                 "description": "Memory Test",
@@ -96,9 +88,9 @@
                 "fail_regex_pattern": "met:\\s*FALSE|RVS-ERROR"
             },
             {
-                "name": "iet_single",
-                "config_file": "iet_single.conf",
-                "description": "Input EDPp Test",
+                "name": "iet_stress",
+                "config_file": "iet_stress.conf",
+                "description": "Peak Power Test",
                 "timeout": 3600,
                 "expected_pass": true,
                 "fail_regex_pattern": "pass:\\s*FALSE|RVS-ERROR"
@@ -118,30 +110,6 @@
                 "timeout": 3600,
                 "expected_pass": true,
                 "fail_regex_pattern": "FAIL|ERROR:|RVS-ERROR"
-            },
-            {
-                "name": "peqt_single",
-                "config_file": "peqt_single.conf",
-                "description": "PCI Express Qualification Tool",
-                "timeout": 1800,
-                "expected_pass": true,
-                "fail_regex_pattern": "peqt false|RVS-ERROR"
-            },
-            {
-                "name": "rcqt_single",
-                "config_file": "rcqt_single.conf",
-                "description": "ROCm Configuration Qualification Tool",
-                "timeout": 1800,
-                "expected_pass": "true",
-                "fail_regex_pattern": "\\[ERROR\\s*\\]|RVS-ERROR|Missing packages\\s*:\\s*([1-9]\\d*)|Version mismatch packages\\s*:\\s*([1-9]\\d*)"
-            },
-            {
-                "name": "tst_single",
-                "config_file": "tst_single.conf",
-                "description": "Thermal Stress Test",
-                "timeout": 1800,
-                "expected_pass": true,
-                "fail_regex_pattern": "pass: FLASE|RVS-ERROR"
             },
             {
                 "name": "babel_stream",

--- a/tests/health/README.md
+++ b/tests/health/README.md
@@ -62,15 +62,11 @@ RVS provides comprehensive GPU validation through multiple test modules. The tes
 #### Supported Test Modules
 
 Individual test modules include:
-- **GPUP** (GPU Properties Test) - Validates GPU properties and capabilities
 - **MEM** (Memory Test) - Validates GPU memory functionality and integrity
 - **GST** (GPU Stress Test) - Validates GPU functionality and performance under load
-- **IET** (Input EDPp Test) - Validates power consumption and thermal behavior
+- **IET** (Peak Power Test) - Validates power consumption and thermal behavior
 - **PEBB** (PCI Express Bandwidth Benchmark) - Measures and validates PCIe bandwidth performance
 - **PBQT** (P2P Benchmark and Qualification Tool) - Validates peer-to-peer communication between GPUs
-- **PEQT** (PCI Express Qualification Tool) - Validates PCIe link quality and stability
-- **RCQT** (ROCm Configuration Qualification Tool) - Validates ROCm configuration and system setup
-- **TST** (Thermal Stress Test) - Validates GPU thermal management under stress
 - **BABEL** (BABEL Benchmark) - GPU memory bandwidth validation using BABEL streaming benchmark
 - **GPU Enumeration** - Basic GPU detection test
 

--- a/tests/health/rvs_cvs.py
+++ b/tests/health/rvs_cvs.py
@@ -590,26 +590,6 @@ def test_rvs_gpu_enumeration(phdl, config_dict):
 
     update_test_result()
 
-def test_rvs_gpup_single(phdl, config_dict, rvs_version, rvs_test_level):
-    """
-    Run RVS GPUP (GPU Properties) test.
-    This test validates GPU properties and capabilities.
-
-    Args:
-      phdl: Parallel SSH handle
-      config_dict: RVS configuration dictionary
-      rvs_version: RVS version string
-      rvs_test_level: Test level (0-5)
-    """
-    # Check if test should be skipped
-    should_skip, skip_reason = should_skip_individual_test(rvs_version, rvs_test_level)
-    if should_skip:
-        pytest.skip(f"test_rvs_gpup_single: {skip_reason}")
-
-    test_name = 'gpup_single'
-    execute_rvs_test(phdl, config_dict, test_name)
-
-
 def test_rvs_mem_test(phdl, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS Memory Test.
@@ -651,9 +631,9 @@ def test_rvs_gst_single(phdl, config_dict, rvs_version, rvs_test_level):
     execute_rvs_test(phdl, config_dict, test_name)
 
 
-def test_rvs_iet_single(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_iet_stress(phdl, config_dict, rvs_version, rvs_test_level):
     """
-    Run RVS IET (Input EDPp Test) - Single GPU validation test.
+    Run RVS IET (Peak Power Test) - Single GPU validation test.
     This test validates power consumption and thermal behavior under load.
 
     Args:
@@ -665,9 +645,9 @@ def test_rvs_iet_single(phdl, config_dict, rvs_version, rvs_test_level):
     # Check if test should be skipped
     should_skip, skip_reason = should_skip_individual_test(rvs_version, rvs_test_level)
     if should_skip:
-        pytest.skip(f"test_rvs_iet_single: {skip_reason}")
+        pytest.skip(f"test_rvs_iet_stress: {skip_reason}")
 
-    test_name = 'iet_single'
+    test_name = 'iet_stress'
     execute_rvs_test(phdl, config_dict, test_name)
 
 
@@ -709,67 +689,6 @@ def test_rvs_pbqt_single(phdl, config_dict, rvs_version, rvs_test_level):
 
     test_name = 'pbqt_single'
     execute_rvs_test(phdl, config_dict, test_name)
-
-
-def test_rvs_peqt_single(phdl, config_dict, rvs_version, rvs_test_level):
-    """
-    Run RVS PEQT (PCI Express Qualification Tool).
-    This test validates PCI Express link quality and stability.
-
-    Args:
-      phdl: Parallel SSH handle
-      config_dict: RVS configuration dictionary
-      rvs_version: RVS version string
-      rvs_test_level: Test level (0-5)
-    """
-    # Check if test should be skipped
-    should_skip, skip_reason = should_skip_individual_test(rvs_version, rvs_test_level)
-    if should_skip:
-        pytest.skip(f"test_rvs_peqt_single: {skip_reason}")
-
-    test_name = 'peqt_single'
-    execute_rvs_test(phdl, config_dict, test_name)
-
-
-def test_rvs_rcqt_single(phdl, config_dict, rvs_version, rvs_test_level):
-    """
-    Run RVS RCQT (ROCm Configuration Qualification Tool).
-    This test validates ROCm configuration and system setup.
-
-    Args:
-      phdl: Parallel SSH handle
-      config_dict: RVS configuration dictionary
-      rvs_version: RVS version string
-      rvs_test_level: Test level (0-5)
-    """
-    # Check if test should be skipped
-    should_skip, skip_reason = should_skip_individual_test(rvs_version, rvs_test_level)
-    if should_skip:
-        pytest.skip(f"test_rvs_rcqt_single: {skip_reason}")
-
-    test_name = 'rcqt_single'
-    execute_rvs_test(phdl, config_dict, test_name)
-
-
-def test_rvs_tst_single(phdl, config_dict, rvs_version, rvs_test_level):
-    """
-    Run RVS TST (Thermal Stress Test).
-    This test validates GPU thermal management under stress conditions.
-
-    Args:
-      phdl: Parallel SSH handle
-      config_dict: RVS configuration dictionary
-      rvs_version: RVS version string
-      rvs_test_level: Test level (0-5)
-    """
-    # Check if test should be skipped
-    should_skip, skip_reason = should_skip_individual_test(rvs_version, rvs_test_level)
-    if should_skip:
-        pytest.skip(f"test_rvs_tst_single: {skip_reason}")
-
-    test_name = 'tst_single'
-    execute_rvs_test(phdl, config_dict, test_name)
-
 
 def test_rvs_babel_stream(phdl, config_dict, rvs_version, rvs_test_level):
     """


### PR DESCRIPTION
* RVS: Removed unwanted rvs tests

Removed the below tests from rvs which are not required: gpup_single
peqt_single
rcqt_single
tst_single

Changed iet_single to iet_stress config.
Updated the RVT related document pages.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
