### PR TITLE
Unify logging and CLI output across CVS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,14 @@ TEST_VENV_DIR = .test_venv
 CVS_VENV_DIR = .cvs_venv
 RUFF_VENV_DIR = .ruff_venv
 RUFF_VERSION = 0.14.8
+# Scoped logging checks: argument count vs %-placeholders (runtime TypeError class).
+PYLINT_VERSION = 4.0.5
 PYTHON := $(shell command -v python3 || command -v python)
 PIP = $(TEST_VENV_DIR)/bin/pip
 CVS_PIP = $(CVS_VENV_DIR)/bin/pip
 RUFF_PIP = $(RUFF_VENV_DIR)/bin/pip
 RUFF = $(RUFF_VENV_DIR)/bin/ruff
+PYLINT = $(RUFF_VENV_DIR)/bin/pylint
 CVS = $(TEST_VENV_DIR)/bin/cvs
 
 .PHONY: all help sdist build test-venv cvs-venv install installtest ut test clean_test_venv clean_cvs_venv clean_sdist clean_pycache clean
@@ -24,7 +27,7 @@ help:
 	@echo "  installtest    - Install from built distribution"
 	@echo "  ut         - Execute all Unittests"
 	@echo "  test       - Execute all UTs and cvs cli tests"
-	@echo "  lint       - Run ruff linter (checks code quality, not formatting)"
+	@echo "  lint       - Run ruff + pylint (logging E1205/E1206 on cvs/)"
 	@echo "  fmt        - Run ruff formatter"
 	@echo "  fmt-check  - Check ruff formatting without modifying files"
 	@echo "  lint-fix   - Run ruff linter with auto-fix (fixes code quality issues, not formatting)"
@@ -48,9 +51,9 @@ ruff-venv:
 	@if [ ! -d $(RUFF_VENV_DIR) ]; then \
 		echo "Creating ruff virtual environment..."; \
 		$(PYTHON) -m venv $(RUFF_VENV_DIR); \
-		echo "Installing ruff..."; \
-		$(RUFF_PIP) install ruff==$(RUFF_VERSION); \
 	fi
+	@echo "Ensuring ruff and pylint..."
+	@$(RUFF_PIP) install -q ruff==$(RUFF_VERSION) pylint==$(PYLINT_VERSION)
 
 cvs-venv: clean_cvs_venv
 	@echo "Creating cvs virtual environment..."
@@ -78,6 +81,15 @@ lint: ruff-venv
 	@echo "Running ruff linter..."
 	@if ! $(RUFF) check . --unsafe-fixes ; then \
 		echo "\n\nLinting failed. Run 'make lint-fix' to auto-fix issues.\n"; exit 1; \
+	fi
+	@echo "Running pylint (logging: E1205/E1206 on cvs/)..."
+	@if ! $(PYLINT) cvs \
+		--disable=all \
+		--enable=logging-too-many-args,logging-too-few-args \
+		-j 0 \
+		--recursive=y \
+		; then \
+		echo "\n\nPylint logging checks failed. Fix logging call argument counts (see E1205/E1206).\n"; exit 1; \
 	fi
 
 fmt: ruff-venv

--- a/cvs/lib/docker_lib.py
+++ b/cvs/lib/docker_lib.py
@@ -46,7 +46,7 @@ def kill_docker_container(phdl, container_name):
 
 def delete_all_containers_and_volumes(phdl):
     # out_dict = phdl.exec('docker rm -vf $(docker ps -aq)')
-    print('Deleting all containers and volumes')
+    log.info('Deleting all containers and volumes')
     # out_dict = phdl.exec('docker system prune -a --volumes --force', timeout=60*10)
     phdl.exec('docker system prune --force', timeout=60 * 10)
 
@@ -120,7 +120,7 @@ def launch_docker_container(
     cmd = cmd + f' --shm-size {shm_size} --name {container_name} {image} '
     cmd = cmd + 'tail -f /dev/null'
 
-    print(f'cmd = {cmd}')
+    log.info(f'cmd = {cmd}')
     out_dict = phdl.exec(cmd, timeout=timeout)
     time.sleep(15)
 

--- a/cvs/lib/html_lib.py
+++ b/cvs/lib/html_lib.py
@@ -39,7 +39,7 @@ def build_html_page_header(filename):
     """
     # Announce action for operator/logs
 
-    print('Build HTML Page header')
+    log.info('Build HTML Page header')
 
     # Open the file in write mode; this truncates any existing file.
     # Use a context manager to ensure the file is properly closed even if an exception occurs.
@@ -296,7 +296,7 @@ def build_html_page_footer(
       - For large pages or to avoid CDN dependency at runtime, you may want to host/serve the JS locally.
     """
 
-    print('Build HTML Page header')
+    log.info('Build HTML Page header')
     with open(filename, 'a') as fp:
         # Open the file in append mode; footer content is added at the end of the document.
         html_lines = '''
@@ -470,7 +470,7 @@ def build_rccl_heatmap(filename, chart_name, title, act_data_json, ref_data_json
         with open(act_data_json, 'r') as fp1:
             act_data_dict = json.load(fp1)
     except Exception as e:
-        print(f'Error reading file {act_data_json} - {e}')
+        log.error(f'Error reading file {act_data_json} - {e}')
 
     try:
         with open(ref_data_json, 'r') as fp2:
@@ -481,7 +481,7 @@ def build_rccl_heatmap(filename, chart_name, title, act_data_json, ref_data_json
             else:
                 ref_data_dict = ref_data_dict_t
     except Exception as e:
-        print(f'Error reading file {ref_data_json} - {e}')
+        log.error(f'Error reading file {ref_data_json} - {e}')
 
     with open(filename, 'a') as fp:
         html_lines = (
@@ -670,12 +670,12 @@ var data = [
          '''
         )
         fp.write(html_lines)
-        print(act_data_dict)
+        log.info("%s", act_data_dict)
         for collective_name in act_data_dict.keys():
-            print(collective_name)
+            log.info("%s", collective_name)
             # Skip if reference data doesn't have this collective
             if collective_name not in ref_data_dict:
-                print(f"Warning: {collective_name} not found in reference data, skipping")
+                log.warning(f"Warning: {collective_name} not found in reference data, skipping")
                 continue
             for msg_size in act_data_dict[collective_name].keys():
                 norm_msg_size = normalize_bytes(int(msg_size))
@@ -683,13 +683,13 @@ var data = [
                 act_bus_bw = act_data_dict[collective_name][msg_size]['bus_bw']
                 # Skip if reference data doesn't have this message size
                 if msg_size not in ref_data_dict[collective_name]:
-                    print(
+                    log.warning(
                         f"Warning: msg_size {msg_size} not found in reference for {collective_name}, using actual as 100%"
                     )
                     pct_val = 100.0
                 else:
                     ref_bus_bw = ref_data_dict[collective_name][msg_size]['bus_bw']
-                    print(act_bus_bw, ref_bus_bw)
+                    log.info("%s %s", act_bus_bw, ref_bus_bw)
                     if ref_bus_bw == 0 or ref_bus_bw == 0.0:
                         pct_val = 100
                     else:
@@ -1071,7 +1071,7 @@ def add_json_data(filename, json_data):
 
 
 def build_rccl_result_default_table(filename, res_dict, bw_dip_threshold=10.0, time_dip_threshold=10.0):
-    print('Build HTML RCCL Result default table')
+    log.info('Build HTML RCCL Result default table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 style="background-color: lightblue">RCCL Results Table</h2>
@@ -1113,8 +1113,8 @@ def build_rccl_result_default_table(filename, res_dict, bw_dip_threshold=10.0, t
                 if float(last_time) > 0.0:
                     time_change_pct = ((float(time) - float(last_time)) / float(last_time)) * 100.0
 
-                print(bus_bw, last_bw, bw_change_pct, bw_dip_threshold)
-                print(time, last_time, time_change_pct, time_dip_threshold)
+                log.info("%s %s %s %s", bus_bw, last_bw, bw_change_pct, bw_dip_threshold)
+                log.info("%s %s %s %s", time, last_time, time_change_pct, time_dip_threshold)
 
                 if bw_change_pct < -(bw_dip_threshold):
                     html_lines = '''<td><span class="label label-danger">''' + str(bus_bw) + '''</td>\n'''
@@ -1136,7 +1136,7 @@ def build_rccl_result_default_table(filename, res_dict, bw_dip_threshold=10.0, t
 
 
 def build_rccl_result_table(filename, res_dict):
-    print('Build HTML RCCL Result table')
+    log.info('Build HTML RCCL Result table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 style="background-color: lightblue">RCCL Results Table</h2>
@@ -1197,15 +1197,15 @@ def build_rccl_heatmap_metadata_table(filename, act_data_json, ref_data_json):
         with open(act_data_json, 'r') as fp1:
             act_data_dict = json.load(fp1)
     except Exception as e:
-        print(f'Error reading file {act_data_json} - {e}')
+        log.error(f'Error reading file {act_data_json} - {e}')
 
     try:
         with open(ref_data_json, 'r') as fp2:
             ref_data_dict = json.load(fp2)
     except Exception as e:
-        print(f'Error reading file {ref_data_json} - {e}')
+        log.error(f'Error reading file {ref_data_json} - {e}')
 
-    print('Build HTML RCCL heatmap Metadata table')
+    log.info('Build HTML RCCL heatmap Metadata table')
     with open(filename, 'a') as fp:
         html_lines = '''
          <br><br>
@@ -1228,7 +1228,7 @@ def build_rccl_heatmap_metadata_table(filename, act_data_json, ref_data_json):
         fp.write(html_lines)
         for key_nam in act_data_dict.keys():
             if 'metadata' in key_nam:
-                print(act_data_dict['metadata'].keys())
+                log.info("%s", list(act_data_dict['metadata'].keys()))
                 if 'gpu_model' in act_data_dict[key_nam].keys():
                     html_lines = f"<td>{act_data_dict['metadata']['gpu_model']}</td>"
                     fp.write(html_lines)
@@ -1276,7 +1276,7 @@ def build_rccl_heatmap_metadata_table(filename, act_data_json, ref_data_json):
                 fp.write(html_lines)
                 html_lines = '<td>Golden</td>'
                 fp.write(html_lines)
-                print(ref_data_dict[key_nam].keys())
+                log.info("%s", list(ref_data_dict[key_nam].keys()))
                 if 'gpu_model' in ref_data_dict[key_nam].keys():
                     html_lines = f"<td>{ref_data_dict['metadata']['gpu_model']}</td>"
                     fp.write(html_lines)
@@ -1323,13 +1323,13 @@ def build_rccl_heatmap_table(filename, title, act_data_json, ref_data_json):
         with open(act_data_json, 'r') as fp1:
             act_data_dict = json.load(fp1)
     except Exception as e:
-        print(f'Error reading file {act_data_json} - {e}')
+        log.error(f'Error reading file {act_data_json} - {e}')
 
     try:
         with open(ref_data_json, 'r') as fp2:
             ref_data_dict_t = json.load(fp2)
     except Exception as e:
-        print(f'Error reading file {ref_data_json} - {e}')
+        log.error(f'Error reading file {ref_data_json} - {e}')
 
     # Handle both wrapped (metadata/result) and unwrapped reference formats
     if 'result' in ref_data_dict_t.keys():
@@ -1338,7 +1338,7 @@ def build_rccl_heatmap_table(filename, title, act_data_json, ref_data_json):
         # Assume unwrapped format - use directly
         ref_data_dict = ref_data_dict_t
 
-    print('Build HTML RCCL heatmap table')
+    log.info('Build HTML RCCL heatmap table')
     missing_ref_keys = []
     missing_ref_msg_sizes = 0
     with open(filename, 'a') as fp:
@@ -1372,7 +1372,7 @@ def build_rccl_heatmap_table(filename, title, act_data_json, ref_data_json):
                 data_type = parts[1]
                 gpu_count = parts[2]
             else:
-                print(f"Warning: Invalid key format {key_nam}, skipping")
+                log.warning(f"Warning: Invalid key format {key_nam}, skipping")
                 continue
             # Skip if reference data doesn't have this test configuration.
             # Some golden reference files use keys without channel suffix (e.g. "all_reduce_perf-float-8")
@@ -1441,12 +1441,14 @@ def build_rccl_heatmap_table(filename, title, act_data_json, ref_data_json):
     # Print a concise summary instead of spamming per-key warnings
     if missing_ref_keys:
         sample = ", ".join(missing_ref_keys[:5])
-        print(
+        log.warning(
             f"Warning: {len(missing_ref_keys)} test keys not found in reference data; "
             f"skipped from table. Sample: {sample}"
         )
     if missing_ref_msg_sizes:
-        print(f"Warning: {missing_ref_msg_sizes} msg_size entries not found in reference data; skipped from table.")
+        log.warning(
+            f"Warning: {missing_ref_msg_sizes} msg_size entries not found in reference data; skipped from table."
+        )
 
 
 def insert_chart(filename, chart_name):
@@ -1705,7 +1707,7 @@ def build_snapshot_stats_diff_table(filename, d_dict, title, table_name, id_name
 
 
 def build_lldp_table(filename, lldp_dict):
-    print('Build HTML training table')
+    log.info('Build HTML training table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 id="lldpid"></h2><br>
@@ -1729,8 +1731,8 @@ def build_lldp_table(filename, lldp_dict):
                 l_dict_list = lldp_dict[node]['lldp']['interface']
                 for l_dict in l_dict_list:
                     intf = list(l_dict.keys())[0]
-                    print(intf)
-                    print(l_dict)
+                    log.info("%s", intf)
+                    log.info("%s", l_dict)
                     chassis_key = list(l_dict[intf]['chassis'].keys())[0]
                     chassis_dict = l_dict[intf]['chassis'][chassis_key]
                     if 'descr' in chassis_dict:
@@ -1788,7 +1790,7 @@ def build_training_results_table(filename, out_dict, title):
       - Encoding: For non-ASCII content, consider using encoding='utf-8' when opening the file.
     """
 
-    print('Build HTML training table')
+    log.info('Build HTML training table')
     with open(filename, 'a') as fp:
         html_lines = (
             '''
@@ -1837,7 +1839,7 @@ def build_training_results_table(filename, out_dict, title):
 
 
 def build_err_log_table(filename, d_dict, title, table_name, id_name):
-    print(f'Build HTML Historic error table {title}')
+    log.info(f'Build HTML Historic error table {title}')
     with open(filename, 'a') as fp:
         html_lines = f'''
 <h2 id="{id_name}"></h2><br>
@@ -1870,7 +1872,7 @@ def build_err_log_table(filename, d_dict, title, table_name, id_name):
 
 
 def build_html_nic_table(filename, rdma_dict, lshw_dict, ip_dict):
-    print('Build HTML product table')
+    log.info('Build HTML product table')
     """
     Append a Network Info HTML table to the given file, summarizing NIC and RDMA device state per node.
 
@@ -2062,7 +2064,7 @@ def build_html_cluster_product_table(filename, model_dict, fw_dict):
 
     """
 
-    print('Build HTML product table')
+    log.info('Build HTML product table')
 
     # Append to the existing HTML file (assumes <body> already opened elsewhere)
     with open(filename, 'a') as fp:
@@ -2169,7 +2171,7 @@ def build_html_gpu_utilization_table(filename, use_dict):
         but you may want to add the closing tag for strict HTML validity.
     """
 
-    print('Build HTML utilization table')
+    log.info('Build HTML utilization table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 id="gpuuseid"></h2><br>
@@ -2297,7 +2299,7 @@ def build_html_mem_utilization_table(filename, use_dict, amd_dict):
 
     """
 
-    print('Build HTML mem utilization table')
+    log.info('Build HTML mem utilization table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 id="memuseid"></h2><br>
@@ -2433,7 +2435,7 @@ def build_html_pcie_xgmi_metrics_table(filename, metrics_dict, amd_dict):
 
     """
 
-    print('Build HTML PCIe metrics table')
+    log.info('Build HTML PCIe metrics table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 id="pciexgmimetid"></h2><br>
@@ -2612,7 +2614,7 @@ def build_html_error_table(filename, metrics_dict, amd_dict):
 
     """
 
-    print('Build HTML Error table')
+    log.info('Build HTML Error table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 id="gpuerrorid"></h2><br>
@@ -2772,7 +2774,7 @@ def build_html_error_table(filename, metrics_dict, amd_dict):
 # TO BE DONE
 """
 def build_html_env_metrics_table():
-    print('Build HTML env metrics table')
+    log.info('Build HTML env metrics table')
     with open(filename, 'a') as fp:
         html_lines = '''
 <h2 id="envmetricsid"></h2><br>
@@ -2805,4 +2807,4 @@ def build_html_env_metrics_table():
 
 
 def build_html_config_table():
-    print('Build config table')
+    log.info('Build config table')

--- a/cvs/lib/ibperf_lib.py
+++ b/cvs/lib/ibperf_lib.py
@@ -81,7 +81,7 @@ def get_ib_bw_pps(phdl, msg_size, cmd):
 
     # Collect the BW, PPS numbers
     for i in range(1, 10):
-        print(f'starting iteration {i} to collect numbers')
+        log.info(f'starting iteration {i} to collect numbers')
         out_dict = phdl.exec(cmd)
         for node in out_dict.keys():
             res_dict[node] = {}
@@ -90,10 +90,10 @@ def get_ib_bw_pps(phdl, msg_size, cmd):
                 match = re.search(pattern, out_dict[node])
                 res_dict[node]['bw'] = match.group(1)
                 res_dict[node]['pps'] = match.group(2)
-                print(f"Node {node} BW - {res_dict[node]['bw']}, MPPS - {res_dict[node]['pps']}")
+                log.info(f"Node {node} BW - {res_dict[node]['bw']}, MPPS - {res_dict[node]['pps']}")
                 continue
             else:
-                print('Sleeping 10 secs for test to complete')
+                log.info('Sleeping 10 secs for test to complete')
                 time.sleep(10)
             fail_test(
                 f'ERROR !!! on node {node} Client did not complete even after max iterations for msg size {msg_size}'
@@ -120,7 +120,7 @@ def get_ib_lat_numb(phdl, msg_size, cmd):
 
     # Collect the BW, PPS numbers
     for i in range(1, 4):
-        print(f'starting iteration {i} to collect numbers')
+        log.info(f'starting iteration {i} to collect numbers')
         out_dict = phdl.exec(cmd)
         for node in out_dict.keys():
             pattern = "{}[\t\s]+[0-9]+[\t\s]+([0-9\.]+)[\t\s]+([0-9\.]+)[\t\s]+([0-9\.]+)[\t\s]+([0-9\.]+)[\t\s]+([0-9\.]+)[\t\s]+([0-9\.]+)[\t\s]+([0-9\.]+)".format(
@@ -135,10 +135,10 @@ def get_ib_lat_numb(phdl, msg_size, cmd):
                 res_dict[node]['t_stdev'] = match.group(5)
                 res_dict[node]['t_99_pct'] = match.group(6)
                 res_dict[node]['t_99_9_pct'] = match.group(7)
-                print(f'Node {node} Avg Lat - {res_dict[node]["t_avg"]}')
+                log.info(f'Node {node} Avg Lat - {res_dict[node]["t_avg"]}')
                 continue
             else:
-                print('Sleeping 10 secs for test to complete')
+                log.info('Sleeping 10 secs for test to complete')
                 time.sleep(10)
             fail_test(
                 f'ERROR !!! on node {node} Client did not complete even after max iterations for msg size {msg_size}'
@@ -148,11 +148,11 @@ def get_ib_lat_numb(phdl, msg_size, cmd):
 
 
 def verify_expected_bw(bw_test, msg_size, qp_count, res_dict, expected_res):
-    print(f'Verifying expected BW for test {bw_test} msg_size {msg_size} QP count {qp_count}')
-    print(expected_res.keys())
-    print(res_dict)
+    log.info(f'Verifying expected BW for test {bw_test} msg_size {msg_size} QP count {qp_count}')
+    log.info("%s", list(expected_res.keys()))
+    log.info("%s", res_dict)
     if bw_test in expected_res.keys():
-        print(expected_res[bw_test].keys())
+        log.info("%s", list(expected_res[bw_test].keys()))
         if msg_size in expected_res[bw_test].keys():
             if qp_count in expected_res[bw_test][msg_size].keys():
                 for node in res_dict.keys():
@@ -163,11 +163,11 @@ def verify_expected_bw(bw_test, msg_size, qp_count, res_dict, expected_res):
 
 
 def verify_expected_lat(lat_test, msg_size, res_dict, expected_res):
-    print(f'Verifying expected BW for test {lat_test} msg_size {msg_size}')
-    print(expected_res.keys())
-    print(res_dict)
+    log.info(f'Verifying expected BW for test {lat_test} msg_size {msg_size}')
+    log.info("%s", list(expected_res.keys()))
+    log.info("%s", res_dict)
     if lat_test in expected_res.keys():
-        print(expected_res[lat_test].keys())
+        log.info("%s", list(expected_res[lat_test].keys()))
         if msg_size in expected_res[lat_test].keys():
             for node in res_dict.keys():
                 if float(res_dict[node]['lat']) >= float(expected_res[lat_test][msg_size]):
@@ -253,7 +253,7 @@ def run_ib_perf_bw_test(
     time.sleep(20)
 
     for instance_no in range(0, inst_count):
-        print('instance_no - {}'.format(instance_no))
+        log.info('instance_no - {}'.format(instance_no))
         try:
             bw_pps_dict = get_ib_bw_pps(phdl, msg_size, f'cat /tmp/ib_perf_{instance_no}_logs')
             for node in bw_pps_dict.keys():
@@ -261,10 +261,10 @@ def run_ib_perf_bw_test(
                 result_dict[node][instance_no]['pps'] = bw_pps_dict[node]['pps']
                 result_dict[node][instance_no]['bw'] = bw_pps_dict[node]['bw']
         except Exception:
-            print('FAILED to get BW, PPS numbers for size - {} qp_count {}'.format(msg_size, qp_count))
+            log.error('FAILED to get BW, PPS numbers for size - {} qp_count {}'.format(msg_size, qp_count))
 
-    print('%%%%%%%%%% BW result_dict %%%%%%%%%%')
-    print(result_dict)
+    log.info('%%%%%%%%%% BW result_dict %%%%%%%%%%')
+    log.info("%s", result_dict)
     return result_dict
 
 
@@ -335,10 +335,10 @@ def run_ib_perf_lat_test(
     time.sleep(20)
 
     for instance_no in range(0, inst_count):
-        print('instance_no - {}'.format(instance_no))
+        log.info('instance_no - {}'.format(instance_no))
         try:
             lat_dict = get_ib_lat_numb(phdl, msg_size, f'cat /tmp/ib_perf_{instance_no}_logs')
-            print(f'%%%%% lat_dict = {lat_dict}')
+            log.info(f'%%%%% lat_dict = {lat_dict}')
             for node in bck_nic_dict.keys():
                 result_dict[node][instance_no] = {}
                 result_dict[node][instance_no]['t_min'] = lat_dict[node]['t_min']
@@ -348,16 +348,16 @@ def run_ib_perf_lat_test(
                 result_dict[node][instance_no]['t_stdev'] = lat_dict[node]['t_stdev']
                 result_dict[node][instance_no]['t_99_pct'] = lat_dict[node]['t_99_pct']
                 result_dict[node][instance_no]['t_99_9_pct'] = lat_dict[node]['t_99_9_pct']
-                print('***** result_dict for lat = {result_dict[node][instance_no]')
+                log.info('***** result_dict for lat = {result_dict[node][instance_no]')
         except Exception:
-            print(
+            log.error(
                 'FAILED to get latency numbers for size - {}'.format(
                     msg_size,
                 )
             )
 
-    print('%%%%%%%%%% LAT result_dict %%%%%%%%%%')
-    print(result_dict)
+    log.info('%%%%%%%%%% LAT result_dict %%%%%%%%%%')
+    log.info("%s", result_dict)
     return result_dict
 
 
@@ -567,8 +567,8 @@ def generate_ibperf_bw_chart(res_dict, excel_file='ib_bw_pps_perf.xlsx'):
 
             avg_bw_data = average_of_lists(split_bw_list)
             avg_pps_data = average_of_lists(split_pps_list)
-            print(split_bw_list)
-            print(split_bw_gpu0_list)
+            log.info("%s", split_bw_list)
+            log.info("%s", split_bw_gpu0_list)
             avg_bw_gpu0_data = average_of_lists(split_bw_gpu0_list)
             avg_bw_gpu1_data = average_of_lists(split_bw_gpu1_list)
             avg_bw_gpu2_data = average_of_lists(split_bw_gpu2_list)
@@ -587,7 +587,7 @@ def generate_ibperf_bw_chart(res_dict, excel_file='ib_bw_pps_perf.xlsx'):
             avg_pps_gpu6_data = average_of_lists(split_pps_gpu6_list)
             avg_pps_gpu7_data = average_of_lists(split_pps_gpu7_list)
 
-            print(f'avg is {avg_bw_data}')
+            log.info(f'avg is {avg_bw_data}')
             # Merge cols for Node IP
             worksheet.merge_range("A2:A3", "Node IP", bold)
             worksheet.merge_range("B2:B3", "Msg Size", bold)
@@ -666,7 +666,7 @@ def generate_ibperf_bw_chart(res_dict, excel_file='ib_bw_pps_perf.xlsx'):
 
             row_end = 4 + len(d_msg_size_list)
 
-            print(f'row_end {row_end}')
+            log.info(f'row_end {row_end}')
             chart.add_series(
                 {
                     "name": "={}!$B$2".format(sheet_name),
@@ -852,11 +852,11 @@ def generate_ibperf_lat_chart(res_dict, excel_file='ib_lat_perf.xlsx'):
                 d_avg_tstdev_list.append(tot_tstdev / 8)
                 d_avg_t99pct_list.append(tot_t99pct / 8)
 
-        print(f'%%%%% d_avg_tmin_list = {d_avg_tmin_list}')
-        print(f'%%%%% d_avg_tmax_list = {d_avg_tmax_list}')
-        print(f'%%%%% d_avg_tavg_list = {d_avg_tavg_list}')
-        print(f'%%%%% d_avg_tstdev_list = {d_avg_tstdev_list}')
-        print(f'%%%%% d_avg_t99pct_list = {d_avg_t99pct_list}')
+        log.info(f'%%%%% d_avg_tmin_list = {d_avg_tmin_list}')
+        log.info(f'%%%%% d_avg_tmax_list = {d_avg_tmax_list}')
+        log.info(f'%%%%% d_avg_tavg_list = {d_avg_tavg_list}')
+        log.info(f'%%%%% d_avg_tstdev_list = {d_avg_tstdev_list}')
+        log.info(f'%%%%% d_avg_t99pct_list = {d_avg_t99pct_list}')
         split_tmin_list = split_list_into_n_chunks(d_avg_tmin_list, len(node_list))
         split_tmax_list = split_list_into_n_chunks(d_avg_tmax_list, len(node_list))
         split_tavg_list = split_list_into_n_chunks(d_avg_tavg_list, len(node_list))
@@ -908,9 +908,9 @@ def generate_ibperf_lat_chart(res_dict, excel_file='ib_lat_perf.xlsx'):
         split_t99pct_gpu6_list = split_list_into_n_chunks(d_t99pct_gpu_6_list, len(node_list))
         split_t99pct_gpu7_list = split_list_into_n_chunks(d_t99pct_gpu_7_list, len(node_list))
 
-        print(split_tmin_list)
-        print(split_tmax_list)
-        print(split_tavg_list)
+        log.info("%s", split_tmin_list)
+        log.info("%s", split_tmax_list)
+        log.info("%s", split_tavg_list)
         avg_tmin_data = average_of_lists(split_tmin_list)
         avg_tmax_data = average_of_lists(split_tmax_list)
         avg_tavg_data = average_of_lists(split_tavg_list)
@@ -1108,7 +1108,7 @@ def generate_ibperf_lat_chart(res_dict, excel_file='ib_lat_perf.xlsx'):
 
         row_end = 4 + len(d_msg_size_list)
 
-        print(f'row_end {row_end}')
+        log.info(f'row_end {row_end}')
         chart.add_series(
             {
                 "name": "={}!$B$2".format(sheet_name),

--- a/cvs/lib/inference/base.py
+++ b/cvs/lib/inference/base.py
@@ -14,7 +14,6 @@ from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 from cvs.lib import linux_utils
 
-
 log = globals.log
 
 inference_err_dict = {
@@ -67,7 +66,7 @@ class InferenceBaseJob:
 
         self.job_cmd = ''
         self.job_cmd_list = []
-        print(self.gpu_type)
+        log.info("%s", self.gpu_type)
 
         # Needed only in the case of distributed inference - placeholder for future
         # Intialize cluster stats dicts ..
@@ -93,9 +92,9 @@ class InferenceBaseJob:
         self.if_dict.setdefault('log_dir', f'{self.home_dir}/LOG_DIR')
         self.if_dict.setdefault('benchmark_script_repo', 'https://github.com/kimbochen/bench_serving.git')
 
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-        print(f'inference_dict = {self.if_dict}')
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info(f'inference_dict = {self.if_dict}')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
 
         # Get model-specific config - check if nested under single_node/multi_node or flat
         if self.distributed_inference:
@@ -170,9 +169,9 @@ class InferenceBaseJob:
         self.server_script = self.bp_dict['server_script']
         self.bench_serv_script = self.bp_dict['bench_serv_script']
 
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-        print(f'benchmark_params_dict = {self.bp_dict}')
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info(f'benchmark_params_dict = {self.bp_dict}')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
 
     # Framework-specific methods to be implemented by derived classes
     def get_server_script_directory(self):
@@ -242,7 +241,7 @@ class InferenceBaseJob:
                 )
                 for node in out_dict.keys():
                     if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
-                        print(out_dict[node])
+                        log.info("%s", out_dict[node])
                         fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
 
     def build_server_inference_job_cmd(
@@ -289,7 +288,7 @@ class InferenceBaseJob:
                     '''
                 formatted_cmd = textwrap_for_yml(cmd)
                 cmd_list.append(formatted_cmd)
-            print(cmd_list)
+            log.info("%s", cmd_list)
             self.s_phdl.exec_cmd_list(cmd_list)
 
         cmd_list = []
@@ -359,7 +358,7 @@ class InferenceBaseJob:
         readiness_pattern = self.readiness_pattern
 
         # Do an early check for fast failures before the long wait
-        print(f'Waiting {self.default_server_precheck_wait_time} secs for server to start writing logs...')
+        log.info(f'Waiting {self.default_server_precheck_wait_time} secs for server to start writing logs...')
         time.sleep(self.default_server_precheck_wait_time)
 
         # Early failure detection
@@ -375,13 +374,13 @@ class InferenceBaseJob:
                 fail_test(error_msg)
                 raise Exception(error_msg)
 
-        print(
+        log.info(
             f'No immediate errors detected. Waiting {self.default_server_wait_time} more secs for server to fully launch...'
         )
         time.sleep(self.default_server_wait_time)
 
         for j in range(0, self.default_server_poll_count):
-            print(f'Polling for application startup complete on all nodes, iteration {j}')
+            log.info(f'Polling for application startup complete on all nodes, iteration {j}')
             cmd_list = []
             for i in range(0, int(self.nnodes)):
                 cmd = f'tail -30 {self.log_dir}/{self.get_log_subdir()}/out-node{i}/{log_file}'
@@ -395,10 +394,10 @@ class InferenceBaseJob:
                     raise Exception(error_msg)
 
             if self.is_server_ready(out_dict, readiness_pattern):
-                print('Server startup confirmed on all nodes')
+                log.info('Server startup confirmed on all nodes')
                 return
 
-            print(f'Waiting {self.default_server_poll_wait_time} secs for next poll')
+            log.info(f'Waiting {self.default_server_poll_wait_time} secs for next poll')
             time.sleep(self.default_server_poll_wait_time)
 
         error_msg = 'Server did not report readiness before timeout; aborting startup'
@@ -442,10 +441,10 @@ class InferenceBaseJob:
 
     def poll_client_completion(self):
         """Poll for client benchmark completion."""
-        print(f'Waiting for {self.default_client_wait_time} secs for benchmark scripts to start')
+        log.info(f'Waiting for {self.default_client_wait_time} secs for benchmark scripts to start')
         time.sleep(self.default_client_wait_time)
         for j in range(0, self.default_client_poll_count):
-            print(f'Polling for Benchmark script to complete on all nodes, iteration {j}')
+            log.info(f'Polling for Benchmark script to complete on all nodes, iteration {j}')
             cmd_list = []
             for i in range(0, int(self.nnodes)):
                 cmd = f'tail -30 {self.log_dir}/{self.get_log_subdir()}/out-node{i}/bench_serv_script.log'
@@ -456,27 +455,27 @@ class InferenceBaseJob:
                     fail_test(f'Failed to run benchmark script on node {node}')
                     return
                 if not re.search('End-to-end Latency', out_dict[node], re.I):
-                    print(f'Waiting {self.default_client_poll_wait_time} secs for next poll')
+                    log.info(f'Waiting {self.default_client_poll_wait_time} secs for next poll')
                     time.sleep(self.default_client_poll_wait_time)
 
     def start_inference_server_job(
         self,
     ):
         """Start inference server - launch and poll for startup."""
-        print('Start Server side Inference on all Nodes')
+        log.info('Start Server side Inference on all Nodes')
         self.launch_server()
         self.poll_server_startup()
 
     def start_inference_client_job(
         self,
     ):
-        print('Start Client side benchmark script on all Nodes')
+        log.info('Start Client side benchmark script on all Nodes')
 
         # Clone bench_serving repo to /app
         self.clone_bench_serving_repo('/app')
 
         if self.distributed_inference:
-            print('Distributed inference - TBD')
+            log.info('Distributed inference - TBD')
             return
 
         # Launch client and poll for completion
@@ -484,7 +483,7 @@ class InferenceBaseJob:
         self.poll_client_completion()
 
     def get_inference_results_dict(self, out_dict):
-        print('Get the inference results dict using get_inference_results_dict')
+        log.info('Get the inference results dict using get_inference_results_dict')
         self.inference_results_dict = {}
         for node in out_dict.keys():
             self.inference_results_dict[node] = {}
@@ -546,13 +545,13 @@ class InferenceBaseJob:
                 match = re.search('P99 E2EL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
                 self.inference_results_dict[node]['p99_e2el_ms'] = match.group(1)
 
-        print(self.inference_results_dict)
+        log.info("%s", self.inference_results_dict)
         return self.inference_results_dict
 
     def scan_for_inference_errors(
         self,
     ):
-        print('Scan for inference errors')
+        log.info('Scan for inference errors')
         inference_pass = True
 
         # Build the list of commands to read each node's inference log file
@@ -592,7 +591,7 @@ class InferenceBaseJob:
             return total_timeout is not None and (time.time() - start_time) >= float(total_timeout)
 
         for itr in range(1, iterations + 1):
-            print(f'Starting iteration {itr}')
+            log.info(f'Starting iteration {itr}')
 
             # Early abort on inference errors
             if not self.scan_for_inference_errors():
@@ -622,9 +621,9 @@ class InferenceBaseJob:
             if not all_complete:
                 if timed_out():
                     msg = f"Timeout while waiting for inference completion after ~{int(time.time() - start_time)}s"
-                    print(msg)
+                    log.warning("%s", msg)
                     return {"status": "timeout", "reason": msg}
-                print('Inference Benchmark is still in progress')
+                log.info('Inference Benchmark is still in progress')
                 # Short progress wait before the longer inter-iteration sleep
                 time.sleep(30)
                 time.sleep(int(waittime_between_iters))
@@ -632,7 +631,7 @@ class InferenceBaseJob:
 
             # Parse/store final results and report success
             res_dict = self.get_inference_results_dict(out_dict)
-            print('Completed Inference, returning !!!')
+            log.info('Completed Inference, returning !!!')
             return {"status": "success", "results": res_dict}
 
             # If we reached here, it means poll for inference completion failed
@@ -640,12 +639,12 @@ class InferenceBaseJob:
         # If we exhaust the iteration cap without completing, treat as timeout (or in_progress if no wall-clock limit)
         if timed_out():
             msg = f"Timeout after maximum iterations ({self.inference_poll_iterations}) and ~{int(time.time() - start_time)}s"
-            print(msg)
+            log.warning("%s", msg)
             return {"status": "timeout", "reason": msg}
         else:
             # If no wall-clock timeout was set and we hit the iteration cap, report in-progress
             msg = f"Reached iteration cap ({self.inference_poll_iterations}) without completion; still in progress"
-            print(msg)
+            log.warning("%s", msg)
             return {"status": "stuck_in_progress", "reason": msg}
 
     def verify_inference_results(
@@ -657,7 +656,7 @@ class InferenceBaseJob:
         The expected results are keyed by: "ISL=X,OSL=Y,TP=Z,CONC=W"
         This method builds that key from current test parameters and compares.
         """
-        print('Verify Inference Completion Msg')
+        log.info('Verify Inference Completion Msg')
 
         # Build the expected result key from current test parameters
         isl = self.bp_dict.get('input_sequence_length', '1024')
@@ -666,22 +665,22 @@ class InferenceBaseJob:
         conc = self.bp_dict.get('max_concurrency', '64')
 
         expected_key = f"ISL={isl},OSL={osl},TP={tp},CONC={conc}"
-        print(f'Looking for expected results with key: {expected_key}')
+        log.info(f'Looking for expected results with key: {expected_key}')
 
         # Get expected results from result_dict
         result_dict = self.bp_dict.get('result_dict', {})
         expected_result_dict = result_dict.get(expected_key, {})
 
         if not expected_result_dict:
-            print(f'Warning: No expected results found for {expected_key}, skipping validation')
+            log.warning(f'Warning: No expected results found for {expected_key}, skipping validation')
             # Scan Dmesg for errors ..
             self.inference_end_time = self.s_phdl.exec('date +"%a %b %e %H:%M"')
             time.sleep(2)
             verify_dmesg_for_errors(self.s_phdl, self.inference_start_time, self.inference_end_time)
-            print(self.inference_results_dict)
+            log.info("%s", self.inference_results_dict)
             return
 
-        print(f'Expected results: {expected_result_dict}')
+        log.info(f'Expected results: {expected_result_dict}')
 
         # Compare actual vs expected for each node
         for node in self.inference_results_dict.keys():
@@ -709,4 +708,4 @@ class InferenceBaseJob:
         self.inference_end_time = self.s_phdl.exec('date +"%a %b %e %H:%M"')
         time.sleep(2)
         verify_dmesg_for_errors(self.s_phdl, self.inference_start_time, self.inference_end_time)
-        print(self.inference_results_dict)
+        log.info("%s", self.inference_results_dict)

--- a/cvs/lib/inference_lib.py
+++ b/cvs/lib/inference_lib.py
@@ -5,7 +5,10 @@ The year included in the foregoing notice is the year of creation of the work.
 All code contained here is Property of Advanced Micro Devices, Inc.
 '''
 
+from cvs.lib import globals
 from cvs.lib.inference_max_lib import InferenceMaxJob, VllmJob
+
+log = globals.log
 
 
 class InferenceJobFactory:
@@ -99,7 +102,7 @@ class InferenceJobFactory:
         # Auto-detect framework if not specified
         if framework is None:
             framework = cls._detect_framework(inference_config_dict)
-            print(f'Auto-detected framework: {framework}')
+            log.info(f'Auto-detected framework: {framework}')
 
         framework_lower = framework.lower()
 

--- a/cvs/lib/jax_training_lib.py
+++ b/cvs/lib/jax_training_lib.py
@@ -97,7 +97,7 @@ class JaxTrainingJob:
         self.job_cmd = ''
         self.job_cmd_list = []
         self.training_result_dict = {}
-        print(self.gpu_type)
+        log.info("%s", self.gpu_type)
 
         # Intialize cluster stats dicts ..
         self.rdma_stats_dict_before = {}
@@ -246,7 +246,7 @@ class JaxTrainingJob:
                 )
                 for node in out_dict.keys():
                     if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
-                        print(out_dict[node])
+                        log.info("%s", out_dict[node])
                         fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
 
     def build_training_job_cmd(
@@ -409,7 +409,7 @@ class JaxTrainingJob:
                       export NVTE_CK_V3_BF16_CVT={self.tc_dict['nvte_ck_v3_bf16_cvt']}' >> /workspace/maxtext/maxtext_env.sh"'''
                 formatted_cmd = textwrap_for_yml(cmd)
                 cmd_list.append(formatted_cmd)
-        print(cmd_list)
+        log.info("%s", cmd_list)
         self.phdl.exec_cmd_list(cmd_list)
 
         cmd_list = []
@@ -455,7 +455,7 @@ class JaxTrainingJob:
 
         """
 
-        print('Start Training on all Nodes')
+        log.info('Start Training on all Nodes')
         cmd_list = []
 
         # Build a docker exec command per node/rank
@@ -501,14 +501,14 @@ class JaxTrainingJob:
 
         # Compute the central tendency of the metric across the stable range of steps
         median_value = statistics.median(list_of_values)
-        print(f'%%%% median_value = {median_value}')
+        log.info(f'%%%% median_value = {median_value}')
 
         # Define acceptable bounds around the median based on the allowed percentage deviation
         upper_bound = median_value * (1 + percentage_off)
         lower_bound = median_value * (1 - percentage_off)
         for i in range(2, self.training_steps):
             if lower_bound <= float(training_results_dict[i][metric_name]) <= upper_bound:
-                print(f'Training step {i} training metric {metric_name} is in expected range')
+                log.info(f'Training step {i} training metric {metric_name} is in expected range')
             else:
                 fail_test(
                     f'FAIL Training step {i} training metric {metric_name} is over {percentage_off}% from median value {median_value} - actual value {training_results_dict[i][metric_name]}'
@@ -582,7 +582,7 @@ class JaxTrainingJob:
         self.check_deviation_from_median(training_results_dict, 'tokens_per_sec_per_gpu', percentage_off)
         # self.check_deviation_from_median( training_results_dict, 'loss', percentage_off )
 
-        print(training_results_dict)
+        log.info("%s", training_results_dict)
         return training_results_dict
 
     def scan_for_training_errors(
@@ -614,7 +614,7 @@ class JaxTrainingJob:
 
         """
 
-        print('Scan for training errors')
+        log.info('Scan for training errors')
         training_pass = True
 
         # Identify which node's output will be used (currently "last" node only)
@@ -677,7 +677,7 @@ class JaxTrainingJob:
         - If require_all_nodes=True and at least one node lags behind, we continue polling (unless timeout).
         """
 
-        print('Poll for training completion')
+        log.info('Poll for training completion')
 
         # Initial wait to give training time to start logging
         time.sleep(60)
@@ -695,7 +695,7 @@ class JaxTrainingJob:
 
         # Poll up to a maximum iteration count (safety cap) as well as wall-clock (if provided)
         for itr in range(1, int(self.training_poll_iterations) + 1):
-            print(f'Starting iteration {itr}')
+            log.info(f'Starting iteration {itr}')
 
             # Early abort on training errors
             if not self.scan_for_training_errors():
@@ -726,9 +726,9 @@ class JaxTrainingJob:
             if not all_complete:
                 if timed_out():
                     msg = f"Timeout while waiting for training completion after ~{int(time.time() - start_time)}s"
-                    print(msg)
+                    log.warning("%s", msg)
                     return {"status": "timeout", "reason": msg}
-                print('Training still in progress')
+                log.info('Training still in progress')
                 # Short progress wait before the longer inter-iteration sleep
                 time.sleep(30)
                 time.sleep(int(waittime_between_iters))
@@ -747,7 +747,7 @@ class JaxTrainingJob:
 
             # Parse/store final results and report success
             self.training_result_dict = self.get_training_results_dict()
-            print('Completed Training, returning !!!')
+            log.info('Completed Training, returning !!!')
             return {"status": "success", "results": self.training_result_dict}
 
             # If we reached here, it means poll for training completion failed
@@ -755,42 +755,48 @@ class JaxTrainingJob:
         # If we exhaust the iteration cap without completing, treat as timeout (or in_progress if no wall-clock limit)
         if timed_out():
             msg = f"Timeout after maximum iterations ({self.training_poll_iterations}) and ~{int(time.time() - start_time)}s"
-            print(msg)
+            log.warning("%s", msg)
             return {"status": "timeout", "reason": msg}
         else:
             # If no wall-clock timeout was set and we hit the iteration cap, report in-progress
             msg = f"Reached iteration cap ({self.training_poll_iterations}) without completion; still in progress"
-            print(msg)
+            log.warning("%s", msg)
             return {"status": "stuck_in_progress", "reason": msg}
 
     def verify_training_results(
         self,
     ):
-        print('Verify Training Completion Msg')
+        log.info('Verify Training Completion Msg')
         last_node = self.host_list[len(self.host_list) - 1]
         last_node_num = len(self.host_list) - 1
         out_dict = self.phdl.exec(f'cat {self.log_dir}/jax-logs/out-node{last_node_num}/training.log')
 
         # Check for proper shutdown first
         if re.search('Distributed task shutdown result: OK', out_dict[last_node], re.I):
-            print("Clean shutdown detected")
+            log.info("Clean shutdown detected")
         else:
             # Fallback: check if all training steps completed successfully
             # This handles the known race condition where PJRT cleanup runs after coordination service exits
             final_step = self.training_steps - 1
             if re.search(f'completed step:\s+{final_step},', out_dict[last_node], re.I):
-                print(
+                log.info(
                     f"Training completed all {self.training_steps} steps successfully. Shutdown message missing but acceptable due to coordination service cleanup race condition."
                 )
             else:
                 fail_test('JAX training did not complete all steps properly')
 
-        print(self.training_result_dict.keys())
+        log.info("%s", list(self.training_result_dict.keys()))
         for i in self.training_result_dict.keys():
-            print("Actual", end="")
-            print(f"Step {i} TFLOPS/s/device = {self.training_result_dict[i]['tflops_per_sec_per_gpu']} ")
-            print("Expected", end="")
-            print(f"Step {i} TFLOPS/s/device = {self.expected_result_dict['tflops_per_sec_per_gpu']} ")
+            log.info(
+                'Actual Step %s TFLOPS/s/device = %s',
+                i,
+                self.training_result_dict[i]['tflops_per_sec_per_gpu'],
+            )
+            log.info(
+                'Expected Step %s TFLOPS/s/device = %s',
+                i,
+                self.expected_result_dict['tflops_per_sec_per_gpu'],
+            )
             if int(i) > 5:
                 if float(self.training_result_dict[i]['tflops_per_sec_per_gpu']) < float(
                     self.expected_result_dict['tflops_per_sec_per_gpu']
@@ -801,7 +807,7 @@ class JaxTrainingJob:
                             Actual = {self.training_result_dict[i]['tflops_per_sec_per_gpu']}"
                     )
                 else:
-                    print(
+                    log.info(
                         f"Step {i} TFLOPS/s/device = {self.training_result_dict[i]['tflops_per_sec_per_gpu']} is above expected threshold {self.expected_result_dict['tflops_per_sec_per_gpu']}"
                     )
                 if float(self.training_result_dict[i]['tokens_per_sec_per_gpu']) < float(
@@ -813,7 +819,7 @@ class JaxTrainingJob:
                             Actual = {self.training_result_dict[i]['tokens_per_sec_per_gpu']}"
                     )
                 else:
-                    print(
+                    log.info(
                         f"Step {i} Tokens/s/device = {self.training_result_dict[i]['tokens_per_sec_per_gpu']} is above expected threshold {self.expected_result_dict['tokens_per_sec_per_gpu']}"
                     )
 
@@ -821,4 +827,4 @@ class JaxTrainingJob:
         self.training_end_time = self.phdl.exec('date +"%a %b %e %H:%M"')
         time.sleep(2)
         verify_dmesg_for_errors(self.phdl, self.training_start_time, self.training_end_time)
-        print(self.training_result_dict)
+        log.info("%s", self.training_result_dict)

--- a/cvs/lib/linux_utils.py
+++ b/cvs/lib/linux_utils.py
@@ -339,18 +339,18 @@ def get_backend_nic_dict(phdl):
         bck_net_dict[node] = []
 
         # Debug output
-        print(f"Node: {node}")
-        print(f"RDMA-capable devices: {rdma_cap_devs.get(node, [])}")
-        print(f"lshw network interfaces: {list(lshw_dict[node].keys())}")
+        log.info(f"Node: {node}")
+        log.info(f"RDMA-capable devices: {rdma_cap_devs.get(node, [])}")
+        log.info(f"lshw network interfaces: {list(lshw_dict[node].keys())}")
 
         # Filter lshw_dict to only RDMA-capable devices
         filtered_lshw = {intf: lshw_dict[node][intf] for intf in rdma_cap_devs.get(node, []) if intf in lshw_dict[node]}
 
-        print(f"Filtered lshw (RDMA-capable only): {list(filtered_lshw.keys())}")
+        log.info(f"Filtered lshw (RDMA-capable only): {list(filtered_lshw.keys())}")
 
         # Now apply the heuristic on the filtered dict: group by description, pick the largest group
         if not filtered_lshw:
-            print(f"WARNING: No RDMA-capable NICs found in lshw for node {node}")
+            log.warning(f"WARNING: No RDMA-capable NICs found in lshw for node {node}")
             continue  # No RDMA-capable NICs
         list_a = []
         list_b = []
@@ -528,8 +528,8 @@ def get_nic_ethtool_stats_dict(phdl, vendor=None):
     # We build a list of interface names per node and then create batches by NIC index.
     cmd_dict = {}
     eth_dev_dict = {}
-    print(node_list)
-    print(bck_nic_dict)
+    log.info("%s", node_list)
+    log.info("%s", bck_nic_dict)
 
     # Build map of nodes to ordered lists of backend interface names
     for node in node_list:
@@ -560,7 +560,7 @@ def get_nic_ethtool_stats_dict(phdl, vendor=None):
             for counter in stats_dict[node][intf].keys():
                 if re.search('err|discard|drop|crc|fcs|reset', counter, re.I):
                     if int(stats_dict[node][intf][counter]) > 0:
-                        print(f'WARN !! {node} {intf} {counter} {stats_dict[node][intf][counter]}')
+                        log.warning(f'WARN !! {node} {intf} {counter} {stats_dict[node][intf][counter]}')
 
     return stats_dict
 
@@ -600,7 +600,7 @@ def get_lldp_dict(phdl):
         if not re.search('lldpcli', out_dict[node]):
             lldp_installed = False
     if lldp_installed is not True:
-        print('Cannot get LLDP Dict as lldpcli is missing')
+        log.warning('Cannot get LLDP Dict as lldpcli is missing')
         return {}
         # try:
         #    phdl.exec('sudo apt update -y')
@@ -609,7 +609,7 @@ def get_lldp_dict(phdl):
         #    print('Error installing LLDP with apt install - {}'.format(e))
         #    return lldp_dict
 
-    print('Get LLDP dict')
+    log.info('Get LLDP dict')
 
     # Execute lldpcli across nodes; expected shape: { node_name: "<json string>", ... }
     out_dict = phdl.exec('sudo lldpcli show neighbors -f json')
@@ -627,15 +627,15 @@ def get_dns_dict(phdl):
         dns_dict[node] = {}
         for line in out_dict[node].split("\n"):
             if re.search('Protocols', line, re.I):
-                print('')
+                log.info('')
             elif re.search('Protocols', line, re.I):
-                print('')
+                log.info('')
             elif re.search('Current DNS Server', line, re.I):
-                print('')
+                log.info('')
             elif re.search('DNS Servers', line, re.I):
-                print('')
+                log.info('')
             elif re.search('DNS Domain', line, re.I):
-                print('')
+                log.info('')
     return dns_dict
 
 
@@ -688,7 +688,7 @@ def get_rdma_stats_dict(phdl):
     # Process each node's output
     for node in out_dict.keys():
         bck_nic_list = bck_nic_dict[node]
-        print(bck_nic_list)
+        log.info("%s", bck_nic_list)
         rdma_stats_dict[node] = {}
 
         # Convert the node's JSON output into Python objects (expected to be a list of dicts)
@@ -802,13 +802,13 @@ def get_gpu_nic_mapping_dict(
 
             # find nearest nic bus no.
             nic_bus_list = nic_bus_dict[node]
-            print(f'nic_bus_list = {nic_bus_list}')
-            print(f'bus_no = {bus_no}')
+            log.info(f'nic_bus_list = {nic_bus_list}')
+            log.info(f'bus_no = {bus_no}')
 
             nearest_nic_bus_no = get_nearest_bus_no(bus_no, nic_bus_list)
 
-            print(f'nic_bus_list = {nic_bus_list}')
-            print(f'nearest_nic_bus_no = {nearest_nic_bus_no}')
+            log.info(f'nic_bus_list = {nic_bus_list}')
+            log.info(f'nearest_nic_bus_no = {nearest_nic_bus_no}')
             for eth_dev in lshw_dict[node].keys():
                 match = re.search(
                     '[0-9a-f]+\:([0-9a-f]+)\:[0-9a-f]+\.[0-9a-f]', lshw_dict[node][eth_dev]['pci_bus'], re.I
@@ -819,7 +819,7 @@ def get_gpu_nic_mapping_dict(
                     gpu_nic_dict[node][card]['rdma_dev'] = lshw_dict[node][eth_dev]['rdma_dev']
                     gpu_nic_dict[node][card]['nic_bdf'] = lshw_dict[node][eth_dev]['pci_bus']
                     continue
-    print(gpu_nic_dict)
+    log.info("%s", gpu_nic_dict)
     return gpu_nic_dict
 
 
@@ -856,5 +856,5 @@ def get_gpu_numa_dict(phdl):
         for node in out_dict.keys():
             gpu_numa_dict[node][card]['numa_node'] = str(out_dict[node]).rstrip('\n').rstrip('\r')
 
-    print(gpu_numa_dict)
+    log.info("%s", gpu_numa_dict)
     return gpu_numa_dict

--- a/cvs/lib/megatron_training_lib.py
+++ b/cvs/lib/megatron_training_lib.py
@@ -144,7 +144,7 @@ class MegatronLlamaTrainingJob:
         self.job_cmd = ''
         self.job_cmd_list = []
         self.training_results_dict = {}
-        print(self.gpu_type)
+        log.info("%s", self.gpu_type)
 
         # Intialize cluster stats dicts ..
         self.rdma_stats_dict_before = {}
@@ -193,11 +193,11 @@ class MegatronLlamaTrainingJob:
         self.rocm_path = detect_rocm_path(self.phdl, tdict['rocm_dir'])
 
         # Get the model parameters dict
-        print('^^^^')
-        print(self.model_params_dict)
-        print(self.model_name)
-        print(self.gpu_type)
-        print('^^^^')
+        log.info('^^^^')
+        log.info("%s", self.model_params_dict)
+        log.info("%s", self.model_name)
+        log.info("%s", self.gpu_type)
+        log.info('^^^^')
         if not self.distributed_training:
             pdict = self.model_params_dict['single_node'][self.model_name][self.gpu_type]
             self.expected_result_dict = self.model_params_dict['single_node'][self.model_name][self.gpu_type][
@@ -300,7 +300,7 @@ class MegatronLlamaTrainingJob:
                 )
                 for node in out_dict.keys():
                     if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
-                        print(out_dict[node])
+                        log.info("%s", out_dict[node])
                         fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
 
     def build_training_job_cmd(
@@ -407,9 +407,9 @@ class MegatronLlamaTrainingJob:
           - self.job_cmd_list (distributed) or self.job_cmd (single-node) has been populated
            by build_training_job_cmd() prior to invocation.
         """
-        print('start training job')
-        print(self.job_cmd_list)
-        print(self.job_cmd)
+        log.info('start training job')
+        log.info("%s", self.job_cmd_list)
+        log.info("%s", self.job_cmd)
         cmd_list = []
         for i in range(0, int(self.nnodes)):
             cmd = f'''docker exec {self.container_name} /bin/bash -c "mkdir -p {self.log_dir}/megatron-logs/out-node{i}"'''
@@ -487,10 +487,10 @@ class MegatronLlamaTrainingJob:
         # Select the log content from the last node
         output = out_dict[last_node]
 
-        print('Extracting results from logs')
-        print('#===========================#')
-        print(output)
-        print('#===========================#')
+        log.info('Extracting results from logs')
+        log.info('#===========================#')
+        log.info("%s", output)
+        log.info('#===========================#')
 
         # Extract throughput per GPU as a list of numbers (strings), if multiple occurrences exist
         # pattern = f'throughput per GPU \(TFLOP/s/GPU\):\s+([0-9\.]+)'
@@ -509,7 +509,7 @@ class MegatronLlamaTrainingJob:
         pattern = 'elapsed time per iteration \(ms\):\s+([0-9\.]+)'
         training_results_dict['elapsed_time_per_iteration'] = re.findall(pattern, output, re.I)
 
-        print(training_results_dict)
+        log.info("%s", training_results_dict)
         return training_results_dict
 
     def scan_for_training_errors(
@@ -545,7 +545,7 @@ class MegatronLlamaTrainingJob:
         - Consider logging or returning which specific patterns matched for better diagnostics.
         """
 
-        print('Scan for training errors')
+        log.info('Scan for training errors')
         training_pass = True  # Default to pass; flip to False if any error pattern is detected
 
         # Identify the node whose log we treat as authoritative (last in the host list)
@@ -599,7 +599,7 @@ class MegatronLlamaTrainingJob:
         - The progress regex for tokens/GPU/s lacks a colon; consider 'tokens\\/GPU\\/s:\\s+[0-9]+'.
         """
 
-        print('Poll for training completion ..')
+        log.info('Poll for training completion ..')
         time.sleep(80)
         last_node = self.host_list[len(self.host_list) - 1]
 
@@ -608,7 +608,7 @@ class MegatronLlamaTrainingJob:
 
         # 10 additional iterations in case time per iteration is longer ..
         for i in range(1, int(self.iterations) + 10):
-            print(f'Starting Iteration {i}')
+            log.info(f'Starting Iteration {i}')
             if not self.scan_for_training_errors():
                 fail_test('Failures seen in training logs, Aborting!!!')
                 return
@@ -616,7 +616,7 @@ class MegatronLlamaTrainingJob:
             output = out_dict[last_node]
 
             if not re.search('throughput per GPU:|tokens\/GPU\/s\s+[0-9]+', output, re.I):
-                print('Training still in progress')
+                log.info('Training still in progress')
             else:
                 if (
                     re.search('throughput per GPU:\s+[NaN|Inf]', output, re.I)
@@ -628,7 +628,7 @@ class MegatronLlamaTrainingJob:
                 else:
                     time.sleep(5)
                     self.training_results_dict = self.get_training_results_dict()
-                    print('Completed Training, returning !!!')
+                    log.info('Completed Training, returning !!!')
                     return
             # Wait secs between every iteration
             time.sleep(int(time_between_iters))
@@ -677,10 +677,10 @@ class MegatronLlamaTrainingJob:
         # Record the training end time; used later for dmesg time-bounded scanning
         self.training_end_time = self.phdl.exec('date')
 
-        print('#==================================================#')
-        print('\t\tTraining Results')
-        print(self.training_results_dict)
-        print('#==================================================#')
+        log.info('#==================================================#')
+        log.info('\t\tTraining Results')
+        log.info("%s", self.training_results_dict)
+        log.info('#==================================================#')
         # Check the parsed training results for invalid numeric values (NaN/Inf)
         if not self.training_results_dict:
             fail_test(
@@ -731,14 +731,14 @@ class MegatronLlamaTrainingJob:
         # Scan Dmesg for errors ..
         verify_dmesg_for_errors(self.phdl, self.training_start_time, self.training_end_time)
 
-        print('^^^^^^^^^^^^^^^^^^^^')
-        print('training_results_dict')
-        print('^^^^^^^^^^^^^^^^^^^^')
-        print(self.training_results_dict)
+        log.info('^^^^^^^^^^^^^^^^^^^^')
+        log.info('training_results_dict')
+        log.info('^^^^^^^^^^^^^^^^^^^^')
+        log.info("%s", self.training_results_dict)
         # Compare perf expected numbers from input JSON file ..
         for result_key in self.training_results_dict.keys():
             if result_key in self.expected_result_dict:
-                print(self.training_results_dict[result_key])
+                log.info("%s", self.training_results_dict[result_key])
                 # check if all nodes have met the expected perf numbers
                 for actual_perf in self.training_results_dict[result_key]:
                     if float(actual_perf) < float(self.expected_result_dict[result_key]):
@@ -748,4 +748,4 @@ class MegatronLlamaTrainingJob:
                            actual = {actual_perf}'
                         )
             else:
-                log.warn(f'Perf result key {result_key} not provided in input JSON file, so will not be checked')
+                log.warning(f'Perf result key {result_key} not provided in input JSON file, so will not be checked')

--- a/cvs/lib/mori_lib.py
+++ b/cvs/lib/mori_lib.py
@@ -105,7 +105,7 @@ def parse_pretty_tables_multi_rank(text: str) -> dict:
     # Write to dict
     # -----------------------------
     output_dict = {"ranks": results}
-    print(output_dict)
+    log.info("%s", output_dict)
     return output_dict
 
 
@@ -194,7 +194,7 @@ class MoriBenchmark:
               ' > /tmp/mori_env_script.sh"
               '''
         formatted_cmd = textwrap_for_cmd(cmd)
-        print(f'%%%%%%% formatted_cmd = {formatted_cmd}')
+        log.info(f'%%%%%%% formatted_cmd = {formatted_cmd}')
         self.phdl.exec(formatted_cmd)
         cmd = f'''docker exec {self.container_name} /bin/bash -c "
               mkdir -p {self.log_dir}"'''
@@ -212,8 +212,8 @@ class MoriBenchmark:
                     /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so;" '
             pout_dict = self.phdl.exec(cmd)
             for node in pout_dict.keys():
-                if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
-                    print(pout_dict[node])
+                if not re.search('hca_id:\s+bnxt_', pout_dict[node], re.I):
+                    log.info("%s", pout_dict[node])
 
     def install_packages(
         self,
@@ -266,15 +266,15 @@ class MoriBenchmark:
                 fail_test('ERROR - dist_write did not complete properly - results not seen')
             else:
                 meta_data, results = parse_ibgda_output(out_dict[node])
-                print(results)
+                log.info("%s", results)
                 m_key = f'''PROCS:{no_of_procs},CTAS:{ctas},THREADS:{threads},QP_COUNT:{qp_count}'''
                 if m_key in exp_res_dict.keys():
                     for row_dict in results:
                         act_msg_size = row_dict['size_bytes']
                         actual_bw = row_dict['bandwidth_gb']
-                        print(f'exp_res_dict = {exp_res_dict}')
-                        print(f'exp_res_dict = {exp_res_dict[m_key].keys()}')
-                        print(act_msg_size)
+                        log.info(f'exp_res_dict = {exp_res_dict}')
+                        log.info(f'exp_res_dict = {exp_res_dict[m_key].keys()}')
+                        log.info("%s", act_msg_size)
                         for exp_msg_size in list(exp_res_dict[m_key].keys()):
                             exp_bw = exp_res_dict[m_key][exp_msg_size]['max_bw']
                             if int(act_msg_size) == int(exp_msg_size):
@@ -285,7 +285,7 @@ class MoriBenchmark:
                                       expected = {exp_bw}, actual = {actual_bw}'
                                     )
                                 else:
-                                    print(
+                                    log.info(
                                         f'IBGDA Mori BW is as expected for  \
                                       PROCS:{no_of_procs},CTAS:{ctas},THREADS:{threads},QP_COUNT:{qp_count} \
                                       expected = {exp_bw}, actual = {actual_bw}'
@@ -462,9 +462,9 @@ class MoriBenchmark:
         elif op_type == "write":
             op_key = "io_write"
 
-        print('^^^^^^^^^^^^^^^^^^^^')
-        print(self.expected_results_dict.keys())
-        print('^^^^^^^^^^^^^^^^^^^^')
+        log.info('^^^^^^^^^^^^^^^^^^^^')
+        log.info("%s", list(self.expected_results_dict.keys()))
+        log.info('^^^^^^^^^^^^^^^^^^^^')
         exp_res_dict = self.expected_results_dict[op_key]
         m_key = (
             'BUFF_SIZE:'
@@ -498,7 +498,7 @@ class MoriBenchmark:
                                       buffer_size,transfer_batch_size,no_of_qp_per_transfer = \
                                       {m_key}''')
                             else:
-                                print(f'''BW is as expected for \
+                                log.info(f'''BW is as expected for \
                                       rank {rank_no}, Msg size {msg_size}, \
                                       actual BW {row_dict['Avg_BW_GBps']}, \
                                       expected BW {exp_max_bw}, \
@@ -513,7 +513,7 @@ class MoriBenchmark:
                                       buffer_size,transfer_batch_size,no_of_qp_per_transfer = \
                                       {m_key}''')
                             else:
-                                print(f'''Latency is as expected for \
+                                log.info(f'''Latency is as expected for \
                                       rank {rank_no}, Msg size {msg_size}, \
                                       actual Avg Lat {row_dict['Avg_Lat_us']}, \
                                       expected Avg Lat {exp_avg_lat}, \

--- a/cvs/lib/parallel_ssh_lib.py
+++ b/cvs/lib/parallel_ssh_lib.py
@@ -51,9 +51,9 @@ class Pssh:
         self.log.debug(f"Environ vars: {self.env_prefix}")
 
         if self.password is None:
-            print(self.reachable_hosts)
-            print(self.user)
-            print(self.pkey)
+            self.log.info("%s", self.reachable_hosts)
+            self.log.info("%s", self.user)
+            self.log.info("%s", self.pkey)
             self.client = ParallelSSHClient(self.reachable_hosts, user=self.user, pkey=self.pkey, keepalive_seconds=30)
         else:
             self.client = ParallelSSHClient(
@@ -96,7 +96,7 @@ class Pssh:
         ]
         unreachable = self.check_connectivity(failed_hosts)
         for host in unreachable:
-            print(f"Host {host} is unreachable, pruning from reachable hosts list.")
+            self.log.warning(f"Host {host} is unreachable, pruning from reachable hosts list.")
             self.unreachable_hosts.append(host)
             self.reachable_hosts.remove(host)
         if len(self.unreachable_hosts) > initial_unreachable_len:
@@ -126,22 +126,22 @@ class Pssh:
         cmd_output = {}
         i = 0
         for item in output:
-            print('#----------------------------------------------------------#')
-            print(f'Host == {item.host} ==')
-            print('#----------------------------------------------------------#')
+            self.log.info('#----------------------------------------------------------#')
+            self.log.info(f'Host == {item.host} ==')
+            self.log.info('#----------------------------------------------------------#')
             cmd_out_str = ''
             if cmd_list:
-                print(cmd_list[i])
+                self.log.debug("%s", cmd_list[i])
             else:
-                print(cmd)
+                self.log.debug("%s", cmd)
             try:
                 for line in item.stdout or []:
                     if print_console:
-                        print(line)
+                        self.log.info("%s", line)
                     cmd_out_str += line.replace('\t', '   ') + '\n'
                 for line in item.stderr or []:
                     if print_console:
-                        print(line)
+                        self.log.info("%s", line)
                     cmd_out_str += line.replace('\t', '   ') + '\n'
             except Timeout as e:
                 if not self.stop_on_errors:
@@ -153,7 +153,7 @@ class Pssh:
                 exc_str = exc_str.replace('\t', '   ')
                 if isinstance(item.exception, Timeout):
                     exc_str += "\nABORT: Timeout Error in Host: " + item.host
-                print(exc_str)
+                self.log.warning("%s", exc_str)
                 cmd_out_str += exc_str + '\n'
             if cmd_list:
                 i += 1
@@ -184,7 +184,7 @@ class Pssh:
         else:
             full_cmd = cmd
 
-        print(f'cmd = {full_cmd}')
+        self.log.info(f'cmd = {full_cmd}')
 
         # Log command execution
         if self.log:
@@ -219,7 +219,7 @@ class Pssh:
         else:
             cmd_list = cmd_list
 
-        print(cmd_list)
+        self.log.info("%s", cmd_list)
 
         # Log command list execution
         if self.log:
@@ -244,7 +244,7 @@ class Pssh:
         return cmd_output
 
     def scp_file(self, local_file, remote_file, recurse=False):
-        print('About to copy local file {} to remote {} on all Hosts'.format(local_file, remote_file))
+        self.log.info('About to copy local file {} to remote {} on all Hosts'.format(local_file, remote_file))
         cmds = self.client.copy_file(local_file, remote_file, recurse=recurse)
         self.client.pool.join()
         for cmd in cmds:
@@ -255,11 +255,11 @@ class Pssh:
         return
 
     def reboot_connections(self):
-        print('Rebooting Connections')
+        self.log.info('Rebooting Connections')
         self.client.run_command('reboot -f', stop_on_errors=self.stop_on_errors)
 
     def destroy_clients(self):
-        print('Destroying Current phdl connections ..')
+        self.log.info('Destroying Current phdl connections ..')
         del self.client
 
 

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -161,10 +161,10 @@ def scan_rccl_logs(output):
         if re.search('NCCL WARN', line):
             warn_list.append(line)
     if len(warn_list) > 0:
-        print('Following warnings were observed in the RCCL test')
-        print('#============#')
-        print(warn_list)
-        print('#============#')
+        log.warning('Following warnings were observed in the RCCL test')
+        log.warning('#============#')
+        log.warning('%s', warn_list)
+        log.warning('#============#')
     if not re.search('#\sAvg bus bandwidth', output):
         fail_test('RCCL test did not complete successfully, no bandwidth numbers printed - pls check')
 
@@ -210,14 +210,14 @@ def check_bus_bw(test_name, output, exp_res_dict):
       - 5% tolerance is applied: test only fails if actual < expected * 0.95
     """
 
-    print(f'exp_res_dict = {exp_res_dict}')
+    log.info(f'exp_res_dict = {exp_res_dict}')
 
     tolerance = 0.95  # 5% tolerance
 
     # New hierarchical structure: {msg_size: {'bus_bw': bw_value}}
     msg_size_list = list(exp_res_dict.keys())
 
-    print(test_name)
+    log.info("%s", test_name)
     # act_res_dict = json.loads(output.replace( '\n', '').replace( '\r', ''))
     act_res_dict = output
     if re.search('alltoall|all_to_all', test_name, re.I):
@@ -228,7 +228,7 @@ def check_bus_bw(test_name, output, exp_res_dict):
                         expected_bw = float(exp_res_dict[msg_size]['bus_bw'])
                         actual_bw = float(act_dict['busBw'])
                         threshold = expected_bw * tolerance
-                        print(f"Comparing: actual={actual_bw}, expected={expected_bw}, threshold={threshold:.2f}")
+                        log.info(f"Comparing: actual={actual_bw}, expected={expected_bw}, threshold={threshold:.2f}")
                         if actual_bw < threshold:
                             fail_test(
                                 f"The actual out-of-place bus BW {actual_bw} for msg size {act_dict['size']} is lower than expected bus BW {expected_bw} (threshold with 5% tolerance: {threshold:.2f})"
@@ -241,7 +241,7 @@ def check_bus_bw(test_name, output, exp_res_dict):
                         expected_bw = float(exp_res_dict[msg_size]['bus_bw'])
                         actual_bw = float(act_dict['busBw'])
                         threshold = expected_bw * tolerance
-                        print(f"Comparing: actual={actual_bw}, expected={expected_bw}, threshold={threshold:.2f}")
+                        log.info(f"Comparing: actual={actual_bw}, expected={expected_bw}, threshold={threshold:.2f}")
                         if actual_bw < threshold:
                             fail_test(
                                 f"The actual in-place bus BW {actual_bw} for msg size {act_dict['size']} is lower than expected bus BW {expected_bw} (threshold with 5% tolerance: {threshold:.2f})"
@@ -261,7 +261,7 @@ def check_bw_dip(test_name, output, exp_res_dict=None):
     # Get reference message sizes if provided
     # If no reference data, skip validation entirely
     if not exp_res_dict:
-        log.info(f"No reference data provided for BW dip check, skipping validation for {test_name}")
+        log.warning(f"No reference data provided for BW dip check, skipping validation for {test_name}")
         return
 
     ref_msg_sizes = set(str(size) for size in exp_res_dict.keys())
@@ -316,7 +316,7 @@ def check_lat_dip(test_name, output, exp_res_dict=None):
     # Get reference message sizes if provided
     # If no reference data, skip validation entirely
     if not exp_res_dict:
-        log.info(f"No reference data provided for latency dip check, skipping validation for {test_name}")
+        log.warning(f"No reference data provided for latency dip check, skipping validation for {test_name}")
         return
 
     ref_msg_sizes = set(str(size) for size in exp_res_dict.keys())
@@ -361,10 +361,10 @@ def check_lat_dip(test_name, output, exp_res_dict=None):
 def convert_to_graph_dict(result_dict):
     graph_dict = {}
     for graph_series_name in result_dict.keys():
-        print(graph_series_name)
+        log.info("%s", graph_series_name)
         graph_dict[graph_series_name] = {}
         dict_list = result_dict[graph_series_name]
-        print(dict_list)
+        log.info("%s", dict_list)
         for dict_item in dict_list:
             msg_size = dict_item['size']
             graph_dict[graph_series_name][msg_size] = {}
@@ -376,7 +376,7 @@ def convert_to_graph_dict(result_dict):
                 graph_dict[graph_series_name][msg_size]['bus_bw'] = dict_item['busBw']
                 graph_dict[graph_series_name][msg_size]['alg_bw'] = dict_item['algBw']
                 graph_dict[graph_series_name][msg_size]['time'] = dict_item['time']
-    print(graph_dict)
+    log.info("%s", graph_dict)
     return graph_dict
 
 
@@ -447,7 +447,7 @@ def aggregate_rccl_test_results(validated_results: List[RcclTests]) -> List[Rccl
             agg_results.append(RcclTestsAggregated.model_validate(row_dict))
         except ValidationError as e:
             error_msg = f"Validation failed for row {row_dict}: {e}"
-            log.error(error_msg)
+            log.error("%s", error_msg)
             errors.append(error_msg)
 
     # Report any validation failures
@@ -545,7 +545,7 @@ def rccl_cluster_test(
       result_out: The raw JSON string read from rccl_result_file on the head node.
     """
 
-    print(f'Starting RCCL Test ..........................................{test_name}')
+    log.info(f'Starting RCCL Test ..........................................{test_name}')
     # Base ROCm path as provided by caller
     ROCM_PATH = rocm_path_var
 
@@ -562,7 +562,7 @@ def rccl_cluster_test(
         f'{RCCL_PATH}:{MPI_PATH}/lib:{ROCM_PATH}/lib:{ROCM_PATH}/lib64:{ROCM_PATH}/hip/lib:$LD_LIBRARY_PATH'
     )
 
-    print(f'%% VPC Node IPs {vpc_node_list}')
+    log.info(f'%% VPC Node IPs {vpc_node_list}')
 
     # Use the first cluster node as the head node (source for collected outputs)
     # The -H {host_params} is obsolete in ompi5.0 and greater, so changing to
@@ -641,9 +641,9 @@ def rccl_cluster_test(
         {test_cmd}
         '''
 
-    print('%%%%%%%%%%%%%%%%')
-    print(cmd)
-    print('%%%%%%%%%%%%%%%%')
+    log.info('%%%%%%%%%%%%%%%%')
+    log.info("%s", cmd)
+    log.info('%%%%%%%%%%%%%%%%')
     try:
         out_dict = shdl.exec(cmd, timeout=500)
         output = out_dict[head_node]
@@ -769,7 +769,7 @@ def rccl_cluster_test_default(
       all_raw_results: List of dictionaries containing all test results from all data types.
     """
 
-    print(f'Starting RCCL Test ..........................................{test_name}')
+    log.info(f'Starting RCCL Test ..........................................{test_name}')
     if min_channels is not None and max_channels is not None:
         log.info(f'Using NCCL channels: min={min_channels}, max={max_channels}')
     else:
@@ -790,7 +790,7 @@ def rccl_cluster_test_default(
         f'{RCCL_PATH}:{MPI_PATH}/lib:{ROCM_PATH}/lib:{ROCM_PATH}/lib64:{ROCM_PATH}/hip/lib:$LD_LIBRARY_PATH'
     )
 
-    print(f'%% VPC Node IPs {vpc_node_list}')
+    log.info(f'%% VPC Node IPs {vpc_node_list}')
 
     # Use the first cluster node as the head node (source for collected outputs)
     # The -H {host_params} is obsolete in ompi5.0 and greater, so changing to
@@ -869,9 +869,9 @@ def rccl_cluster_test_default(
         {test_cmd}
         '''
 
-        print('%%%%%%%%%%%%%%%%')
-        print(cmd)
-        print('%%%%%%%%%%%%%%%%')
+        log.info('%%%%%%%%%%%%%%%%')
+        log.info("%s", cmd)
+        log.info('%%%%%%%%%%%%%%%%')
         try:
             out_dict = shdl.exec(cmd, timeout=500)
             output = out_dict[head_node]
@@ -905,8 +905,7 @@ def rccl_cluster_test_default(
                     "Please inspect the rccl-tests stdout/stderr and re-run.\n"
                     "================================================================\n"
                 )
-                print(msg)
-                log.error(msg)
+                log.error("%s", msg)
                 fail_test(msg)
             else:
                 log.error(f'Validation Failed: {e}')
@@ -932,7 +931,7 @@ def rccl_cluster_test_default(
                 json.dump([result.model_dump() for result in aggregated_rccl_tests], f, indent=2)
             log.info(f'Saved aggregated results to {aggregated_path}')
         else:
-            log.info('Aggregation skipped: only one run found')
+            log.warning('Aggregation skipped: only one run found')
     except ValidationError as e:
         log.error(f'Validation Failed: {e}')
         fail_test(f'RCCL Test schema validation failed: {e}')
@@ -1051,7 +1050,7 @@ def rccl_single_node_test(
       result_out: The raw JSON string read from rccl_result_file on all nodes
     """
 
-    print(f'Starting RCCL Test ..........................................{test_name}')
+    log.info(f'Starting RCCL Test ..........................................{test_name}')
     # Base ROCm path as provided by caller
     ROCM_PATH = rocm_path_var
 
@@ -1081,9 +1080,9 @@ def rccl_single_node_test(
            export LD_LIBRARY_PATH={LD_LIBRARY_PATH}; \
            {test_cmd}'''
 
-    print('%%%%%%%%%%%%%%%%')
-    print(cmd)
-    print('%%%%%%%%%%%%%%%%')
+    log.info('%%%%%%%%%%%%%%%%')
+    log.info("%s", cmd)
+    log.info('%%%%%%%%%%%%%%%%')
     try:
         out_dict = phdl.exec(cmd, timeout=500)
         for node in out_dict.keys():

--- a/cvs/lib/report_plugins.py
+++ b/cvs/lib/report_plugins.py
@@ -69,7 +69,7 @@ class HtmlReportManager:
                 shutil.rmtree(log_dir)
                 log.info("Removed stale log directory: %s", log_dir)
             except Exception as e:
-                log.info(f"Failed to remove stale log directory: {log_dir} - {e}")
+                log.warning(f"Failed to remove stale log directory: {log_dir} - {e}")
         log_dir.mkdir(parents=True, exist_ok=True)
 
     def write_test_log(self, report, test_name=None):
@@ -380,7 +380,7 @@ class HtmlReportManager:
         # Resolve path after session completes; report file is expected to exist by now.
         htmlpath = Path(self._htmlpath).resolve()
         if not htmlpath.is_file():
-            log.info("Skipping zip bundle creation because HTML report was not found: %s", htmlpath)
+            log.warning("Skipping zip bundle creation because HTML report was not found: %s", htmlpath)
             return
 
         # Inject Reports section into main HTML report
@@ -425,7 +425,7 @@ class HtmlReportManager:
                         zf.write(filepath, Path(self._test_html_dir) / filepath.name)
                         files_added += 1
             else:
-                log.info("Log directory not found while zipping (continuing): %s", log_dir)
+                log.warning("Log directory not found while zipping (continuing): %s", log_dir)
 
         size_mb = zip_path.stat().st_size / (1024 * 1024)
         log.info("Report archive created: %s (%.1f MB, files=%d)", zip_path, size_mb, files_added)

--- a/cvs/lib/rocm_plib.py
+++ b/cvs/lib/rocm_plib.py
@@ -36,11 +36,11 @@ def get_amd_smi_fw_dict(phdl):
 def get_amd_smi_ras_metrics_dict(phdl):
     ras_dict = {}
     ras_dict_t = convert_phdl_json_to_dict(phdl.exec('sudo amd-smi metric --ecc --json'))
-    print(ras_dict_t)
+    log.info("%s", ras_dict_t)
     for node in ras_dict_t.keys():
         ras_dict[node] = {}
-        print('^^^^^')
-        print(ras_dict_t[node])
+        log.info('^^^^^')
+        log.info("%s", ras_dict_t[node])
         if isinstance(ras_dict_t[node], dict):
             if 'gpu_data' in ras_dict_t[node].keys():
                 for gpu_dict in list(ras_dict_t[node]['gpu_data']):

--- a/cvs/lib/sglang_disagg_lib.py
+++ b/cvs/lib/sglang_disagg_lib.py
@@ -133,7 +133,7 @@ class SglangDisaggPD:
         self.job_cmd = ''
         self.job_cmd_list = []
         self.inference_results_dict = {}
-        print(self.gpu_type)
+        log.info("%s", self.gpu_type)
 
         # ------------------------------------------------------------------
         # Extract commonly used inference parameters for convenience
@@ -167,9 +167,9 @@ class SglangDisaggPD:
         self.inf_dict.setdefault('queue_timeout_secs', '60')
         self.inf_dict.setdefault('max_retries', '5')
 
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-        print(f'inference_dict = {self.inf_dict}')
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info(f'inference_dict = {self.inf_dict}')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
         self.container_image = self.inf_dict['container_image']
         self.container_name = self.inf_dict['container_name']
 
@@ -205,9 +205,9 @@ class SglangDisaggPD:
 
         self.inference_poll_iterations = self.bp_dict['inference_poll_iterations']
 
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-        print(f'benchmark_params_dict = {self.bp_dict}')
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info(f'benchmark_params_dict = {self.bp_dict}')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
 
     def install_container_packages(
         self,
@@ -231,7 +231,7 @@ class SglangDisaggPD:
         - Proxy/router nodes
         """
 
-        print('Run pre inference tasks')
+        log.info('Run pre inference tasks')
         # Install ip tools
         cmd = f'docker exec {self.container_name} /bin/bash -c " \
             sudo apt -y update; \
@@ -271,12 +271,12 @@ class SglangDisaggPD:
             pout_dict = self.p_phdl.exec(cmd)
             dout_dict = self.d_phdl.exec(cmd)
             for node in pout_dict.keys():
-                if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
-                    print(pout_dict[node])
+                if not re.search('hca_id:\s+bnxt_', pout_dict[node], re.I):
+                    log.info("%s", pout_dict[node])
                     fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
             for node in dout_dict.keys():
-                if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
-                    print(dout_dict[node])
+                if not re.search('hca_id:\s+bnxt_', dout_dict[node], re.I):
+                    log.info("%s", dout_dict[node])
                     fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
 
     def check_ibv_devices(
@@ -443,9 +443,9 @@ class SglangDisaggPD:
         max_jobs (int): Maximum number of concurrent jobs to launch within
                         the RMSNorm test to stress the kernel.
         """
-        print('#================ * * * =========================#')
-        print('Run rmsnorm2d')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Run rmsnorm2d')
+        log.info('#================ * * * =========================#')
         # ------------------------------------------------------------------
         # Construct command to run RMSNorm test inside the container
         #
@@ -458,14 +458,14 @@ class SglangDisaggPD:
                 python /sgl-workspace/aiter/op_tests/test_rmsnorm2d.py > /tmp/rsmnorm_test.log 2>&1 &" '''
         for hdl in [self.p_phdl, self.d_phdl, self.r_phdl]:
             out_dict = hdl.exec(cmd)
-        print('Wait 180 secs for tests to complete')
+        log.info('Wait 180 secs for tests to complete')
         time.sleep(180)
         for hdl in [self.p_phdl, self.d_phdl, self.r_phdl]:
             cmd = f'''docker exec {self.container_name} /bin/bash -c  "cat /tmp/rsmnorm_test.log" '''
             out_dict = hdl.exec(cmd)
             for node in out_dict.keys():
                 if re.search('fail', out_dict[node], re.I):
-                    print(f'Some failures observed in test rmsnorm on node {node}')
+                    log.warning(f'Some failures observed in test rmsnorm on node {node}')
                     fail_test(f'Some failures observed in test rmsnorm on node {node}')
 
     # supported --dtype {auto,half,float16,bfloat16,float,float32}
@@ -493,13 +493,13 @@ class SglangDisaggPD:
         dtype (str): Model compute datatype (e.g., fp16, bf16, auto)
         kv_cache_dtype (str): KV cache datatype (e.g., fp16, bf16, auto)
         """
-        print('#================ * * * =========================#')
-        print('Create Prefill launch script on Prefill nodes')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Create Prefill launch script on Prefill nodes')
+        log.info('#================ * * * =========================#')
 
         cmd_list = []
         prefill_node_list = self.inf_dict['prefill_node_list']
-        print('%%%% self.prefill_nnodes {}'.format(self.prefill_nnodes))
+        log.info('%%%% self.prefill_nnodes {}'.format(self.prefill_nnodes))
         for i in range(0, int(self.prefill_nnodes)):
             cmd = f'''docker exec {self.container_name} /bin/bash -c  "echo  '
                       export NNODES={self.prefill_nnodes}
@@ -520,13 +520,13 @@ class SglangDisaggPD:
                               --log-level {self.inf_dict['log_level']}' > /tmp/prefill_launch_script.sh" '''
             formatted_cmd = textwrap_for_yml(cmd)
             cmd_list.append(formatted_cmd)
-        print('%%%%%%%%%%%%%%%%%%%')
-        print(cmd_list)
-        print('%%%%%%%%%%%%%%%%%%%')
+        log.info('%%%%%%%%%%%%%%%%%%%')
+        log.info("%s", cmd_list)
+        log.info('%%%%%%%%%%%%%%%%%%%')
         self.p_phdl.exec_cmd_list(cmd_list)
-        print('#================ * * * =========================#')
-        print('Launching Prefill servers on Prefill nodes')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Launching Prefill servers on Prefill nodes')
+        log.info('#================ * * * =========================#')
         cmd_list = []
         for i in range(0, int(self.prefill_nnodes)):
             cmd = f'''docker exec {self.container_name} /bin/bash -c " \
@@ -562,12 +562,12 @@ class SglangDisaggPD:
         dtype (str): Model compute datatype (e.g., fp16, bf16, auto)
         kv_cache_dtype (str): KV cache datatype (e.g., fp16, bf16, auto)
         """
-        print('#================ * * * =========================#')
-        print('Create Decode launch script on Decode nodes')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Create Decode launch script on Decode nodes')
+        log.info('#================ * * * =========================#')
         cmd_list = []
         decode_node_list = self.inf_dict['decode_node_list']
-        print('%%%% self.decode_nnodes {}'.format(self.decode_nnodes))
+        log.info('%%%% self.decode_nnodes {}'.format(self.decode_nnodes))
         for i in range(0, int(self.decode_nnodes)):
             # ------------------------------------------------------------------
             # Construct a command that writes a Decode server launch script
@@ -606,13 +606,13 @@ class SglangDisaggPD:
                               --log-level {self.inf_dict['log_level']}' > /tmp/decode_launch_script.sh" '''
             formatted_cmd = textwrap_for_yml(cmd)
             cmd_list.append(formatted_cmd)
-        print('%%%%%%%%%%%%%%%%%%%')
-        print(cmd_list)
-        print('%%%%%%%%%%%%%%%%%%%')
+        log.info('%%%%%%%%%%%%%%%%%%%')
+        log.info("%s", cmd_list)
+        log.info('%%%%%%%%%%%%%%%%%%%')
         self.d_phdl.exec_cmd_list(cmd_list)
-        print('#================ * * * =========================#')
-        print('Launching Decode servers on Decode nodes')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Launching Decode servers on Decode nodes')
+        log.info('#================ * * * =========================#')
         cmd_list = []
         for i in range(0, int(self.decode_nnodes)):
             cmd = f'''docker exec {self.container_name} /bin/bash -c " \
@@ -645,7 +645,7 @@ class SglangDisaggPD:
         This method enforces a startup delay and then actively polls each server
         to confirm readiness before inference traffic is sent.
         """
-        print('Waiting 120 secs after launching decode script')
+        log.info('Waiting 120 secs after launching decode script')
         time.sleep(120)
         for node_no in range(0, self.prefill_nnodes):
             self.poll_for_server_ready(node_no, 'prefill')
@@ -694,9 +694,9 @@ class SglangDisaggPD:
         decode_str = ''
         for decode_node in self.decode_node_list:
             decode_str = decode_str + f"--decode http://{decode_node}:{self.inf_dict['decode_serv_port']} "
-        print('#================ * * * =========================#')
-        print('Create Proxy Router launch script on Proxy Router nodes')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Create Proxy Router launch script on Proxy Router nodes')
+        log.info('#================ * * * =========================#')
 
         # ------------------------------------------------------------------
         # Create the Proxy Router launch script
@@ -723,9 +723,9 @@ class SglangDisaggPD:
                     '''
         formatted_cmd = textwrap_for_yml(cmd)
         self.r_phdl.exec(formatted_cmd)
-        print('#================ * * * =========================#')
-        print('Launch Proxy Router script on Proxy Router nodes')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Launch Proxy Router script on Proxy Router nodes')
+        log.info('#================ * * * =========================#')
         cmd = f'''docker exec {self.container_name} /bin/bash -c " \
                    chmod 755 /tmp/proxy_router_launch_script.sh; \
                    mkdir -p {self.log_dir}/proxy_router_node; \
@@ -734,7 +734,7 @@ class SglangDisaggPD:
                    {self.log_dir}/proxy_router_node/proxy_router.log 2>&1 &" '''
         formatted_cmd = textwrap_for_yml(cmd)
         self.r_phdl.exec(formatted_cmd)
-        print('Waiting 120 secs after launching proxy router script')
+        log.info('Waiting 120 secs after launching proxy router script')
         time.sleep(120)
 
     def run_gsm8k_benchmark_test(self, d_type='auto'):
@@ -754,9 +754,9 @@ class SglangDisaggPD:
         - Routes requests to Prefill servers
         - Coordinates Decode servers for token generation
         """
-        print('#================ * * * =========================#')
-        print('Create Benchmark script')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Create Benchmark script')
+        log.info('#================ * * * =========================#')
 
         i_dict = self.bp_dict['inference_tests']['gsm8k']
         # ------------------------------------------------------------------
@@ -817,9 +817,9 @@ class SglangDisaggPD:
         d_type (str): Data type identifier used to select expected
                       performance thresholds (e.g., fp16, bf16, auto).
         """
-        print('#================ * * * =========================#')
-        print('Benchmark Random Dataset')
-        print('#================ * * * =========================#')
+        log.info('#================ * * * =========================#')
+        log.info('Benchmark Random Dataset')
+        log.info('#================ * * * =========================#')
         i_dict = self.bp_dict['inference_tests']['bench_serv_random']
         # ------------------------------------------------------------------
         # Construct command to run sglang.bench_serving with random dataset
@@ -883,21 +883,21 @@ class SglangDisaggPD:
         if re.search('prefill', sglang_function):
             head_node = self.prefill_node_list[0]
             for j in range(1, no_of_iterations):
-                print(f'Starting poll iteration {j}')
+                log.info(f'Starting poll iteration {j}')
                 out_dict = self.p_phdl.exec(
                     f'grep -B 20 -A 20 "200 OK" {self.log_dir}/prefill_node{node_no}/prefill_server.log'
                 )
                 if re.search('GET|POST', out_dict[head_node], re.I):
-                    print('Wait 60 secs to start serving traffic')
+                    log.info('Wait 60 secs to start serving traffic')
                     time.sleep(60)
                     # if re.search('fired up and ready to roll', out_dict[head_node], re.I ):
                     #    print('Prefill server {node_no} ready to serve')
                     return
                 else:
-                    print('Wait for 120 secs and continue polling')
+                    log.info('Wait for 120 secs and continue polling')
                     time.sleep(120)
             head_node = self.prefill_node_list[0]
-            print(f'Prefill node {node_no} did not get to ready to serve 200 OK state in {j} iterations')
+            log.warning(f'Prefill node {node_no} did not get to ready to serve 200 OK state in {j} iterations')
             fail_test(f'Prefill node {node_no} did not get to ready to serve 200 OK state in {j} iterations')
         # ------------------------------------------------------------------
         # Decode server readiness check
@@ -905,20 +905,20 @@ class SglangDisaggPD:
         elif re.search('decode', sglang_function):
             head_node = self.decode_node_list[0]
             for j in range(1, no_of_iterations):
-                print(f'Starting poll iteration {j}')
+                log.info(f'Starting poll iteration {j}')
                 out_dict = self.d_phdl.exec(
                     f'grep -B 20 -A 20 "200 OK" {self.log_dir}/decode_node{node_no}/decode_server.log'
                 )
                 if re.search('GET|POST', out_dict[head_node]):
-                    print('Wait 60 secs to start serving traffic')
+                    log.info('Wait 60 secs to start serving traffic')
                     time.sleep(60)
                     # if re.search('fired up and ready to roll', out_dict[head_node], re.I ):
                     #    print('Decode server {node_no} ready to serve')
                     return
                 else:
-                    print('Wait for 120 secs and continue polling')
+                    log.info('Wait for 120 secs and continue polling')
                     time.sleep(120)
-            print(f'Decode node {node_no} did not get to ready to serve 200 OK state in {j} iterations')
+            log.warning(f'Decode node {node_no} did not get to ready to serve 200 OK state in {j} iterations')
             fail_test(f'Decode node {node_no} did not get to ready to serve 200 OK state in {j} iterations')
 
     def get_inference_results_dict(self, out_dict):
@@ -944,8 +944,8 @@ class SglangDisaggPD:
             raw stdout/stderr text produced by the benchmark on that node.
         """
         self.inference_results_dict = {}
-        print('Inside get_inference_results_dict')
-        print(out_dict)
+        log.info('Inside get_inference_results_dict')
+        log.info("%s", out_dict)
         for node in out_dict.keys():
             self.inference_results_dict[node] = {}
             if re.search('Successful requests:', out_dict[node], re.I):
@@ -1003,7 +1003,7 @@ class SglangDisaggPD:
                 match = re.search('P99 E2EL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
                 self.inference_results_dict[node]['p99_e2el_ms'] = match.group(1)
 
-        print(self.inference_results_dict)
+        log.info("%s", self.inference_results_dict)
         return self.inference_results_dict
 
     def scan_for_inference_errors(
@@ -1026,7 +1026,7 @@ class SglangDisaggPD:
         The method ensures that even if benchmarks complete, silent or
         non-fatal errors do not go unnoticed.
         """
-        print('Scan for inference errors')
+        log.info('Scan for inference errors')
         inference_pass = True
 
         # Build the list of commands to read each node's inference log file
@@ -1109,7 +1109,7 @@ class SglangDisaggPD:
         # Poll loop: periodically inspect benchmark logs for completion
         # ------------------------------------------------------------------
         for itr in range(1, iterations + 1):
-            print(f'Starting iteration {itr}')
+            log.info(f'Starting iteration {itr}')
 
             # --------------------------------------------------------------
             # Early exit if any inference errors are detected
@@ -1154,9 +1154,9 @@ class SglangDisaggPD:
             if not all_complete:
                 if timed_out():
                     msg = f"Timeout while waiting for inference completion after ~{int(time.time() - start_time)}s"
-                    print(msg)
+                    log.warning("%s", msg)
                     return {"status": "timeout", "reason": msg}
-                print('Inference still in progress')
+                log.info('Inference still in progress')
                 # Short progress wait before the longer inter-iteration sleep
                 time.sleep(30)
                 time.sleep(int(waittime_between_iters))
@@ -1168,7 +1168,7 @@ class SglangDisaggPD:
             # Parse benchmark results and return structured output.
             # --------------------------------------------------------------
             self.get_inference_results_dict(out_dict)
-            print('Completed Inference, returning !!!')
+            log.info('Completed Inference, returning !!!')
             return {"status": "success", "results": self.inference_results_dict}
 
             # If we reached here, it means poll for inference completion failed
@@ -1176,12 +1176,12 @@ class SglangDisaggPD:
         # If we exhaust the iteration cap without completing, treat as timeout (or in_progress if no wall-clock limit)
         if timed_out():
             msg = f"Timeout after maximum iterations ({self.inference_poll_iterations}) and ~{int(time.time() - start_time)}s"
-            print(msg)
+            log.warning("%s", msg)
             return {"status": "timeout", "reason": msg}
         else:
             # If no wall-clock timeout was set and we hit the iteration cap, report in-progress
             msg = f"Reached iteration cap ({self.inference_poll_iterations}) without completion; still in progress"
-            print(msg)
+            log.warning("%s", msg)
             return {"status": "stuck_in_progress", "reason": msg}
 
     def verify_inference_results(self, test_name, expected_result_dict):
@@ -1199,20 +1199,20 @@ class SglangDisaggPD:
 
         It acts as the final gate for inference validation.
         """
-        print('Verify Inference Completion Msg')
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
-        print(self.inference_results_dict)
-        print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info('Verify Inference Completion Msg')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info("%s", self.inference_results_dict)
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
         # ------------------------------------------------------------------
         # Validate metrics on a per-node basis
         # ------------------------------------------------------------------
         for node in self.inference_results_dict.keys():
-            print('%%%% node {}'.format(node))
+            log.info('%%%% node {}'.format(node))
             for metric_name in expected_result_dict.keys():
-                print('%%% metric_name {}'.format(metric_name))
+                log.info('%%% metric_name {}'.format(metric_name))
                 if metric_name in self.inference_results_dict[node].keys():
                     # latency metric, so actual should be lower than expected ..
-                    print('%% metric found in inference results ^^^')
+                    log.info('%% metric found in inference results ^^^')
                     # ------------------------------------------------------
                     # Latency metrics (e.g., TTFT, TPOT)
                     #
@@ -1220,8 +1220,8 @@ class SglangDisaggPD:
                     # Fail if actual latency exceeds expected threshold.
                     # ------------------------------------------------------
                     if re.search('ms', metric_name, re.I):
-                        print(self.inference_results_dict[node][metric_name])
-                        print(expected_result_dict[metric_name])
+                        log.info("%s", self.inference_results_dict[node][metric_name])
+                        log.info("%s", expected_result_dict[metric_name])
                         if float(self.inference_results_dict[node][metric_name]) > float(
                             expected_result_dict[metric_name]
                         ):
@@ -1258,4 +1258,4 @@ class SglangDisaggPD:
         verify_dmesg_for_errors(self.d_phdl, self.inference_start_time, self.inference_end_time)
         verify_dmesg_for_errors(self.r_phdl, self.inference_start_time, self.inference_end_time)
         verify_dmesg_for_errors(self.b_phdl, self.inference_start_time, self.inference_end_time)
-        print(self.inference_results_dict)
+        log.info("%s", self.inference_results_dict)

--- a/cvs/lib/unittests/test_html_lib.py
+++ b/cvs/lib/unittests/test_html_lib.py
@@ -1,9 +1,8 @@
+import logging
 import unittest
 import tempfile
 import os
 import json
-from io import StringIO
-from unittest.mock import patch
 
 # Import the module under test
 import cvs.lib.html_lib as html_lib
@@ -360,8 +359,7 @@ class TestBuildRcclHeatmapTable(unittest.TestCase):
             self.assertIn("245.5", content)
             self.assertIn("250.0", content)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_missing_keys_summary_not_spam(self, mock_stdout):
+    def test_missing_keys_summary_not_spam(self):
         """Test that missing keys show summary, not individual warnings."""
         actual_data = {
             "all_reduce_perf-float-8": {"1048576": {"bus_bw": "245.5", "alg_bw": "122.75", "time": "42.3"}},
@@ -376,19 +374,19 @@ class TestBuildRcclHeatmapTable(unittest.TestCase):
         self._create_json_file(self.actual_json_filename, actual_data)
         self._create_json_file(self.ref_json_filename, ref_data)
 
-        html_lib.build_rccl_heatmap_table(
-            self.html_filename, "Missing Keys Test", self.actual_json_filename, self.ref_json_filename
-        )
+        with self.assertLogs(html_lib.log, level=logging.WARNING) as log_cm:
+            html_lib.build_rccl_heatmap_table(
+                self.html_filename, "Missing Keys Test", self.actual_json_filename, self.ref_json_filename
+            )
 
-        output = mock_stdout.getvalue()
+        output = "\n".join(log_cm.output)
         # Should have summary message
         self.assertIn("2 test keys not found in reference data", output)
         self.assertIn("skipped from table", output)
         # Should show sample keys
         self.assertTrue("broadcast_perf-bfloat16-16" in output or "reduce_scatter_perf-float-4" in output)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_missing_message_sizes_summary(self, mock_stdout):
+    def test_missing_message_sizes_summary(self):
         """Test that missing message sizes are counted and summarized."""
         actual_data = {
             "all_reduce_perf-float-8": {
@@ -407,16 +405,16 @@ class TestBuildRcclHeatmapTable(unittest.TestCase):
         self._create_json_file(self.actual_json_filename, actual_data)
         self._create_json_file(self.ref_json_filename, ref_data)
 
-        html_lib.build_rccl_heatmap_table(
-            self.html_filename, "Missing Msg Sizes", self.actual_json_filename, self.ref_json_filename
-        )
+        with self.assertLogs(html_lib.log, level=logging.WARNING) as log_cm:
+            html_lib.build_rccl_heatmap_table(
+                self.html_filename, "Missing Msg Sizes", self.actual_json_filename, self.ref_json_filename
+            )
 
-        output = mock_stdout.getvalue()
+        output = "\n".join(log_cm.output)
         # Should show count of missing message sizes
         self.assertIn("2 msg_size entries not found in reference data", output)
 
-    @patch('sys.stdout', new_callable=StringIO)
-    def test_invalid_key_format_skipped(self, mock_stdout):
+    def test_invalid_key_format_skipped(self):
         """Test that keys with invalid format are skipped with warning."""
         actual_data = {
             "invalid-key": {  # Only 2 parts
@@ -431,11 +429,12 @@ class TestBuildRcclHeatmapTable(unittest.TestCase):
         self._create_json_file(self.actual_json_filename, actual_data)
         self._create_json_file(self.ref_json_filename, ref_data)
 
-        html_lib.build_rccl_heatmap_table(
-            self.html_filename, "Invalid Key Test", self.actual_json_filename, self.ref_json_filename
-        )
+        with self.assertLogs(html_lib.log, level=logging.WARNING) as log_cm:
+            html_lib.build_rccl_heatmap_table(
+                self.html_filename, "Invalid Key Test", self.actual_json_filename, self.ref_json_filename
+            )
 
-        output = mock_stdout.getvalue()
+        output = "\n".join(log_cm.output)
         # Should warn about invalid format
         self.assertIn("Invalid key format", output)
         self.assertIn("invalid-key", output)

--- a/cvs/lib/utils_lib.py
+++ b/cvs/lib/utils_lib.py
@@ -55,12 +55,12 @@ def update_test_result():
 
 
 def print_test_output(log, out_dict):
-    print('#========================================================#')
-    print('\t\t ** Test Output **')
-    print('#========================================================#')
+    log.info('#========================================================#')
+    log.info('\t\t ** Test Output **')
+    log.info('#========================================================#')
     for node in out_dict.keys():
-        print(f'==== {node} ====')
-        print(out_dict[node])
+        log.info(f'==== {node} ====')
+        log.info("%s", out_dict[node])
 
 
 def scan_test_results(out_dict):
@@ -114,17 +114,17 @@ def scan_test_results(out_dict):
                 before_words = words[max(0, target_word_index - word_count) : target_word_index]
                 # Get the words after the match
                 after_words = words[target_word_index + 1 : min(len(words), target_word_index + word_count + 1)]
-                print(f"Words before: {before_words}")
-                print(f"Words after: {after_words}")
-                print(f'Test failed in scan_result on node {host} due to pattern ')
+                log.error(f"Words before: {before_words}")
+                log.error(f"Words after: {after_words}")
+                log.error(f'Test failed in scan_result on node {host} due to pattern ')
             fail_test(
                 f'Test failed in scan_result on node {host} due to pattern {before_words} {actual_word} {after_words}'
             )
 
 
 def json_to_dict(json_string):
-    print('^^^^^^^^^')
-    print(json_string)
+    log.info('^^^^^^^^^')
+    log.info("%s", json_string)
     return json.loads(json_string)
 
 
@@ -160,7 +160,7 @@ def convert_phdl_json_to_dict(dict_json):
             # Parse the JSON content for this node
             out_dict[node] = json_to_dict(dict_json[node])
         except Exception:
-            print(f'ERROR converting Json output to dict for node {node}')
+            log.error(f'ERROR converting Json output to dict for node {node}')
             fail_test(f'ERROR converting Json output to dict for node {node}')
             out_dict[node] = {}
     return out_dict
@@ -235,10 +235,10 @@ def convert_hms_to_secs(time_string):
             total_seconds = (hours * 3600) + (minutes * 60) + seconds
             return total_seconds
         else:
-            print("Invalid time format. Please use 'hr:min:sec'.")
+            log.warning("Invalid time format. Please use 'hr:min:sec'.")
             return None
     except ValueError:
-        print("Invalid time format. Please ensure hours, minutes, and seconds are numeric.")
+        log.warning("Invalid time format. Please ensure hours, minutes, and seconds are numeric.")
         return None
 
 
@@ -284,7 +284,7 @@ def _resolve_placeholders_in_dict(target_dict, replacements, context_name=""):
             error_msg += "with an appropriate value before running the tests.\n"
             error_msg += f"{'=' * 70}\n"
 
-            log.error(error_msg)
+            log.error("%s", error_msg)
             # print(error_msg, file=sys.stderr)
             sys.exit(1)
 

--- a/cvs/lib/verify_lib.py
+++ b/cvs/lib/verify_lib.py
@@ -200,7 +200,7 @@ def verify_dmesg_for_errors(phdl, start_time_dict, end_time_dict, till_end_flag=
       - Consider handling cases where regex extraction fails (no match) to avoid attribute errors.
     """
 
-    print('scan dmesg')
+    log.info('scan dmesg')
 
     err_dict = {}
 
@@ -475,7 +475,7 @@ def full_dmesg_scan(
       - Consider adding case-insensitive filtering (e.g., grep -i) where appropriate.
     """
 
-    print('scan dmesg')
+    log.info('scan dmesg')
 
     err_dict = {}
 
@@ -529,7 +529,7 @@ def verify_driver_errors(phdl):
         aggregate matches and report them collectively before failing.
     """
 
-    print('Scan for AMD GPU driver errors')
+    log.info('Scan for AMD GPU driver errors')
 
     err_dict = {}
     # Collect AMDGPU-related kernel messages filtered for likely error terms
@@ -674,7 +674,7 @@ def compare_cluster_metrics_snapshots(s_dict_before, s_dict_after):
       - All diff values for matched stats are numeric or numeric strings (castable to int).
     """
 
-    print('Compare 2 cluster snapshots')
+    log.info('Compare 2 cluster snapshots')
     # err_dict will capture the ERROR, WARN log messages at a node level which have seen
     # increment in values for any error or warning counters. The same can be obtained
     # from the complete test log by doing a grep on ERROR|WARN and snapshot
@@ -704,8 +704,7 @@ def compare_cluster_metrics_snapshots(s_dict_before, s_dict_after):
                     if re.search(f'{warn_stats_pattern}', stat_nam, re.I):
                         if int(diff_dict[key_nam][node][dev_nam][stat_nam]) > 0:
                             msg = f'WARN !! cluster snapshot showing some warning counters going up - {key_nam} {node} {dev_nam} {stat_nam} have incremented by {diff_dict[key_nam][node][dev_nam][stat_nam]} Before = {s_dict_before[key_nam][node][dev_nam][stat_nam]} After = {s_dict_after[key_nam][node][dev_nam][stat_nam]}'
-                            log.warn(msg)
-                            print(msg)
+                            log.warning("%s", msg)
                             err_dict[key_nam][node].append(msg)
                         err_stats_diff_dict[key_nam][node][dev_nam][stat_nam] = {}
                         err_stats_diff_dict[key_nam][node][dev_nam][stat_nam]['before'] = s_dict_before[key_nam][node][
@@ -722,8 +721,7 @@ def compare_cluster_metrics_snapshots(s_dict_before, s_dict_after):
                     elif re.search(f'{err_stats_pattern}', stat_nam, re.I):
                         if int(diff_dict[key_nam][node][dev_nam][stat_nam]) > 0:
                             msg = f'ERROR !! cluster snapshot showing some error counters going up - {key_nam} {node} {dev_nam} {stat_nam} have incremented by {diff_dict[key_nam][node][dev_nam][stat_nam]} Before = {s_dict_before[key_nam][node][dev_nam][stat_nam]} After = {s_dict_after[key_nam][node][dev_nam][stat_nam]}'
-                            log.error(msg)
-                            print(msg)
+                            log.error("%s", msg)
                             err_dict[key_nam][node].append(msg)
                         err_stats_diff_dict[key_nam][node][dev_nam][stat_nam] = {}
                         err_stats_diff_dict[key_nam][node][dev_nam][stat_nam]['before'] = s_dict_before[key_nam][node][
@@ -740,8 +738,7 @@ def compare_cluster_metrics_snapshots(s_dict_before, s_dict_after):
                     elif re.search(f'{threshold_stats_pattern}', stat_nam, re.I):
                         if int(diff_dict[key_nam][node][dev_nam][stat_nam]) > threshold_counter_val:
                             msg = f'WARN !! cluster snapshot showing some threshold warn counters going up - {key_nam} {node} {dev_nam} {stat_nam} have incremented by {diff_dict[key_nam][node][dev_nam][stat_nam]} Before = {s_dict_before[key_nam][node][dev_nam][stat_nam]} After = {s_dict_after[key_nam][node][dev_nam][stat_nam]}'
-                            log.warn(msg)
-                            print(msg)
+                            log.warning("%s", msg)
                             err_dict[key_nam][node].append(msg)
                         err_stats_diff_dict[key_nam][node][dev_nam][stat_nam] = {}
                         err_stats_diff_dict[key_nam][node][dev_nam][stat_nam]['before'] = s_dict_before[key_nam][node][
@@ -754,5 +751,5 @@ def compare_cluster_metrics_snapshots(s_dict_before, s_dict_after):
                             err_stats_diff_dict[key_nam][node][dev_nam][stat_nam]['after']
                         ) - int(err_stats_diff_dict[key_nam][node][dev_nam][stat_nam]['before'])
 
-    print('Completed comparing the cluster snapshots')
+    log.info('Completed comparing the cluster snapshots')
     return err_dict, err_stats_diff_dict

--- a/cvs/monitors/cluster-mon/backend/app/core/config.py
+++ b/cvs/monitors/cluster-mon/backend/app/core/config.py
@@ -2,11 +2,15 @@
 Configuration management for GPU cluster monitor.
 """
 
-from pydantic_settings import BaseSettings
-from pydantic import Field
-from typing import Optional, List
-import yaml
+import logging
 from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+logger = logging.getLogger(__name__)
 
 
 class JumpHostConfig(BaseSettings):
@@ -160,15 +164,15 @@ try:
     yaml_path = Path("../config/cluster.yaml").resolve()
 
     if yaml_path.exists():
-        print(f"Loading configuration from: {yaml_path}")
+        logger.info(f"Loading configuration from: {yaml_path}")
         settings = Settings.load_from_yaml(str(yaml_path))
-        print(f"Jump host enabled: {settings.ssh.jump_host.enabled}")
-        print(f"Jump host: {settings.ssh.jump_host.host}")
+        logger.info(f"Jump host enabled: {settings.ssh.jump_host.enabled}")
+        logger.info(f"Jump host: {settings.ssh.jump_host.host}")
     else:
-        print(f"YAML file not found at: {yaml_path}, using defaults")
+        logger.warning(f"YAML file not found at: {yaml_path}, using defaults")
         settings = Settings()
 except Exception as e:
-    print(f"Error loading YAML config: {e}")
+    logger.error(f"Error loading YAML config: {e}")
     import traceback
 
     traceback.print_exc()

--- a/cvs/monitors/cluster-mon/backend/app/core/cvs_parallel_ssh_reliable.py
+++ b/cvs/monitors/cluster-mon/backend/app/core/cvs_parallel_ssh_reliable.py
@@ -78,9 +78,9 @@ class Pssh:
 
         # Add authentication
         if self.password is None:
-            print(self.reachable_hosts)
-            print(self.user)
-            print(self.pkey)
+            logger.info(self.reachable_hosts)
+            logger.info(self.user)
+            logger.info(self.pkey)
             client_params['pkey'] = self.pkey
         else:
             client_params['password'] = self.password
@@ -234,7 +234,7 @@ class Pssh:
         Handle connection failures during command execution.
         Re-probes all hosts and recreates client if reachability changed.
         """
-        logger.info("Handling connection failure - re-probing hosts...")
+        logger.warning("Handling connection failure - re-probing hosts...")
         changed = self.refresh_host_reachability()
 
         if changed:
@@ -258,7 +258,7 @@ class Pssh:
         ]
         unreachable = self.check_connectivity(failed_hosts)
         for host in unreachable:
-            print(f"Host {host} is unreachable, pruning from reachable hosts list.")
+            logger.info(f"Host {host} is unreachable, pruning from reachable hosts list.")
             self.unreachable_hosts.append(host)
             self.reachable_hosts.remove(host)
         if len(self.unreachable_hosts) > initial_unreachable_len:
@@ -296,22 +296,22 @@ class Pssh:
         cmd_output = {}
         i = 0
         for item in output:
-            print('#----------------------------------------------------------#')
-            print(f'Host == {item.host} ==')
-            print('#----------------------------------------------------------#')
+            logger.info('#----------------------------------------------------------#')
+            logger.info(f'Host == {item.host} ==')
+            logger.info('#----------------------------------------------------------#')
             cmd_out_str = ''
             if cmd_list:
-                print(cmd_list[i])
+                logger.debug(cmd_list[i])
             else:
-                print(cmd)
+                logger.debug(cmd)
             try:
                 for line in item.stdout or []:
                     if print_console:
-                        print(line)
+                        logger.info(line)
                     cmd_out_str += line.replace('\t', '   ') + '\n'
                 for line in item.stderr or []:
                     if print_console:
-                        print(line)
+                        logger.info(line)
                     cmd_out_str += line.replace('\t', '   ') + '\n'
             except Timeout as e:
                 if not self.stop_on_errors:
@@ -323,7 +323,7 @@ class Pssh:
                 exc_str = exc_str.replace('\t', '   ')
                 if isinstance(item.exception, Timeout):
                     exc_str += "\nABORT: Timeout Error in Host: " + item.host
-                print(exc_str)
+                logger.info(exc_str)
                 cmd_out_str += exc_str + '\n'
             if cmd_list:
                 i += 1
@@ -380,7 +380,7 @@ class Pssh:
             logger.info(f"  Timeout: {timeout if timeout else 'default'}")
             logger.info(f"  Stop on errors: {self.stop_on_errors}")
 
-            print(f'cmd = {cmd}')
+            logger.info(f'cmd = {cmd}')
 
             try:
                 if timeout is None:
@@ -409,7 +409,7 @@ class Pssh:
         which runs the same command on all hosts.
         Returns a dictionary of host as key and command output as values
         """
-        print(cmd_list)
+        logger.info(cmd_list)
         if timeout is None:
             output = self.client.run_command('%s', host_args=cmd_list, stop_on_errors=self.stop_on_errors)
         else:
@@ -420,7 +420,7 @@ class Pssh:
         return cmd_output
 
     def scp_file(self, local_file, remote_file, recurse=False):
-        print('About to copy local file {} to remote {} on all Hosts'.format(local_file, remote_file))
+        logger.info('About to copy local file {} to remote {} on all Hosts'.format(local_file, remote_file))
         cmds = self.client.copy_file(local_file, remote_file, recurse=recurse)
         self.client.pool.join()
         for cmd in cmds:
@@ -439,11 +439,11 @@ class Pssh:
         return self.unreachable_hosts.copy()
 
     def reboot_connections(self):
-        print('Rebooting Connections')
+        logger.info('Rebooting Connections')
         self.client.run_command('reboot -f', stop_on_errors=self.stop_on_errors)
 
     def destroy_clients(self):
-        print('Destroying Current phdl connections ..')
+        logger.info('Destroying Current phdl connections ..')
         if self.client:
             del self.client
 

--- a/cvs/monitors/cluster-mon/backend/app/core/jump_host_pssh.py
+++ b/cvs/monitors/cluster-mon/backend/app/core/jump_host_pssh.py
@@ -379,7 +379,7 @@ class JumpHostPssh:
         Handle connection failures during command execution.
         Re-probes all hosts via jump host.
         """
-        logger.info("Handling connection failure - re-probing hosts via jump host...")
+        logger.warning("Handling connection failure - re-probing hosts via jump host...")
         changed = self.refresh_host_reachability()
 
         if changed:

--- a/cvs/monitors/cluster-mon/backend/app/core/simple_config.py
+++ b/cvs/monitors/cluster-mon/backend/app/core/simple_config.py
@@ -3,9 +3,13 @@ Simplified configuration loader - reads directly from YAML.
 Avoids Pydantic BaseSettings nested model issues.
 """
 
-import yaml
+import logging
 from pathlib import Path
 from typing import List, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
 
 
 class SimpleConfig:
@@ -33,7 +37,7 @@ class SimpleConfig:
                 data = yaml.safe_load(f)
                 self.config_data = data.get("cluster", {})
         else:
-            print(f"Warning: Config file not found at {self.yaml_path}")
+            logger.warning(f"Warning: Config file not found at {self.yaml_path}")
             self.config_data = {}
 
     def get_nodes_file(self) -> str:

--- a/cvs/parsers/pytorch_xdit_flux.py
+++ b/cvs/parsers/pytorch_xdit_flux.py
@@ -242,12 +242,12 @@ class FluxOutputParser:
                 f"PASS: Average pipe_time {result.avg_pipe_time_s:.2f}s <= "
                 f"threshold {max_avg_time:.2f}s (GPU: {gpu_type})"
             )
-            log.info(message)
+            log.info("%s", message)
             return True, message
         else:
             message = (
                 f"FAIL: Average pipe_time {result.avg_pipe_time_s:.2f}s > "
                 f"threshold {max_avg_time:.2f}s (GPU: {gpu_type})"
             )
-            log.error(message)
+            log.error("%s", message)
             return False, message

--- a/cvs/parsers/pytorch_xdit_wan.py
+++ b/cvs/parsers/pytorch_xdit_wan.py
@@ -374,12 +374,12 @@ class WanOutputParser:
                 f"PASS: Average total_time {result.avg_total_time_s:.2f}s <= "
                 f"threshold {max_avg_time:.2f}s (GPU: {gpu_type})"
             )
-            log.info(message)
+            log.info("%s", message)
             return True, message
         else:
             message = (
                 f"FAIL: Average total_time {result.avg_total_time_s:.2f}s > "
                 f"threshold {max_avg_time:.2f}s (GPU: {gpu_type})"
             )
-            log.error(message)
+            log.error("%s", message)
             return False, message

--- a/cvs/runners/aorta.py
+++ b/cvs/runners/aorta.py
@@ -691,7 +691,7 @@ class AortaRunner(BaseRunner):
                     artifacts["tracelens_analysis"] = analysis_result
                     log.info(f"Container TraceLens analysis completed: {analysis_result}")
                 else:
-                    log.info("Container TraceLens skipped or failed; host will parse raw traces")
+                    log.warning("Container TraceLens skipped or failed; host will parse raw traces")
 
             # Run GEMM analysis if enabled (optional, same as TraceLens)
             if self.config.analysis.enable_gemm_analysis and trace_dir and trace_dir.exists():

--- a/cvs/tests/benchmark/test_aorta.py
+++ b/cvs/tests/benchmark/test_aorta.py
@@ -309,7 +309,7 @@ class TestAortaBenchmark:
 
         # Log warnings (for all statuses)
         for warning in parse_result.warnings:
-            log.warning(warning)
+            log.warning("%s", warning)
 
         log.info(f"Parsed {len(parse_result.results)} rank metrics")
 

--- a/cvs/tests/health/agfhc_cvs.py
+++ b/cvs/tests/health/agfhc_cvs.py
@@ -66,7 +66,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -85,7 +85,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -118,7 +118,7 @@ def phdl(cluster_dict):
     Returns:
     Pssh: A handle to execute commands across all nodes.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(

--- a/cvs/tests/health/csp_qual_agfhc.py
+++ b/cvs/tests/health/csp_qual_agfhc.py
@@ -68,7 +68,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -87,7 +87,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -127,7 +127,7 @@ def get_log_results(phdl, out_dict):
         pattern = '"total_failed":\s+0,'
         if not re.search(pattern, res_dict[node], re.I):
             fail_test(f'Total failed tests in results.json is not zero on node {node}')
-            print('Dumping journal log from all nodes for reference')
+            log.info('Dumping journal log from all nodes for reference')
             phdl.exec_cmd_list(jrl_cmd_list)
             phdl.exec_cmd_list(err_cmd_list)
 
@@ -141,7 +141,7 @@ def phdl(cluster_dict):
     Returns:
     Pssh: A handle to execute commands across all nodes.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -164,7 +164,7 @@ def test_version_check(phdl, config_dict):
         time.sleep(2)
         phdl.exec(f'sudo mkdir {log_dir}')
     except Exception:
-        print(f'Error creating log directory {log_dir}')
+        log.error(f'Error creating log directory {log_dir}')
     out_dict = phdl.exec(f'sudo ls -ld {log_dir}')
     for node in out_dict.keys():
         if re.search('no such', out_dict[node], re.I):

--- a/cvs/tests/health/install/install_agfhc.py
+++ b/cvs/tests/health/install/install_agfhc.py
@@ -68,7 +68,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -87,7 +87,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -122,7 +122,7 @@ def phdl(cluster_dict):
     Returns:
     Pssh: A handle to execute commands across all nodes.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -158,10 +158,10 @@ def test_install_agfhc(
     # Check if install directory exists, otherwise create.
     out_dict = phdl.exec(f'ls -ld {install_dir}')
     for node in out_dict.keys():
-        print(f'node ip {node}')
-        print(out_dict[node])
+        log.info(f'node ip {node}')
+        log.info("%s", out_dict[node])
         if re.search('No such file or directory', out_dict[node], re.I):
-            print(f'Install directory {install_dir} does not exist, creating')
+            log.info(f'Install directory {install_dir} does not exist, creating')
             hdl.exec(f'mkdir -p {install_dir}')
 
     # Copy the package to the install directory and untar
@@ -175,16 +175,16 @@ def test_install_agfhc(
     try:
         out_dict = hdl.exec(f'cd {install_dir};sudo ./install', timeout=90)
         for node in out_dict.keys():
-            print(out_dict[node])
+            log.info("%s", out_dict[node])
             if re.search('Error|No such file', out_dict[node], re.I):
                 fail_test(f'Installation of AGFHC failed on node {node}')
     except Exception as e:
-        print(f'Install of AGFHC failed, hit exception {e}')
+        log.error(f'Install of AGFHC failed, hit exception {e}')
 
     # verify agfhc path exists after installation ..
     out_dict = phdl.exec(f'ls -l {config_dict["path"]}/agfhc')
     for node in out_dict.keys():
-        print(out_dict[node])
+        log.info("%s", out_dict[node])
         if re.search('No such file', out_dict[node], re.I):
             fail_test(f'Installation of AGFHC failed on node {node}')
     update_test_result()

--- a/cvs/tests/health/install/install_babelstream.py
+++ b/cvs/tests/health/install/install_babelstream.py
@@ -70,7 +70,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -96,7 +96,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -137,7 +137,7 @@ def phdl(cluster_dict):
       Pssh: A handle that runs commands in parallel and returns a dict of node -> output.
 
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -173,7 +173,7 @@ def test_install_babelstream(phdl, shdl, config_dict):
     path = config_dict['path']
     git_install_path = config_dict['git_install_path']
     git_url = config_dict['git_url']
-    print(git_install_path)
+    log.info("%s", git_install_path)
     if config_dict['nfs_install'] is True:
         hdl = shdl
     else:

--- a/cvs/tests/health/install/install_rocblas.py
+++ b/cvs/tests/health/install/install_rocblas.py
@@ -67,7 +67,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -91,7 +91,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -132,7 +132,7 @@ def phdl(cluster_dict):
       Pssh: A handle that executes commands across all nodes and returns dict[node] -> output.
 
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -167,7 +167,7 @@ def test_rocblas_install(
     """
 
     globals.error_list = []
-    print('Testcase install rocblas')
+    log.info('Testcase install rocblas')
 
     if config_dict['nfs_install'] is True:
         hdl = shdl

--- a/cvs/tests/health/install/install_rvs.py
+++ b/cvs/tests/health/install/install_rvs.py
@@ -141,7 +141,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -163,7 +163,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -204,7 +204,7 @@ def phdl(cluster_dict):
     Returns:
       Pssh: Handle that executes commands on all nodes and returns dict[node] -> output.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -293,7 +293,7 @@ def test_install_rvs(phdl, shdl, config_dict):
 
     # If RVS is not found or configs are missing, install it
     if not rvs_found or not config_found:
-        log.info('RVS not found, attempting to install from artifactory repo first')
+        log.warning('RVS not found, attempting to install from artifactory repo first')
 
         # First try to install from artifactory repo
         package_installed = False
@@ -311,7 +311,7 @@ def test_install_rvs(phdl, shdl, config_dict):
                 out_dict[node],
                 re.I,
             ):
-                log.info(f'RVS package installation failed on node {node}, will try building from source')
+                log.warning(f'RVS package installation failed on node {node}, will try building from source')
             else:
                 log.info(f'RVS package installation successful on node {node}')
                 package_installed = True
@@ -341,7 +341,7 @@ def test_install_rvs(phdl, shdl, config_dict):
                         rocm_path = actual_rocm
                     break
             if not rvs_bin_found:
-                log.info('RVS binary not found after package install, falling back to source build')
+                log.warning('RVS binary not found after package install, falling back to source build')
                 package_installed = False
 
         # If package installation failed, build from source

--- a/cvs/tests/health/install/install_transferbench.py
+++ b/cvs/tests/health/install/install_transferbench.py
@@ -143,7 +143,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -166,7 +166,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -209,7 +209,7 @@ def phdl(cluster_dict):
       Pssh: Handle that executes commands on all nodes and returns dict[node] -> output.
 
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/health/rvs_cvs.py
+++ b/cvs/tests/health/rvs_cvs.py
@@ -40,7 +40,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -53,13 +53,13 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
 @pytest.fixture(scope="module")
 def phdl(cluster_dict):
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(

--- a/cvs/tests/health/transferbench_cvs.py
+++ b/cvs/tests/health/transferbench_cvs.py
@@ -39,7 +39,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -52,7 +52,7 @@ def config_dict(config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
 
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -111,7 +111,7 @@ def detect_rocm_path(phdl, config_rocm_path):
 
 def parse_tb_a2a_bw(out_dict, exp_dict):
     for node in out_dict.keys():
-        print(exp_dict)
+        log.info("%s", exp_dict)
         rtotal_list = re.findall(
             r'(?:│\s+)?RTotal\s+(?:│\s+)?([0-9\.]+)\s+([0-9\.]+)\s+([0-9\.]+)\s+([0-9\.]+)\s+([0-9\.]+)\s+([0-9\.]+)\s+([0-9\.]+)\s+([0-9\.]+)\s*',
             out_dict[node],
@@ -148,7 +148,7 @@ def parse_tb_p2p_bw(out_dict, exp_dict):
 
 def parse_tb_scaling_bw(out_dict, exp_dict):
     for node in out_dict.keys():
-        print(f"^^^^^ {out_dict[node]} ^^^^^^")
+        log.info(f"^^^^^ {out_dict[node]} ^^^^^^")
         match = re.search('Best\s+[0-9\.]+\(\s[0-9]+\)\s+[0-9\.]+\(\s[0-9]+\)\s+([0-9\.]+)', out_dict[node])
         gpu0_bw = float(match.group(1))
         if float(gpu0_bw) < float(exp_dict['best_gpu0_bw']):
@@ -303,7 +303,7 @@ def parse_tb_example_test_results(out_dict, exp_dict):
 
 @pytest.fixture(scope="module")
 def phdl(cluster_dict):
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -315,7 +315,7 @@ def test_transfer_bench_example_tests_1_6_t(phdl, config_dict):
     log.info('Testcase Run TransferBench example tests 1-6')
     path = config_dict['path']
     rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    print(config_dict)
+    log.info("%s", config_dict)
     example_path = config_dict['example_tests_path']
     out_dict = phdl.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench {example_path}/example.cfg'",

--- a/cvs/tests/ibperf/ib_perf_bw_test.py
+++ b/cvs/tests/ibperf/ib_perf_bw_test.py
@@ -86,7 +86,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -108,7 +108,7 @@ def config_dict(config_file, cluster_dict):
 
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -132,7 +132,7 @@ def phdl(cluster_dict):
       - nhdl_dict is currently unused; it can be removed unless used elsewhere.
       - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
 
@@ -217,7 +217,7 @@ def test_ib_bw_perf(phdl, bw_test, config_dict):
     gpu_nic_dict = linux_utils.get_gpu_nic_mapping_dict(phdl)
     gpu_numa_dict = linux_utils.get_gpu_numa_dict(phdl)
 
-    print(gpu_nic_dict)
+    log.info("%s", gpu_nic_dict)
     bck_nic_dict_lshw = linux_utils.get_backend_nic_dict(phdl)
     rdma_nic_dict = linux_utils.get_active_rdma_nic_dict(phdl)
 
@@ -225,7 +225,7 @@ def test_ib_bw_perf(phdl, bw_test, config_dict):
     for node in rdma_nic_dict.keys():
         bck_nic_dict[node] = {}
         for rdma_dev in rdma_nic_dict[node].keys():
-            print(bck_nic_dict_lshw[node])
+            log.info("%s", bck_nic_dict_lshw[node])
             if rdma_nic_dict[node][rdma_dev]['eth_device'] in bck_nic_dict_lshw[node]:
                 bck_nic_dict[node][rdma_dev] = rdma_nic_dict[node][rdma_dev]
 
@@ -261,8 +261,8 @@ def test_ib_bw_perf(phdl, bw_test, config_dict):
                     config_dict['expected_results'],
                 )
 
-    print('%%%%%%%%% ib_bw_dict %%%%%%%%%%')
-    print(ib_bw_dict)
+    log.info('%%%%%%%%% ib_bw_dict %%%%%%%%%%')
+    log.info("%s", ib_bw_dict)
     update_test_result()
 
 
@@ -281,13 +281,13 @@ def test_ib_lat_perf(phdl, lat_test, config_dict):
     for node in rdma_nic_dict.keys():
         bck_nic_dict[node] = {}
         for rdma_dev in rdma_nic_dict[node].keys():
-            print(bck_nic_dict_lshw[node])
+            log.info("%s", bck_nic_dict_lshw[node])
             if rdma_nic_dict[node][rdma_dev]['eth_device'] in bck_nic_dict_lshw[node]:
                 bck_nic_dict[node][rdma_dev] = rdma_nic_dict[node][rdma_dev]
 
-    print(f'%%%%%% bck_nic_dict %%%%% {bck_nic_dict}')
-    print(f'%%%%%% gpu_nic_dict %%%%% {gpu_nic_dict}')
-    print(f'%%%%%% gpu_numa_dict %%%%% {gpu_numa_dict}')
+    log.info(f'%%%%%% bck_nic_dict %%%%% {bck_nic_dict}')
+    log.info(f'%%%%%% gpu_nic_dict %%%%% {gpu_nic_dict}')
+    log.info(f'%%%%%% gpu_numa_dict %%%%% {gpu_numa_dict}')
 
     rocm_path = ibperf_lib.detect_rocm_path(phdl, config_dict.get('rocm_dir', ''))
     for msg_size in config_dict['msg_size_list']:
@@ -314,8 +314,8 @@ def test_ib_lat_perf(phdl, lat_test, config_dict):
                 lat_test, msg_size, ib_lat_dict[lat_test][msg_size], config_dict['expected_results']
             )
 
-    print('%%%%%%%%%%% ib_lat_dict %%%%%%%%%')
-    print(ib_lat_dict)
+    log.info('%%%%%%%%%%% ib_lat_dict %%%%%%%%%')
+    log.info("%s", ib_lat_dict)
     update_test_result()
 
 

--- a/cvs/tests/ibperf/install_ibperf_tools.py
+++ b/cvs/tests/ibperf/install_ibperf_tools.py
@@ -84,7 +84,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -106,7 +106,7 @@ def config_dict(config_file, cluster_dict):
 
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -130,7 +130,7 @@ def phdl(cluster_dict):
       - nhdl_dict is currently unused; it can be removed unless used elsewhere.
       - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     if len(node_list) < 2:

--- a/cvs/tests/inference/inferencemax/inferencemax_gpt_oss_120b_single.py
+++ b/cvs/tests/inference/inferencemax/inferencemax_gpt_oss_120b_single.py
@@ -77,7 +77,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -101,7 +101,7 @@ def benchmark_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
 
-    log.info(benchmark_params_dict)
+    log.info("%s", benchmark_params_dict)
     return benchmark_params_dict
 
 
@@ -126,9 +126,9 @@ def hf_token(inference_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -153,7 +153,7 @@ def s_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -181,7 +181,7 @@ def c_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -204,8 +204,8 @@ def gpu_type(s_phdl, cluster_dict):
       - Consider validating this value against an expected set of GPU types to catch typos early.
     """
 
-    print(s_phdl)
-    print(dir(s_phdl))
+    log.info("%s", s_phdl)
+    log.info("%s", list(dir(s_phdl)))
     head_node = s_phdl.host_list[0]
     smi_out_dict = s_phdl.exec('rocm-smi -a | head -30')
     smi_out = smi_out_dict[head_node]
@@ -266,7 +266,7 @@ def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_di
     )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     out_dict = s_phdl.exec('docker ps')
     for node in out_dict.keys():
         if not re.search(f'{container_name}', out_dict[node], re.I):

--- a/cvs/tests/inference/pytorch_xdit/pytorch_xdit_flux1_dev_single.py
+++ b/cvs/tests/inference/pytorch_xdit/pytorch_xdit_flux1_dev_single.py
@@ -131,8 +131,8 @@ class LocalPssh:
         )
         out = (completed.stdout or "") + (completed.stderr or "")
         if print_console:
-            print(f"cmd = {_redact_secrets(cmd)}")
-            print(out)
+            log.info(f"cmd = {_redact_secrets(cmd)}")
+            log.info("%s", out)
         return {self.host_list[0]: out}
 
     def exec_cmd_list(self, cmd_list, timeout=None, print_console=True):
@@ -148,8 +148,8 @@ class LocalPssh:
             )
             out_str = (completed.stdout or "") + (completed.stderr or "")
             if print_console:
-                print(f"cmd = {_redact_secrets(cmd)}")
-                print(out_str)
+                log.info(f"cmd = {_redact_secrets(cmd)}")
+                log.info("%s", out_str)
             out[host] = out_str
         return out
 
@@ -192,7 +192,7 @@ def cluster_dict(cluster_file):
         log.error(f"Cluster config validation failed: {e}")
         pytest.fail(f"Invalid cluster configuration: {e}")
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 

--- a/cvs/tests/inference/pytorch_xdit/pytorch_xdit_wan22_14b_single.py
+++ b/cvs/tests/inference/pytorch_xdit/pytorch_xdit_wan22_14b_single.py
@@ -97,8 +97,8 @@ class LocalPssh:
         )
         out = (completed.stdout or "") + (completed.stderr or "")
         if print_console:
-            print(f"cmd = {_redact_secrets(cmd)}")
-            print(out)
+            log.info(f"cmd = {_redact_secrets(cmd)}")
+            log.info("%s", out)
         return {self.host_list[0]: out}
 
     def exec_cmd_list(self, cmd_list, timeout=None, print_console=True):
@@ -114,8 +114,8 @@ class LocalPssh:
             )
             out_str = (completed.stdout or "") + (completed.stderr or "")
             if print_console:
-                print(f"cmd = {_redact_secrets(cmd)}")
-                print(out_str)
+                log.info(f"cmd = {_redact_secrets(cmd)}")
+                log.info("%s", out_str)
             out[host] = out_str
         return out
 
@@ -171,7 +171,7 @@ def cluster_dict(cluster_file):
         log.error(f"Cluster config validation failed: {e}")
         pytest.fail(f"Invalid cluster configuration: {e}")
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -634,7 +634,7 @@ def test_parse_and_validate_results(s_phdl, inference_dict, benchmark_params_dic
         overall_result = type("Tmp", (), {"avg_total_time_s": agg.overall_avg_total_time_s})()
         parser = WanOutputParser(output_dir, expected_artifact="video.mp4")  # only used for threshold selection
         passed, message = parser.validate_threshold(overall_result, expected_results, gpu_type)
-        log.info(message)
+        log.info("%s", message)
         if not passed:
             fail_test(message)
         update_test_result()
@@ -664,7 +664,7 @@ def test_parse_and_validate_results(s_phdl, inference_dict, benchmark_params_dic
     log.info(f"  Step times: {[f'{t:.2f}' for t in result.step_times]}")
 
     passed, message = parser.validate_threshold(result, expected_results, gpu_type)
-    log.info(message)
+    log.info("%s", message)
     if not passed:
         fail_test(message)
     update_test_result()

--- a/cvs/tests/inference/sglang/sglang_deepseek_r1_671b_distributed.py
+++ b/cvs/tests/inference/sglang/sglang_deepseek_r1_671b_distributed.py
@@ -77,7 +77,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -101,7 +101,7 @@ def benchmark_params_dict(inference_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
 
-    log.info(benchmark_params_dict)
+    log.info("%s", benchmark_params_dict)
     return benchmark_params_dict
 
 
@@ -126,15 +126,15 @@ def hf_token(inference_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
 @pytest.fixture(scope="module")
 def p_phdl(cluster_dict, inference_dict):
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     p_phdl = Pssh(
         log,
@@ -193,7 +193,7 @@ def gpu_type(p_phdl, cluster_dict):
       - Consider validating this value against an expected set of GPU types to catch typos early.
     """
 
-    print(p_phdl)
+    log.info("%s", p_phdl)
     head_node = p_phdl.host_list[0]
     smi_out_dict = p_phdl.exec('rocm-smi -a | head -30')
     smi_out = smi_out_dict[head_node]
@@ -217,7 +217,7 @@ def test_cleanup_stale_containers(p_phdl, d_phdl, r_phdl, b_phdl, inference_dict
         docker_lib.delete_all_containers_and_volumes(a_phdl)
 
     # Cleanup log directory from one of the nodes
-    print('Cleaning up log directory')
+    log.info('Cleaning up log directory')
     r_phdl.exec(f"sudo rm -rf {inference_dict['log_dir']}")
     time.sleep(5)
 
@@ -234,20 +234,20 @@ def test_launch_inference_containers(p_phdl, d_phdl, r_phdl, b_phdl, inference_d
         if (inference_dict['proxy_router_node'] in inference_dict['prefill_node_list']) or (
             inference_dict['proxy_router_node'] in inference_dict['decode_node_list']
         ):
-            print('Already part of the handle list, no need to add')
+            log.info('Already part of the handle list, no need to add')
         else:
             hdl_list.extend(r_phdl)
     else:
         if (inference_dict['proxy_router_node'] in inference_dict['prefill_node_list']) or (
             inference_dict['proxy_router_node'] in inference_dict['decode_node_list']
         ):
-            print('Already part of the handle list, no need to add')
+            log.info('Already part of the handle list, no need to add')
         else:
             hdl_list.extend(r_phdl)
         if (inference_dict['benchmark_serv_node'] in inference_dict['prefill_node_list']) or (
             inference_dict['benchmark_serv_node'] in inference_dict['decode_node_list']
         ):
-            print('Already part of the handle list, no need to add')
+            log.info('Already part of the handle list, no need to add')
         else:
             hdl_list.extend(b_phdl)
 
@@ -264,7 +264,7 @@ def test_launch_inference_containers(p_phdl, d_phdl, r_phdl, b_phdl, inference_d
         )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     for a_phdl in [p_phdl, d_phdl, r_phdl, b_phdl]:
         out_dict = a_phdl.exec('docker ps')
         for node in out_dict.keys():

--- a/cvs/tests/inference/sglang/sglang_llama_70b_distributed.py
+++ b/cvs/tests/inference/sglang/sglang_llama_70b_distributed.py
@@ -77,7 +77,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -101,7 +101,7 @@ def benchmark_params_dict(inference_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
 
-    log.info(benchmark_params_dict)
+    log.info("%s", benchmark_params_dict)
     return benchmark_params_dict
 
 
@@ -126,15 +126,15 @@ def hf_token(inference_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
 @pytest.fixture(scope="module")
 def p_phdl(cluster_dict, inference_dict):
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     p_phdl = Pssh(
         log,
@@ -193,7 +193,7 @@ def gpu_type(p_phdl, cluster_dict):
       - Consider validating this value against an expected set of GPU types to catch typos early.
     """
 
-    print(p_phdl)
+    log.info("%s", p_phdl)
     head_node = p_phdl.host_list[0]
     smi_out_dict = p_phdl.exec('rocm-smi -a | head -30')
     smi_out = smi_out_dict[head_node]
@@ -217,7 +217,7 @@ def test_cleanup_stale_containers(p_phdl, d_phdl, r_phdl, b_phdl, inference_dict
         docker_lib.delete_all_containers_and_volumes(a_phdl)
 
     # Cleanup log directory from one of the nodes
-    print('Cleaning up log directory')
+    log.info('Cleaning up log directory')
     r_phdl.exec(f"sudo rm -rf {inference_dict['log_dir']}")
     time.sleep(5)
 
@@ -234,20 +234,20 @@ def test_launch_inference_containers(p_phdl, d_phdl, r_phdl, b_phdl, inference_d
         if (inference_dict['proxy_router_node'] in inference_dict['prefill_node_list']) or (
             inference_dict['proxy_router_node'] in inference_dict['decode_node_list']
         ):
-            print('Already part of the handle list, no need to add')
+            log.info('Already part of the handle list, no need to add')
         else:
             hdl_list.extend(r_phdl)
     else:
         if (inference_dict['proxy_router_node'] in inference_dict['prefill_node_list']) or (
             inference_dict['proxy_router_node'] in inference_dict['decode_node_list']
         ):
-            print('Already part of the handle list, no need to add')
+            log.info('Already part of the handle list, no need to add')
         else:
             hdl_list.extend(r_phdl)
         if (inference_dict['benchmark_serv_node'] in inference_dict['prefill_node_list']) or (
             inference_dict['benchmark_serv_node'] in inference_dict['decode_node_list']
         ):
-            print('Already part of the handle list, no need to add')
+            log.info('Already part of the handle list, no need to add')
         else:
             hdl_list.extend(b_phdl)
 
@@ -264,7 +264,7 @@ def test_launch_inference_containers(p_phdl, d_phdl, r_phdl, b_phdl, inference_d
         )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     for a_phdl in [p_phdl, d_phdl, r_phdl, b_phdl]:
         out_dict = a_phdl.exec('docker ps')
         for node in out_dict.keys():

--- a/cvs/tests/inference/vllm/vllm_deepseek31_685b_single.py
+++ b/cvs/tests/inference/vllm/vllm_deepseek31_685b_single.py
@@ -86,7 +86,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -110,7 +110,7 @@ def benchmark_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
 
-    log.info(benchmark_params_dict)
+    log.info("%s", benchmark_params_dict)
     return benchmark_params_dict
 
 
@@ -134,7 +134,7 @@ def pytest_generate_tests(metafunc):
     """
     config_file = metafunc.config.getoption("config_file")
     if not config_file or not os.path.exists(config_file):
-        print(f'Warning: Missing or invalid config file {config_file}')
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
         return
 
     with open(config_file) as fp:
@@ -145,7 +145,7 @@ def pytest_generate_tests(metafunc):
     model_config = benchmark_params.get(MODEL_NAME, {})
 
     if not model_config:
-        print(f'Warning: Model {MODEL_NAME} not found in config')
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
         return
 
     # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
@@ -214,10 +214,10 @@ def hf_token(inference_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
         raise
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
         raise
     return hf_token
 
@@ -243,7 +243,7 @@ def s_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -271,7 +271,7 @@ def c_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -331,7 +331,7 @@ def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_di
     )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     out_dict = s_phdl.exec('docker ps')
     for node in out_dict.keys():
         if not re.search(f'{container_name}', out_dict[node], re.I):
@@ -412,7 +412,7 @@ def test_vllm_inference(c_phdl, s_phdl, inference_dict, benchmark_params_dict, h
 
 def test_print_results_table():
     globals.error_list = []
-    print(inf_res_dict)
+    log.info("%s", inf_res_dict)
     pprint(inf_res_dict, depth=3)
     rows = []
     headers = [
@@ -449,5 +449,5 @@ def test_print_results_table():
                 ]
             )
 
-    print(tabulate(rows, headers=headers, tablefmt="github"))
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
     update_test_result()

--- a/cvs/tests/inference/vllm/vllm_gpt_oss_120b_single.py
+++ b/cvs/tests/inference/vllm/vllm_gpt_oss_120b_single.py
@@ -85,7 +85,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -109,7 +109,7 @@ def benchmark_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
 
-    log.info(benchmark_params_dict)
+    log.info("%s", benchmark_params_dict)
     return benchmark_params_dict
 
 
@@ -133,7 +133,7 @@ def pytest_generate_tests(metafunc):
     """
     config_file = metafunc.config.getoption("config_file")
     if not config_file or not os.path.exists(config_file):
-        print(f'Warning: Missing or invalid config file {config_file}')
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
         return
 
     with open(config_file) as fp:
@@ -144,7 +144,7 @@ def pytest_generate_tests(metafunc):
     model_config = benchmark_params.get(MODEL_NAME, {})
 
     if not model_config:
-        print(f'Warning: Model {MODEL_NAME} not found in config')
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
         return
 
     # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
@@ -213,10 +213,10 @@ def hf_token(inference_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
         raise
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
         raise
     return hf_token
 
@@ -242,7 +242,7 @@ def s_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -270,7 +270,7 @@ def c_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -330,7 +330,7 @@ def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_di
     )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     out_dict = s_phdl.exec('docker ps')
     for node in out_dict.keys():
         if not re.search(f'{container_name}', out_dict[node], re.I):
@@ -447,5 +447,5 @@ def test_print_results_table():
                 ]
             )
 
-    print(tabulate(rows, headers=headers, tablefmt="github"))
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
     update_test_result()

--- a/cvs/tests/inference/vllm/vllm_qwen3_235b_single.py
+++ b/cvs/tests/inference/vllm/vllm_qwen3_235b_single.py
@@ -85,7 +85,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -109,7 +109,7 @@ def benchmark_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
 
-    log.info(benchmark_params_dict)
+    log.info("%s", benchmark_params_dict)
     return benchmark_params_dict
 
 
@@ -133,7 +133,7 @@ def pytest_generate_tests(metafunc):
     """
     config_file = metafunc.config.getoption("config_file")
     if not config_file or not os.path.exists(config_file):
-        print(f'Warning: Missing or invalid config file {config_file}')
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
         return
 
     with open(config_file) as fp:
@@ -144,7 +144,7 @@ def pytest_generate_tests(metafunc):
     model_config = benchmark_params.get(MODEL_NAME, {})
 
     if not model_config:
-        print(f'Warning: Model {MODEL_NAME} not found in config')
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
         return
 
     # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
@@ -213,10 +213,10 @@ def hf_token(inference_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
         raise
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
         raise
     return hf_token
 
@@ -242,7 +242,7 @@ def s_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -270,7 +270,7 @@ def c_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -330,7 +330,7 @@ def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_di
     )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     out_dict = s_phdl.exec('docker ps')
     for node in out_dict.keys():
         if not re.search(f'{container_name}', out_dict[node], re.I):
@@ -445,5 +445,5 @@ def test_print_results_table():
                 ]
             )
 
-    print(tabulate(rows, headers=headers, tablefmt="github"))
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
     update_test_result()

--- a/cvs/tests/inference/vllm/vllm_qwen3_80b_single.py
+++ b/cvs/tests/inference/vllm/vllm_qwen3_80b_single.py
@@ -85,7 +85,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -109,7 +109,7 @@ def benchmark_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
 
-    log.info(benchmark_params_dict)
+    log.info("%s", benchmark_params_dict)
     return benchmark_params_dict
 
 
@@ -133,7 +133,7 @@ def pytest_generate_tests(metafunc):
     """
     config_file = metafunc.config.getoption("config_file")
     if not config_file or not os.path.exists(config_file):
-        print(f'Warning: Missing or invalid config file {config_file}')
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
         return
 
     with open(config_file) as fp:
@@ -144,7 +144,7 @@ def pytest_generate_tests(metafunc):
     model_config = benchmark_params.get(MODEL_NAME, {})
 
     if not model_config:
-        print(f'Warning: Model {MODEL_NAME} not found in config')
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
         return
 
     # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
@@ -213,10 +213,10 @@ def hf_token(inference_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
         raise
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
         raise
     return hf_token
 
@@ -242,7 +242,7 @@ def s_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -270,7 +270,7 @@ def c_phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -362,7 +362,7 @@ def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_di
     )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     out_dict = s_phdl.exec('docker ps')
     for node in out_dict.keys():
         if not re.search(f'{container_name}', out_dict[node], re.I):
@@ -476,5 +476,5 @@ def test_print_results_table():
                 ]
             )
 
-    print(tabulate(rows, headers=headers, tablefmt="github"))
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
     update_test_result()

--- a/cvs/tests/mori/mori_benchmark_test.py
+++ b/cvs/tests/mori/mori_benchmark_test.py
@@ -68,7 +68,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -83,7 +83,7 @@ def mori_dict(mori_config_file, cluster_dict):
 
 @pytest.fixture(scope="module")
 def phdl(cluster_dict):
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -97,7 +97,7 @@ def gpu_type(phdl, cluster_dict):
       str: The GPU type (e.g., 'mi300', 'mi300x') used to select model parameters and logic.
     """
 
-    print(phdl)
+    log.info("%s", phdl)
     head_node = phdl.host_list[0]
     smi_out_dict = phdl.exec('rocm-smi -a | head -30')
     smi_out = smi_out_dict[head_node]
@@ -178,7 +178,7 @@ def test_launch_mori_container(phdl, mori_dict):
     )
     # ADD verifications ..
     time.sleep(30)
-    print('Verify if the containers have been launched properly')
+    log.info('Verify if the containers have been launched properly')
     out_dict = phdl.exec('docker ps')
     for node in out_dict.keys():
         if not re.search(f'{container_name}', out_dict[node], re.I):

--- a/cvs/tests/platform/host_configs_cvs.py
+++ b/cvs/tests/platform/host_configs_cvs.py
@@ -60,7 +60,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -83,7 +83,7 @@ def config_dict(config_file, cluster_dict):
 
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -113,7 +113,7 @@ def phdl(cluster_dict):
       - Scope is module-level so the connection is reused for all tests in this module.
       - Assumes Pssh is available in scope and accepts (log, node_list, user, pkey) in its constructor.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/rccl/rccl_heatmap_cvs.py
+++ b/cvs/tests/rccl/rccl_heatmap_cvs.py
@@ -90,7 +90,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -116,7 +116,7 @@ def config_dict(config_file, cluster_dict):
 
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -140,7 +140,7 @@ def phdl(cluster_dict):
       - nhdl_dict is currently unused; it can be removed unless used elsewhere.
       - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -259,7 +259,7 @@ data_type_full_list = [
 def pytest_generate_tests(metafunc):
     config_file = metafunc.config.getoption("config_file")
     if not config_file or not os.path.exists(config_file):
-        print(f'Warning: Missing or invalid config file {config_file}')
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
         return
 
     with open(config_file) as fp:
@@ -427,7 +427,7 @@ def test_rccl_perf(cluster_dict, config_dict, rccl_collective, gpu_count, data_t
         env_source_script=config_dict['env_source_script'],
     )
 
-    print(result_dict)
+    log.info("%s", result_dict)
     key_name = f'{rccl_collective}-{data_type}-{gpu_count}-ch{channel_config}'
     rccl_res_dict[key_name] = result_dict
 
@@ -448,10 +448,10 @@ def test_rccl_perf(cluster_dict, config_dict, rccl_collective, gpu_count, data_t
 
 
 def test_gen_graph(request):
-    print('Final Global result dict')
-    print(rccl_res_dict)
+    log.info('Final Global result dict')
+    log.info("%s", rccl_res_dict)
     rccl_graph_dict = rccl_lib.convert_to_graph_dict(rccl_res_dict)
-    print(rccl_graph_dict)
+    log.info("%s", rccl_graph_dict)
 
     current_datetime = datetime.now()
     time_stamp = current_datetime.strftime("%Y-%m-%d-%H-%M-%S")
@@ -471,15 +471,15 @@ def test_gen_graph(request):
     )
 
     if copied_path:
-        print(f'Perf report saved and added to report bundle: {copied_path}')
+        log.info(f'Perf report saved and added to report bundle: {copied_path}')
     else:
-        print(
+        log.info(
             f'Perf report is saved under {html_file}, pls copy it to your web server under /var/www/html folder to view'
         )
 
 
 def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
-    print('Generate Heatmap')
+    log.info('Generate Heatmap')
     current_datetime = datetime.now()
     time_stamp = current_datetime.strftime("%Y-%m-%d-%H-%M-%S")
     heatmap_file = f'/tmp/rccl_heatmap_{time_stamp}.html'
@@ -490,7 +490,7 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
     heatmap_title = config_dict.get('heatmap_title', 'RCCL Performance Heatmap')
 
     # Collect system metadata from compute nodes
-    print('Collecting system metadata...')
+    log.info('Collecting system metadata...')
     # Environment variables are now automatically extracted from config_dict
     # You can optionally pass env_vars=['PATH', 'LD_LIBRARY_PATH'] to capture shell vars
     metadata = collect_system_metadata(phdl, cluster_dict, config_dict)
@@ -502,14 +502,14 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
     structured_json_file = f'/tmp/rccl_result_with_metadata_{time_stamp}.json'
     with open(structured_json_file, "w") as fp:
         json.dump(structured_output, fp, indent=4)
-    print(f'Saved structured results with metadata to {structured_json_file}')
+    log.info(f'Saved structured results with metadata to {structured_json_file}')
 
     # Save original format for backward compatibility (used by HTML generation)
     with open(rccl_res_json_file, "w") as fp:
         json.dump(rccl_graph_dict, fp, indent=4)
 
     # Collect and save aggregated data from individual test runs
-    print('Collecting aggregated data from individual test runs...')
+    log.info('Collecting aggregated data from individual test runs...')
     aggregated_data = {}
     for key_name in rccl_res_dict.keys():
         # Parse the key to get test parameters
@@ -526,11 +526,11 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
                     with open(aggregated_file, 'r') as fp:
                         agg_data = json.load(fp)
                         aggregated_data[key_name] = agg_data
-                        print(f'Loaded aggregated data from {aggregated_file}')
+                        log.info(f'Loaded aggregated data from {aggregated_file}')
                 else:
-                    print(f'Warning: Aggregated file not found: {aggregated_file}')
+                    log.warning(f'Warning: Aggregated file not found: {aggregated_file}')
             except Exception as e:
-                print(f'Warning: Failed to load aggregated data from {aggregated_file}: {e}')
+                log.warning(f'Warning: Failed to load aggregated data from {aggregated_file}: {e}')
 
     # Save aggregated data with metadata
     if aggregated_data:
@@ -538,7 +538,7 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
         aggregated_json_file = f'/tmp/rccl_result_final_aggregated_{time_stamp}.json'
         with open(aggregated_json_file, "w") as fp:
             json.dump(aggregated_output, fp, indent=4)
-        print(f'Saved final aggregated results to {aggregated_json_file}')
+        log.info(f'Saved final aggregated results to {aggregated_json_file}')
 
     # Generate HTML heatmap and reports
     html_lib.add_html_begin(heatmap_file)
@@ -553,7 +553,7 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
     )
 
     if copied_path:
-        print(f'Heatmap report saved and added to report bundle: {copied_path}')
+        log.info(f'Heatmap report saved and added to report bundle: {copied_path}')
 
     # Get management/login node IP from cluster config
     mgmt_node = cluster_dict.get('head_node_dict', {}).get('mgmt_ip', None)
@@ -586,8 +586,8 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
 
     # If on compute node, copy files to management node
     if on_compute_node and mgmt_node:
-        print(f'Running on compute node: {current_host}')
-        print(f'Copying results to management node: {mgmt_node}:{output_dir}/')
+        log.info(f'Running on compute node: {current_host}')
+        log.info(f'Copying results to management node: {mgmt_node}:{output_dir}/')
         is_remote_copy = True
 
         # Get SSH key and username from cluster config
@@ -607,18 +607,18 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
                     result = os.system(scp_cmd)
                     if result == 0:
                         copied_files[os.path.basename(src_file)] = dst_path
-                        print(f'Copied {os.path.basename(src_file)} to {mgmt_node}:{dst_path}')
+                        log.info(f'Copied {os.path.basename(src_file)} to {mgmt_node}:{dst_path}')
                     else:
-                        print(f'Failed to copy {os.path.basename(src_file)} (exit code: {result})')
+                        log.warning(f'Failed to copy {os.path.basename(src_file)} (exit code: {result})')
                 except Exception as e:
-                    print(f'Error copying {src_file}: {e}')
+                    log.error(f'Error copying {src_file}: {e}')
     else:
         # On management node or no mgmt_node configured - copy locally
-        print(f'Running on management node: {current_host}')
+        log.info(f'Running on management node: {current_host}')
         try:
             os.makedirs(output_dir, exist_ok=True)
         except Exception as e:
-            print(f'Warning: Could not create {output_dir}: {e}')
+            log.warning(f'Warning: Could not create {output_dir}: {e}')
             output_dir = '/tmp'
 
         for src_file in files_to_copy:
@@ -627,27 +627,27 @@ def test_gen_heatmap(request, phdl, cluster_dict, config_dict):
                 try:
                     shutil.copy2(src_file, dst_file)
                     copied_files[os.path.basename(src_file)] = dst_file
-                    print(f'Copied {os.path.basename(src_file)} to {dst_file}')
+                    log.info(f'Copied {os.path.basename(src_file)} to {dst_file}')
                 except Exception as e:
-                    print(f'Failed to copy {src_file}: {e}')
+                    log.warning(f'Failed to copy {src_file}: {e}')
 
-    print('\n=== RCCL Test Results ===')
-    print('Generated files:')
-    print(f'  - Heatmap: {heatmap_file}')
-    print(f'  - Structured results: {structured_json_file}')
-    print(f'  - Aggregated results: {aggregated_json_file if aggregated_data else "N/A"}')
+    log.info('\n=== RCCL Test Results ===')
+    log.info('Generated files:')
+    log.info(f'  - Heatmap: {heatmap_file}')
+    log.info(f'  - Structured results: {structured_json_file}')
+    log.info(f'  - Aggregated results: {aggregated_json_file if aggregated_data else "N/A"}')
 
     if copied_files:
         if is_remote_copy:
-            print(f'\n Results copied to management node ({mgmt_node}):')
-            print(f'  Location: {output_dir}/')
-            print('  Files:')
+            log.info(f'\n Results copied to management node ({mgmt_node}):')
+            log.info(f'  Location: {output_dir}/')
+            log.info('  Files:')
             for filename in copied_files.keys():
-                print(f'    - {filename}')
-            print(f'\nAccess results on {mgmt_node} with:')
-            print(f'  ls {output_dir}/rccl_*{time_stamp}*')
+                log.info(f'    - {filename}')
+            log.info(f'\nAccess results on {mgmt_node} with:')
+            log.info(f'  ls {output_dir}/rccl_*{time_stamp}*')
         else:
-            print(f'\n Files available in: {output_dir}/')
+            log.info(f'\n Files available in: {output_dir}/')
             for filename in copied_files.keys():
-                print(f'    - {filename}')
-    print('=========================\n')
+                log.info(f'    - {filename}')
+    log.info('=========================\n')

--- a/cvs/tests/rccl/rccl_multinode_cvs.py
+++ b/cvs/tests/rccl/rccl_multinode_cvs.py
@@ -85,7 +85,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -111,7 +111,7 @@ def config_dict(config_file, cluster_dict):
 
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -135,7 +135,7 @@ def phdl(cluster_dict):
       - nhdl_dict is currently unused; it can be removed unless used elsewhere.
       - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -206,7 +206,7 @@ def pytest_generate_tests(metafunc):
     """
     config_file = metafunc.config.getoption("config_file")
     if not config_file or not os.path.exists(config_file):
-        print(f'Warning: Missing or invalid config file {config_file}')
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
         return
 
     with open(config_file) as fp:
@@ -417,7 +417,7 @@ def test_rccl_perf(
         env_source_script=config_dict['env_source_script'],
     )
 
-    print(result_dict)
+    log.info("%s", result_dict)
     key_name = f'{rccl_collective}-{rccl_algo}-{rccl_protocol}-{qp_scale}-{nccl_pxn_disable}'
     rccl_res_dict[key_name] = result_dict
 
@@ -438,10 +438,10 @@ def test_rccl_perf(
 
 
 def test_gen_graph(request):
-    print('Final Global result dict')
-    print(rccl_res_dict)
+    log.info('Final Global result dict')
+    log.info("%s", rccl_res_dict)
     rccl_graph_dict = rccl_lib.convert_to_graph_dict(rccl_res_dict)
-    print(rccl_graph_dict)
+    log.info("%s", rccl_graph_dict)
 
     proc_id = os.getpid()
 
@@ -460,8 +460,8 @@ def test_gen_graph(request):
     )
 
     if copied_path:
-        print(f'Perf report saved and added to report bundle: {copied_path}')
+        log.info(f'Perf report saved and added to report bundle: {copied_path}')
     else:
-        print(
+        log.info(
             f'Perf report is saved under {html_file}, pls copy it to your web server under /var/www/html folder to view'
         )

--- a/cvs/tests/rccl/rccl_multinode_default_cvs.py
+++ b/cvs/tests/rccl/rccl_multinode_default_cvs.py
@@ -87,7 +87,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -113,7 +113,7 @@ def config_dict(config_file, cluster_dict):
 
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -137,7 +137,7 @@ def phdl(cluster_dict):
       - nhdl_dict is currently unused; it can be removed unless used elsewhere.
       - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -341,7 +341,7 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
         env_source_script=config_dict['env_source_script'],
     )
 
-    print(result_dict)
+    log.info("%s", result_dict)
     key_name = f'{rccl_collective}'
     rccl_res_dict[key_name] = result_dict
 
@@ -362,10 +362,10 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
 
 
 def test_gen_graph(request):
-    print('Final Global result dict')
-    print(rccl_res_dict)
+    log.info('Final Global result dict')
+    log.info("%s", rccl_res_dict)
     rccl_graph_dict = rccl_lib.convert_to_graph_dict(rccl_res_dict)
-    print(rccl_graph_dict)
+    log.info("%s", rccl_graph_dict)
 
     proc_id = os.getpid()
 
@@ -384,8 +384,8 @@ def test_gen_graph(request):
     )
 
     if copied_path:
-        print(f'Perf report saved and added to report bundle: {copied_path}')
+        log.info(f'Perf report saved and added to report bundle: {copied_path}')
     else:
-        print(
+        log.info(
             f'Perf report is saved under {html_file}, pls copy it to your web server under /var/www/html folder to view'
         )

--- a/cvs/tests/rccl/rccl_singlenode_cvs.py
+++ b/cvs/tests/rccl/rccl_singlenode_cvs.py
@@ -87,7 +87,7 @@ def cluster_dict(cluster_file):
 
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -113,7 +113,7 @@ def config_dict(config_file, cluster_dict):
 
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     config_dict = resolve_test_config_placeholders(config_dict, cluster_dict)
-    log.info(config_dict)
+    log.info("%s", config_dict)
     return config_dict
 
 
@@ -137,7 +137,7 @@ def phdl(cluster_dict):
       - nhdl_dict is currently unused; it can be removed unless used elsewhere.
       - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
@@ -294,7 +294,7 @@ def test_singlenode_perf(phdl, cluster_dict, config_dict, rccl_collective):
         env_source_script=config_dict['env_source_script'],
     )
 
-    print(result_dict)
+    log.info("%s", result_dict)
     key_name = f'{rccl_collective}'
     rccl_res_dict[key_name] = result_dict
 
@@ -315,10 +315,10 @@ def test_singlenode_perf(phdl, cluster_dict, config_dict, rccl_collective):
 
 
 def test_gen_graph(request):
-    print('Final Global result dict')
-    print(rccl_res_dict)
+    log.info('Final Global result dict')
+    log.info("%s", rccl_res_dict)
     rccl_graph_dict = rccl_lib.convert_to_graph_dict(rccl_res_dict)
-    print(rccl_graph_dict)
+    log.info("%s", rccl_graph_dict)
 
     proc_id = os.getpid()
 
@@ -337,8 +337,8 @@ def test_gen_graph(request):
     )
 
     if copied_path:
-        print(f'Perf report saved and added to report bundle: {copied_path}')
+        log.info(f'Perf report saved and added to report bundle: {copied_path}')
     else:
-        print(
+        log.info(
             f'Perf report is saved under {html_file}, pls copy it to your web server under /var/www/html folder to view'
         )

--- a/cvs/tests/training/jax/jax_llama3_1_405b_distributed.py
+++ b/cvs/tests/training/jax/jax_llama3_1_405b_distributed.py
@@ -77,7 +77,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -125,7 +125,7 @@ def model_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     model_params_dict = resolve_test_config_placeholders(model_params_dict, cluster_dict)
 
-    log.info(model_params_dict)
+    log.info("%s", model_params_dict)
     return model_params_dict
 
 
@@ -150,9 +150,9 @@ def hf_token(training_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -176,7 +176,7 @@ def phdl(cluster_dict):
       - Initializes a Pssh handle with provided credentials.
     """
 
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/training/jax/jax_llama3_1_70b_distributed.py
+++ b/cvs/tests/training/jax/jax_llama3_1_70b_distributed.py
@@ -77,7 +77,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -125,7 +125,7 @@ def model_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     model_params_dict = resolve_test_config_placeholders(model_params_dict, cluster_dict)
 
-    log.info(model_params_dict)
+    log.info("%s", model_params_dict)
     return model_params_dict
 
 
@@ -150,9 +150,9 @@ def hf_token(training_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -176,7 +176,7 @@ def phdl(cluster_dict):
       - Initializes a Pssh handle with provided credentials.
     """
 
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/training/jax/jax_llama3_1_70b_single.py
+++ b/cvs/tests/training/jax/jax_llama3_1_70b_single.py
@@ -77,7 +77,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -125,7 +125,7 @@ def model_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     model_params_dict = resolve_test_config_placeholders(model_params_dict, cluster_dict)
 
-    log.info(model_params_dict)
+    log.info("%s", model_params_dict)
     return model_params_dict
 
 
@@ -150,9 +150,9 @@ def hf_token(training_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -176,7 +176,7 @@ def phdl(cluster_dict):
       - Initializes a Pssh handle with provided credentials.
     """
 
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/training/megatron/megatron_llama3_1_70b_distributed.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_70b_distributed.py
@@ -79,7 +79,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -127,7 +127,7 @@ def model_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     model_params_dict = resolve_test_config_placeholders(model_params_dict, cluster_dict)
 
-    log.info(model_params_dict)
+    log.info("%s", model_params_dict)
     return model_params_dict
 
 
@@ -152,9 +152,9 @@ def hf_token(training_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -179,7 +179,7 @@ def phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/training/megatron/megatron_llama3_1_70b_single.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_70b_single.py
@@ -78,7 +78,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -125,7 +125,7 @@ def model_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     model_params_dict = resolve_test_config_placeholders(model_params_dict, cluster_dict)
 
-    log.info(model_params_dict)
+    log.info("%s", model_params_dict)
     return model_params_dict
 
 
@@ -150,9 +150,9 @@ def hf_token(training_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -177,7 +177,7 @@ def phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/training/megatron/megatron_llama3_1_8b_distributed.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_8b_distributed.py
@@ -79,7 +79,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -127,7 +127,7 @@ def model_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     model_params_dict = resolve_test_config_placeholders(model_params_dict, cluster_dict)
 
-    log.info(model_params_dict)
+    log.info("%s", model_params_dict)
     return model_params_dict
 
 
@@ -152,9 +152,9 @@ def hf_token(training_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -179,7 +179,7 @@ def phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)

--- a/cvs/tests/training/megatron/megatron_llama3_1_8b_single.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_8b_single.py
@@ -78,7 +78,7 @@ def cluster_dict(cluster_file):
     # Resolve path placeholders like {user-id} in cluster config
     cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
 
-    log.info(cluster_dict)
+    log.info("%s", cluster_dict)
     return cluster_dict
 
 
@@ -126,7 +126,7 @@ def model_params_dict(training_config_file, cluster_dict):
     # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
     model_params_dict = resolve_test_config_placeholders(model_params_dict, cluster_dict)
 
-    log.info(model_params_dict)
+    log.info("%s", model_params_dict)
     return model_params_dict
 
 
@@ -151,9 +151,9 @@ def hf_token(training_dict):
         with open(hf_token_file, 'r') as fp:
             hf_token = fp.read().rstrip("\n")
     except FileNotFoundError:
-        print(f"Error: The file '{hf_token_file}' was not found.")
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        log.error(f"An error occurred: {e}")
     return hf_token
 
 
@@ -178,7 +178,7 @@ def phdl(cluster_dict):
     Notes:
       - This fixture has module scope, so a single connection handle is reused for all tests in the module.
     """
-    print(cluster_dict)
+    log.info("%s", cluster_dict)
     env_vars = cluster_dict.get("env_vars")
     node_list = list(cluster_dict['node_dict'].keys())
     phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)


### PR DESCRIPTION
- Use cvs.lib.globals.log in library and test code; replace print with appropriate log.info, log.warning, or log.error where messages are diagnostic or operational.
- Correct log levels for failures, timeouts, skips, and validation messages.
- Keep print() for user-facing CLI paths: main.py plugin load, extension.ini parse warnings, monitors/base.py, generators (heatmap, cluster_json), and check_cluster_health monitor output.
- Remove duplicate log.info after log.warn/log.error in verify_lib snapshot diff.
- Fix html_lib heatmap tests to assert on logging with assertLogs instead of mocked stdout.
- make lint: run Ruff as before, then Pylint on cvs/ with only logging logging-too-many-args (E1205) and logging-too-few-args (E1206); install pylint in .ruff_venv alongside ruff.

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
