### PR TITLE
rccl: fail schema when wrong > 0

### DIFF
--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -30,6 +30,25 @@ rccl_err_dict = {
 }
 
 
+def _is_severe_wrong_corruption_error(err: ValidationError) -> bool:
+    """
+    Detect the rccl-tests '#wrong' corruption failure from a pydantic ValidationError.
+    This is used to provide explicit, high-signal feedback to the user.
+    """
+    # Prefer structured parsing when available
+    try:
+        for item in err.errors():
+            msg = item.get('msg', '') or ''
+            if 'SEVERE DATA CORRUPTION' in msg or "'#wrong'" in msg or 'wrong=' in msg:
+                return True
+    except Exception:
+        pass
+
+    # Fallback to string search
+    s = str(err)
+    return 'SEVERE DATA CORRUPTION' in s or "'#wrong'" in s
+
+
 def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
     """
     Check if UCX is available in the OpenMPI build.
@@ -830,8 +849,29 @@ def rccl_cluster_test_default(
             all_validated_results.extend(validated)
             all_raw_results.extend(dtype_result_out)
         except ValidationError as e:
-            log.error(f'Validation Failed: {e}')
-            fail_test(f'RCCL Test {dtype} schema validation failed: {e}')
+            if _is_severe_wrong_corruption_error(e):
+                msg = (
+                    "\n"
+                    "==================== SEVERE DATA CORRUPTION ====================\n"
+                    "RCCL rccl-tests JSON schema validation failed due to '#wrong' > 0.\n"
+                    "This indicates invalid/corrupted rccl-tests results.\n"
+                    "\n"
+                    f"data_type: {dtype}\n"
+                    f"result_file: {dtype_result_file}\n"
+                    "\n"
+                    "Action: aborting further RCCL iterations/data types.\n"
+                    "Please inspect the rccl-tests stdout/stderr and re-run.\n"
+                    "================================================================\n"
+                )
+                print(msg)
+                log.error(msg)
+                fail_test(msg)
+            else:
+                log.error(f'Validation Failed: {e}')
+                fail_test(f'RCCL Test {dtype} schema validation failed: {e}')
+
+            # IMPORTANT: schema validation failures should stop further iterations/data types
+            raise RuntimeError(f'RCCL Test {dtype} schema validation failed') from e
 
     # Save the results to a main result file
     with open(rccl_result_file, 'w') as f:

--- a/cvs/schema/rccl.py
+++ b/cvs/schema/rccl.py
@@ -111,7 +111,10 @@ class RcclTests(BaseModel):
         if self.wrong < 0:
             raise ValueError(f'wrong must be >= 0, got {self.wrong}')
         if self.wrong > 0:
-            raise ValueError(f'wrong must be 0 after normalization, got {self.wrong}')
+            raise ValueError(
+                f"SEVERE DATA CORRUPTION: rccl-tests reported non-zero '#wrong' after normalization "
+                f"(wrong={self.wrong}). Results are invalid/corrupted."
+            )
         return self
 
     @field_validator('time', 'algBw', 'busBw')

--- a/cvs/unittests/test_rccl_schema_validation.py
+++ b/cvs/unittests/test_rccl_schema_validation.py
@@ -1,0 +1,43 @@
+import unittest
+
+from pydantic import ValidationError
+
+from cvs.schema.rccl import RcclTests
+
+
+class TestRcclSchemaValidation(unittest.TestCase):
+    def _base_payload(self):
+        return {
+            "numCycle": 1,
+            "name": "allreduce",  # exercise normalization
+            "size": 1024,
+            "type": "float",
+            "redop": "sum",
+            "inPlace": 0,
+            "time": 1.0,
+            "algBw": 100.0,
+            "busBw": 90.0,
+        }
+
+    def test_wrong_na_normalizes_to_zero_and_passes(self):
+        payload = {**self._base_payload(), "wrong": " N/A "}
+        parsed = RcclTests.model_validate(payload)
+        self.assertEqual(parsed.wrong, 0)
+
+        payload2 = {**self._base_payload(), "wrong": "na"}
+        parsed2 = RcclTests.model_validate(payload2)
+        self.assertEqual(parsed2.wrong, 0)
+
+    def test_wrong_positive_fails_after_normalization(self):
+        payload = {**self._base_payload(), "wrong": 1}
+        with self.assertRaises(ValidationError):
+            RcclTests.model_validate(payload)
+
+        payload2 = {**self._base_payload(), "wrong": "1"}
+        with self.assertRaises(ValidationError):
+            RcclTests.model_validate(payload2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/cvs/unittests/test_rccl_schema_validation.py
+++ b/cvs/unittests/test_rccl_schema_validation.py
@@ -40,4 +40,3 @@ class TestRcclSchemaValidation(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/cvs/unittests/test_rccl_schema_validation.py
+++ b/cvs/unittests/test_rccl_schema_validation.py
@@ -30,12 +30,14 @@ class TestRcclSchemaValidation(unittest.TestCase):
 
     def test_wrong_positive_fails_after_normalization(self):
         payload = {**self._base_payload(), "wrong": 1}
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as ctx:
             RcclTests.model_validate(payload)
+        self.assertIn("SEVERE DATA CORRUPTION", str(ctx.exception))
 
         payload2 = {**self._base_payload(), "wrong": "1"}
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as ctx2:
             RcclTests.model_validate(payload2)
+        self.assertIn("SEVERE DATA CORRUPTION", str(ctx2.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Ensure rccl-tests JSON results are rejected when `wrong` indicates errors/corruption after normalization.

## Technical Details

- Normalize `wrong` (strip strings; treat NaN/Inf as 0)
- Reject `wrong > 0` via Pydantic model validation
- Add unittest coverage

## Test Plan

- `python3 -m unittest -v cvs.unittests.test_rccl_schema_validation`

## Test Result

- Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.