### PR TITLE
Add CVS Aorta Benchmark CI workflow (with artifact upload)

### DIFF
--- a/.github/workflows/aorta-benchmark.yml
+++ b/.github/workflows/aorta-benchmark.yml
@@ -1,0 +1,47 @@
+name: CVS Aorta Benchmark
+
+on:
+  push:
+    branches:
+      - users/arravikum/aorta_benchmark
+  workflow_dispatch:
+    inputs:
+      test_type:
+        description: "Type of Benchmark test run"
+        type: string
+        required: true
+        default: "Aorta Benchmark"
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+      
+
+permissions:
+  contents: read
+
+jobs:
+  cvs-aorta-benchmark:
+    name: cvs Aorta Benchmark Tests
+    runs-on: linux-vultr-mi325-scale-runner
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
+      options: -v /runner/config:/home/awsconfig/
+    steps:
+      - name: Checkout TheRock repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/cvs"
+
+      - name: Test Aorta Benchmark Tests
+        run: |
+          cd /home/arravikum/cvs_aorta/cvs-sbatch
+          ./run_direct.sh --cluster ./cluster_config.json --config ./config_aorta_test.yaml --test ../cvs/cvs/tests/benchmark/test_aorta.py
+
+
+
+
+          

--- a/.github/workflows/aorta-benchmark.yml
+++ b/.github/workflows/aorta-benchmark.yml
@@ -26,16 +26,35 @@ jobs:
     name: cvs Aorta Benchmark Tests
     runs-on: linux-vultr-mi325-scale-runner
     steps:
-      - name: Checkout TheRock repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: "ROCm/cvs"
-
       - name: Test Aorta Benchmark Tests
         shell: bash
         run: |
           cd /home/arravikum/cvs_aorta/cvs-sbatch
           ./run_direct.sh --cluster ./cluster_config.json --config ./config_aorta_test.yaml --test ../cvs/cvs/tests/benchmark/test_aorta.py
+
+      - name: Collect pytest HTML report
+        if: always()
+        shell: bash
+        run: |
+          echo "Searching for latest pytest_report.html..."
+          REPORT_PATH=$(find /tmp -type f -name pytest_report.html -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n1 | awk '{print $2}')
+          
+          if [ -z "$REPORT_PATH" ]; then
+            echo "No pytest_report.html found"
+            exit 0
+          fi
+
+          echo "Found report at: $REPORT_PATH"
+          cp "$REPORT_PATH" ./pytest_report.html
+          ls -lah ./pytest_report.html
+
+      - name: Upload pytest HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aorta-benchmark-pytest-report
+          path: pytest_report.html
+
 
 
 

--- a/.github/workflows/aorta-benchmark.yml
+++ b/.github/workflows/aorta-benchmark.yml
@@ -36,9 +36,10 @@ jobs:
         if: always()
         shell: bash
         run: |
-          echo "Searching for latest pytest_report.html..."
-          REPORT_PATH=$(find /tmp -type f -name pytest_report.html -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n1 | awk '{print $2}')
-          
+          echo "Searching for pytest_report.html..."
+
+          REPORT_PATH=$(ls -t /tmp/cvs_*/pytest_report.html 2>/dev/null | head -n1)
+
           if [ -z "$REPORT_PATH" ]; then
             echo "No pytest_report.html found"
             exit 0
@@ -47,6 +48,7 @@ jobs:
           echo "Found report at: $REPORT_PATH"
           cp "$REPORT_PATH" ./pytest_report.html
           ls -lah ./pytest_report.html
+
 
       - name: Upload pytest HTML report
         if: always()

--- a/.github/workflows/aorta-benchmark.yml
+++ b/.github/workflows/aorta-benchmark.yml
@@ -37,6 +37,7 @@ jobs:
           repository: "ROCm/cvs"
 
       - name: Test Aorta Benchmark Tests
+        shell: bash
         run: |
           cd /home/arravikum/cvs_aorta/cvs-sbatch
           ./run_direct.sh --cluster ./cluster_config.json --config ./config_aorta_test.yaml --test ../cvs/cvs/tests/benchmark/test_aorta.py

--- a/.github/workflows/aorta-benchmark.yml
+++ b/.github/workflows/aorta-benchmark.yml
@@ -25,11 +25,6 @@ jobs:
   cvs-aorta-benchmark:
     name: cvs Aorta Benchmark Tests
     runs-on: linux-vultr-mi325-scale-runner
-    permissions:
-      id-token: write
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
-      options: -v /runner/config:/home/awsconfig/
     steps:
       - name: Checkout TheRock repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/aorta-benchmark.yml
+++ b/.github/workflows/aorta-benchmark.yml
@@ -11,11 +11,6 @@ on:
         type: string
         required: true
         default: "Aorta Benchmark"
-  pull_request:
-    types:
-      - labeled
-      - opened
-      - synchronize
       
 
 permissions:


### PR DESCRIPTION
Adds a new GitHub Actions workflow to run the CVS Aorta benchmark (test_aorta.py) on the MI325 scale runner.

The workflow:

1. Executes the benchmark via run_direct.sh

2. Runs in Non-SLURM/manual cluster mode

3. Uploads the generated pytest HTML report as a workflow artifact

This enables automated benchmark validation and easier debugging directly from CI.