### PR TITLE
Fix the html folder/zip file name

### DIFF
--- a/cvs/conftest.py
+++ b/cvs/conftest.py
@@ -16,10 +16,12 @@ from cvs.lib.report_plugins import HtmlReportManager
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
-    if config.args:
-        suite_name = Path(config.args[0]).stem
-    else:
-        suite_name = "test"
+    suite_name = "test"
+    for arg in config.args:
+        bare = arg.split("::")[0]
+        if not bare.startswith("-") and bare.endswith(".py"):
+            suite_name = Path(bare).stem
+            break
     config._test_html_dir = f"{suite_name}_html"
     config._html_report_manager = HtmlReportManager(config)
 

--- a/cvs/conftest.py
+++ b/cvs/conftest.py
@@ -22,6 +22,7 @@ def pytest_configure(config):
         if not bare.startswith("-") and bare.endswith(".py"):
             suite_name = Path(bare).stem
             break
+    config._suite_name = suite_name
     config._test_html_dir = f"{suite_name}_html"
     config._html_report_manager = HtmlReportManager(config)
 

--- a/cvs/lib/report_plugins.py
+++ b/cvs/lib/report_plugins.py
@@ -147,11 +147,13 @@ class HtmlReportManager:
         timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H%M%S")
 
         invocation_params = getattr(session.config, "invocation_params", None)
-        if invocation_params and hasattr(invocation_params, "args") and invocation_params.args:
-            # Prefer suite/test target name for archive readability.
-            suite_name_part = Path(invocation_params.args[0]).stem
-        else:
-            suite_name_part = htmlpath.stem
+        invocation_args = getattr(invocation_params, "args", [])
+        suite_name_part = htmlpath.stem
+        for arg in invocation_args:
+            bare = arg.split("::")[0]
+            if not bare.startswith("-") and bare.endswith(".py"):
+                suite_name_part = Path(bare).stem
+                break
 
         zip_path = report_dir / f"{suite_name_part}_{timestamp}.zip"
         log_dir = report_dir / self._test_html_dir

--- a/cvs/lib/report_plugins.py
+++ b/cvs/lib/report_plugins.py
@@ -146,14 +146,7 @@ class HtmlReportManager:
         report_dir = htmlpath.parent
         timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H%M%S")
 
-        invocation_params = getattr(session.config, "invocation_params", None)
-        invocation_args = getattr(invocation_params, "args", [])
-        suite_name_part = htmlpath.stem
-        for arg in invocation_args:
-            bare = arg.split("::")[0]
-            if not bare.startswith("-") and bare.endswith(".py"):
-                suite_name_part = Path(bare).stem
-                break
+        suite_name_part = getattr(session.config, "_suite_name", htmlpath.stem)
 
         zip_path = report_dir / f"{suite_name_part}_{timestamp}.zip"
         log_dir = report_dir / self._test_html_dir


### PR DESCRIPTION
## Motivation

The HTML report folder and zip archive were being named after the first raw pytest argument instead of the actual test suite name. 

## Technical Details

files relied on `args[0]` to derive the suite name, assuming it was always the test file path. When users pass extra pytest flags (e.g. `-vvv`, `-s`) via `extra_pytest_args`, these can appear before the test path in the args list.

**Fix:** Instead of using `args[0]`, iterate over the args and find the first argument that:
1. Does not start with `-` (skip flags)
2. Ends with `.py` (must be an actual Python test file)
3. Strips `::test_function` suffixes before extracting the stem

Falls back to `"test"` (for the log directory) or `htmlpath.stem` (for the zip name) if no `.py` argument is found.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
