### PR TITLE
Fix AORTA benchmark config resolution and documentation

### DIFF
--- a/cvs/input/config_file/aorta/aorta_benchmark.yaml
+++ b/cvs/input/config_file/aorta/aorta_benchmark.yaml
@@ -6,7 +6,7 @@
 # Path to Aorta on the host. test_aorta resolves placeholders like other CVS test configs
 # ({user-id}, {user}, {home}, {home-mount-dir}, {node-dir-name}) using the validated cluster username.
 # If the directory does not exist, set aorta_auto_clone: true and aorta_clone_url.
-aorta_path: /scratch/users/{user-id}/aorta
+aorta_path: /scratch/users/{user-id}/aorta # change to your own path
 # aorta_auto_clone: false
 # aorta_clone_url: "https://github.com/your-org/aorta.git"  # set when using auto-clone
 

--- a/cvs/input/config_file/aorta/aorta_benchmark.yaml
+++ b/cvs/input/config_file/aorta/aorta_benchmark.yaml
@@ -6,7 +6,7 @@
 # Path to Aorta on the host. test_aorta resolves placeholders like other CVS test configs
 # ({user-id}, {user}, {home}, {home-mount-dir}, {node-dir-name}) using the validated cluster username.
 # If the directory does not exist, set aorta_auto_clone: true and aorta_clone_url.
-aorta_path: /scratch/users/{user-id}/aorta # change to your own path
+aorta_path: /home/{user-id}/aorta # change to your own path
 # aorta_auto_clone: false
 # aorta_clone_url: "https://github.com/your-org/aorta.git"  # set when using auto-clone
 

--- a/cvs/input/config_file/aorta/aorta_benchmark.yaml
+++ b/cvs/input/config_file/aorta/aorta_benchmark.yaml
@@ -3,8 +3,9 @@
 # analysis is optional; when enabled and available in the image, Excel reports are used
 # first, otherwise host parses raw traces (TraceLens in venv or basic JSON parsing).
 
-# Path to Aorta repository on shared filesystem (placeholder resolved from cluster config).
-# If the directory does not exist, set aorta_auto_clone: true and aorta_clone_url to clone it.
+# Path to Aorta on the host. test_aorta resolves placeholders like other CVS test configs
+# ({user-id}, {user}, {home}, {home-mount-dir}, {node-dir-name}) using the validated cluster username.
+# If the directory does not exist, set aorta_auto_clone: true and aorta_clone_url.
 aorta_path: /scratch/users/{user-id}/aorta
 # aorta_auto_clone: false
 # aorta_clone_url: "https://github.com/your-org/aorta.git"  # set when using auto-clone
@@ -26,7 +27,7 @@ docker:
 
 # RCCL build configuration
 rccl:
-  clone_url: https://github.com/rocm/rccl.git
+  clone_url: https://github.com/ROCm/rccl
   branch: develop
   build_path: /mnt/rccl
 

--- a/cvs/lib/unittests/test_utils_lib.py
+++ b/cvs/lib/unittests/test_utils_lib.py
@@ -1,7 +1,9 @@
 # cvs/lib/unittests/test_utils_lib.py
 import unittest
 from unittest.mock import patch
+
 import cvs.lib.utils_lib as utils_lib
+from cvs.parsers.schemas import AortaBenchmarkConfigFile
 
 
 class TestUtilsLib(unittest.TestCase):
@@ -16,6 +18,26 @@ class TestUtilsLib(unittest.TestCase):
         out_dict = {'host1': 'some output success'}
         utils_lib.scan_test_results(out_dict)
         mock_fail_test.assert_not_called()
+
+
+class TestResolveTestConfigPlaceholdersAorta(unittest.TestCase):
+    """Aorta benchmark YAML uses the same resolver as other CVS test suites (see tests/benchmark/test_aorta.py)."""
+
+    def test_user_id_resolves_in_aorta_path(self):
+        raw = {"aorta_path": "/scratch/users/{user-id}/aorta"}
+        cluster = {"username": "jdoe", "home_mount_dir_name": "home", "node_dir_name": "root"}
+        resolved = utils_lib.resolve_test_config_placeholders(raw, cluster)
+        self.assertEqual(resolved["aorta_path"], "/scratch/users/jdoe/aorta")
+        cfg = AortaBenchmarkConfigFile.model_validate(resolved)
+        self.assertEqual(cfg.aorta_path, "/scratch/users/jdoe/aorta")
+
+    def test_explicit_aorta_path_unchanged(self):
+        raw = {"aorta_path": "/opt/my-aorta"}
+        cluster = {"username": "jdoe", "home_mount_dir_name": "home", "node_dir_name": "root"}
+        resolved = utils_lib.resolve_test_config_placeholders(raw, cluster)
+        self.assertEqual(resolved["aorta_path"], "/opt/my-aorta")
+        cfg = AortaBenchmarkConfigFile.model_validate(resolved)
+        self.assertEqual(cfg.aorta_path, "/opt/my-aorta")
 
 
 if __name__ == '__main__':

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -382,10 +382,9 @@ class AortaBenchmarkConfigFile(BaseModel):
     Validates structure and provides sensible defaults.
     Fails fast with clear error messages if configuration is invalid.
 
-    Usage:
-        with open("aorta_benchmark.yaml") as f:
-            raw = yaml.safe_load(f)
-        config = AortaBenchmarkConfigFile.model_validate(raw)
+    For ``test_aorta``, load YAML, apply ``resolve_test_config_placeholders`` with the resolved
+    cluster dict (same as other CVS suites), then ``model_validate``. Standalone tools may validate
+    raw YAML without placeholder resolution if paths are already absolute.
     """
 
     model_config = ConfigDict(extra="forbid")  # Catch typos in top-level keys

--- a/cvs/tests/benchmark/README.md
+++ b/cvs/tests/benchmark/README.md
@@ -4,15 +4,15 @@ The benchmark tests run distributed training benchmarks validated by CVS. The **
 
 For details on arguments and their purpose, see the main README under the CVS parent folder.
 
-1. **Config file:** Edit `cvs/input/config_file/aorta/aorta_benchmark.yaml` and set `aorta_path` to the absolute path of your Aorta repository. Do not leave the default `<changeme>`.
-2. **Cluster file:** Provide a valid cluster file (e.g. `input/cluster_file/cluster.json`) with node and user settings.
+1. **Config file:** Edit `input/config_file/aorta/aorta_benchmark.yaml`. You may use path placeholders (`{user-id}`, `{home}`, etc.); `test_aorta` resolves them after the cluster file is validated, like other CVS suites. Use an absolute path or valid placeholders, and ensure the tree exists (or enable `aorta_auto_clone` with `aorta_clone_url`).
+2. **Cluster file:** Provide a valid cluster file (e.g. `input/cluster_file/cluster.json`) with node and user settings. If your SSH key is not under `/home/<username>/.ssh/`, set `priv_key_file` explicitly (the template assumes that layout).
 
-Example from the CVS repo root (directory containing ``cvs`` and ``input``):
+Run from the **CVS package directory**—the directory that contains the `input` folder (the inner `cvs` directory in a normal checkout, next to `tests` and `lib`):
 
 ```bash
-(myenv) [user@host]~/cvs:(main)$ pwd
-/home/user/cvs/cvs
-(myenv) [user@host]~/cvs:(main)$ cvs run test_aorta --cluster_file input/cluster_file/cluster.json --config_file input/config_file/aorta/aorta_benchmark.yaml --html=logs/www/html/cvs/aorta.html --capture=tee-sys --self-contained-html --log-file=logs/aorta.log -vvv -s
+(myenv) [user@host myproject/cvs]$ pwd
+/home/user/myproject/cvs
+(myenv) [user@host myproject/cvs]$ cvs run test_aorta --cluster_file input/cluster_file/cluster.json --config_file input/config_file/aorta/aorta_benchmark.yaml --html=logs/www/html/cvs/aorta.html --capture=tee-sys --self-contained-html --log-file=logs/aorta.log -vvv -s
 ```
 
 With HTML report and full logging (see also `docs/reference/configuration-files/aorta.rst`):

--- a/cvs/tests/benchmark/test_aorta.py
+++ b/cvs/tests/benchmark/test_aorta.py
@@ -93,9 +93,7 @@ def validated_cluster_config(cluster_file) -> ClusterConfigFile:
 
 
 @pytest.fixture(scope="module")
-def validated_aorta_config(
-    config_file, validated_cluster_config: ClusterConfigFile
-) -> AortaBenchmarkConfigFile:
+def validated_aorta_config(config_file, validated_cluster_config: ClusterConfigFile) -> AortaBenchmarkConfigFile:
     """
     Load and validate Aorta benchmark configuration.
 

--- a/cvs/tests/benchmark/test_aorta.py
+++ b/cvs/tests/benchmark/test_aorta.py
@@ -15,6 +15,7 @@ import logging
 from pathlib import Path
 
 import pytest
+import yaml
 
 from cvs.runners.aorta import (
     AortaRunner,
@@ -32,11 +33,15 @@ from cvs.parsers.schemas import (
     # Config validation schemas
     ClusterConfigFile,
     AortaBenchmarkConfigFile,
-    validate_config_file,
 )
 
 from cvs.lib import globals
-from cvs.lib.utils_lib import fail_test, update_test_result, resolve_cluster_config_placeholders
+from cvs.lib.utils_lib import (
+    fail_test,
+    update_test_result,
+    resolve_cluster_config_placeholders,
+    resolve_test_config_placeholders,
+)
 
 log = logging.getLogger(__name__)
 
@@ -88,16 +93,27 @@ def validated_cluster_config(cluster_file) -> ClusterConfigFile:
 
 
 @pytest.fixture(scope="module")
-def validated_aorta_config(config_file) -> AortaBenchmarkConfigFile:
+def validated_aorta_config(
+    config_file, validated_cluster_config: ClusterConfigFile
+) -> AortaBenchmarkConfigFile:
     """
     Load and validate Aorta benchmark configuration.
 
-    Fails fast with clear error messages if config is invalid.
+    Resolves the same path placeholders as other CVS test configs (using the validated
+    cluster config), then validates against the schema and checks paths.
     """
     log.info(f"Validating Aorta config: {config_file}")
 
     try:
-        config = validate_config_file(config_file, config_type="aorta")
+        with open(config_file) as f:
+            raw_config = yaml.safe_load(f)
+        if raw_config is None:
+            pytest.fail("AORTA CONFIG VALIDATION FAILED:\nConfiguration file is empty")
+
+        cluster_dict = validated_cluster_config.model_dump(mode="python")
+        resolved_config = resolve_test_config_placeholders(raw_config, cluster_dict)
+
+        config = AortaBenchmarkConfigFile.model_validate(resolved_config)
         log.info(f"Aorta config valid: image={config.docker.image}")
 
         # Additional path validation

--- a/docs/how-to/run-cvs-tests.rst
+++ b/docs/how-to/run-cvs-tests.rst
@@ -158,17 +158,14 @@ Here's the test script:
 
 ====================
 
-Aorta test
---------------------
+Aorta benchmark
+---------------
 
-The benchmark tests run distributed training benchmarks validated by CVS. The Aorta benchmark executes an Aorta-based workload in a Docker container with RCCL, collects PyTorch profiler traces, and validates iteration time, compute ratio, overlap ratio, and rank balance against configurable thresholds.
+The Aorta benchmark runs an Aorta-based workload in a Docker container with RCCL, collects PyTorch profiler traces, and validates iteration time, compute ratio, overlap ratio, and rank balance against configurable thresholds in ``aorta_benchmark.yaml``.
 
-Note for users: where to put Aorta (aorta_path)
-Prefer a path on local or scratch storage (e.g. /scratch/...) for aorta_path when running this benchmark.
+**Where to put Aorta (``aorta_path``):** Prefer local or scratch storage (for example under ``/scratch/``). If ``aorta_path`` is on NFS (such as home directories under ``/home``), the container can hit *Permission denied* when creating ``artifacts/`` because many NFS exports use *root_squash*. Use a non-root-squashed path or adjust exports; set ``aorta_path`` accordingly in ``aorta_benchmark.yaml``.
 
-If aorta_path points to a directory on NFS (for example your home directory under /home), the container may fail with Permission denied when creating the artifacts/ output directory. Many NFS exports use root_squash, so the process running as root inside the container is treated as a non-privileged user on the NFS server and cannot create directories in your tree. Using a path on local disk or on a non–root-squashed filesystem (e.g. /scratch) avoids this. No code changes are required—use a suitable path in aorta_benchmark.yaml for aorta_path.
-
-You can list all available aorta test cases using the CLI:
+List tests in this suite:
 
 .. code:: bash
 
@@ -176,19 +173,19 @@ You can list all available aorta test cases using the CLI:
 
 .. code:: text
 
-  Available tests in host_configs_cvs:
+  Available tests in test_aorta:
     - test_validate_runner_config
     - test_run_benchmark
     - test_parse_results
     - test_validate_thresholds
     - test_generate_report
 
-Here's the test script:
+Run from the CVS package directory (the directory that contains ``input/``), for example:
 
 .. code:: bash
 
+  cd /path/to/your/cvs-checkout/cvs
   cvs run test_aorta --cluster_file input/cluster_file/cluster.json --config_file input/config_file/aorta/aorta_benchmark.yaml --html=/var/www/html/cvs/aorta.html --capture=tee-sys --self-contained-html --log-file=/tmp/aorta.log -vvv -s
-                                                                                                            133,1         14%
 
 
 Burn-in health test scripts

--- a/docs/install/cvs-install.rst
+++ b/docs/install/cvs-install.rst
@@ -144,7 +144,7 @@ The cluster file is a JSON file containing the cluster's IP addresses. You must 
      cvs copy-config cluster.json --output ~/my_cluster.json
 
 2. Edit the management IP (``"mgmt_ip"``) and node dictionary (``"node_dict"``) with the list of IPs of your cluster.
-3. Ensure the user-id (``"{user-id}"``) and ``priv_key_file`` match your setup.
+3. Ensure the user-id (``"{user-id}"``) and ``priv_key_file`` match your setup. The sample ``priv_key_file`` assumes home is ``/home/<username>``; if your site uses a different layout (for example ``/home/ORG/<user>``), set ``priv_key_file`` to the real key path. Resolving ``{user-id}`` in ``username`` does not fix a wrong key path.
 
 Here's a code snippet of the ``cluster.json`` file for reference:
 

--- a/docs/reference/configuration-files/aorta.rst
+++ b/docs/reference/configuration-files/aorta.rst
@@ -11,20 +11,29 @@ The Aorta benchmark runs distributed training with RCCL in a container, collects
 ``aorta_benchmark.yaml``
 ========================
 
-Here's a code snippet of the ``aorta_benchmark.yaml`` file for reference:
+The shipped sample is ``cvs/input/config_file/aorta/aorta_benchmark.yaml`` (path relative to the CVS package directory; see *How to run* below).
+
+Path placeholders
+-----------------
+
+When you run ``test_aorta``, the suite loads the cluster file, resolves cluster placeholders (e.g. ``{user-id}`` in ``username``), then resolves **Aorta YAML** placeholders with the same helper used by other CVS test configs: ``{user-id}``, ``{user}``, ``{home}``, ``{home-mount-dir}``, ``{node-dir-name}``. Replacement values come from the validated cluster model (username and optional ``home_mount_dir_name`` / ``node_dir_name``). Manual ``<changeme>`` markers are rejected.
+
+You may instead use fully absolute paths with no placeholders. Other entry points that validate YAML directly (without ``test_aorta``) do not perform this step unless they call the resolver explicitly.
 
 .. note::
 
-  Set ``aorta_path`` to the absolute path of your Aorta repository on the host. The runner bind-mounts this path into the container. Do not leave the default ``<changeme>``.
+  ``aorta_path`` must exist on the host unless ``aorta_auto_clone`` is true and ``aorta_clone_url`` is set; the runner can then clone into ``aorta_path`` during setup.
 
-.. dropdown:: ``aorta_benchmark.yaml``
+.. dropdown:: Example ``aorta_benchmark.yaml`` (aligned with the shipped sample)
 
   .. code:: yaml
 
-    # Path to Aorta repository on host (bind-mounted into container)
-    aorta_path: <changeme>
+    aorta_path: /scratch/users/{user-id}/aorta
+    aorta_auto_clone: false
+    aorta_clone_url: null
+
     container_mount_path: /mnt
-    base_config: config/distributed.yaml
+    base_config: config/profile_overlap_2gpu.yaml
 
     docker:
       image: jeffdaily/pytorch:torchrec-dlrm-complete
@@ -34,7 +43,7 @@ Here's a code snippet of the ``aorta_benchmark.yaml`` file for reference:
       privileged: true
 
     rccl:
-      clone_url: https://github.com/rocm/rccl.git
+      clone_url: https://github.com/ROCmSoftwarePlatform/rccl.git
       branch: develop
       build_path: /mnt/rccl
 
@@ -47,153 +56,167 @@ Here's a code snippet of the ``aorta_benchmark.yaml`` file for reference:
       RCCL_MSCCL_ENABLE: 0
 
     training_overrides:
-      training.max_steps: 100
-      profiling.active: 10
+      training.max_steps: 15
+      profiling.active: 6
 
-    build_script: scripts/build_rccl.sh
+    build_script: scripts/launch_rocm.sh
     experiment_script: scripts/launch_rocm.sh
     gpus_per_node: 8
-    timeout_seconds: 10800
-    skip_rccl_build: false
+    timeout_seconds: 3600
+    skip_rccl_build: true
 
     analysis:
       enable_tracelens: false
       enable_gemm_analysis: false
       tracelens_script: scripts/tracelens_single_config/run_tracelens_single_config.sh
+      gemm_script: scripts/gemm_analysis/run_tracelens_analysis.sh
       skip_if_exists: false
 
     expected_results:
-      max_avg_iteration_ms: 7000
-      min_compute_ratio: 0.8
+      max_avg_iteration_ms: 12000
+      min_compute_ratio: 0.01
       min_overlap_ratio: 0.0
-      max_time_variance_ratio: 0.2
+      max_time_variance_ratio: 0.5
 
 Parameters
 ==========
 
-Here's an exhaustive list of the available parameters in the Aorta benchmark configuration file.
+The **middle column** is the **schema default**: the value Pydantic applies when you **omit** that key from your YAML. It is not a promise about the checked-in sample file.
+
+The **dropdown above** is the full **shipped** ``aorta_benchmark.yaml``. Where the sample lists a key, that value wins for that file; compare the sample to the middle column to see explicit overrides.
+
+.. note::
+
+  The shipped sample commonly overrides schema defaults for ``base_config``, ``build_script``, ``experiment_script``, ``timeout_seconds``, ``skip_rccl_build``, ``training_overrides``, ``analysis.enable_tracelens``, and ``expected_results``.
 
 .. list-table::
    :widths: 3 3 5
    :header-rows: 1
 
    * - Configuration parameters
-     - Default values
+     - Schema default if omitted
      - Description
    * - ``aorta_path``
      - (required)
-     - Absolute path to Aorta repository on host; bind-mounted into container
+     - Absolute path to Aorta on the host; bind-mounted into the container. Placeholders resolved in ``test_aorta`` as described above.
+   * - ``aorta_auto_clone``
+     - ``false``
+     - If true and ``aorta_path`` is missing, clone from ``aorta_clone_url`` during runner setup.
+   * - ``aorta_clone_url``
+     - ``null``
+     - Git URL for Aorta when using auto-clone.
    * - ``container_mount_path``
      - ``/mnt``
-     - Mount point inside container for ``aorta_path``
+     - Mount point inside the container for ``aorta_path``.
    * - ``base_config``
      - ``config/distributed.yaml``
-     - Aorta config file path relative to ``aorta_path``
+     - Aorta config file path relative to ``aorta_path``.
    * - ``docker.image``
      - ``jeffdaily/pytorch:torchrec-dlrm-complete``
-     - Docker image for the benchmark container
+     - Docker image for the benchmark container.
    * - ``docker.container_name``
      - ``aorta-benchmark``
-     - Name of the container
+     - Container name.
    * - ``docker.shm_size``
      - ``17G``
-     - Shared memory size for the container
+     - Shared memory size for the container.
    * - ``docker.network_mode``
      - ``host``
-     - Docker network mode
+     - Docker network mode.
    * - ``docker.privileged``
      - true
-     - Run container in privileged mode
+     - Run the container in privileged mode.
    * - ``rccl.clone_url``
-     - ``https://github.com/rocm/rccl.git``
-     - RCCL git repository URL (used if building RCCL inside container)
+     - ``https://github.com/ROCmSoftwarePlatform/rccl.git``
+     - RCCL Git URL (used when building RCCL in the container).
    * - ``rccl.branch``
      - ``develop``
-     - RCCL branch to build
+     - RCCL branch to build.
    * - ``rccl.build_path``
      - ``/mnt/rccl``
-     - Path inside container for RCCL build
+     - Path inside the container for the RCCL build.
    * - ``environment.NCCL_MAX_NCHANNELS``
      - 112
-     - Maximum NCCL channels
+     - Maximum NCCL channels.
    * - ``environment.NCCL_MAX_P2P_NCHANNELS``
      - 112
-     - Maximum NCCL P2P channels
+     - Maximum NCCL P2P channels.
    * - ``environment.NCCL_DEBUG``
      - ``VERSION``
-     - NCCL debug level
+     - NCCL debug level.
    * - ``environment.TORCH_NCCL_HIGH_PRIORITY``
      - 1
-     - Enable high-priority NCCL streams
+     - High-priority NCCL streams.
    * - ``environment.OMP_NUM_THREADS``
      - 1
-     - OpenMP thread count
+     - OpenMP thread count.
    * - ``environment.RCCL_MSCCL_ENABLE``
      - 0
-     - Enable MSCCL
+     - MSCCL enable flag.
    * - ``training_overrides``
-     - (key-value overrides)
-     - Overrides passed to Aorta via ``--override`` (e.g. ``training.max_steps``, ``profiling.active``)
+     - ``{}``
+     - Overrides passed to Aorta via ``--override`` (e.g. ``training.max_steps``, ``profiling.active``).
    * - ``build_script``
      - ``scripts/build_rccl.sh``
-     - RCCL build script path relative to container mount
+     - RCCL build script path relative to the container mount (skipped when ``skip_rccl_build`` is true).
    * - ``experiment_script``
-     - ``scripts/launch_rocm.sh``
-     - Experiment/launch script path relative to container mount
+     - ``scripts/rccl_exp.sh``
+     - Experiment/launch script path relative to the container mount.
    * - ``gpus_per_node``
      - 8
-     - Number of GPUs per node
+     - GPUs per node.
    * - ``timeout_seconds``
      - 10800
-     - Benchmark timeout in seconds
+     - Benchmark timeout in seconds.
    * - ``skip_rccl_build``
-     - false
-     - If true, skip RCCL build (use existing build in ``aorta_path``)
+     - ``false``
+     - If true, skip building RCCL (use an existing build / container setup).
    * - ``analysis.enable_tracelens``
-     - false
-     - Run TraceLens analysis after benchmark (optional, host parsing works without it)
+     - ``true``
+     - Run TraceLens in the container when available (shipped sample sets ``false``).
    * - ``analysis.enable_gemm_analysis``
-     - false
-     - Run GEMM analysis (for sweep experiments)
+     - ``false``
+     - Run GEMM analysis (sweep workflows).
    * - ``analysis.tracelens_script``
      - ``scripts/tracelens_single_config/run_tracelens_single_config.sh``
-     - TraceLens script path relative to ``aorta_path``
+     - TraceLens script relative to ``aorta_path``.
    * - ``analysis.gemm_script``
      - ``scripts/gemm_analysis/run_tracelens_analysis.sh``
-     - GEMM analysis script path relative to ``aorta_path``
+     - GEMM analysis script relative to ``aorta_path``.
    * - ``analysis.skip_if_exists``
-     - false
-     - Skip analysis if ``tracelens_analysis`` directory already exists
+     - ``false``
+     - Skip analysis if ``tracelens_analysis`` already exists.
    * - ``expected_results.max_avg_iteration_ms``
-     - e.g. 7000
-     - Maximum acceptable average iteration time (ms); validation fails if exceeded
+     - optional
+     - Maximum acceptable average iteration time (ms).
    * - ``expected_results.min_compute_ratio``
-     - e.g. 0.8
-     - Minimum acceptable compute ratio (compute time / total iteration time)
+     - optional
+     - Minimum compute ratio (compute time / iteration time).
    * - ``expected_results.min_overlap_ratio``
-     - e.g. 0.0
-     - Minimum acceptable compute-communication overlap ratio
+     - optional
+     - Minimum compute–communication overlap ratio.
    * - ``expected_results.max_time_variance_ratio``
-     - e.g. 0.2
-     - Maximum acceptable iteration time variance (e.g. std/mean); used for rank balance
+     - optional
+     - Maximum iteration time variance across ranks (e.g. std/mean).
 
 How to run
 ==========
 
-From the CVS repo root (directory containing ``cvs`` and ``input``):
+Use the **CVS package directory** as the working directory: the directory that contains the ``input`` tree (in a typical clone, the inner ``cvs`` directory next to ``tests`` and ``lib``). Example:
 
 .. code-block:: bash
 
+  cd /path/to/your/cvs-checkout/cvs
   cvs run test_aorta \
       --cluster_file input/cluster_file/cluster.json \
       --config_file input/config_file/aorta/aorta_benchmark.yaml \
       -v --log-cli-level=INFO
 
-Provide a valid ``cluster_file`` and ensure ``aorta_path`` in the config points to an existing Aorta checkout. The runner will build RCCL (unless ``skip_rccl_build`` is true), run the experiment script, collect ``torch_traces`` (PyTorch profiler output), and optionally run TraceLens in the container. Results are parsed on the host from raw traces or from TraceLens reports when present.
+Provide a valid ``cluster_file``. Ensure ``aorta_path`` exists after placeholder resolution, or enable auto-clone with a valid URL. With ``skip_rccl_build: false``, the runner builds RCCL from ``rccl.clone_url`` unless skipped; with ``skip_rccl_build: true``, the experiment script runs without that build step. The runner collects ``torch_traces`` (PyTorch profiler output) and optionally runs TraceLens inside the container. Parsing and threshold checks run on the host.
+
+Alternate mirrors for ``rccl.clone_url`` may work if they track the same upstream; the canonical default string in schema, runner, and sample is ``https://github.com/ROCmSoftwarePlatform/rccl.git``.
 
 Expected results and artifacts
 ==============================
 
-Validation uses the ``expected_results`` thresholds: iteration time must be within ``max_avg_iteration_ms``, compute and overlap ratios must meet the minimums, and time variance across ranks must not exceed ``max_time_variance_ratio``. Exact pass values depend on cluster size and hardware.
-
-Artifacts produced under the configured output directory include training logs, ``torch_profiler`` (or equivalent) trace data, and optionally ``tracelens_analysis`` when TraceLens is enabled. The test report (e.g. ``aorta_benchmark_report.json``) summarizes metrics and pass/fail per threshold.
+Validation uses ``expected_results`` when fields are set. Artifact layout depends on the Aorta run; the test report (e.g. ``aorta_benchmark_report.json`` under the runner output directory) summarizes metrics. Prefer scratch or local disk for ``aorta_path`` when NFS ``root_squash`` prevents the container from writing ``artifacts/`` under your tree.

--- a/docs/reference/configuration-files/aorta.rst
+++ b/docs/reference/configuration-files/aorta.rst
@@ -28,7 +28,7 @@ You may instead use fully absolute paths with no placeholders. Other entry point
 
   .. code:: yaml
 
-    aorta_path: /scratch/users/{user-id}/aorta
+    aorta_path: /home/{user-id}/aorta
     aorta_auto_clone: false
     aorta_clone_url: null
 


### PR DESCRIPTION
- Align the AORTA benchmark flow with the validated behavior by resolving AORTA config placeholders before schema/path checks, so the shipped sample config works like other CVS suites. 
- Refresh the AORTA README and reference/how-to docs to match the current runner behavior, document auto-clone and SSH key path caveats.