### PR TITLE
fix(cvs exec): pass logger to Pssh instead of None

### DIFF
--- a/cvs/cli_plugins/exec_plugin.py
+++ b/cvs/cli_plugins/exec_plugin.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import sys
 import os
 
@@ -59,9 +60,10 @@ Exec Commands:
             print("Error: No hosts found in cluster file.")
             sys.exit(1)
 
-        # Create Pssh instance
+        # Create Pssh instance (Pssh requires a logger; it calls log.debug/info/warning)
+        log = logging.getLogger(__name__)
         try:
-            pssh = Pssh(log=None, host_list=hosts, user=username, pkey=pkey, stop_on_errors=False)
+            pssh = Pssh(log=log, host_list=hosts, user=username, pkey=pkey, stop_on_errors=False)
         except Exception as e:
             print(f"Error initializing Pssh: {e}")
             sys.exit(1)


### PR DESCRIPTION
Pssh.__init__ calls log.debug immediately; log=None caused 'NoneType' object has no attribute 'debug' when running cvs exec.

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
