### PR TITLE
fixed exec syntax, it needs a command not only strings

### DIFF
--- a/cvs/tests/ibperf/ib_perf_bw_test.py
+++ b/cvs/tests/ibperf/ib_perf_bw_test.py
@@ -233,7 +233,7 @@ def test_ib_bw_perf(phdl, bw_test, config_dict):
         for qp_count in config_dict['qp_count_list']:
             # Log a message to Dmesg to create a timestamp record
             start_time = phdl.exec('date +"%a %b %e %H:%M"')
-            phdl.exec(f'Starting Test {bw_test} for {msg_size} and QP count {qp_count} | sudo tee /dev/kmsg')
+            phdl.exec(f'echo "Starting Test {bw_test} for {msg_size} and QP count {qp_count}" | sudo -n tee /dev/kmsg')
             ib_bw_dict[bw_test][msg_size][qp_count] = ibperf_lib.run_ib_perf_bw_test(
                 phdl,
                 bw_test,
@@ -292,7 +292,7 @@ def test_ib_lat_perf(phdl, lat_test, config_dict):
         ib_lat_dict[lat_test][msg_size] = {}
         # Log a message to Dmesg to create a timestamp record
         start_time = phdl.exec('date +"%a %b %e %H:%M"')
-        phdl.exec(f'sudo echo "Starting Test {lat_test} for {msg_size} | sudo tee /dev/kmsg"')
+        phdl.exec(f'echo "Starting Test {lat_test} for {msg_size}" | sudo -n tee /dev/kmsg')
         ib_lat_dict[lat_test][msg_size] = ibperf_lib.run_ib_perf_lat_test(
             phdl,
             lat_test,


### PR DESCRIPTION
  - it fixes the following run-time error
    [err]   bash: line 1: Starting: command not found

## Motivation

CVS exec command syntax is wrong without this fix

## Technical Details

exec was given only string but a command must exists

## Test Plan

This error was revealed while running perftest. The error is non-fatal.

## Test Result

With this fix, bash error command will not be seen in the log

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
