### PR TITLE
Multi-orchestrator backend: pluggable baremetal/container execution layer + RVS health migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,12 @@ cvs copy-config --list
 Then copy specific files as needed:
 
 ```bash
-# Copy cluster configuration
+# Copy cluster configuration (baremetal backend, default)
 cvs copy-config cluster.json --output /tmp/cvs/input/cluster_file/cluster.json
+
+# Or copy the container-backend cluster template (today consumed by rvs_cvs only;
+# other suites and `cvs exec` ignore the orchestrator key and run on the host)
+cvs copy-config cluster_container.json --output /tmp/cvs/input/cluster_file/cluster_container.json
 
 # Alternatively, generate cluster configuration for multiple hosts (see 'Generate Cluster Configuration File' section below)
 
@@ -147,6 +151,8 @@ cvs copy-config cluster.json --output /tmp/cvs/input/cluster_file/cluster.json
 cvs copy-config rccl/rccl_config.json --output /tmp/cvs/input/config_file/rccl_config.json
 cvs copy-config health/mi300_health_config.json --output /tmp/cvs/input/config_file/health_config.json
 ```
+
+For the container backend, see the published [container-mode how-to](https://rocm.docs.amd.com/projects/cvs/en/latest/how-to/run-with-containers.html) and the in-tree reference next to the templates: [`cvs/input/cluster_file/README.md`](cvs/input/cluster_file/README.md).
 
 Or copy all configuration files at once:
 

--- a/cvs/core/__init__.py
+++ b/cvs/core/__init__.py
@@ -1,0 +1,3 @@
+from cvs.core.orchestrators.factory import OrchestratorFactory, OrchestratorConfig
+
+__all__ = ['OrchestratorFactory', 'OrchestratorConfig']

--- a/cvs/core/orchestrators/baremetal.py
+++ b/cvs/core/orchestrators/baremetal.py
@@ -1,0 +1,277 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+from cvs.core.orchestrators.base import Orchestrator
+from cvs.lib.parallel_ssh_lib import Pssh
+
+
+class BaremetalOrchestrator(Orchestrator):
+    """
+    Baremetal orchestrator implementation using Parallel-SSH.
+
+    Executes commands directly on host systems via SSH without containers.
+    Provides the foundation for containerized orchestrators.
+
+    Integrates with OrchestratorConfig for standardized configuration.
+    """
+
+    def __init__(self, log, config, stop_on_errors=False):
+        """
+        Initialize baremetal orchestrator from OrchestratorConfig.
+
+        Args:
+            log: Logger instance
+            config: OrchestratorConfig instance
+            stop_on_errors: Whether to stop execution on first error
+        """
+        super().__init__(log, config, stop_on_errors)
+
+        # Set orchestrator type for runtime identification
+        self.orchestrator_type = "baremetal"
+
+        # SSH port for MPI communication (overridable by subclasses)
+        self.ssh_port = 22
+
+        # Extract hosts from OrchestratorConfig node_dict
+        self.hosts = (
+            list(config.node_dict.keys())
+            if isinstance(config.node_dict, dict)
+            else [node.get('mgmt_ip') for node in config.node_dict]
+        )
+
+        self.head_node = self.hosts[0]  # First node is head
+
+        self.user = config.get('username')
+        self.pkey = config.get('priv_key_file')
+        self.password = config.get('password')  # Optional
+
+        # Initialize TWO ParallelSSH handles like original CVS pattern:
+        # head - Single head node (for mpirun, result collection, etc.)
+        # all - Parallel across all nodes (for setup, cleanup, verification)
+        self.head = Pssh(
+            log,
+            [self.head_node],
+            user=self.user,
+            password=self.password,
+            pkey=self.pkey,
+            host_key_check=False,
+            stop_on_errors=self.stop_on_errors,
+        )
+        self.all = Pssh(
+            log,
+            self.hosts,
+            user=self.user,
+            password=self.password,
+            pkey=self.pkey,
+            host_key_check=False,
+            stop_on_errors=self.stop_on_errors,
+        )
+
+    def exec(self, cmd, hosts=None, timeout=None):
+        """
+        Execute command across hosts via SSH (baremetal execution).
+
+        Args:
+            cmd: Command to execute
+            hosts: Target hosts (if None, uses all hosts)
+            timeout: Command timeout
+
+        Returns:
+            Dictionary mapping hosts to execution results
+        """
+        if hosts is None:
+            hosts = self.hosts
+
+        # Use appropriate handle based on target hosts
+        if set(hosts) == set(self.hosts):
+            return self.all.exec(cmd, timeout=timeout)
+        else:
+            # For arbitrary subset (including head node), create temporary handle
+            pssh = Pssh(
+                self.log,
+                hosts,
+                user=self.user,
+                password=self.password,
+                pkey=self.pkey,
+                host_key_check=False,
+                stop_on_errors=self.stop_on_errors,
+            )
+            return pssh.exec(cmd, timeout=timeout)
+
+    def exec_on_head(self, cmd, timeout=None):
+        """
+        Execute command on head node only via SSH.
+
+        Args:
+            cmd: Command to execute
+            timeout: Command timeout
+
+        Returns:
+            Dictionary mapping head node to execution result
+        """
+        return self.head.exec(cmd, timeout=timeout)
+
+    def setup_env(self, hosts, env_script=None):
+        """Set up environment on hosts."""
+        if not env_script:
+            self.log.info("No environment script specified, skipping setup")
+            return True
+
+        self.log.info(f"Setting up environment on {len(hosts)} hosts")
+
+        # Use appropriate handle
+        if set(hosts) == set(self.hosts):
+            result = self.all.exec(f"bash {env_script}", timeout=60, detailed=True)
+        elif len(hosts) == 1 and hosts[0] == self.head_node:
+            result = self.exec_on_head(f"bash {env_script}", timeout=60, detailed=True)
+        else:
+            pssh = Pssh(
+                self.log,
+                hosts,
+                user=self.user,
+                password=self.password,
+                pkey=self.pkey,
+                host_key_check=False,
+                stop_on_errors=self.stop_on_errors,
+            )
+            result = pssh.exec(f"bash {env_script}", timeout=60, detailed=True)
+
+        # Check if all hosts succeeded
+        success = all(output['exit_code'] == 0 for output in result.values())
+
+        if not success:
+            failed = [host for host, output in result.items() if output['exit_code'] != 0]
+            self.log.error(f"Environment setup failed on hosts: {failed}")
+
+        return success
+
+    def cleanup(self, hosts):
+        """Clean up resources after test execution."""
+        self.log.info(f"Cleaning up on {len(hosts)} hosts")
+        # Basic cleanup - no specific resources to clean for SSH-only orchestrator
+        return True
+
+    def build_mpi_cmd(
+        self,
+        rank_cmd,
+        mpi_hosts,
+        ranks_per_host,
+        env_vars,
+        mpi_install_dir,
+        mpi_extra_args=None,
+        no_of_global_ranks=None,
+    ):
+        """
+        Build MPI command string for distributed execution.
+
+        Args:
+            rank_cmd: The command to execute on each MPI rank
+            mpi_hosts: List of host IPs/names for MPI hostfile
+            ranks_per_host: Number of MPI ranks per host (uniform across hosts)
+            env_vars: Dict of environment variables to set
+            mpi_install_dir: Path to MPI installation directory
+            mpi_extra_args: List of additional mpirun arguments
+            no_of_global_ranks: Total number of MPI ranks (optional, defaults to len(mpi_hosts) * ranks_per_host)
+
+        Returns:
+            Full MPI command string
+        """
+        # Create MPI hostfile
+        host_file_params = ''
+        for host in mpi_hosts:
+            host_file_params += f'{host} slots={ranks_per_host}\n'
+
+        # Create hostfile on head node
+        cmd = 'sudo rm -f /tmp/mpi_hosts.txt'
+        self.exec_on_head(cmd)
+
+        cmd = f'bash -c \'echo "{host_file_params}" > /tmp/mpi_hosts.txt\''
+        self.exec_on_head(cmd)
+
+        # Build MPI runner arguments
+        if no_of_global_ranks is None:
+            no_of_global_ranks = len(mpi_hosts) * ranks_per_host
+        mpi_runner_args = [
+            '--np',
+            str(no_of_global_ranks),
+            '--allow-run-as-root',
+            '--hostfile',
+            '/tmp/mpi_hosts.txt',
+        ]
+
+        if mpi_extra_args:
+            mpi_runner_args.extend(mpi_extra_args)
+
+        full_mpi_cmd = self.get_mpi_command(rank_cmd, mpi_runner_args, env_vars, mpi_install_dir)
+
+        return full_mpi_cmd
+
+    def distribute_using_mpi(
+        self,
+        rank_cmd,
+        mpi_hosts,
+        ranks_per_host,
+        env_vars,
+        mpi_install_dir,
+        mpi_extra_args=None,
+        no_of_global_ranks=None,
+    ):
+        """
+        Distribute MPI job across hosts using the provided arguments.
+
+        Args:
+            rank_cmd: The command to execute on each MPI rank
+            mpi_hosts: List of host IPs/names for MPI hostfile
+            ranks_per_host: Number of MPI ranks per host (uniform across hosts)
+            env_vars: Dict of environment variables to set
+            mpi_install_dir: Path to MPI installation directory
+            mpi_extra_args: List of additional mpirun arguments
+            no_of_global_ranks: Total number of MPI ranks (optional, defaults to len(mpi_hosts) * ranks_per_host)
+
+        Returns:
+            Execution results from head node
+        """
+        full_mpi_cmd = self.build_mpi_cmd(
+            rank_cmd, mpi_hosts, ranks_per_host, env_vars, mpi_install_dir, mpi_extra_args, no_of_global_ranks
+        )
+
+        self.log.info("Launching MPI job")
+        self.log.debug(f"MPI command: {full_mpi_cmd}")
+
+        # Execute on head node
+        result = self.exec_on_head(full_mpi_cmd, timeout=500)  # Default timeout
+
+        return result
+
+    def get_mpi_command(self, rank_cmd, mpi_runner_args, env_vars, mpi_install_dir):
+        """
+        Get the full MPI command string without executing it.
+
+        Args:
+            rank_cmd: The command to execute on each MPI rank
+            mpi_runner_args: List of mpirun arguments
+            env_vars: Dict of environment variables to set
+            mpi_install_dir: Path to MPI installation directory
+
+        Returns:
+            Full MPI command string
+        """
+        # Build environment variable arguments for mpirun
+        env_args = []
+        for key, value in env_vars.items():
+            env_args.append(f'-x {key}={value}')
+
+        # Build MPI runner arguments string
+        mpi_runner_args_str = ' '.join(mpi_runner_args)
+
+        # Add SSH options to auto-resolve host key issues in test environments
+        ssh_options = f'--mca plm_rsh_agent ssh --mca plm_rsh_args "-p {self.ssh_port} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
+
+        # Construct full MPI command
+        full_mpi_cmd = f'{mpi_install_dir}/mpirun {ssh_options} {mpi_runner_args_str} {" ".join(env_args)} {rank_cmd}'
+
+        return full_mpi_cmd

--- a/cvs/core/orchestrators/base.py
+++ b/cvs/core/orchestrators/base.py
@@ -1,0 +1,111 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+from abc import ABC, abstractmethod
+
+
+class Orchestrator(ABC):
+    """
+    Abstract base class for orchestrator backends.
+
+    Orchestrators handle distributed test execution across cluster nodes.
+    Different backends (PSSH, Slurm, K8s) implement this interface to provide
+    pluggable execution strategies while maintaining separation from host management.
+    """
+
+    def __init__(self, log, config, stop_on_errors=False):
+        """
+        Initialize orchestrator with configuration.
+
+        Args:
+            log: Logger instance
+            config: Configuration dictionary containing orchestrator settings
+            stop_on_errors: Whether to stop execution on first error
+        """
+        self.log = log
+        self.config = config
+        self.stop_on_errors = stop_on_errors
+
+    @abstractmethod
+    def exec(self, cmd, hosts=None, timeout=None):
+        """
+        Execute command across hosts using the orchestrator's execution strategy.
+
+        This is the primary execution method that handles container vs baremetal
+        execution transparently based on orchestrator configuration.
+
+        Args:
+            cmd: Command to execute
+            hosts: Target hosts (if None, uses all hosts)
+            timeout: Command timeout in seconds
+
+        Returns:
+            Dictionary mapping hosts to execution results
+        """
+        pass
+
+    @abstractmethod
+    def exec_on_head(self, cmd, timeout=None):
+        """
+        Execute command on head node only.
+
+        Args:
+            cmd: Command to execute
+            timeout: Command timeout in seconds
+
+        """
+        pass
+
+    @abstractmethod
+    def setup_env(self, hosts, env_script=None):
+        """
+        Set up execution environment on target hosts.
+
+        Args:
+            hosts: List of host addresses
+            env_script: Optional script to source for environment setup
+
+        Returns:
+            True if setup succeeded, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    def cleanup(self, hosts):
+        """
+        Clean up resources after test execution.
+
+        Args:
+            hosts: List of host addresses
+
+        Returns:
+            True if cleanup succeeded, False otherwise
+        """
+        pass
+
+    def distribute_using_mpi(self, rank_cmd, mpi_hosts, ranks_per_host, env_vars, mpi_install_dir, mpi_extra_args=None):
+        """
+        Distribute MPI job across hosts using the provided arguments.
+
+        This method provides MPI-based distribution for orchestrators that support it.
+        Default implementation raises NotImplementedError.
+
+        Args:
+            rank_cmd: The command to execute on each MPI rank
+            mpi_hosts: List of host IPs/names for MPI hostfile
+            ranks_per_host: Number of MPI ranks per host (uniform across hosts)
+            env_vars: Dict of environment variables to set
+            mpi_install_dir: Path to MPI installation directory
+            mpi_extra_args: List of additional mpirun arguments
+
+        Returns:
+            Execution results
+
+        Raises:
+            NotImplementedError: If MPI distribution is not supported
+        """
+        raise NotImplementedError(f"MPI distribution not supported by {self.__class__.__name__}")

--- a/cvs/core/orchestrators/container.py
+++ b/cvs/core/orchestrators/container.py
@@ -1,0 +1,589 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+from cvs.core.orchestrators.baremetal import BaremetalOrchestrator
+import getpass
+import re
+from cvs.core.runtimes import RuntimeFactory
+
+
+# Default container configuration - matches the original docker command
+DEFAULT_CONTAINER_ARGS = {
+    "devices": [
+        "/dev/kfd",  # Kernel Fusion Driver (ROCm)
+        "/dev/dri",  # Direct Rendering Infrastructure
+        "/dev/infiniband",  # All infiniband devices
+    ],
+    "capabilities": [
+        "SYS_PTRACE",  # Debug processes
+        "IPC_LOCK",  # Lock memory for RDMA
+        "SYS_ADMIN",  # Administrative operations
+    ],
+    "security_opts": [
+        "seccomp=unconfined",  # Disable seccomp for RDMA
+        "apparmor=unconfined",  # Disable apparmor
+    ],
+    "groups": [
+        "video",  # Video group for GPU access
+    ],
+    "ulimits": [
+        "memlock=-1",  # Unlimited memory locking for RDMA
+    ],
+    "environment": {
+        "GPUS": "8",  # Number of GPUs (from original command)
+        "MULTINODE": "true",  # Multinode mode
+    },
+    "network_mode": "host",
+    "ipc_mode": "host",
+    "privileged": True,
+}
+
+
+class ContainerOrchestrator(BaremetalOrchestrator):
+    """
+    Container-based orchestrator that extends BaremetalOrchestrator for containerized execution.
+
+    Uses SSH transport (via BaremetalOrchestrator) but executes commands in containers
+    on cluster nodes. Supports long-running containers for efficient command execution
+    with multiple container runtimes (Docker, Enroot, etc.).
+
+    Container lifecycle is managed through setup_containers() and teardown_containers() methods,
+    which should be called explicitly by test code when needed.
+    """
+
+    def __init__(self, log, config, stop_on_errors=False):
+        """
+        Initialize container orchestrator.
+
+        Args:
+            log: Logger instance
+            config: OrchestratorConfig instance
+            stop_on_errors: Whether to stop execution on first error
+
+        Note:
+            Containers are not automatically launched. Use setup_containers() for explicit control.
+        """
+        super().__init__(log, config, stop_on_errors)
+
+        # Set orchestrator type for runtime identification
+        self.orchestrator_type = "container"
+
+        # Override SSH port for container SSH daemons
+        self.ssh_port = 2224
+
+        # Container-specific initialization
+        self.container_config = config.get('container', {})
+        if not self.container_config:
+            raise ValueError("ContainerOrchestrator requires 'container' config in OrchestratorConfig")
+
+        self.container_enabled = True
+        self.container_id = None  # Track running container ID
+
+        # Initialize container runtime
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_name = runtime_config.get('name', 'docker')
+        self.runtime = RuntimeFactory.create(runtime_name, log, self)
+        self.log.info(f"ContainerOrchestrator initialized with runtime: {runtime_name}")
+
+        # Note: Containers are not auto-launched here. Use setup_containers() for explicit control.
+
+    def get_volumes(self):
+        """
+        Get volume mounts, merging defaults with config.json runtime args.
+
+        Returns:
+            list: List of volume mount strings in format "host_path:container_path"
+        """
+        import getpass
+
+        user = getpass.getuser()
+
+        # Start with dynamic user-specific mounts (from original command)
+        volumes = [
+            f"/home/{user}:/workspace",  # User home directory
+            f"/home/{user}/.ssh:/host_ssh",  # SSH keys for multinode
+        ]
+
+        # Merge with config.json runtime args
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        config_volumes = runtime_args.get('volumes', [])
+        volumes.extend(config_volumes)
+
+        return volumes
+
+    def get_devices(self):
+        """
+        Get device passthroughs, merging defaults with config.json runtime args.
+
+        Returns:
+            list: List of device paths to passthrough
+        """
+        devices = list(DEFAULT_CONTAINER_ARGS['devices'])
+
+        # InfiniBand devices are added via shell expansion in docker run command
+        # to ensure per-host discovery at runtime
+
+        # Merge with config.json runtime args
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        config_devices = runtime_args.get('devices', [])
+        devices.extend(config_devices)
+
+        return devices
+
+    def get_capabilities(self):
+        """
+        Get Linux capabilities, merging defaults with config.json runtime args.
+
+        Returns:
+            list: List of capability names
+        """
+        capabilities = list(DEFAULT_CONTAINER_ARGS['capabilities'])
+
+        # Merge with config.json runtime args
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        config_capabilities = runtime_args.get('cap_add', [])
+        capabilities.extend(config_capabilities)
+
+        return capabilities
+
+    def get_security_opts(self):
+        """
+        Get security options, merging defaults with config.json runtime args.
+
+        Returns:
+            list: List of security option strings
+        """
+        security_opts = list(DEFAULT_CONTAINER_ARGS['security_opts'])
+
+        # Merge with config.json runtime args
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        config_security_opts = runtime_args.get('security_opt', [])
+        security_opts.extend(config_security_opts)
+
+        return security_opts
+
+    def get_groups(self):
+        """
+        Get group additions, merging defaults with config.json runtime args.
+
+        Returns:
+            list: List of group names to add
+        """
+        groups = list(DEFAULT_CONTAINER_ARGS['groups'])
+
+        # Merge with config.json runtime args
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        config_groups = runtime_args.get('group_add', [])
+        groups.extend(config_groups)
+
+        return groups
+
+    def get_ulimits(self):
+        """
+        Get ulimits, merging defaults with config.json runtime args.
+
+        Returns:
+            list: List of ulimit strings
+        """
+        ulimits = list(DEFAULT_CONTAINER_ARGS['ulimits'])
+
+        # Merge with config.json runtime args
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        config_ulimits = runtime_args.get('ulimit', [])
+        ulimits.extend(config_ulimits)
+
+        return ulimits
+
+    def get_environment(self):
+        """
+        Get environment variables, merging defaults with config.json.
+
+        Returns:
+            dict: Dictionary of environment variable names to values
+        """
+        environment = dict(DEFAULT_CONTAINER_ARGS['environment'])
+
+        # Merge with config.json container env
+        config_env = self.container_config.get('env', {})
+        environment.update(config_env)
+
+        return environment
+
+    def get_network_mode(self):
+        """
+        Get network mode, checking config.json first then defaults.
+
+        Returns:
+            str: Network mode string
+        """
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        return runtime_args.get('network', DEFAULT_CONTAINER_ARGS['network_mode'])
+
+    def get_ipc_mode(self):
+        """
+        Get IPC mode, checking config.json first then defaults.
+
+        Returns:
+            str: IPC mode string
+        """
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        return runtime_args.get('ipc', DEFAULT_CONTAINER_ARGS['ipc_mode'])
+
+    def is_privileged(self):
+        """
+        Check if privileged mode should be enabled, checking config.json first then defaults.
+
+        Returns:
+            bool: True if containers should run in privileged mode
+        """
+        runtime_config = self.container_config.get('runtime', {})
+        runtime_args = runtime_config.get('args', {})
+        return runtime_args.get('privileged', DEFAULT_CONTAINER_ARGS['privileged'])
+
+    def setup_containers(
+        self,
+        volumes=None,
+        devices=None,
+        capabilities=None,
+        security_opts=None,
+        environment=None,
+        groups=None,
+        ulimits=None,
+    ):
+        """
+        Set up containers based on configuration.
+
+        This method should be called explicitly by tests when they need containers.
+        It respects the 'enabled' flag and handles container lifecycle appropriately.
+        If 'launch' is true, checks that containers are already running and sets container_id.
+        If containers are not running when expected, fails and informs the user.
+
+        Args:
+            volumes: Optional list of volume mounts (uses standards if not provided)
+            devices: Optional list of device passthroughs (uses standards if not provided)
+            capabilities: Optional list of Linux capabilities (uses standards if not provided)
+            security_opts: Optional list of security options (uses standards if not provided)
+            environment: Optional dict of environment variables (uses standards if not provided)
+            groups: Optional list of groups to add (uses standards if not provided)
+            ulimits: Optional list of ulimits (uses standards if not provided)
+
+        Returns:
+            bool: True if containers were set up successfully or no setup needed
+        """
+        if not self.container_config or not self.container_config.get('enabled', False):
+            self.log.debug("Container mode not enabled, skipping setup")
+            return True
+
+        if self.container_config.get('launch', False):
+            # Launch containers
+            self.log.info("Launching containers...")
+            container_name = self.get_container_name(self.container_config, self.container_config['image'])
+            self.container_id = container_name
+
+            # Use provided parameters or get standards
+            volumes = volumes if volumes is not None else self.get_volumes()
+            devices = devices if devices is not None else self.get_devices()
+            capabilities = capabilities if capabilities is not None else self.get_capabilities()
+            security_opts = security_opts if security_opts is not None else self.get_security_opts()
+            environment = environment if environment is not None else self.get_environment()
+            groups = groups if groups is not None else self.get_groups()
+            ulimits = ulimits if ulimits is not None else self.get_ulimits()
+
+            # Create a modified container config with standard settings
+            modified_config = dict(self.container_config)
+
+            # Ensure runtime config exists
+            if 'runtime' not in modified_config:
+                modified_config['runtime'] = {}
+            if 'args' not in modified_config['runtime']:
+                modified_config['runtime']['args'] = {}
+
+            # Set standard runtime args if not already set
+            runtime_args = modified_config['runtime']['args']
+            if 'network' not in runtime_args:
+                runtime_args['network'] = self.get_network_mode()
+            if 'ipc' not in runtime_args:
+                runtime_args['ipc'] = self.get_ipc_mode()
+            if 'privileged' not in runtime_args:
+                runtime_args['privileged'] = self.is_privileged()
+
+            # Add InfiniBand device discovery via shell expansion (per-host)
+            ib_device_expansion = '$(for dev in /dev/infiniband/*; do echo -n "--device $dev:$dev "; done)'
+
+            return self.runtime.setup_containers(
+                modified_config,
+                container_name,
+                volumes=volumes,
+                devices=devices,
+                capabilities=capabilities,
+                security_opts=security_opts,
+                environment=environment,
+                groups=groups,
+                ulimits=ulimits,
+                device_expansion=ib_device_expansion,
+            )
+
+        # Assume containers are running
+        image = self.container_config.get('image')
+        if not image:
+            self.log.error("Container image not specified in config")
+            return False
+
+        container_name = self.get_container_name(self.container_config, image)
+        return self.verify_containers_running(container_name)
+
+    def setup_sshd(self):
+        """
+        Setup SSH daemon in containers for passwordless communication.
+
+        This method:
+        - Copies SSH keys from /host_ssh mounted volume to /root/.ssh
+        - Fixes permissions on SSH directory
+        - Starts sshd on port 2224
+        - Validates SSH daemon started successfully
+
+        Returns:
+            bool: True if SSH setup succeeded on all nodes, False otherwise
+
+        Raises:
+            RuntimeError: If no containers are currently running
+        """
+        if not self.container_id:
+            raise RuntimeError("No containers running. Call setup_containers() first.")
+
+        self.log.info(f"Setting up SSH daemon in containers: {self.container_id}")
+
+        # Execute SSH setup commands
+        # Note: Commands with shell operators must be wrapped in bash -c for proper execution inside container
+        ssh_setup_commands = [
+            "mkdir -p /root/.ssh",
+            "bash -c 'cp -r /host_ssh/* /root/.ssh/'",  # bash -c ensures glob expands inside container
+            "chown -R root:root /root/.ssh",
+            "bash -c 'chmod 700 /root/.ssh && chmod 600 /root/.ssh/*'",
+            "mkdir -p /run/sshd",  # Create privilege separation directory for sshd
+            "/usr/sbin/sshd -p2224",
+        ]
+
+        for cmd in ssh_setup_commands:
+            result = self.exec(cmd, timeout=10, detailed=True)
+            # Check if command succeeded on all hosts
+            for hostname, output in result.items():
+                if output['exit_code'] != 0:
+                    self.log.error(f"SSH setup command failed on {hostname}: {cmd}")
+                    return False
+
+        # Wait for sshd to start
+        import time
+
+        time.sleep(2)
+
+        # Validate sshd is running by checking process
+        check_cmd = "pgrep -f 'sshd.*2224' > /dev/null 2>&1"
+        result = self.exec(check_cmd, timeout=10, detailed=True)
+
+        # Check if all hosts have sshd running
+        for hostname, output in result.items():
+            if output['exit_code'] != 0:
+                self.log.error(f"SSH daemon validation failed on {hostname}")
+                return False
+            else:
+                self.log.info(f"SSH daemon started successfully on {hostname}")
+
+        return True
+
+    def verify_containers_running(self, container_name):
+        """
+        Verify that containers with the given name are running on all hosts.
+
+        Args:
+            container_name: Name of the container to check
+
+        Returns:
+            bool: True if container is running on all hosts, False otherwise
+        """
+        # Check if container is running on all hosts
+        cmd = f"sudo docker ps --filter name=^{container_name}$ --filter status=running --format '{{{{.Names}}}}'"
+        self.log.debug(f"Checking if container '{container_name}' is running on all hosts")
+        result = self.all.exec(cmd, timeout=30)
+
+        # Verify container is running on all hosts
+        failed_hosts = []
+        for host, output in result.items():
+            if output.get('exit_code') != 0:
+                failed_hosts.append(f"{host} (exit code {output.get('exit_code')})")
+                continue
+            running_name = output.get('stdout', '').strip()
+            if running_name != container_name:
+                failed_hosts.append(f"{host} (container not running, found: '{running_name}')")
+
+        if failed_hosts:
+            self.log.error(f"Container '{container_name}' not running on hosts: {failed_hosts}")
+            return False
+
+        self.container_id = container_name
+        self.log.info(f"Verified container '{container_name}' is running on all hosts")
+        return True
+
+    def teardown_containers(self):
+        """
+        Tear down containers if they are running.
+
+        This method should be called explicitly by tests for cleanup.
+        It respects the 'enabled' flag and handles container lifecycle appropriately.
+        If 'launch' is true, assumes containers should not be stopped (externally managed).
+
+        Returns:
+            bool: True if containers were torn down successfully or no teardown needed
+        """
+        if not self.container_config or not self.container_config.get('enabled', False):
+            self.log.debug("Container mode not enabled, skipping teardown")
+            return True
+
+        if self.container_config.get('launch', False):
+            self.log.debug("launch is true, not stopping externally managed containers")
+            return True
+
+        if not self.container_id:
+            self.log.debug("No containers running")
+            return True
+
+        self.log.info("Tearing down containers...")
+        self.log.info(f"Stopping containers: {self.container_id}")
+        success = self.runtime.teardown_containers(self.container_id)
+        self.container_id = None
+        return success
+
+    @staticmethod
+    def sanitize_container_name(image_name):
+        """
+        Sanitize an image name to create a valid container name.
+
+        Replaces any character that is not alphanumeric or underscore with underscore.
+
+        Args:
+            image_name: Docker image name (e.g., "rocm/cvs:latest")
+
+        Returns:
+            Sanitized string suitable for container name
+        """
+        return re.sub(r'[^a-zA-Z0-9_]', '_', image_name)
+
+    @staticmethod
+    def get_container_name(container_config, image):
+        """
+        Get container name from config or generate default.
+
+        Args:
+            container_config: Container configuration dict
+            image: Docker image name
+
+        Returns:
+            Container name string
+        """
+        container_name = container_config.get('name')
+        if not container_name:
+            # Default: $(whoami)_<sanitize_image_name>
+            username = getpass.getuser()
+            sanitized_image = ContainerOrchestrator.sanitize_container_name(image)
+            container_name = f"{username}_{sanitized_image}"
+        return container_name
+
+    def exec(self, cmd, hosts=None, timeout=None, detailed=False):
+        """
+        Execute command in running containers.
+
+        Args:
+            cmd: Command to execute inside container
+            hosts: Target hosts (if None, uses all hosts)
+            timeout: Command timeout
+            detailed: If True, return detailed execution info including exit_code
+
+        Returns:
+            Dictionary mapping hosts to execution results
+
+        Raises:
+            RuntimeError: If no containers are currently running
+        """
+        if not self.container_id:
+            raise RuntimeError("No containers running. Call setup_containers() first.")
+
+        return self.runtime.exec(self.container_id, cmd, hosts, timeout, detailed)
+
+    def exec_on_head(self, cmd, timeout=None):
+        """
+        Execute command directly on head node (baremetal).
+
+        Args:
+            cmd: Command to execute on head node
+            timeout: Command timeout
+
+        Returns:
+            Dictionary mapping head node to execution result
+        """
+        return self.runtime.exec_on_head(self.container_id, cmd, timeout)
+
+    def distribute_using_mpi(
+        self,
+        rank_cmd,
+        mpi_hosts,
+        ranks_per_host,
+        env_vars,
+        mpi_install_dir,
+        mpi_extra_args=None,
+        no_of_global_ranks=None,
+    ):
+        """
+        Distribute MPI job across hosts using containers.
+
+        Args:
+            rank_cmd: The command to execute on each MPI rank
+            mpi_hosts: List of host IPs/names for MPI hostfile
+            ranks_per_host: Number of MPI ranks per host (uniform across hosts)
+            env_vars: Dict of environment variables to set
+            mpi_install_dir: Path to MPI installation directory
+            mpi_extra_args: List of additional mpirun arguments
+            no_of_global_ranks: Total number of MPI ranks (optional, defaults to len(mpi_hosts) * ranks_per_host)
+
+        Returns:
+            Execution results
+        """
+        # Use parent class to build MPI command with wrapped rank command
+        full_mpi_cmd = super().build_mpi_cmd(
+            rank_cmd, mpi_hosts, ranks_per_host, env_vars, mpi_install_dir, mpi_extra_args, no_of_global_ranks
+        )
+
+        self.log.info("Launching MPI job in containers")
+        self.log.debug(f"MPI command: {full_mpi_cmd}")
+
+        # Execute on head node
+        return self.exec_on_head(full_mpi_cmd, timeout=600)
+
+    def cleanup(self, hosts):
+        """
+        Clean up container resources after test execution.
+
+        Args:
+            hosts: List of host addresses
+
+        Returns:
+            True if cleanup succeeded, False otherwise
+        """
+        if self.container_id:
+            self.log.info("Tearing down containers")
+            success = self.runtime.teardown_containers(self.container_id)
+            if success:
+                self.container_id = None
+            return success
+        return True

--- a/cvs/core/orchestrators/container.py
+++ b/cvs/core/orchestrators/container.py
@@ -413,19 +413,18 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         Returns:
             bool: True if container is running on all hosts, False otherwise
         """
-        # Check if container is running on all hosts
-        cmd = f"sudo docker ps --filter name=^{container_name}$ --filter status=running --format '{{{{.Names}}}}'"
         self.log.debug(f"Checking if container '{container_name}' is running on all hosts")
-        result = self.all.exec(cmd, timeout=30)
+        result = self.runtime.is_running(container_name)
 
         # Verify container is running on all hosts
         failed_hosts = []
-        for host, output in result.items():
-            if output.get('exit_code') != 0:
-                failed_hosts.append(f"{host} (exit code {output.get('exit_code')})")
+        for host, info in result.items():
+            exit_code = info.get('exit_code')
+            if exit_code != 0:
+                failed_hosts.append(f"{host} (exit code {exit_code})")
                 continue
-            running_name = output.get('stdout', '').strip()
-            if running_name != container_name:
+            if not info.get('running'):
+                running_name = info.get('name', '')
                 failed_hosts.append(f"{host} (container not running, found: '{running_name}')")
 
         if failed_hosts:
@@ -442,7 +441,7 @@ class ContainerOrchestrator(BaremetalOrchestrator):
 
         This method should be called explicitly by tests for cleanup.
         It respects the 'enabled' flag and handles container lifecycle appropriately.
-        If 'launch' is true, assumes containers should not be stopped (externally managed).
+        If 'launch' is False, assumes containers should not be stopped (externally managed).
 
         Returns:
             bool: True if containers were torn down successfully or no teardown needed
@@ -451,8 +450,8 @@ class ContainerOrchestrator(BaremetalOrchestrator):
             self.log.debug("Container mode not enabled, skipping teardown")
             return True
 
-        if self.container_config.get('launch', False):
-            self.log.debug("launch is true, not stopping externally managed containers")
+        if not self.container_config.get('launch', False):
+            self.log.debug("launch is False, not stopping externally managed containers")
             return True
 
         if not self.container_id:

--- a/cvs/core/orchestrators/factory.py
+++ b/cvs/core/orchestrators/factory.py
@@ -1,0 +1,177 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+from cvs.core.orchestrators.baremetal import BaremetalOrchestrator
+from cvs.core.orchestrators.container import ContainerOrchestrator
+
+
+class OrchestratorConfig:
+    """
+    Configuration for orchestrator creation.
+
+    Contains only the configuration keys required by orchestrators.
+
+    Expected keys in cluster_config.json or <testsuite>_config.json:
+    - orchestrator: Type of orchestrator ('baremetal', 'container', etc.) [optional, default: 'baremetal']
+    - node_dict: List/dict of cluster nodes [required, no default]
+    - username: SSH username for node access [required, no default]
+    - priv_key_file: Path to SSH private key file [required, no default]
+    - password: Optional SSH password (if not using key-based auth) [default: None]
+    - head_node_dict: Optional head node configuration with 'mgmt_ip' key [default: {}]
+    - container: Optional container configuration for docker orchestrator [default: {}]
+          Example container configuration:
+          ```json
+          "container": {
+            "enabled": true,
+            "launch": false,
+            "runtime": {
+              "name": "docker",
+              "args": {
+                "volumes": ["/host/path:/container/path:ro"],
+                "devices": ["/dev/kfd", "/dev/dri"],
+                "env": {"GPUS": "8", "MULTINODE": "true"},
+                "cap_add": ["SYS_PTRACE"],
+                "security_opt": ["apparmor=unconfined", "seccomp=unconfined"],
+                "group_add": ["video"],
+                "network": "host",
+                "ipc": "host",
+                "ulimit": ["memlock=-1"],
+                "privileged": true
+              }
+            },
+            "image": "rocm/cvs:latest",
+            "name": "myuser_rocm_cvs_latest"
+          }
+          ```
+          launch: Containers are already running, test suite should not start/stop them [default: false]
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Initialize orchestrator configuration.
+
+        Args:
+            **kwargs: Required orchestrator configuration keys
+        """
+        self.orchestrator = kwargs['orchestrator']
+        self.node_dict = kwargs['node_dict']
+        self.username = kwargs['username']
+        self.priv_key_file = kwargs['priv_key_file']
+        self.password = kwargs.get('password')
+        self.head_node_dict = kwargs.get('head_node_dict', {})
+        self.container = kwargs.get('container', {})
+
+    def get(self, key, default=None):
+        """Get configuration value with default."""
+        return getattr(self, key, default)
+
+    @classmethod
+    def from_configs(cls, cluster_config, testsuite_config=None):
+        """
+        Create config from multiple configuration sources.
+
+        Merges cluster_config.json and <testsuite>_config.json configurations, with testsuite_config
+        taking precedence for overlapping keys.
+
+        Args:
+            cluster_config: Cluster configuration (dict or path to cluster_config.json)
+                           Required keys: orchestrator, node_dict, username, priv_key_file
+                           Optional keys: container,
+                           head_node_dict, password (defaults provided for missing optional keys)
+                           Container structure: {enabled: bool, launch: bool, runtime: {name: str, args: dict}, image: str, name: str, ...}
+            testsuite_config: Test suite specific configuration (dict or path to <testsuite>_config.json)
+                            Can override any keys from cluster_config
+
+        Returns:
+            OrchestratorConfig instance with extracted orchestrator keys
+        """
+        # Handle file paths or dicts
+        if isinstance(cluster_config, str):
+            import json  # Lazy import - only loaded when reading config files
+
+            with open(cluster_config) as f:
+                cluster_config = json.load(f)
+
+        if isinstance(testsuite_config, str):
+            import json  # Lazy import - only loaded when reading config files
+
+            with open(testsuite_config) as f:
+                testsuite_config = json.load(f)
+
+        # Merge configurations
+        merged_config = cluster_config.copy()
+        if testsuite_config:
+            merged_config.update(testsuite_config)
+
+        # Extract only required keys for orchestrators
+        required_config = {
+            'orchestrator': merged_config.get('orchestrator', 'baremetal'),
+            'node_dict': merged_config.get('node_dict'),
+            'username': merged_config.get('username'),
+            'priv_key_file': merged_config.get('priv_key_file'),
+            'password': merged_config.get('password'),
+            'head_node_dict': merged_config.get('head_node_dict', {}),
+            'container': merged_config.get('container', {}),
+        }
+
+        # Validate required keys
+        if required_config['node_dict'] is None:
+            raise ValueError("node_dict must be provided in configuration")
+        if required_config['username'] is None:
+            raise ValueError("username must be provided in configuration")
+        if required_config['priv_key_file'] is None:
+            raise ValueError("priv_key_file must be provided in configuration")
+
+        return cls(**required_config)
+
+
+class OrchestratorFactory:
+    """
+    Factory for creating orchestrator instances based on configuration.
+
+    Provides pluggable architecture for adding new backends without
+    modifying existing test code.
+    """
+
+    @staticmethod
+    def create_orchestrator(log, config, stop_on_errors=False):
+        """
+        Create orchestrator instance from configuration.
+
+        Args:
+            log: Logger instance
+            config: OrchestratorConfig instance
+            stop_on_errors: Whether to stop execution on first error
+
+        Returns:
+            Orchestrator instance
+
+        Raises:
+            ValueError: If orchestrator type is unsupported
+            TypeError: If config is not OrchestratorConfig instance
+        """
+        if not isinstance(config, OrchestratorConfig):
+            raise TypeError("config must be OrchestratorConfig instance")
+
+        orchestrator_type = config.orchestrator.lower()
+
+        if orchestrator_type == 'baremetal':
+            return BaremetalOrchestrator(log, config, stop_on_errors)
+        elif orchestrator_type == 'container':
+            return ContainerOrchestrator(log, config, stop_on_errors)
+        else:
+            raise ValueError(f"Unsupported orchestrator type: {orchestrator_type}")
+
+    @staticmethod
+    def get_supported_backends():
+        """
+        Get list of supported orchestrator backends.
+
+        Returns:
+            List of backend names
+        """
+        return ['baremetal', 'container']

--- a/cvs/core/orchestrators/factory.py
+++ b/cvs/core/orchestrators/factory.py
@@ -56,7 +56,16 @@ class OrchestratorConfig:
 
         Args:
             **kwargs: Required orchestrator configuration keys
+
+        Raises:
+            ValueError: If any required key (orchestrator, node_dict, username,
+                priv_key_file) is missing.
         """
+        required = ('orchestrator', 'node_dict', 'username', 'priv_key_file')
+        missing = [k for k in required if k not in kwargs]
+        if missing:
+            raise ValueError(f"OrchestratorConfig missing required keys: {missing}")
+
         self.orchestrator = kwargs['orchestrator']
         self.node_dict = kwargs['node_dict']
         self.username = kwargs['username']

--- a/cvs/core/orchestrators/unittests/test_baremetal.py
+++ b/cvs/core/orchestrators/unittests/test_baremetal.py
@@ -1,0 +1,76 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+# Unit tests for cvs/core/orchestrators/baremetal.py: BaremetalOrchestrator construction
+# and command-dispatch surface (exec, exec_on_head, cleanup) used by the migrated
+# rvs_cvs.py orch fixture. Mocks Pssh so tests run with no SSH.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cvs.core.orchestrators.factory import OrchestratorConfig
+from cvs.core.orchestrators.baremetal import BaremetalOrchestrator
+
+
+def _make_orch_config():
+    """Minimal OrchestratorConfig that satisfies BaremetalOrchestrator.__init__
+    without touching disk or SSH."""
+    return OrchestratorConfig(
+        orchestrator="baremetal",
+        node_dict={"10.0.0.1": {}, "10.0.0.2": {}},
+        username="testuser",
+        priv_key_file="/dev/null",
+        password=None,
+        head_node_dict={"mgmt_ip": "10.0.0.1"},
+        container={},
+    )
+
+
+class TestBaremetalOrchestrator(unittest.TestCase):
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_init_constructs_pssh_handles(self, mock_pssh):
+        BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        # __init__ creates two Pssh handles: self.head and self.all.
+        self.assertEqual(mock_pssh.call_count, 2)
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_init_sets_orchestrator_type(self, _mock_pssh):
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        self.assertEqual(orch.orchestrator_type, "baremetal")
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_init_picks_first_node_as_head(self, _mock_pssh):
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        # _make_orch_config inserts 10.0.0.1 first.
+        self.assertEqual(orch.head_node, "10.0.0.1")
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_exec_delegates_to_all_when_targeting_full_set(self, _mock_pssh):
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        orch.all = MagicMock()
+        orch.all.exec.return_value = {"10.0.0.1": "ok", "10.0.0.2": "ok"}
+        result = orch.exec("ls", timeout=5)
+        orch.all.exec.assert_called_once_with("ls", timeout=5)
+        self.assertEqual(result, {"10.0.0.1": "ok", "10.0.0.2": "ok"})
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_exec_on_head_delegates_to_head_handle(self, _mock_pssh):
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        orch.head = MagicMock()
+        orch.head.exec.return_value = {"10.0.0.1": "ok"}
+        result = orch.exec_on_head("hostname", timeout=10)
+        orch.head.exec.assert_called_once_with("hostname", timeout=10)
+        self.assertEqual(result, {"10.0.0.1": "ok"})
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_cleanup_returns_true(self, _mock_pssh):
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        self.assertTrue(orch.cleanup(orch.hosts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/core/orchestrators/unittests/test_container.py
+++ b/cvs/core/orchestrators/unittests/test_container.py
@@ -1,0 +1,145 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+# Unit tests for cvs/core/orchestrators/container.py: ContainerOrchestrator construction
+# (incl. SSH port override and runtime wiring) and the setup_containers / teardown_containers
+# short-circuit semantics inherited by the rvs_cvs.py orch fixture. Mocks Pssh and
+# RuntimeFactory so tests run with no SSH or container runtime.
+#
+# The teardown_containers short-circuit at cvs/core/orchestrators/container.py:439 is
+# pinned here so any future change has a loud canary.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cvs.core.orchestrators.factory import OrchestratorConfig
+from cvs.core.orchestrators.container import ContainerOrchestrator
+
+
+def _make_orch_config(launch=False, enabled=True):
+    """Minimal OrchestratorConfig that satisfies ContainerOrchestrator.__init__
+    without touching disk or SSH."""
+    return OrchestratorConfig(
+        orchestrator="container",
+        node_dict={"10.0.0.1": {}, "10.0.0.2": {}},
+        username="testuser",
+        priv_key_file="/dev/null",
+        password=None,
+        head_node_dict={"mgmt_ip": "10.0.0.1"},
+        container={
+            "enabled": enabled,
+            "launch": launch,
+            "image": "rocm/cvs:test",
+            "name": "cvs_iter_test",
+            "runtime": {"name": "docker", "args": {}},
+        },
+    )
+
+
+class TestContainerOrchestrator(unittest.TestCase):
+    def _make(self, _mock_pssh, _mock_rf, launch=False, enabled=True):
+        cfg = _make_orch_config(launch=launch, enabled=enabled)
+        runtime = MagicMock(name="docker_runtime")
+        _mock_rf.create.return_value = runtime
+        orch = ContainerOrchestrator(MagicMock(), cfg)
+        return orch, runtime
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_init_creates_runtime_via_factory(self, _mock_pssh, mock_rf):
+        orch, runtime = self._make(_mock_pssh, mock_rf)
+        self.assertIs(orch.runtime, runtime)
+        # docker is the default runtime when container.runtime.name == "docker".
+        mock_rf.create.assert_called_once()
+        self.assertEqual(mock_rf.create.call_args[0][0], "docker")
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_init_sets_orchestrator_type(self, _mock_pssh, mock_rf):
+        orch, _ = self._make(_mock_pssh, mock_rf)
+        self.assertEqual(orch.orchestrator_type, "container")
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_init_overrides_ssh_port_to_container_sshd(self, _mock_pssh, mock_rf):
+        orch, _ = self._make(_mock_pssh, mock_rf)
+        self.assertEqual(orch.ssh_port, 2224)
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_setup_containers_launch_true_delegates_to_runtime(self, _mock_pssh, mock_rf):
+        orch, runtime = self._make(_mock_pssh, mock_rf, launch=True)
+        runtime.setup_containers.return_value = True
+        result = orch.setup_containers()
+        self.assertTrue(result)
+        runtime.setup_containers.assert_called_once()
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_setup_containers_short_circuits_when_disabled(self, _mock_pssh, mock_rf):
+        orch, runtime = self._make(_mock_pssh, mock_rf, enabled=False)
+        result = orch.setup_containers()
+        self.assertTrue(result)  # Disabled is treated as success / no-op.
+        runtime.setup_containers.assert_not_called()
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_teardown_containers_short_circuits_when_launch_false(self, _mock_pssh, mock_rf):
+        # launch:false means containers are externally managed; teardown is a no-op.
+        orch, runtime = self._make(_mock_pssh, mock_rf, launch=False)
+        orch.container_id = "test_container"
+        self.assertTrue(orch.teardown_containers())
+        runtime.teardown_containers.assert_not_called()
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_teardown_containers_calls_runtime_when_launch_true(self, _mock_pssh, mock_rf):
+        # launch:true means CVS owns the container lifecycle; teardown delegates to runtime.
+        orch, runtime = self._make(_mock_pssh, mock_rf, launch=True)
+        orch.container_id = "test_container"
+        runtime.teardown_containers.return_value = True
+        self.assertTrue(orch.teardown_containers())
+        runtime.teardown_containers.assert_called_once_with("test_container")
+        # container_id cleared on successful teardown.
+        self.assertIsNone(orch.container_id)
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_teardown_containers_short_circuits_when_disabled(self, _mock_pssh, mock_rf):
+        orch, runtime = self._make(_mock_pssh, mock_rf, enabled=False)
+        orch.container_id = "test_container"
+        self.assertTrue(orch.teardown_containers())
+        runtime.teardown_containers.assert_not_called()
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_teardown_containers_short_circuits_when_no_container_id(self, _mock_pssh, mock_rf):
+        # container_id stays None when prepare/setup never ran; teardown is a no-op
+        # even with launch=True (CVS-owned), since there is nothing to tear down.
+        orch, runtime = self._make(_mock_pssh, mock_rf, launch=True)
+        self.assertIsNone(orch.container_id)
+        self.assertTrue(orch.teardown_containers())
+        runtime.teardown_containers.assert_not_called()
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_init_requires_container_config(self, _mock_pssh, _mock_rf):
+        # ContainerOrchestrator raises if 'container' config is empty. Construct
+        # the config directly to bypass the helper's auto-population.
+        cfg = OrchestratorConfig(
+            orchestrator="container",
+            node_dict={"10.0.0.1": {}},
+            username="testuser",
+            priv_key_file="/dev/null",
+            container={},
+        )
+        with self.assertRaises(ValueError):
+            ContainerOrchestrator(MagicMock(), cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/core/orchestrators/unittests/test_factory.py
+++ b/cvs/core/orchestrators/unittests/test_factory.py
@@ -1,0 +1,151 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+# Unit tests for cvs/core/orchestrators/factory.py: OrchestratorFactory.create_orchestrator
+# dispatch and OrchestratorConfig construction / from_configs validation. Mocks Pssh and
+# RuntimeFactory so tests run without SSH or container runtime.
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFactory
+from cvs.core.orchestrators.baremetal import BaremetalOrchestrator
+from cvs.core.orchestrators.container import ContainerOrchestrator
+
+
+def _make_orch_config(orchestrator="baremetal", with_container=False, launch=False, enabled=True):
+    """Minimal OrchestratorConfig that satisfies BaremetalOrchestrator and (optionally)
+    ContainerOrchestrator __init__ without touching disk or SSH."""
+    kwargs = dict(
+        orchestrator=orchestrator,
+        node_dict={"10.0.0.1": {}, "10.0.0.2": {}},
+        username="testuser",
+        priv_key_file="/dev/null",
+        password=None,
+        head_node_dict={"mgmt_ip": "10.0.0.1"},
+        container={},
+    )
+    if with_container or orchestrator == "container":
+        kwargs["container"] = {
+            "enabled": enabled,
+            "launch": launch,
+            "image": "rocm/cvs:test",
+            "name": "cvs_iter_test",
+            "runtime": {"name": "docker", "args": {}},
+        }
+    return OrchestratorConfig(**kwargs)
+
+
+class TestOrchestratorFactory(unittest.TestCase):
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_create_returns_baremetal_for_baremetal_string(self, _mock_pssh):
+        cfg = _make_orch_config(orchestrator="baremetal")
+        orch = OrchestratorFactory.create_orchestrator(MagicMock(), cfg)
+        self.assertIsInstance(orch, BaremetalOrchestrator)
+
+    @patch("cvs.core.orchestrators.container.RuntimeFactory")
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_create_returns_container_for_container_string(self, _mock_pssh, _mock_rf):
+        cfg = _make_orch_config(orchestrator="container")
+        orch = OrchestratorFactory.create_orchestrator(MagicMock(), cfg)
+        self.assertIsInstance(orch, ContainerOrchestrator)
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_create_raises_for_unsupported_string(self, _mock_pssh):
+        # Bypass OrchestratorConfig.from_configs validation by constructing
+        # the config object directly with an unsupported orchestrator value.
+        cfg = _make_orch_config(orchestrator="slurm")
+        with self.assertRaises(ValueError):
+            OrchestratorFactory.create_orchestrator(MagicMock(), cfg)
+
+    def test_create_raises_typeerror_for_non_config(self):
+        with self.assertRaises(TypeError):
+            OrchestratorFactory.create_orchestrator(MagicMock(), {"orchestrator": "baremetal"})
+
+    def test_get_supported_backends_lists_both(self):
+        backends = OrchestratorFactory.get_supported_backends()
+        self.assertIn("baremetal", backends)
+        self.assertIn("container", backends)
+
+
+class TestOrchestratorConfig(unittest.TestCase):
+    def test_get_returns_default_for_missing_key(self):
+        cfg = _make_orch_config()
+        self.assertEqual(cfg.get("nonexistent_key", "fallback"), "fallback")
+
+    def test_get_returns_value_for_existing_attr(self):
+        cfg = _make_orch_config()
+        self.assertEqual(cfg.get("username"), "testuser")
+
+    def test_from_configs_defaults_orchestrator_to_baremetal_when_omitted(self):
+        cluster = {"node_dict": {"1.1.1.1": {}}, "username": "u", "priv_key_file": "/dev/null"}
+        cfg = OrchestratorConfig.from_configs(cluster)
+        self.assertEqual(cfg.orchestrator, "baremetal")
+
+    def test_from_configs_merges_testsuite_over_cluster(self):
+        cluster = {
+            "orchestrator": "baremetal",
+            "node_dict": {"1.1.1.1": {}},
+            "username": "cluster_user",
+            "priv_key_file": "/dev/null",
+        }
+        testsuite = {"username": "testsuite_user"}
+        cfg = OrchestratorConfig.from_configs(cluster, testsuite)
+        self.assertEqual(cfg.username, "testsuite_user")
+
+    def test_from_configs_raises_when_node_dict_missing(self):
+        cluster = {"username": "u", "priv_key_file": "/dev/null"}
+        with self.assertRaises(ValueError):
+            OrchestratorConfig.from_configs(cluster)
+
+    def test_from_configs_raises_when_username_missing(self):
+        cluster = {"node_dict": {"1.1.1.1": {}}, "priv_key_file": "/dev/null"}
+        with self.assertRaises(ValueError):
+            OrchestratorConfig.from_configs(cluster)
+
+    def test_from_configs_raises_when_priv_key_file_missing(self):
+        cluster = {"node_dict": {"1.1.1.1": {}}, "username": "u"}
+        with self.assertRaises(ValueError):
+            OrchestratorConfig.from_configs(cluster)
+
+    def test_init_raises_valueerror_for_missing_required_key(self):
+        # Direct construction with a missing required key should surface a clear
+        # ValueError listing what's missing, not a bare KeyError.
+        with self.assertRaises(ValueError) as ctx:
+            OrchestratorConfig(
+                orchestrator="baremetal",
+                node_dict={"1.1.1.1": {}},
+                username="u",
+                # priv_key_file deliberately omitted
+            )
+        self.assertIn("priv_key_file", str(ctx.exception))
+
+    def test_from_configs_reads_from_file_path(self):
+        # Round-trip a real JSON file through from_configs to exercise the
+        # path-handling branch (the rvs_cvs.py orch fixture goes through this).
+        cluster = {
+            "orchestrator": "baremetal",
+            "node_dict": {"1.1.1.1": {}, "1.1.1.2": {}},
+            "username": "u",
+            "priv_key_file": "/dev/null",
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(cluster, f)
+            path = f.name
+        try:
+            cfg = OrchestratorConfig.from_configs(path)
+            self.assertEqual(cfg.orchestrator, "baremetal")
+            self.assertEqual(len(cfg.node_dict), 2)
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/core/runtimes/__init__.py
+++ b/cvs/core/runtimes/__init__.py
@@ -1,0 +1,13 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+from .base import ContainerRuntime
+from .docker import DockerRuntime
+from .enroot import EnrootRuntime
+from .factory import RuntimeFactory
+
+__all__ = ['ContainerRuntime', 'DockerRuntime', 'EnrootRuntime', 'RuntimeFactory']

--- a/cvs/core/runtimes/base.py
+++ b/cvs/core/runtimes/base.py
@@ -1,0 +1,32 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+from typing import Protocol
+
+
+class ContainerRuntime(Protocol):
+    """Protocol for container runtime implementations."""
+
+    def setup_containers(self, container_config, container_name):
+        """Set up containers on all nodes."""
+        ...
+
+    def teardown_containers(self, container_name):
+        """Tear down containers on all nodes."""
+        ...
+
+    def exec(self, container_name, cmd, hosts=None, timeout=None):
+        """Execute command in running containers."""
+        ...
+
+    def exec_on_head(self, container_name, cmd, timeout=None):
+        """Execute command directly on head node (baremetal)."""
+        ...
+
+    def load_image(self, tar_path, timeout=None):
+        """Load container image from tar file on all hosts."""
+        ...

--- a/cvs/core/runtimes/base.py
+++ b/cvs/core/runtimes/base.py
@@ -19,6 +19,16 @@ class ContainerRuntime(Protocol):
         """Tear down containers on all nodes."""
         ...
 
+    def is_running(self, container_name):
+        """Check whether a container with the given name is running on each host.
+
+        Returns:
+            dict: per-host result with keys 'running' (bool), 'name' (str, the
+            actually-running container name found on that host, or empty), and
+            'exit_code' (int, the underlying probe command's exit code).
+        """
+        ...
+
     def exec(self, container_name, cmd, hosts=None, timeout=None):
         """Execute command in running containers."""
         ...

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -1,0 +1,239 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+
+class DockerRuntime:
+    """Docker container runtime implementation."""
+
+    def __init__(self, log, orchestrator):
+        self.log = log
+        self.orchestrator = orchestrator  # Reference to orchestrator for SSH execution
+
+    def check_image_exists(self, image_name):
+        """Check if the Docker image exists on all nodes."""
+        cmd = f"sudo docker images --format '{{{{.Repository}}}}:{{{{.Tag}}}}' | grep -q '^{image_name}$'"
+        result = self.orchestrator.all.exec(cmd, timeout=30, detailed=True)
+        # If grep succeeds (exit 0), image exists; if not, not found
+        return all(res.get('exit_code') == 0 for res in result.values())
+
+    def setup_containers(
+        self,
+        container_config,
+        container_name,
+        volumes=None,
+        devices=None,
+        capabilities=None,
+        security_opts=None,
+        environment=None,
+        groups=None,
+        ulimits=None,
+        device_expansion=None,
+    ):
+        """Set up long-running Docker containers on all nodes.
+
+        Args:
+            container_config: Container configuration dictionary
+            container_name: Name to assign to the containers
+            volumes: Optional list of volume mounts (overrides config)
+            devices: Optional list of device passthroughs (overrides config)
+            capabilities: Optional list of Linux capabilities (overrides config)
+            security_opts: Optional list of security options (overrides config)
+            environment: Optional dict of environment variables (overrides config)
+            groups: Optional list of groups to add (overrides config)
+            ulimits: Optional list of ulimits (overrides config)
+            device_expansion: Optional shell expansion string for dynamic device discovery
+        """
+        if not container_config or not container_config.get('image'):
+            self.log.warning("No container config or image specified, skipping container start")
+            return False
+
+        launch = container_config.get('launch', False)
+        if not launch:
+            self.log.info("Container launch disabled, assuming containers are already running")
+            return True
+
+        image = container_config['image']
+
+        # Use provided parameters or fall back to config
+        volumes = volumes if volumes is not None else container_config.get('volumes', [])
+        gpu_passthrough = container_config.get('gpu_passthrough', True)
+        container_env = environment if environment is not None else container_config.get('env', {})
+
+        # Build docker run command with additional args
+        runtime_config = container_config.get('runtime', {})
+        runtime_args_config = runtime_config.get('args', {})
+
+        # Override runtime args with provided parameters
+        if devices is not None:
+            runtime_args_config = dict(runtime_args_config)
+            runtime_args_config['devices'] = devices
+        if capabilities is not None:
+            runtime_args_config = dict(runtime_args_config)
+            runtime_args_config['cap_add'] = capabilities
+        if security_opts is not None:
+            runtime_args_config = dict(runtime_args_config)
+            runtime_args_config['security_opt'] = security_opts
+        if groups is not None:
+            runtime_args_config = dict(runtime_args_config)
+            runtime_args_config['group_add'] = groups
+        if ulimits is not None:
+            runtime_args_config = dict(runtime_args_config)
+            runtime_args_config['ulimit'] = ulimits
+
+        additional_args = self._build_runtime_args(runtime_args_config)
+
+        # Basic args
+        vol_args = ' '.join([f'-v {v}' for v in volumes])
+        env_args = ' '.join([f'-e {k}={v}' for k, v in container_env.items()])
+        gpu_args = '--gpus all' if gpu_passthrough else ''
+        network_args = '--network host' if not runtime_args_config.get('network') else ''
+
+        # Combine all arguments
+        all_args = [gpu_args, network_args, vol_args, env_args] + additional_args
+        if device_expansion:
+            all_args.append(device_expansion)
+        all_args_str = ' '.join(arg for arg in all_args if arg)
+
+        # Load image from tar if specified
+        if 'image_tar' in container_config:
+            if not self.check_image_exists(container_config['image']):
+                self.log.info(f"Loading image from tar: {container_config['image_tar']}")
+                load_result = self.load_image(container_config['image_tar'], timeout=300)
+                failed_load = [host for host, res in load_result.items() if res.get('exit_code') != 0]
+                if failed_load:
+                    self.log.error(f"Failed to load image tar on hosts: {failed_load}")
+                    return False
+            else:
+                self.log.info(f"Image {container_config['image']} already exists, skipping tar load")
+
+        cmd = f"sudo docker run -d --name {container_name} {all_args_str} {image} sleep infinity"
+
+        self.log.info(f"Starting long-running containers on {len(self.orchestrator.hosts)} nodes: {container_name}")
+        self.log.debug(f"Container start command: {cmd}")
+
+        # Remove any existing container with the same name
+        remove_cmd = f"sudo docker rm -f {container_name} || true"
+        self.orchestrator.all.exec(remove_cmd, timeout=30, print_console=False)
+
+        result = self.orchestrator.all.exec(cmd, timeout=60, detailed=True)
+
+        # Check if all hosts started successfully
+        success = all(output['exit_code'] == 0 for output in result.values())
+
+        if not success:
+            failed = [host for host, output in result.items() if output['exit_code'] != 0]
+            self.log.error(f"Container startup failed on hosts: {failed}")
+            # Clean up partial starts
+            self.teardown_containers(container_name)
+            return False
+
+        self.log.info(f"Containers started successfully: {container_name}")
+        return True
+
+    def teardown_containers(self, container_name):
+        """Stop and remove Docker containers on all nodes."""
+        if not container_name:
+            self.log.info("No container to stop")
+            return True
+
+        self.log.info(f"Stopping containers: {container_name}")
+
+        # Force remove container (stops if running)
+        cmd = f"sudo docker rm -f {container_name} 2>/dev/null || true"
+        result = self.orchestrator.all.exec(cmd, timeout=30, print_console=False, detailed=True)
+
+        success = all(output['exit_code'] == 0 for output in result.values())
+        if not success:
+            self.log.warning("Container stop had issues on some hosts")
+
+        return success
+
+    def exec(self, container_name, cmd, hosts=None, timeout=None, detailed=False):
+        """Execute command in running Docker containers."""
+        # Use docker exec to run command in existing container
+        exec_cmd = f"sudo docker exec {container_name} {cmd}"
+        if hosts:
+            # Execute on specific hosts
+            results = {}
+            for host in hosts:
+                results.update(self.orchestrator.all.exec_on_host(exec_cmd, host, timeout=timeout, detailed=detailed))
+            return results
+        else:
+            return self.orchestrator.all.exec(exec_cmd, timeout=timeout, detailed=detailed)
+
+    def exec_on_head(self, container_name, cmd, timeout=None):
+        """Execute command directly on head node (container)."""
+        exec_cmd = f"sudo docker exec {container_name} {cmd}"
+        return self.orchestrator.head.exec(exec_cmd, timeout=timeout)
+
+    @staticmethod
+    def _build_runtime_args(runtime_args_config):
+        """Build container runtime arguments from configuration."""
+        args = []
+
+        if not runtime_args_config:
+            return args
+
+        # Volumes
+        volumes = runtime_args_config.get('volumes', [])
+        for vol in volumes:
+            args.extend(['-v', vol])
+
+        # Devices
+        devices = runtime_args_config.get('devices', [])
+        for dev in devices:
+            args.extend(['--device', dev])
+
+        # Environment variables
+        env_vars = runtime_args_config.get('env', {})
+        for key, value in env_vars:
+            args.extend(['-e', f'{key}={value}'])
+
+        # Capabilities
+        cap_add = runtime_args_config.get('cap_add', [])
+        for cap in cap_add:
+            args.extend(['--cap-add', cap])
+
+        # Security options
+        security_opt = runtime_args_config.get('security_opt', [])
+        for opt in security_opt:
+            args.extend(['--security-opt', opt])
+
+        # Group add
+        group_add = runtime_args_config.get('group_add', [])
+        for group in group_add:
+            args.extend(['--group-add', group])
+
+        # Network
+        network = runtime_args_config.get('network')
+        if network:
+            args.extend(['--network', network])
+
+        # IPC
+        ipc = runtime_args_config.get('ipc')
+        if ipc:
+            args.extend(['--ipc', ipc])
+
+        # Ulimit
+        ulimit = runtime_args_config.get('ulimit', [])
+        for ul in ulimit:
+            args.extend(['--ulimit', ul])
+
+        # Privileged
+        if runtime_args_config.get('privileged', False):
+            args.append('--privileged')
+
+        return args
+
+    def load_image(self, tar_path, timeout=None):
+        """Load container image from tar file on all hosts."""
+        cmd = f"sudo docker load < {tar_path}"
+        timeout = timeout or 600  # Default 10 minutes
+
+        # Load on all hosts for image distribution
+        result = self.orchestrator.all.exec(cmd, timeout=timeout, detailed=True)
+        return result

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -35,8 +35,15 @@ class DockerRuntime:
     ):
         """Set up long-running Docker containers on all nodes.
 
+        AMD GPU passthrough is provided by the device flags auto-injected from
+        ``DEFAULT_CONTAINER_ARGS`` (``/dev/kfd``, ``/dev/dri``,
+        ``/dev/infiniband``). CVS is AMD-only, so no NVIDIA-style ``--gpus all``
+        flag is emitted.
+
         Args:
-            container_config: Container configuration dictionary
+            container_config: Container configuration dictionary. Recognized
+                top-level keys include ``image``, ``launch``, ``runtime`` (with
+                nested ``args``), and ``env``.
             container_name: Name to assign to the containers
             volumes: Optional list of volume mounts (overrides config)
             devices: Optional list of device passthroughs (overrides config)
@@ -60,7 +67,6 @@ class DockerRuntime:
 
         # Use provided parameters or fall back to config
         volumes = volumes if volumes is not None else container_config.get('volumes', [])
-        gpu_passthrough = container_config.get('gpu_passthrough', True)
         container_env = environment if environment is not None else container_config.get('env', {})
 
         # Build docker run command with additional args
@@ -84,16 +90,24 @@ class DockerRuntime:
             runtime_args_config = dict(runtime_args_config)
             runtime_args_config['ulimit'] = ulimits
 
+        # The positional 'volumes' arg is the single source of truth for -v flags
+        # (it already merges auto-injected mounts with runtime.args.volumes via
+        # ContainerOrchestrator.get_volumes()). Strip from runtime_args_config so
+        # _build_runtime_args does not re-emit them, otherwise user-supplied
+        # volumes would appear twice in the final docker run command.
+        if 'volumes' in runtime_args_config:
+            runtime_args_config = dict(runtime_args_config)
+            runtime_args_config.pop('volumes', None)
+
         additional_args = self._build_runtime_args(runtime_args_config)
 
         # Basic args
         vol_args = ' '.join([f'-v {v}' for v in volumes])
         env_args = ' '.join([f'-e {k}={v}' for k, v in container_env.items()])
-        gpu_args = '--gpus all' if gpu_passthrough else ''
         network_args = '--network host' if not runtime_args_config.get('network') else ''
 
         # Combine all arguments
-        all_args = [gpu_args, network_args, vol_args, env_args] + additional_args
+        all_args = [network_args, vol_args, env_args] + additional_args
         if device_expansion:
             all_args.append(device_expansion)
         all_args_str = ' '.join(arg for arg in all_args if arg)
@@ -133,6 +147,30 @@ class DockerRuntime:
 
         self.log.info(f"Containers started successfully: {container_name}")
         return True
+
+    def is_running(self, container_name):
+        """Check whether a container with the given name is running on each host.
+
+        Args:
+            container_name: Name of the container to check.
+
+        Returns:
+            dict: per-host result with keys 'running' (bool), 'name' (str, the
+            actually-running container name found on that host, or empty), and
+            'exit_code' (int, exit code of the underlying ``docker ps`` probe).
+        """
+        cmd = f"sudo docker ps --filter name=^{container_name}$ --filter status=running --format '{{{{.Names}}}}'"
+        raw = self.orchestrator.all.exec(cmd, timeout=30, detailed=True)
+        out = {}
+        for host, res in raw.items():
+            exit_code = res.get('exit_code')
+            running_name = (res.get('output') or '').strip()
+            out[host] = {
+                'exit_code': exit_code,
+                'running': exit_code == 0 and running_name == container_name,
+                'name': running_name,
+            }
+        return out
 
     def teardown_containers(self, container_name):
         """Stop and remove Docker containers on all nodes."""

--- a/cvs/core/runtimes/enroot.py
+++ b/cvs/core/runtimes/enroot.py
@@ -1,0 +1,34 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+
+class EnrootRuntime:
+    """Enroot container runtime implementation."""
+
+    def __init__(self, log, orchestrator):
+        self.log = log
+        self.orchestrator = orchestrator
+
+    def setup_containers(self, container_config, container_name):
+        """Set up Enroot containers - not yet implemented."""
+        self.log.warning("Enroot runtime not yet implemented")
+        return False
+
+    def teardown_containers(self, container_name):
+        """Tear down Enroot containers - not yet implemented."""
+        self.log.warning("Enroot runtime not yet implemented")
+        return True
+
+    def exec(self, container_name, cmd, hosts=None, timeout=None):
+        """Execute in Enroot containers - not yet implemented."""
+        self.log.error("Enroot runtime not yet implemented")
+        return {}
+
+    def exec_on_head(self, container_name, cmd, timeout=None):
+        """Execute on head in Enroot containers - not yet implemented."""
+        self.log.error("Enroot runtime not yet implemented")
+        return {}

--- a/cvs/core/runtimes/enroot.py
+++ b/cvs/core/runtimes/enroot.py
@@ -23,6 +23,11 @@ class EnrootRuntime:
         self.log.warning("Enroot runtime not yet implemented")
         return True
 
+    def is_running(self, container_name):
+        """Check Enroot container status - not yet implemented."""
+        self.log.error("Enroot runtime not yet implemented")
+        return {}
+
     def exec(self, container_name, cmd, hosts=None, timeout=None):
         """Execute in Enroot containers - not yet implemented."""
         self.log.error("Enroot runtime not yet implemented")

--- a/cvs/core/runtimes/factory.py
+++ b/cvs/core/runtimes/factory.py
@@ -1,0 +1,25 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+from .docker import DockerRuntime
+from .enroot import EnrootRuntime
+
+
+class RuntimeFactory:
+    """Factory for creating container runtime instances."""
+
+    @staticmethod
+    def create(runtime_name, log, orchestrator):
+        """Create a container runtime instance."""
+        runtime_name = runtime_name.lower()
+
+        if runtime_name == 'docker':
+            return DockerRuntime(log, orchestrator)
+        elif runtime_name == 'enroot':
+            return EnrootRuntime(log, orchestrator)
+        else:
+            raise ValueError(f"Unsupported container runtime: {runtime_name}")

--- a/cvs/core/runtimes/unittests/test_docker.py
+++ b/cvs/core/runtimes/unittests/test_docker.py
@@ -1,0 +1,115 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+# Unit tests for cvs/core/runtimes/docker.py: DockerRuntime.setup_containers
+# command-rendering invariants. Mocks the orchestrator's Pssh handle so we can
+# capture the rendered `docker run` command without touching SSH or docker.
+#
+# Pinned invariants:
+#   - User-supplied runtime.args.volumes must NOT be double-listed.
+#   - --gpus all must NEVER be emitted: CVS is AMD-only and AMD GPU access
+#     comes from the auto-injected --device /dev/kfd /dev/dri /dev/infiniband
+#     in DEFAULT_CONTAINER_ARGS. The flag is NVIDIA/CDI-specific and breaks
+#     AMD-only docker without the AMD container toolkit.
+
+import unittest
+from unittest.mock import MagicMock
+
+from cvs.core.runtimes.docker import DockerRuntime
+
+
+def _make_runtime(captured):
+    """DockerRuntime wired to a MagicMock orchestrator that captures the
+    `docker run` cmd string into the supplied list."""
+
+    def _fake_exec(cmd, timeout=None, detailed=False, print_console=True):
+        # The first call DockerRuntime.setup_containers makes is `docker rm -f`
+        # for a stale container; the second is the actual `docker run`. We only
+        # care about the run cmd.
+        if cmd.startswith("sudo docker run"):
+            captured.append(cmd)
+        # Mock a successful detailed result so setup_containers returns True.
+        return {"host1": {"output": "", "exit_code": 0}}
+
+    orchestrator = MagicMock()
+    orchestrator.hosts = ["host1"]
+    orchestrator.all.exec.side_effect = _fake_exec
+
+    log = MagicMock()
+    return DockerRuntime(log, orchestrator)
+
+
+def _container_config(launch=True, image="img:test", extra_runtime_args=None, **extra):
+    """Minimal container config dict for setup_containers."""
+    cfg = {
+        "enabled": True,
+        "launch": launch,
+        "image": image,
+        "name": "cvs_iter_test",
+        "runtime": {"name": "docker", "args": dict(extra_runtime_args or {})},
+    }
+    cfg.update(extra)
+    return cfg
+
+
+class TestDockerRuntimeSetupContainers(unittest.TestCase):
+    def test_user_volume_listed_once(self):
+        # With runtime.args.volumes=['/foo:/bar'] AND positional volumes that
+        # already include '/foo:/bar' (mirroring what
+        # ContainerOrchestrator.get_volumes() produces), the rendered docker
+        # run cmd must contain '-v /foo:/bar' EXACTLY ONCE -- vol_args is the
+        # single source of truth; _build_runtime_args must not re-emit it.
+        captured = []
+        rt = _make_runtime(captured)
+        cfg = _container_config(extra_runtime_args={"volumes": ["/foo:/bar"]})
+
+        rt.setup_containers(
+            container_config=cfg,
+            container_name="cvs_iter_test",
+            volumes=["/home/u:/workspace", "/home/u/.ssh:/host_ssh", "/foo:/bar"],
+        )
+
+        self.assertEqual(len(captured), 1, f"Expected 1 docker run cmd, got: {captured}")
+        cmd = captured[0]
+        self.assertEqual(
+            cmd.count("-v /foo:/bar"),
+            1,
+            f"User volume '/foo:/bar' must appear exactly once in:\n{cmd}",
+        )
+
+    def test_cmd_never_contains_gpus_all(self):
+        # CVS is AMD-only. The rendered docker run cmd must never contain
+        # '--gpus all', regardless of any container_config knob a future caller
+        # might re-introduce. Asserts in three scenarios:
+        #   1. minimal config, no GPU-related keys
+        #   2. legacy config that sets gpu_passthrough=True (must be ignored)
+        #   3. config with extra runtime args
+        # AMD GPU access is provided by --device /dev/kfd /dev/dri /dev/infiniband
+        # via DEFAULT_CONTAINER_ARGS -- not by --gpus all.
+        for label, cfg in [
+            ("minimal", _container_config()),
+            ("legacy_gpu_passthrough_true", _container_config(gpu_passthrough=True)),
+            ("with_extra_runtime_args", _container_config(extra_runtime_args={"network": "host"})),
+        ]:
+            with self.subTest(scenario=label):
+                captured = []
+                rt = _make_runtime(captured)
+                rt.setup_containers(
+                    container_config=cfg,
+                    container_name="cvs_iter_test",
+                    volumes=["/home/u:/workspace"],
+                )
+                self.assertEqual(len(captured), 1)
+                self.assertNotIn(
+                    "--gpus all",
+                    captured[0],
+                    f"[{label}] '--gpus all' must never appear in docker cmd:\n{captured[0]}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/input/cluster_file/README.md
+++ b/cvs/input/cluster_file/README.md
@@ -1,0 +1,147 @@
+# Cluster files
+
+Each CVS run is pointed at a cluster file via `--cluster_file <path>`. The
+file declares the SSH credentials, the node list, and the **execution
+backend** (`baremetal` or `container`). This directory ships two starter
+templates; copy the one that matches your shape, edit the placeholders,
+and pass the result to `cvs run`.
+
+| File | Backend | Use when |
+| --- | --- | --- |
+| [`cluster.json`](cluster.json) | baremetal (default) | ROCm, RVS, RCCL, etc. are installed on the host filesystem; you want to validate the production environment as-is. |
+| [`cluster_container.json`](cluster_container.json) | container | Workloads run inside a long-lived per-host container; the host only needs Docker, GPUs, and SSH. Best for reproducible release validation, CI, or validating the same image you ship to prod. |
+
+The choice is made entirely in the cluster file. The `cvs run ...` invocation
+does not change.
+
+## Scope today
+
+The orchestrator and its container backend are wired through a focused entry
+point. Today, only the surfaces below honor the `orchestrator` key and the
+`container` block:
+
+| Surface | Honors `orchestrator: container`? | Notes |
+| --- | --- | --- |
+| `cvs run rvs_cvs` | Yes | Lifecycle is owned by the `orch` fixture in [`cvs/tests/health/rvs_cvs.py`](../../tests/health/rvs_cvs.py). |
+| All other `cvs run <suite>` | No | Other suites have not been migrated to the orchestrator yet and run on the host filesystem. |
+| `cvs exec` | No | Always runs the command on the host via parallel SSH, regardless of the `orchestrator` value. Useful for verifying container state from outside (e.g. `sudo docker ps`). |
+| Custom Python scripts | Yes (escape hatch) | Use `OrchestratorConfig.from_configs(...)` and `OrchestratorFactory.create_orchestrator(...)` directly. See [`cvs/core/orchestrators/factory.py`](../../core/orchestrators/factory.py). |
+
+If you want a non-RVS suite to support the container backend, that work is
+tracked separately as a per-suite migration; this PR does not change those
+suites.
+
+## When to use container mode
+
+- Reproducibility: the test environment is the image, byte-for-byte across nodes
+- CI: the same image used in CI is the one validated against the cluster
+- "Validate what we ship": pin the workload to the release image
+- Minimal host footprint: the host only needs Docker, the kernel driver, and SSH; ROCm/RVS live in the image
+
+## Quick start (container mode)
+
+```bash
+cp cvs/input/cluster_file/cluster_container.json /tmp/my_cluster.json
+
+# Edit the placeholders:
+#   - {user-id}                  -> your SSH user
+#   - /home/{user-id}/.ssh/...   -> path to your private key
+#   - {xx.xx.xx.xx|hostname-N}   -> real public IPs or hostnames
+#   - container.image            -> a pullable image with rvs preinstalled
+
+cvs run rvs_cvs \
+    --cluster_file /tmp/my_cluster.json \
+    --config_file cvs/input/config_file/health/mi300_health_config.json
+```
+
+## The `container` block schema
+
+Consumed by `ContainerOrchestrator` in [`cvs/core/orchestrators/container.py`](../../core/orchestrators/container.py); extracted from the cluster file by `OrchestratorConfig.from_configs` in [`cvs/core/orchestrators/factory.py`](../../core/orchestrators/factory.py).
+
+| Key | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `enabled` | bool | `false` | Master switch. Must be `true` for the container backend to do anything; if `false`, `setup_containers` and `teardown_containers` short-circuit to no-ops. |
+| `launch` | bool | `false` | `true` = CVS owns lifecycle (starts on `setup_containers`, stops on `teardown_containers`). `false` = containers are externally managed; CVS only verifies they are running and never stops them. |
+| `image` | str | (required) | Image with the test dependencies (rvs, etc.) pre-installed and an sshd you can start on port 2224. Must be present locally on each node OR pullable from a reachable registry. |
+| `name` | str | (required) | Container name on each host. For parallel runs make this per-iteration unique (e.g. `cvs_iter_<run_id>`). |
+| `runtime.name` | str | `"docker"` | Container runtime. Supported: `docker` (concrete), `enroot` (stub). |
+| `runtime.args` | dict | `{}` | Backend-specific runtime arguments (see below). Defaults from `DEFAULT_CONTAINER_ARGS` in [`cvs/core/orchestrators/container.py`](../../core/orchestrators/container.py) apply for any key omitted here. |
+
+### `runtime.args` (docker) reference
+
+List args (`volumes`, `devices`, `cap_add`, `security_opt`, `group_add`,
+`ulimit`) **append to** the baked-in `DEFAULT_CONTAINER_ARGS`. Scalars
+(`network`, `ipc`, `privileged`) **override** the default when set,
+otherwise inherit it. An empty `args: {}` already yields a working
+RDMA-ready container; the keys below are only needed to extend or override.
+
+| Arg | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `network` | str | `"host"` | `--network` mode. `host` for clusters sharing the host net stack. |
+| `ipc` | str | `"host"` | `--ipc` mode. `host` enables cross-process IPC required for RDMA. |
+| `privileged` | bool | `true` | `--privileged`. Required for device passthrough and RDMA. |
+| `volumes` | list | `[]` (appended) | `host:container[:ro]` mounts. The container always also receives `/home/$user:/workspace` and `/home/$user/.ssh:/host_ssh` injected by the orchestrator. |
+| `devices` | list | `["/dev/kfd","/dev/dri","/dev/infiniband"]` (appended) | Device passthroughs. Per-host `/dev/infiniband/*` is also discovered at runtime. |
+| `cap_add` | list | `["SYS_PTRACE","IPC_LOCK","SYS_ADMIN"]` (appended) | Linux capabilities. |
+| `security_opt` | list | `["seccomp=unconfined","apparmor=unconfined"]` (appended) | Security profile relaxations needed for RDMA + ptrace. |
+| `group_add` | list | `["video"]` (appended) | Supplementary groups inside the container. |
+| `ulimit` | list | `["memlock=-1"]` (appended) | Per-process resource limits. `memlock=-1` is required for RDMA. |
+
+## `launch` truth table (teardown semantics)
+
+`teardown_containers()` short-circuits in three cases per [`cvs/core/orchestrators/container.py`](../../core/orchestrators/container.py) (around line 439). This is pinned by the test `test_teardown_containers_short_circuits_when_launch_true` in [`cvs/core/orchestrators/unittests/test_container.py`](../../core/orchestrators/unittests/test_container.py).
+
+| `enabled` | `launch` | `container_id` | Behavior |
+| --- | --- | --- | --- |
+| `false` | * | * | Short-circuit (no-op, returns `True`). |
+| `true` | `true` | * | Short-circuit. The container is externally managed; CVS does not stop it. |
+| `true` | `false` | unset | Short-circuit. Nothing was started. |
+| `true` | `false` | set | Calls `runtime.teardown_containers(container_id)`. |
+
+## Prerequisites on each cluster node
+
+- **Docker** installed and the SSH user has passwordless `sudo docker`.
+- **Host driver** loaded so `/dev/kfd` and `/dev/dri/*` (and `/dev/infiniband/*` if RDMA is in scope) are present for passthrough.
+- **`~/.ssh/`** of the SSH user is reachable; the orchestrator mounts it as `/host_ssh` and copies keys into `/root/.ssh` inside the container so `setup_sshd` can start an in-container sshd on port 2224.
+- **The image** is either pre-loaded on every node (`docker load`) or pullable from a reachable registry. Inside the image you need: `openssh-server` (for the in-container sshd), the workload binaries the suite invokes (e.g. `/opt/rocm/bin/rvs`), and any ROCm runtime libs the workload needs.
+
+## What happens when you run a backend-blind suite
+
+```mermaid
+sequenceDiagram
+    participant TestFix as orch fixture
+    participant Factory as OrchestratorFactory
+    participant ContainerOrch as ContainerOrchestrator
+    participant Docker as docker daemon on host
+    participant Sshd as container sshd:2224
+
+    TestFix->>Factory: create_orchestrator(cfg)
+    Factory->>ContainerOrch: __init__
+    TestFix->>ContainerOrch: setup_containers()
+    ContainerOrch->>Docker: docker run --privileged ... image
+    TestFix->>ContainerOrch: setup_sshd()
+    ContainerOrch->>Sshd: start sshd inside container on port 2224
+    TestFix->>ContainerOrch: orch.exec("rvs -c ...")
+    ContainerOrch->>Sshd: ssh root@host:2224 "rvs -c ..."
+    Sshd-->>TestFix: stdout
+    TestFix->>ContainerOrch: teardown_containers()
+    ContainerOrch->>Docker: docker stop and rm
+```
+
+The same `cvs run` command works against either backend; only the cluster
+file changes. The `orch` fixture in [`cvs/tests/health/rvs_cvs.py`](../../tests/health/rvs_cvs.py) gates the lifecycle hooks on `cfg.orchestrator == "container"`, so the baremetal path stays a no-op for those calls.
+
+## Common pitfalls
+
+- **Forgot `enabled: true`**. The container block exists but the orchestrator silently no-ops every lifecycle call. Symptom: `orch.exec` errors with "no container running".
+- **Image without `openssh-server`**. `setup_sshd` cannot start sshd on port 2224; `orch.exec` then fails to connect. Make sure your image installs `openssh-server` and exposes the binary at `/usr/sbin/sshd`.
+- **Image without the workload binary**. `cvs run rvs_cvs` will execute `rvs` inside the container; if the image lacks `/opt/rocm/bin/rvs` the test fails with a `command not found` flavor error.
+- **`launch: true` plus a stale container with the same `name`**. `docker run` refuses to start because the name is taken. Either pick a per-iteration unique name or stop the stale container first.
+- **Port 2224 collision on the host**. With `network: host` the in-container sshd binds to 2224 in the host's network namespace. If something else on the host already listens on 2224 the bind fails. Stop the conflicting service or change the in-image sshd port (and update the orchestrator's port to match).
+
+## See also
+
+- [`cvs/core/orchestrators/factory.py`](../../core/orchestrators/factory.py) - canonical key list (`OrchestratorConfig.__init__` and `from_configs`).
+- [`cvs/core/orchestrators/container.py`](../../core/orchestrators/container.py) - `ContainerOrchestrator` implementation, `DEFAULT_CONTAINER_ARGS`, the `setup_containers` / `setup_sshd` / `teardown_containers` lifecycle.
+- [`cvs/tests/health/rvs_cvs.py`](../../tests/health/rvs_cvs.py) - the `orch` fixture that consumes this cluster file in test code.
+- [`cvs/core/orchestrators/unittests/`](../../core/orchestrators/unittests/) - the test suite that pins the schema and lifecycle behaviors documented above (`test_factory.py`, `test_baremetal.py`, `test_container.py`).

--- a/cvs/input/cluster_file/cluster_container.json
+++ b/cvs/input/cluster_file/cluster_container.json
@@ -1,0 +1,58 @@
+{
+    "_orchestrator_comment": "Execution backend. 'container' routes workload commands through the container runtime (docker by default). Host-namespace commands still reach the physical host. See cvs/input/cluster_file/README.md.",
+    "orchestrator": "container",
+
+    "_user_comment": "{user-id} resolves to the current login user at runtime. Replace with a literal username if you want to pin it.",
+    "username": "{user-id}",
+
+    "_key_comment": "Absolute path to the SSH private key. Same key is used for all nodes.",
+    "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
+
+    "_head_comment": "Head node. mgmt_ip MUST match one of the keys in node_dict.",
+    "head_node_dict": {
+        "mgmt_ip": "{xx.xx.xx.xx|hostname-1}"
+    },
+
+    "_env_vars_comment": "Custom env variables exported on every host before each command (PATH overrides, ROCm/UCX flags, etc.).",
+    "env_vars": {},
+
+    "_node_comment": "Cluster member nodes keyed by public IP or hostname. Replace -1 / -2 suffixes with your real IPs/hostnames; add or remove entries to scale to N nodes.",
+    "_vpc_comment": "vpc_ip is the address reachable from other nodes in the cluster. Set equal to the public IP if there is no separate VPC.",
+    "node_dict": {
+        "{xx.xx.xx.xx|hostname-1}": {
+            "bmc_ip": "NA",
+            "vpc_ip": "{xx.xx.xx.xx|hostname-1}"
+        },
+        "{xx.xx.xx.xx|hostname-2}": {
+            "bmc_ip": "NA",
+            "vpc_ip": "{xx.xx.xx.xx|hostname-2}"
+        }
+    },
+
+    "_container_block_comment": "Container backend configuration. Consumed by ContainerOrchestrator in cvs/core/orchestrators/container.py. See README.md for the full schema and launch:true/launch:false semantics.",
+    "container": {
+        "_enabled_comment": "Master switch. Must be true for the container backend to do anything; if false, setup_containers/teardown_containers short-circuit to no-ops.",
+        "enabled": true,
+
+        "_launch_comment": "true = CVS owns container lifecycle (starts on setup_containers, stops on teardown_containers). false = containers are externally managed; CVS only verifies they are running and never stops them.",
+        "launch": true,
+
+        "_image_comment": "Image with test dependencies (rvs, etc.) pre-installed and an sshd you can start on port 2224. Must be present locally on each node OR pullable from a reachable registry.",
+        "image": "rocm/cvs:latest",
+
+        "_name_comment": "Container name on each host. For parallel runs make this per-iteration unique (e.g. cvs_iter_<run_id>).",
+        "name": "cvs_container",
+
+        "runtime": {
+            "_name_comment": "Supported: 'docker' (concrete), 'enroot' (stub).",
+            "name": "docker",
+
+            "_args_comment": "Backend-specific runtime arguments. Defaults from cvs/core/orchestrators/container.py:DEFAULT_CONTAINER_ARGS apply for any key omitted here. List args (volumes/devices/cap_add/security_opt/group_add/ulimit) append to defaults; scalars (network/ipc/privileged) override.",
+            "args": {
+                "network": "host",
+                "ipc": "host",
+                "privileged": true
+            }
+        }
+    }
+}

--- a/cvs/lib/parallel_ssh_lib.py
+++ b/cvs/lib/parallel_ssh_lib.py
@@ -110,18 +110,24 @@ class Pssh:
                     self.reachable_hosts, user=self.user, password=self.password, keepalive_seconds=30
                 )
 
-    def inform_unreachability(self, cmd_output):
+    def inform_unreachability(self, cmd_output, include_exit_codes=False):
         """
         Update cmd_output with "Host Unreachable" for all hosts in self.unreachable_hosts.
-        This ensures that the output dictionary reflects the status of pruned hosts.
+        Handles both string and structured formats based on include_exit_codes.
         """
         for host in self.unreachable_hosts:
-            cmd_output[host] = cmd_output.get(host, "") + "\nABORT: Host Unreachable Error"
+            if include_exit_codes:
+                existing = cmd_output.get(host, {'output': '', 'exit_code': -1})
+                existing['output'] += "\nABORT: Host Unreachable Error"
+                existing['exit_code'] = -1  # Ensure unreachable hosts have error exit code
+                cmd_output[host] = existing
+            else:
+                cmd_output[host] = cmd_output.get(host, "") + "\nABORT: Host Unreachable Error"
 
-    def _process_output(self, output, cmd=None, cmd_list=None, print_console=True):
+    def _process_output(self, output, cmd=None, cmd_list=None, print_console=True, include_exit_codes=False):
         """
         Helper method to process output from run_command, collect results, and handle pruning.
-        Returns cmd_output dictionary.
+        Returns cmd_output dictionary. If include_exit_codes=True, returns structured format.
         """
         cmd_output = {}
         i = 0
@@ -157,27 +163,36 @@ class Pssh:
                 cmd_out_str += exc_str + '\n'
             if cmd_list:
                 i += 1
-            cmd_output[item.host] = cmd_out_str
+
+            if include_exit_codes:
+                # Use -1 for exit code when command couldn't execute due to exceptions
+                exit_code = getattr(item, 'exit_code', -1) if item.exception is None else -1
+                cmd_output[item.host] = {'output': cmd_out_str, 'exit_code': exit_code}
+            else:
+                cmd_output[item.host] = cmd_out_str
 
         if not self.stop_on_errors:
             self.prune_unreachable_hosts(output)
-            self.inform_unreachability(cmd_output)
+            self.inform_unreachability(cmd_output, include_exit_codes)
 
         return cmd_output
 
-    def _handle_timeout_exception(self, output, e):
+    def inform_unreachability_structured(self, cmd_output):
         """
-        Helper method to handle Timeout exceptions by setting exceptions for all hosts in output.
-        Since Timeout is raised once for the operation, assume all hosts are affected.
+        Update cmd_output with "Host Unreachable" for all hosts in self.unreachable_hosts.
+        Handles structured output format.
         """
-        if output is not None and isinstance(e, Timeout):
-            for item in output:
-                if item.exception is None:
-                    item.exception = e
+        for host in self.unreachable_hosts:
+            existing = cmd_output.get(host, {'output': '', 'exit_code': -1})
+            existing['output'] += "\nABORT: Host Unreachable Error"
+            existing['exit_code'] = -1  # Ensure unreachable hosts have error exit code
+            cmd_output[host] = existing
 
-    def exec(self, cmd, timeout=None, print_console=True):
+    def exec(self, cmd, timeout=None, print_console=True, detailed=False):
         """
-        Returns a dictionary of host as key and command output as values
+        Returns a dictionary of host as key and command output as values.
+        If detailed=True, returns structured dict with 'output' and 'exit_code' keys.
+        If detailed=False (default), returns output strings.
         """
         if self.env_prefix:
             full_cmd = f"{self.env_prefix} ; {cmd}"
@@ -199,7 +214,9 @@ class Pssh:
             output = self.client.run_command(full_cmd, stop_on_errors=self.stop_on_errors)
         else:
             output = self.client.run_command(full_cmd, read_timeout=timeout, stop_on_errors=self.stop_on_errors)
-        cmd_output = self._process_output(output, cmd=full_cmd, print_console=print_console)
+        cmd_output = self._process_output(
+            output, cmd=full_cmd, print_console=print_console, include_exit_codes=detailed
+        )
 
         # Log per-host execution completion
         if self.log:

--- a/cvs/lib/parallel_ssh_lib.py
+++ b/cvs/lib/parallel_ssh_lib.py
@@ -39,8 +39,8 @@ class Pssh:
         env_vars=None,
     ):
         self.log = log
-        self.host_list = host_list
-        self.reachable_hosts = host_list
+        self.host_list = list(host_list)
+        self.reachable_hosts = list(host_list)
         self.user = user
         self.pkey = pkey
         self.password = password
@@ -165,8 +165,17 @@ class Pssh:
                 i += 1
 
             if include_exit_codes:
-                # Use -1 for exit code when command couldn't execute due to exceptions
-                exit_code = getattr(item, 'exit_code', -1) if item.exception is None else -1
+                # -1 means "unknown / aborted": either the command raised before
+                # an exit code was available, or the SSH channel hasn't reached
+                # EOF yet (parallel-ssh's HostOutput.exit_code property returns
+                # None in that case, which would silently break consumers that
+                # compare against 0).
+                if item.exception is not None:
+                    exit_code = -1
+                else:
+                    exit_code = item.exit_code
+                    if exit_code is None:
+                        exit_code = -1
                 cmd_output[item.host] = {'output': cmd_out_str, 'exit_code': exit_code}
             else:
                 cmd_output[item.host] = cmd_out_str
@@ -177,16 +186,15 @@ class Pssh:
 
         return cmd_output
 
-    def inform_unreachability_structured(self, cmd_output):
+    def _handle_timeout_exception(self, output, e):
         """
-        Update cmd_output with "Host Unreachable" for all hosts in self.unreachable_hosts.
-        Handles structured output format.
+        Helper method to handle Timeout exceptions by setting exceptions for all hosts in output.
+        Since Timeout is raised once for the operation, assume all hosts are affected.
         """
-        for host in self.unreachable_hosts:
-            existing = cmd_output.get(host, {'output': '', 'exit_code': -1})
-            existing['output'] += "\nABORT: Host Unreachable Error"
-            existing['exit_code'] = -1  # Ensure unreachable hosts have error exit code
-            cmd_output[host] = existing
+        if output is not None and isinstance(e, Timeout):
+            for item in output:
+                if item.exception is None:
+                    item.exception = e
 
     def exec(self, cmd, timeout=None, print_console=True, detailed=False):
         """
@@ -267,8 +275,8 @@ class Pssh:
         for cmd in cmds:
             try:
                 cmd.get()
-            except IOError:
-                raise Exception("Expected IOError exception, got none")
+            except IOError as e:
+                raise IOError(f"scp '{local_file}' -> '{remote_file}' failed: {e}") from e
         return
 
     def reboot_connections(self):

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -8,6 +8,7 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 # Standard libraries
 import re
 import json
+from typing import List
 from pathlib import Path
 
 # Third party libraries
@@ -15,7 +16,7 @@ import pandas as pd
 from pydantic import ValidationError
 
 from cvs.lib import globals
-from cvs.schema.rccl import RcclTestsAggregated, RcclTestsMultinodeRaw
+from cvs.schema.rccl import RcclTests, RcclTestsAggregated, RcclTestsMultinodeRaw
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 
@@ -48,12 +49,12 @@ def _is_severe_wrong_corruption_error(err: ValidationError) -> bool:
     return 'SEVERE DATA CORRUPTION' in s or "'#wrong'" in s
 
 
-def is_ucx_available_in_mpi(orch, mpi_path, head_node):
+def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
     """
     Check if UCX is available in the OpenMPI build.
 
     Parameters:
-      orch: Orchestrator instance for executing commands.
+      shdl: SSH handle to execute commands on the remote node.
       mpi_path: Path to the MPI installation directory.
       head_node: The head node hostname for retrieving command output.
 
@@ -63,7 +64,7 @@ def is_ucx_available_in_mpi(orch, mpi_path, head_node):
     # First, try ompi_info
     check_ucx_cmd = f'{mpi_path}/bin/ompi_info | grep "pml: ucx" | wc -l'
     try:
-        ucx_check_out = orch.exec_on_head(check_ucx_cmd)
+        ucx_check_out = shdl.exec(check_ucx_cmd)
         ucx_available = int(ucx_check_out[head_node].strip()) > 0
         log.info("UCX available in OpenMPI build" if ucx_available else "UCX not available in OpenMPI build")
         return ucx_available
@@ -74,7 +75,7 @@ def is_ucx_available_in_mpi(orch, mpi_path, head_node):
     libmpi_path = f'{mpi_path}/lib/libmpi.so'
     check_ldd_cmd = f'ldd {libmpi_path} | grep ucx | wc -l'
     try:
-        ldd_out = orch.exec_on_head(check_ldd_cmd)
+        ldd_out = shdl.exec(check_ldd_cmd)
         ucx_available = int(ldd_out[head_node].strip()) > 0
         log.info("UCX linked in libmpi.so" if ucx_available else "UCX not linked in libmpi.so")
         return ucx_available
@@ -120,8 +121,8 @@ def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, u
     Determine MPI PML (Point-to-Point Messaging Layer) configuration based on user config or auto-detection.
 
     Parameters:
-      orch: Orchestrator instance for executing commands.
       mpi_pml: User-specified PML mode ('auto', 'ucx', or 'ob1').
+      shdl: SSH handle to execute commands on the remote node.
       mpi_path: Path to the MPI installation directory.
       head_node: The head node hostname for retrieving command output.
       net_dev_list: UCX network device(s) to use (UCX_NET_DEVICES).
@@ -134,7 +135,7 @@ def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, u
     """
     if mpi_pml.lower() == "auto":
         # Auto-detect UCX availability
-        ucx_available = is_ucx_available_in_mpi(orch, mpi_path, head_node)
+        ucx_available = is_ucx_available_in_mpi(shdl, mpi_path, head_node)
         pml_param = "--mca pml ob1" if not ucx_available else ""
     elif mpi_pml.lower() == "ucx":
         # User explicitly requested UCX
@@ -148,7 +149,7 @@ def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, u
         log.info("Using pml ob1 (user-specified)")
     else:
         log.warning(f"Unknown mpi_pml value '{mpi_pml}', defaulting to auto-detection")
-        ucx_available = is_ucx_available_in_mpi(orch, mpi_path, head_node)
+        ucx_available = is_ucx_available_in_mpi(shdl, mpi_path, head_node)
         pml_param = "--mca pml ob1" if not ucx_available else ""
 
     ucx_params = (
@@ -411,7 +412,7 @@ def convert_to_graph_dict(result_dict):
     return graph_dict
 
 
-def aggregate_rccl_test_results(validated_results):
+def aggregate_rccl_test_results(validated_results: List[RcclTests]) -> List[RcclTestsAggregated]:
     """
     Aggregate multiple rccl-test results into mean/std per (name, size, type, inPlace)
     Args: validated_results: List[RcclTests] - list of validated rccl-test results
@@ -606,35 +607,24 @@ def rccl_regression(
         {test_cmd}'''
 
     log.info('%%%%%%%%%%%%%%%%')
-    log.info('MPI Hosts: %s', vpc_node_list)
-    log.info('Ranks per host: %s', proc_per_node)
-    log.info('Env Vars: %s', env_vars)
-    log.info('Rank Cmd: %s', rank_cmd)
-    log.info('MPI Install Dir: %s', mpi_install_dir)
+    log.info("%s", cmd)
     log.info('%%%%%%%%%%%%%%%%')
 
     try:
-        out_dict = orch.distribute_using_mpi(
-            rank_cmd, vpc_node_list, proc_per_node, env_vars, mpi_install_dir, mpi_extra_args
-        )
+        out_dict = shdl.exec(cmd, timeout=500)
         output = out_dict[head_node]
         scan_rccl_logs(output)
     except Exception as e:
-        log.error(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
-        fail_test(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
+        log.error(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
+        fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
 
     # Read the JSON results emitted by the RCCL test binary
-    cat_cmd = f'cat {rccl_result_file}'
-
-    result_dict_out = orch.exec(cat_cmd, hosts=[head_node])
+    result_dict_out = shdl.exec(f'cat {rccl_result_file}')
     result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
 
     # Collect basic GPU information via rocm-smi
-    smi_cmd = 'rocm-smi -a | head -30'
-
-    smi_out_dict = orch.exec(smi_cmd, hosts=[head_node])
+    smi_out_dict = shdl.exec('rocm-smi -a | head -30')
     smi_out = smi_out_dict[head_node]
-
     get_model_from_rocm_smi_output(smi_out)
 
     # If requested, verify measured bus bandwidths against provided expected Bandwidth
@@ -676,7 +666,8 @@ def rccl_perf(
     Run an RCCL collective test across a cluster via MPI and verify results.
 
     Arguments:
-      orch: Orchestrator instance for test execution.
+      phdl: Parallel ssh handle to run commands on all nodes.
+      shdl: ssh handle to the first node in the cluster.
       test_name: RCCL test binary name (e.g., all_reduce_perf).
       cluster_node_list: List of cluster node hostnames/IPs (first is treated as head node).
       vpc_node_list: List of hostnames/IPs to pass to mpirun -H as hosts - \
@@ -794,25 +785,19 @@ def rccl_perf(
         '''
 
         log.info('%%%%%%%%%%%%%%%%')
-        log.info('MPI Hosts: %s', vpc_node_list)
-        log.info('Ranks per host: %s', proc_per_node)
-        log.info('Env Vars: %s', env_vars)
-        log.info('Rank Cmd: %s', rank_cmd)
-        log.info('MPI Install Dir: %s', mpi_install_dir)
+        log.info("%s", cmd)
         log.info('%%%%%%%%%%%%%%%%')
         try:
-            out_dict = orch.distribute_using_mpi(
-                rank_cmd, vpc_node_list, proc_per_node, env_vars, mpi_install_dir, mpi_extra_args
-            )
+            out_dict = shdl.exec(cmd, timeout=500)
             output = out_dict[head_node]
             # print(output)
             scan_rccl_logs(output)
         except Exception as e:
-            log.error(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
-            fail_test(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
+            log.error(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
+            fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
 
         # Read the JSON results emitted by the RCCL test binary
-        result_dict_out = orch.exec(f'cat {dtype_result_file}')
+        result_dict_out = shdl.exec(f'cat {dtype_result_file}')
         dtype_result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
         # Validate the results against the schema fail if results are not valid
         try:
@@ -872,7 +857,7 @@ def rccl_perf(
         fail_test(f'RCCL Test aggregation failed: {e}')
 
     # Collect basic GPU information via rocm-smi
-    smi_out_dict = orch.exec_on_head('rocm-smi -a | head -30')
+    smi_out_dict = shdl.exec('rocm-smi -a | head -30')
     smi_out = smi_out_dict[head_node]
     get_model_from_rocm_smi_output(smi_out)
 

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -8,7 +8,6 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 # Standard libraries
 import re
 import json
-from typing import List
 from pathlib import Path
 
 # Third party libraries
@@ -16,7 +15,7 @@ import pandas as pd
 from pydantic import ValidationError
 
 from cvs.lib import globals
-from cvs.schema.rccl import RcclTests, RcclTestsAggregated, RcclTestsMultinodeRaw
+from cvs.schema.rccl import RcclTestsAggregated, RcclTestsMultinodeRaw
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 
@@ -49,12 +48,12 @@ def _is_severe_wrong_corruption_error(err: ValidationError) -> bool:
     return 'SEVERE DATA CORRUPTION' in s or "'#wrong'" in s
 
 
-def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
+def is_ucx_available_in_mpi(orch, mpi_path, head_node):
     """
     Check if UCX is available in the OpenMPI build.
 
     Parameters:
-      shdl: SSH handle to execute commands on the remote node.
+      orch: Orchestrator instance for executing commands.
       mpi_path: Path to the MPI installation directory.
       head_node: The head node hostname for retrieving command output.
 
@@ -64,7 +63,7 @@ def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
     # First, try ompi_info
     check_ucx_cmd = f'{mpi_path}/bin/ompi_info | grep "pml: ucx" | wc -l'
     try:
-        ucx_check_out = shdl.exec(check_ucx_cmd)
+        ucx_check_out = orch.exec_on_head(check_ucx_cmd)
         ucx_available = int(ucx_check_out[head_node].strip()) > 0
         log.info("UCX available in OpenMPI build" if ucx_available else "UCX not available in OpenMPI build")
         return ucx_available
@@ -75,7 +74,7 @@ def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
     libmpi_path = f'{mpi_path}/lib/libmpi.so'
     check_ldd_cmd = f'ldd {libmpi_path} | grep ucx | wc -l'
     try:
-        ldd_out = shdl.exec(check_ldd_cmd)
+        ldd_out = orch.exec_on_head(check_ldd_cmd)
         ucx_available = int(ldd_out[head_node].strip()) > 0
         log.info("UCX linked in libmpi.so" if ucx_available else "UCX not linked in libmpi.so")
         return ucx_available
@@ -121,8 +120,8 @@ def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, u
     Determine MPI PML (Point-to-Point Messaging Layer) configuration based on user config or auto-detection.
 
     Parameters:
+      orch: Orchestrator instance for executing commands.
       mpi_pml: User-specified PML mode ('auto', 'ucx', or 'ob1').
-      shdl: SSH handle to execute commands on the remote node.
       mpi_path: Path to the MPI installation directory.
       head_node: The head node hostname for retrieving command output.
       net_dev_list: UCX network device(s) to use (UCX_NET_DEVICES).
@@ -135,7 +134,7 @@ def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, u
     """
     if mpi_pml.lower() == "auto":
         # Auto-detect UCX availability
-        ucx_available = is_ucx_available_in_mpi(shdl, mpi_path, head_node)
+        ucx_available = is_ucx_available_in_mpi(orch, mpi_path, head_node)
         pml_param = "--mca pml ob1" if not ucx_available else ""
     elif mpi_pml.lower() == "ucx":
         # User explicitly requested UCX
@@ -149,7 +148,7 @@ def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, u
         log.info("Using pml ob1 (user-specified)")
     else:
         log.warning(f"Unknown mpi_pml value '{mpi_pml}', defaulting to auto-detection")
-        ucx_available = is_ucx_available_in_mpi(shdl, mpi_path, head_node)
+        ucx_available = is_ucx_available_in_mpi(orch, mpi_path, head_node)
         pml_param = "--mca pml ob1" if not ucx_available else ""
 
     ucx_params = (
@@ -412,7 +411,7 @@ def convert_to_graph_dict(result_dict):
     return graph_dict
 
 
-def aggregate_rccl_test_results(validated_results: List[RcclTests]) -> List[RcclTestsAggregated]:
+def aggregate_rccl_test_results(validated_results):
     """
     Aggregate multiple rccl-test results into mean/std per (name, size, type, inPlace)
     Args: validated_results: List[RcclTests] - list of validated rccl-test results
@@ -607,24 +606,35 @@ def rccl_regression(
         {test_cmd}'''
 
     log.info('%%%%%%%%%%%%%%%%')
-    log.info("%s", cmd)
+    log.info('MPI Hosts: %s', vpc_node_list)
+    log.info('Ranks per host: %s', proc_per_node)
+    log.info('Env Vars: %s', env_vars)
+    log.info('Rank Cmd: %s', rank_cmd)
+    log.info('MPI Install Dir: %s', mpi_install_dir)
     log.info('%%%%%%%%%%%%%%%%')
 
     try:
-        out_dict = shdl.exec(cmd, timeout=500)
+        out_dict = orch.distribute_using_mpi(
+            rank_cmd, vpc_node_list, proc_per_node, env_vars, mpi_install_dir, mpi_extra_args
+        )
         output = out_dict[head_node]
         scan_rccl_logs(output)
     except Exception as e:
-        log.error(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
-        fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
+        log.error(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
+        fail_test(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
 
     # Read the JSON results emitted by the RCCL test binary
-    result_dict_out = shdl.exec(f'cat {rccl_result_file}')
+    cat_cmd = f'cat {rccl_result_file}'
+
+    result_dict_out = orch.exec(cat_cmd, hosts=[head_node])
     result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
 
     # Collect basic GPU information via rocm-smi
-    smi_out_dict = shdl.exec('rocm-smi -a | head -30')
+    smi_cmd = 'rocm-smi -a | head -30'
+
+    smi_out_dict = orch.exec(smi_cmd, hosts=[head_node])
     smi_out = smi_out_dict[head_node]
+
     get_model_from_rocm_smi_output(smi_out)
 
     # If requested, verify measured bus bandwidths against provided expected Bandwidth
@@ -666,8 +676,7 @@ def rccl_perf(
     Run an RCCL collective test across a cluster via MPI and verify results.
 
     Arguments:
-      phdl: Parallel ssh handle to run commands on all nodes.
-      shdl: ssh handle to the first node in the cluster.
+      orch: Orchestrator instance for test execution.
       test_name: RCCL test binary name (e.g., all_reduce_perf).
       cluster_node_list: List of cluster node hostnames/IPs (first is treated as head node).
       vpc_node_list: List of hostnames/IPs to pass to mpirun -H as hosts - \
@@ -785,19 +794,25 @@ def rccl_perf(
         '''
 
         log.info('%%%%%%%%%%%%%%%%')
-        log.info("%s", cmd)
+        log.info('MPI Hosts: %s', vpc_node_list)
+        log.info('Ranks per host: %s', proc_per_node)
+        log.info('Env Vars: %s', env_vars)
+        log.info('Rank Cmd: %s', rank_cmd)
+        log.info('MPI Install Dir: %s', mpi_install_dir)
         log.info('%%%%%%%%%%%%%%%%')
         try:
-            out_dict = shdl.exec(cmd, timeout=500)
+            out_dict = orch.distribute_using_mpi(
+                rank_cmd, vpc_node_list, proc_per_node, env_vars, mpi_install_dir, mpi_extra_args
+            )
             output = out_dict[head_node]
             # print(output)
             scan_rccl_logs(output)
         except Exception as e:
-            log.error(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
-            fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
+            log.error(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
+            fail_test(f'Hit Exceptions with rccl cmd - exception {repr(e)}')
 
         # Read the JSON results emitted by the RCCL test binary
-        result_dict_out = shdl.exec(f'cat {dtype_result_file}')
+        result_dict_out = orch.exec(f'cat {dtype_result_file}')
         dtype_result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
         # Validate the results against the schema fail if results are not valid
         try:
@@ -857,7 +872,7 @@ def rccl_perf(
         fail_test(f'RCCL Test aggregation failed: {e}')
 
     # Collect basic GPU information via rocm-smi
-    smi_out_dict = shdl.exec('rocm-smi -a | head -30')
+    smi_out_dict = orch.exec_on_head('rocm-smi -a | head -30')
     smi_out = smi_out_dict[head_node]
     get_model_from_rocm_smi_output(smi_out)
 

--- a/cvs/lib/unittests/test_parallel_ssh_lib.py
+++ b/cvs/lib/unittests/test_parallel_ssh_lib.py
@@ -353,6 +353,118 @@ class TestPsshExec(unittest.TestCase):
             self.assertNotIn("error line1", call)
             self.assertNotIn("output2 line1", call)
 
+    def test_exec_detailed_true_successful(self):
+        # Test: Execute command successfully with detailed=True
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        mock_output1.stdout = ["output1 line1", "output1 line2"]
+        mock_output1.stderr = ["error1 line1"]
+        mock_output1.exception = None
+        mock_output1.exit_code = 0
+
+        mock_output2 = MagicMock()
+        mock_output2.host = "host2"
+        mock_output2.stdout = ["output2 line1"]
+        mock_output2.stderr = []
+        mock_output2.exception = None
+        mock_output2.exit_code = 0
+
+        self.mock_client.run_command.return_value = [mock_output1, mock_output2]
+
+        result = self.pssh.exec("echo hello", detailed=True)
+
+        self.assertIn("host1", result)
+        self.assertIn("host2", result)
+
+        # Check structure
+        self.assertIsInstance(result["host1"], dict)
+        self.assertIsInstance(result["host2"], dict)
+        self.assertIn("output", result["host1"])
+        self.assertIn("exit_code", result["host1"])
+        self.assertIn("output", result["host2"])
+        self.assertIn("exit_code", result["host2"])
+
+        # Check content
+        self.assertIn("output1 line1", result["host1"]["output"])
+        self.assertIn("output1 line2", result["host1"]["output"])
+        self.assertIn("error1 line1", result["host1"]["output"])
+        self.assertIn("output2 line1", result["host2"]["output"])
+        self.assertEqual(result["host1"]["exit_code"], 0)
+        self.assertEqual(result["host2"]["exit_code"], 0)
+
+    def test_exec_detailed_true_with_exit_code_failure(self):
+        # Test: Execute command with non-zero exit code and detailed=True
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        mock_output1.stdout = ["success output"]
+        mock_output1.stderr = []
+        mock_output1.exception = None
+        mock_output1.exit_code = 0
+
+        mock_output2 = MagicMock()
+        mock_output2.host = "host2"
+        mock_output2.stdout = []
+        mock_output2.stderr = ["command failed"]
+        mock_output2.exception = None
+        mock_output2.exit_code = 1
+
+        self.mock_client.run_command.return_value = [mock_output1, mock_output2]
+
+        result = self.pssh.exec("failing command", detailed=True)
+
+        self.assertEqual(result["host1"]["exit_code"], 0)
+        self.assertEqual(result["host2"]["exit_code"], 1)
+        self.assertIn("success output", result["host1"]["output"])
+        self.assertIn("command failed", result["host2"]["output"])
+
+    @patch.object(Pssh, "check_connectivity")
+    def test_exec_detailed_true_with_exception(self, mock_check_connectivity):
+        # Test: Execute command with exception and detailed=True
+        self.pssh.stop_on_errors = False
+        from pssh.exceptions import ConnectionError
+
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        mock_output1.stdout = ["success output"]
+        mock_output1.stderr = []
+        mock_output1.exception = None
+        mock_output1.exit_code = 0
+
+        mock_output2 = MagicMock()
+        mock_output2.host = "host2"
+        mock_output2.stdout = []
+        mock_output2.stderr = []
+        mock_output2.exception = ConnectionError("Connection failed")
+        mock_output2.exit_code = None  # No exit code available for exceptions
+
+        self.mock_client.run_command.return_value = [mock_output1, mock_output2]
+        mock_check_connectivity.return_value = []  # No pruning
+
+        result = self.pssh.exec("echo hello", detailed=True)
+
+        self.assertEqual(result["host1"]["exit_code"], 0)
+        self.assertEqual(result["host2"]["exit_code"], -1)  # -1 for exceptions
+        self.assertIn("success output", result["host1"]["output"])
+        self.assertIn("Connection failed", result["host2"]["output"])
+
+    def test_exec_detailed_false_backward_compatibility(self):
+        # Test: detailed=False (default) maintains backward compatibility
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        mock_output1.stdout = ["output1 line1"]
+        mock_output1.stderr = []
+        mock_output1.exception = None
+        mock_output1.exit_code = 0
+
+        self.mock_client.run_command.return_value = [mock_output1]
+
+        result = self.pssh.exec("echo hello", detailed=False)
+
+        # Should return string, not dict
+        self.assertIsInstance(result["host1"], str)
+        self.assertNotIsInstance(result["host1"], dict)
+        self.assertIn("output1 line1", result["host1"])
+
 
 class TestPsshExecCmdList(unittest.TestCase):
     @patch("cvs.lib.parallel_ssh_lib.ParallelSSHClient")

--- a/cvs/lib/unittests/test_parallel_ssh_lib.py
+++ b/cvs/lib/unittests/test_parallel_ssh_lib.py
@@ -317,6 +317,49 @@ class TestPsshExec(unittest.TestCase):
         mock_prune.assert_not_called()
         mock_inform.assert_not_called()
 
+    @patch.object(Pssh, "prune_unreachable_hosts")
+    @patch.object(Pssh, "inform_unreachability")
+    def test_exec_stdout_timeout_during_iteration_stop_on_errors_false(self, mock_inform, mock_prune):
+        # Regression: when Timeout is raised mid-stdout-iteration AND stop_on_errors=False,
+        # _process_output must call _handle_timeout_exception (which got accidentally removed
+        # in an earlier refactor). Without the helper restored, this raises AttributeError.
+        from pssh.exceptions import Timeout
+
+        self.pssh.stop_on_errors = False
+
+        timeout_error = Timeout("Read timed out")
+
+        # host1: stdout iteration raises Timeout mid-stream
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        # Iterating stdout raises Timeout
+        mock_output1.stdout = MagicMock()
+        mock_output1.stdout.__iter__ = MagicMock(side_effect=timeout_error)
+        mock_output1.stderr = []
+        mock_output1.exception = None
+
+        # host2: clean run, no exception yet
+        mock_output2 = MagicMock()
+        mock_output2.host = "host2"
+        mock_output2.stdout = ["ok"]
+        mock_output2.stderr = []
+        mock_output2.exception = None
+
+        self.mock_client.run_command.return_value = [mock_output1, mock_output2]
+
+        # Must NOT raise AttributeError (the bug we are guarding against).
+        # The Pssh code catches Timeout when stop_on_errors=False and routes through
+        # _handle_timeout_exception, which propagates the timeout to all items so the
+        # subsequent item.exception handling block formats and records it.
+        result = self.pssh.exec("echo hello", timeout=10)
+
+        # _handle_timeout_exception must populate item.exception on items that had None
+        # so the subsequent formatting block records the timeout for both hosts.
+        self.assertIs(mock_output1.exception, timeout_error)
+        self.assertIs(mock_output2.exception, timeout_error)
+        self.assertIn("host1", result)
+        self.assertIn("host2", result)
+
     @patch("builtins.print")
     def test_exec_print_console_false(self, mock_print):
         # Test: Execute command with print_console=False, verify output lines are not printed
@@ -447,6 +490,33 @@ class TestPsshExec(unittest.TestCase):
         self.assertIn("success output", result["host1"]["output"])
         self.assertIn("Connection failed", result["host2"]["output"])
 
+    def test_process_output_normalizes_none_exit_code(self):
+        # Regression (L3): when the SSH channel has not reached EOF,
+        # parallel-ssh's HostOutput.exit_code property returns None
+        # (pssh/clients/native/single.py: get_exit_status returns None
+        # when not channel.eof()). The previous implementation used
+        # getattr(item, 'exit_code', -1) -- but the -1 default only
+        # fires on AttributeError, never when the property returns None.
+        # Result: cmd_output[host]['exit_code'] could be None, breaking
+        # downstream consumers in docker.py/container.py that compare
+        # exit_code against 0 (None != 0 -> spurious failure;
+        # None == 0 -> spurious success).
+        # The contract is exit_code: int, with -1 meaning "unknown/aborted".
+        mock_output = MagicMock()
+        mock_output.host = "host1"
+        mock_output.stdout = ["partial output"]
+        mock_output.stderr = []
+        mock_output.exception = None
+        mock_output.exit_code = None  # channel not EOF'd yet
+
+        self.mock_client.run_command.return_value = [mock_output]
+
+        result = self.pssh.exec("slow command", detailed=True)
+
+        # Must be -1 (the documented "unknown" sentinel), not None.
+        self.assertEqual(result["host1"]["exit_code"], -1)
+        self.assertIsNotNone(result["host1"]["exit_code"])
+
     def test_exec_detailed_false_backward_compatibility(self):
         # Test: detailed=False (default) maintains backward compatibility
         mock_output1 = MagicMock()
@@ -464,6 +534,27 @@ class TestPsshExec(unittest.TestCase):
         self.assertIsInstance(result["host1"], str)
         self.assertNotIsInstance(result["host1"], dict)
         self.assertIn("output1 line1", result["host1"])
+
+    @patch("cvs.lib.parallel_ssh_lib.ParallelSSHClient")
+    def test_init_does_not_alias_caller_host_list(self, mock_pssh_client):
+        # Regression (B2): Pssh.__init__ must not alias the caller's host_list.
+        # Before the fix, self.reachable_hosts and self.host_list both pointed to
+        # the caller's list object, so prune_unreachable_hosts (which calls
+        # self.reachable_hosts.remove(...)) silently mutated the caller's list.
+        # This bit BaremetalOrchestrator on the stop_on_errors=False path:
+        # a single transient ConnectionError/Timeout/SessionError permanently
+        # shrunk the orchestrator's view of the cluster.
+        mock_pssh_client.return_value = MagicMock()
+        original = ["a", "b", "c"]
+        pssh = Pssh(self.mock_log, original, user="user", password="pass")
+        # Simulate what prune_unreachable_hosts does internally.
+        pssh.reachable_hosts.remove("b")
+        # (i) Caller's list must be untouched.
+        self.assertEqual(original, ["a", "b", "c"])
+        # (ii) Internal reachable view reflects the prune.
+        self.assertEqual(pssh.reachable_hosts, ["a", "c"])
+        # (iii) host_list is a stable snapshot of the original input.
+        self.assertEqual(pssh.host_list, ["a", "b", "c"])
 
 
 class TestPsshExecCmdList(unittest.TestCase):
@@ -828,6 +919,47 @@ class TestPsshExecCmdList(unittest.TestCase):
             self.assertNotIn("host1 output line2", call)
             self.assertNotIn("host1 error line1", call)
             self.assertNotIn("host2 output line1", call)
+
+
+class TestPsshScpFile(unittest.TestCase):
+    @patch("cvs.lib.parallel_ssh_lib.ParallelSSHClient")
+    def setUp(self, mock_pssh_client):
+        self.mock_client = MagicMock()
+        mock_pssh_client.return_value = self.mock_client
+        self.mock_log = MagicMock()
+        self.pssh = Pssh(self.mock_log, ["host1", "host2"], user="user", password="pass")
+
+    def test_scp_file_preserves_original_io_error(self):
+        # Regression (B3): scp_file's exception handler used to read:
+        #
+        #     except IOError:
+        #         raise Exception("Expected IOError exception, got none")
+        #
+        # which is logically inverted (the message fires precisely when an
+        # IOError WAS caught), raises bare Exception instead of IOError,
+        # drops the original traceback (no `from e`), and includes neither
+        # the host nor the file path. This made debugging scp failures
+        # nearly impossible -- the user saw "Expected IOError exception,
+        # got none" and had no way to recover the actual cause.
+        original_error = IOError("Permission denied")
+
+        fake_cmd = MagicMock()
+        fake_cmd.get.side_effect = original_error
+        self.mock_client.copy_file.return_value = [fake_cmd]
+
+        with self.assertRaises(IOError) as ctx:
+            self.pssh.scp_file("/local/x", "/remote/y")
+
+        # Must be IOError, not bare Exception (so callers catching IOError
+        # actually catch it).
+        self.assertIs(type(ctx.exception), IOError)
+        # Must surface both file paths in the message so the user knows
+        # which copy failed.
+        self.assertIn("/local/x", str(ctx.exception))
+        self.assertIn("/remote/y", str(ctx.exception))
+        # Must chain the original exception via __cause__ so the original
+        # traceback is recoverable.
+        self.assertIs(ctx.exception.__cause__, original_error)
 
 
 if __name__ == "__main__":

--- a/cvs/tests/health/README.md
+++ b/cvs/tests/health/README.md
@@ -59,6 +59,10 @@ pytest -vvv --log-file=/tmp/test.log -s ./tests/health/rvs_cvs.py --cluster_file
 
 RVS provides comprehensive GPU validation through multiple test modules. The test suite intelligently adapts based on RVS version and GPU hardware detected.
 
+#### Container mode
+
+`rvs_cvs` is currently the only CVS test suite that consumes the orchestrator and can run inside a per-host container instead of on the host filesystem. To use it, copy the `cluster_container.json` template (`cvs copy-config cluster_container.json --output ...`), set the container `image` and `name`, and pass the resulting cluster file to `cvs run rvs_cvs`. See the in-tree reference at [`cvs/input/cluster_file/README.md`](../../input/cluster_file/README.md) and the published [container-mode how-to](https://rocm.docs.amd.com/projects/cvs/en/latest/how-to/run-with-containers.html). Other suites and `cvs exec` ignore the `orchestrator` key and run on the host.
+
 #### Supported Test Modules
 
 Individual test modules include:

--- a/cvs/tests/health/rvs_cvs.py
+++ b/cvs/tests/health/rvs_cvs.py
@@ -12,7 +12,7 @@ import re
 import json
 from packaging import version
 
-from cvs.lib.parallel_ssh_lib import *
+from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFactory
 from cvs.lib.utils_lib import *
 
 from cvs.lib import globals
@@ -58,19 +58,21 @@ def config_dict(config_file, cluster_dict):
 
 
 @pytest.fixture(scope="module")
-def phdl(cluster_dict):
-    log.info("%s", cluster_dict)
-    env_vars = cluster_dict.get("env_vars")
-    node_list = list(cluster_dict['node_dict'].keys())
-    phdl = Pssh(
-        log,
-        node_list,
-        user=cluster_dict['username'],
-        pkey=cluster_dict['priv_key_file'],
-        stop_on_errors=False,
-        env_vars=env_vars,
-    )
-    return phdl
+def orch(pytestconfig, request):
+    cluster_file = pytestconfig.getoption("cluster_file")
+    config_file = pytestconfig.getoption("config_file")
+    cfg = OrchestratorConfig.from_configs(cluster_file, config_file)
+    orch = OrchestratorFactory.create_orchestrator(log, cfg)
+
+    if cfg.orchestrator == "container":
+        container_name = orch.get_container_name(orch.container_config, orch.container_config['image'])
+        if not orch.setup_containers():
+            pytest.fail(f"Failed to launch container : {container_name}")
+        if not orch.setup_sshd():
+            pytest.fail(f"Failed to setup sshd in container : {container_name}")
+        request.addfinalizer(orch.teardown_containers)
+
+    return orch
 
 
 @pytest.fixture(scope="module")
@@ -94,20 +96,20 @@ def rvs_test_level(config_dict):
 
 
 @pytest.fixture(scope="module")
-def rvs_version(phdl, config_dict):
+def rvs_version(orch, config_dict):
     """
     Detect RVS version from all nodes.
     Returns the minimum version across all nodes.
     """
-    return get_rvs_version(phdl, config_dict['path'])
+    return get_rvs_version(orch, config_dict['path'])
 
 
-def get_rvs_version(phdl, rvs_path):
+def get_rvs_version(orch, rvs_path):
     """
     Get RVS version from all nodes.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       rvs_path: Path to RVS binary
 
     Returns:
@@ -115,7 +117,7 @@ def get_rvs_version(phdl, rvs_path):
     """
     version_dict = {}
 
-    out_dict = phdl.exec(f'{rvs_path}/rvs --version', timeout=30)
+    out_dict = orch.exec(f'{rvs_path}/rvs --version', timeout=30)
 
     for node in out_dict.keys():
         output = out_dict[node].strip()
@@ -201,12 +203,12 @@ def should_skip_individual_test(rvs_version_str, rvs_test_level):
     return (True, f"RVS version {rvs_version_str} >= 1.3.0: Running LEVEL-{rvs_test_level} test instead")
 
 
-def get_gpu_device_name(phdl):
+def get_gpu_device_name(orch):
     """
     Detect GPU device name from amd-smi JSON output to match with RVS config folders.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
 
     Returns:
       dict: Dictionary of node -> device name (e.g., 'MI300X', 'MI308X', 'MI300XHF', etc.)
@@ -214,7 +216,7 @@ def get_gpu_device_name(phdl):
     device_map = {}
 
     # Execute amd-smi command to get GPU information in JSON format
-    out_dict = phdl.exec('sudo amd-smi static -a -g 0 --json', timeout=30)
+    out_dict = orch.exec('sudo amd-smi static -a -g 0 --json', timeout=30)
 
     for node in out_dict.keys():
         output = out_dict[node]
@@ -254,13 +256,13 @@ def get_gpu_device_name(phdl):
     return device_map
 
 
-def get_available_device_folders(phdl, base_config_path):
+def get_available_device_folders(orch, base_config_path):
     """
     Get list of available MI300 variant device-specific folders in RVS config directory.
     Only returns folders starting with 'MI3' (MI300 variants).
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       base_config_path: Base path for RVS configurations
 
     Returns:
@@ -268,7 +270,7 @@ def get_available_device_folders(phdl, base_config_path):
     """
     available_folders = {}
 
-    out_dict = phdl.exec(f'ls -d {base_config_path}/*/ 2>/dev/null', timeout=30)
+    out_dict = orch.exec(f'ls -d {base_config_path}/*/ 2>/dev/null', timeout=30)
 
     for node in out_dict.keys():
         output = out_dict[node]
@@ -291,13 +293,13 @@ def get_available_device_folders(phdl, base_config_path):
     return available_folders
 
 
-def determine_rvs_config_path(phdl, config_dict, config_file):
+def determine_rvs_config_path(orch, config_dict, config_file):
     """
     Determine the correct configuration file path for RVS tests.
     Dynamically detects GPU device and checks for device-specific config folders.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       config_file: Name of the configuration file to look for
 
@@ -309,10 +311,10 @@ def determine_rvs_config_path(phdl, config_dict, config_file):
     default_path = f"{base_path}/{config_file}"
 
     # Step 1: Detect GPU device name on each node
-    device_map = get_gpu_device_name(phdl)
+    device_map = get_gpu_device_name(orch)
 
     # Step 2: Get available device-specific folders
-    available_folders = get_available_device_folders(phdl, base_path)
+    available_folders = get_available_device_folders(orch, base_path)
 
     # Step 3: Check for device-specific config on each node
     device_specific_exists = False
@@ -327,7 +329,7 @@ def determine_rvs_config_path(phdl, config_dict, config_file):
             # Device-specific folder exists, check if config file is present
             device_specific_path = f"{base_path}/{device_name}/{config_file}"
 
-            out_dict = phdl.exec(f'ls -l {device_specific_path}', timeout=30)
+            out_dict = orch.exec(f'ls -l {device_specific_path}', timeout=30)
             if not re.search('No such file', out_dict[node], re.I):
                 log.info(f'Node {node}: Device-specific config found: {device_specific_path}')
                 device_specific_exists = True
@@ -346,7 +348,7 @@ def determine_rvs_config_path(phdl, config_dict, config_file):
 
     # Step 4: Fall back to default config (no device subfolder)
     log.info('Falling back to default config path')
-    out_dict = phdl.exec(f'ls -l {default_path}', timeout=30)
+    out_dict = orch.exec(f'ls -l {default_path}', timeout=30)
 
     for node in out_dict.keys():
         if not re.search('No such file', out_dict[node], re.I):
@@ -385,12 +387,12 @@ def parse_rvs_test_results(test_config, out_dict):
             log.info(f'RVS {test_name} test passed on node {node}')
 
 
-def execute_rvs_test(phdl, config_dict, test_name):
+def execute_rvs_test(orch, config_dict, test_name):
     """
     Generic function to execute any RVS test.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       test_name: Name of the test to execute
     """
@@ -411,7 +413,7 @@ def execute_rvs_test(phdl, config_dict, test_name):
     timeout = test_config.get('timeout', 9000)
 
     # Determine config path
-    config_path = determine_rvs_config_path(phdl, config_dict, config_file)
+    config_path = determine_rvs_config_path(orch, config_dict, config_file)
 
     # TEMP-FIX start
     if test_name == 'gst_single':
@@ -422,7 +424,7 @@ def execute_rvs_test(phdl, config_dict, test_name):
             temp_config = "/tmp/gst_single.conf"
 
             # Step 1 & 2: Copy config file to /tmp (overwrite if exists)
-            copy_result = phdl.exec(f'cp {source_config} {temp_config}', timeout=30)
+            copy_result = orch.exec(f'cp {source_config} {temp_config}', timeout=30)
 
             # Verify copy was successful
             for node in copy_result.keys():
@@ -436,7 +438,7 @@ def execute_rvs_test(phdl, config_dict, test_name):
             ]
 
             for sed_cmd in sed_commands:
-                sed_result = phdl.exec(sed_cmd, timeout=30)
+                sed_result = orch.exec(sed_cmd, timeout=30)
                 for node in sed_result.keys():
                     if sed_result[node].strip():
                         log.warning(f'Node {node}: sed command output: {sed_result[node]}')
@@ -455,7 +457,7 @@ def execute_rvs_test(phdl, config_dict, test_name):
         else:
             rvs_cmd = f'{rvs_path}/rvs -c {config_path}'
 
-        out_dict = phdl.exec(f'{rvs_cmd}', timeout=timeout)
+        out_dict = orch.exec(f'{rvs_cmd}', timeout=timeout)
         print_test_output(log, out_dict)
         scan_test_results(out_dict)
 
@@ -509,7 +511,7 @@ def parse_rvs_level_results(test_config, out_dict, level):
 ################################################################################
 
 
-def test_rvs_level_config(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_level_config(orch, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS LEVEL-based configuration test.
     This test runs all RVS modules collectively using the -r (run level) option.
@@ -522,7 +524,7 @@ def test_rvs_level_config(phdl, config_dict, rvs_version, rvs_test_level):
     Level 5: Maximum stress testing
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       rvs_test_level: Test level (0-5)
       rvs_version: RVS version string
@@ -558,7 +560,7 @@ def test_rvs_level_config(phdl, config_dict, rvs_version, rvs_test_level):
     rvs_cmd = f'sudo {rvs_path}/rvs -r {rvs_test_level}'
 
     log.info(f'Executing: {rvs_cmd}')
-    out_dict = phdl.exec(rvs_cmd, timeout=timeout)
+    out_dict = orch.exec(rvs_cmd, timeout=timeout)
     print_test_output(log, out_dict)
     scan_test_results(out_dict)
 
@@ -568,13 +570,13 @@ def test_rvs_level_config(phdl, config_dict, rvs_version, rvs_test_level):
     update_test_result()
 
 
-def test_rvs_gpu_enumeration(phdl, config_dict):
+def test_rvs_gpu_enumeration(orch, config_dict):
     """
     Run RVS GPU enumeration test to detect and validate GPU presence.
     This is a basic connectivity and detection test.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
     """
     globals.error_list = []
@@ -583,7 +585,7 @@ def test_rvs_gpu_enumeration(phdl, config_dict):
     rvs_path = config_dict['path']
 
     # Run GPU enumeration (using gpup module)
-    out_dict = phdl.exec(f'{rvs_path}/rvs -g', timeout=60)
+    out_dict = orch.exec(f'{rvs_path}/rvs -g', timeout=60)
     print_test_output(log, out_dict)
     scan_test_results(out_dict)
 
@@ -595,13 +597,13 @@ def test_rvs_gpu_enumeration(phdl, config_dict):
     update_test_result()
 
 
-def test_rvs_mem_test(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_mem_test(orch, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS Memory Test.
     This test validates GPU memory functionality and integrity.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       rvs_version: RVS version string
       rvs_test_level: Test level (0-5)
@@ -612,17 +614,17 @@ def test_rvs_mem_test(phdl, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_mem_test: {skip_reason}")
 
     test_name = 'mem_test'
-    execute_rvs_test(phdl, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name)
 
 
-def test_rvs_gst_single(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_gst_single(orch, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS GST (GPU Stress Test) - Single GPU validation test.
     This test runs the GPU stress test configuration to validate GPU functionality
     and performance under load.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       rvs_version: RVS version string
       rvs_test_level: Test level (0-5)
@@ -633,16 +635,16 @@ def test_rvs_gst_single(phdl, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_gst_single: {skip_reason}")
 
     test_name = 'gst_single'
-    execute_rvs_test(phdl, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name)
 
 
-def test_rvs_iet_stress(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_iet_stress(orch, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS IET (Peak Power Test) - Single GPU validation test.
     This test validates power consumption and thermal behavior under load.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       rvs_version: RVS version string
       rvs_test_level: Test level (0-5)
@@ -653,16 +655,16 @@ def test_rvs_iet_stress(phdl, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_iet_stress: {skip_reason}")
 
     test_name = 'iet_stress'
-    execute_rvs_test(phdl, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name)
 
 
-def test_rvs_pebb_single(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_pebb_single(orch, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS PEBB (PCI Express Bandwidth Benchmark).
     This test measures and validates PCI Express bandwidth performance.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       rvs_version: RVS version string
       rvs_test_level: Test level (0-5)
@@ -673,16 +675,16 @@ def test_rvs_pebb_single(phdl, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_pebb_single: {skip_reason}")
 
     test_name = 'pebb_single'
-    execute_rvs_test(phdl, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name)
 
 
-def test_rvs_pbqt_single(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_pbqt_single(orch, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS PBQT (P2P Benchmark and Qualification Tool).
     This test validates peer-to-peer communication between GPUs.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       rvs_version: RVS version string
       rvs_test_level: Test level (0-5)
@@ -693,16 +695,16 @@ def test_rvs_pbqt_single(phdl, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_pbqt_single: {skip_reason}")
 
     test_name = 'pbqt_single'
-    execute_rvs_test(phdl, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name)
 
 
-def test_rvs_babel_stream(phdl, config_dict, rvs_version, rvs_test_level):
+def test_rvs_babel_stream(orch, config_dict, rvs_version, rvs_test_level):
     """
     Run RVS BABEL Benchmark test.
     This test runs the BABEL streaming benchmark for GPU memory bandwidth validation.
 
     Args:
-      phdl: Parallel SSH handle
+      orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       rvs_version: RVS version string
       rvs_test_level: Test level (0-5)
@@ -713,4 +715,4 @@ def test_rvs_babel_stream(phdl, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_babel_stream: {skip_reason}")
 
     test_name = 'babel_stream'
-    execute_rvs_test(phdl, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name)

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -16,7 +16,7 @@ import json
 from cvs.lib import rccl_lib
 from cvs.lib import html_lib
 
-from cvs.core import OrchestratorFactory, OrchestratorConfig
+from cvs.lib.parallel_ssh_lib import *
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 
@@ -118,27 +118,53 @@ def config_dict(config_file, cluster_dict):
 
 
 @pytest.fixture(scope="module")
-def orch(cluster_file, config_file):
+def phdl(cluster_dict):
     """
-    Create and return an orchestrator instance for test execution.
+    Build and return a parallel SSH handle (Pssh) for all cluster nodes.
 
     Args:
-      cluster_file (str): Path to cluster configuration JSON
-      config_file (str): Path to test configuration JSON
+      cluster_dict (dict): Cluster metadata fixture containing:
+        - node_dict: dict of node_name -> node_details
+        - username: SSH username
+        - priv_key_file: path to SSH private key
 
     Returns:
-      Orchestrator: Orchestrator instance for running tests
+      Pssh: Handle configured for all nodes (for broadcast/parallel operations).
 
     Notes:
-      - Creates orchestrator using OrchestratorConfig.from_configs()
-      - Container setup is handled by test_launch_container
-      - Handles cleanup and container teardown automatically on teardown
+      - Prints the cluster_dict for quick debugging; consider replacing with log.debug.
+      - Module-scoped so a single shared handle is used across all tests in the module.
+      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
+      - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    log.info("Creating orchestrator from config files")
-    config = OrchestratorConfig.from_configs(cluster_file, config_file)
-    orch = OrchestratorFactory.create_orchestrator(log, config)
-    yield orch
-    orch.cleanup(orch.hosts)
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return phdl
+
+
+@pytest.fixture(scope="module")
+def shdl(cluster_dict):
+    """
+    Build and return a parallel SSH handle (Pssh) for the head node only.
+
+    Args:
+      cluster_dict (dict): Cluster metadata fixture (see phdl docstring).
+
+    Returns:
+      Pssh: Handle configured for the first node (head node) in node_dict.
+
+    Notes:
+      - Useful when commands should be executed only from a designated head node.
+      - Module scope ensures a single connection context for the duration of the module.
+      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
+    """
+    node_list = list(cluster_dict['node_dict'].keys())
+    env_vars = cluster_dict.get("env_vars")
+    head_node = node_list[0]
+    shdl = Pssh(log, [head_node], user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return shdl
 
 
 @pytest.fixture(scope="module")
@@ -165,63 +191,41 @@ def vpc_node_list(cluster_dict):
 # Start of test cases.
 
 
-def test_launch_container(orch):
+def test_collect_hostinfo(phdl):
     """
-    Launch containers and validate setup - runs first due to definition order.
-
-    This test must run before any other tests that require containers.
-    If this test fails, subsequent container-dependent tests will also fail.
-
-    In baremetal mode (no containers configured), this test passes without action.
-    """
-    # Check orchestrator type
-    if orch.orchestrator_type == "baremetal":
-        log.info("Baremetal orchestrator detected - skipping container launch")
-        pytest.skip("Baremetal mode: no containers to launch")
-
-    log.info("Launching containers on cluster nodes")
-    success = orch.setup_containers()
-    assert success, "Container launch failed on one or more nodes"
-
-    log.info("Setting up SSH daemon in containers")
-    success = orch.setup_sshd()
-    assert success, "SSH daemon setup failed on one or more nodes"
-
-
-def test_collect_hostinfo(orch):
-    """
-    Collect basic ROCm/host info from all nodes using orchestrator.
+    Collect basic ROCm/host info from all nodes.
 
     Behavior:
       - Executes common ROCm commands to capture version and agent info.
-      - If container is enabled, executes inside container to get container ROCm version.
       - Does not parse output; relies on update_test_result to finalize status.
+
+    Notes:
+      - globals.error_list is reset before test (pattern used across tests).
     """
 
     globals.error_list = []
-    orch.exec('cat /opt/rocm/.info/version')
-    orch.exec('hipconfig')
-    orch.exec('rocm_agent_enumerator')
+    phdl.exec('cat /opt/rocm/.info/version')
+    phdl.exec('hipconfig')
+    phdl.exec('rocm_agent_enumerator')
     update_test_result()
 
 
-def test_collect_networkinfo(orch):
+def test_collect_networkinfo(phdl):
     """
-    Collect basic RDMA/verbs info from all nodes using orchestrator.
+    Collect basic RDMA/verbs info from all nodes.
 
     Behavior:
       - Executes 'rdma link' and 'ibv_devinfo' to snapshot network capabilities.
-      - Always executes on baremetal host regardless of orchestrator type.
       - Does not parse output; relies on update_test_result to finalize status.
     """
 
     globals.error_list = []
-    orch.all.exec('rdma link')
-    orch.all.exec('ibv_devinfo')
+    phdl.exec('rdma link')
+    phdl.exec('ibv_devinfo')
     update_test_result()
 
 
-def test_disable_firewall(orch):
+def test_disable_firewall(phdl):
     globals.error_list = []
     sudo_status = get_passwordless_sudo_status(phdl)
     no_sudo_nodes = [node for node, ok in sudo_status.items() if not ok]
@@ -233,7 +237,7 @@ def test_disable_firewall(orch):
         return
     phdl.exec('sudo service ufw stop')
     time.sleep(2)
-    out_dict = orch.all.exec('sudo service ufw status')
+    out_dict = phdl.exec('sudo service ufw status')
     for node in out_dict.keys():
         if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
@@ -266,12 +270,13 @@ def test_print_env_once(phdl, shdl, config_dict):
         "broadcast_perf",
     ],
 )
-def test_rccl_perf(orch, cluster_dict, config_dict, rccl_collective):
+def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
     """
     Execute RCCL performance test across the cluster with given parameters.
 
     Parameters (from fixtures and config):
-      - orch: orchestrator for remote execution and MPI (baremetal, container, etc.).
+      - phdl: parallel execution handle for nodes (expects exec/exec_cmd_list).
+      - shdl: switch or auxiliary handle used by rccl_lib (implementation-specific).
       - cluster_dict: cluster topology and credentials (expects node_dict, username, etc.).
       - config_dict: test configuration with RCCL/MPI paths, env, and thresholds.
       - rccl_collective: which RCCL collective test to run (e.g., "all_reduce_perf").

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -16,7 +16,7 @@ import json
 from cvs.lib import rccl_lib
 from cvs.lib import html_lib
 
-from cvs.lib.parallel_ssh_lib import *
+from cvs.core import OrchestratorFactory, OrchestratorConfig
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 
@@ -118,53 +118,27 @@ def config_dict(config_file, cluster_dict):
 
 
 @pytest.fixture(scope="module")
-def phdl(cluster_dict):
+def orch(cluster_file, config_file):
     """
-    Build and return a parallel SSH handle (Pssh) for all cluster nodes.
+    Create and return an orchestrator instance for test execution.
 
     Args:
-      cluster_dict (dict): Cluster metadata fixture containing:
-        - node_dict: dict of node_name -> node_details
-        - username: SSH username
-        - priv_key_file: path to SSH private key
+      cluster_file (str): Path to cluster configuration JSON
+      config_file (str): Path to test configuration JSON
 
     Returns:
-      Pssh: Handle configured for all nodes (for broadcast/parallel operations).
+      Orchestrator: Orchestrator instance for running tests
 
     Notes:
-      - Prints the cluster_dict for quick debugging; consider replacing with log.debug.
-      - Module-scoped so a single shared handle is used across all tests in the module.
-      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
-      - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
+      - Creates orchestrator using OrchestratorConfig.from_configs()
+      - Container setup is handled by test_launch_container
+      - Handles cleanup and container teardown automatically on teardown
     """
-    log.info("%s", cluster_dict)
-    env_vars = cluster_dict.get("env_vars")
-    node_list = list(cluster_dict['node_dict'].keys())
-    phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
-    return phdl
-
-
-@pytest.fixture(scope="module")
-def shdl(cluster_dict):
-    """
-    Build and return a parallel SSH handle (Pssh) for the head node only.
-
-    Args:
-      cluster_dict (dict): Cluster metadata fixture (see phdl docstring).
-
-    Returns:
-      Pssh: Handle configured for the first node (head node) in node_dict.
-
-    Notes:
-      - Useful when commands should be executed only from a designated head node.
-      - Module scope ensures a single connection context for the duration of the module.
-      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
-    """
-    node_list = list(cluster_dict['node_dict'].keys())
-    env_vars = cluster_dict.get("env_vars")
-    head_node = node_list[0]
-    shdl = Pssh(log, [head_node], user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
-    return shdl
+    log.info("Creating orchestrator from config files")
+    config = OrchestratorConfig.from_configs(cluster_file, config_file)
+    orch = OrchestratorFactory.create_orchestrator(log, config)
+    yield orch
+    orch.cleanup(orch.hosts)
 
 
 @pytest.fixture(scope="module")
@@ -191,41 +165,63 @@ def vpc_node_list(cluster_dict):
 # Start of test cases.
 
 
-def test_collect_hostinfo(phdl):
+def test_launch_container(orch):
     """
-    Collect basic ROCm/host info from all nodes.
+    Launch containers and validate setup - runs first due to definition order.
+
+    This test must run before any other tests that require containers.
+    If this test fails, subsequent container-dependent tests will also fail.
+
+    In baremetal mode (no containers configured), this test passes without action.
+    """
+    # Check orchestrator type
+    if orch.orchestrator_type == "baremetal":
+        log.info("Baremetal orchestrator detected - skipping container launch")
+        pytest.skip("Baremetal mode: no containers to launch")
+
+    log.info("Launching containers on cluster nodes")
+    success = orch.setup_containers()
+    assert success, "Container launch failed on one or more nodes"
+
+    log.info("Setting up SSH daemon in containers")
+    success = orch.setup_sshd()
+    assert success, "SSH daemon setup failed on one or more nodes"
+
+
+def test_collect_hostinfo(orch):
+    """
+    Collect basic ROCm/host info from all nodes using orchestrator.
 
     Behavior:
       - Executes common ROCm commands to capture version and agent info.
+      - If container is enabled, executes inside container to get container ROCm version.
       - Does not parse output; relies on update_test_result to finalize status.
-
-    Notes:
-      - globals.error_list is reset before test (pattern used across tests).
     """
 
     globals.error_list = []
-    phdl.exec('cat /opt/rocm/.info/version')
-    phdl.exec('hipconfig')
-    phdl.exec('rocm_agent_enumerator')
+    orch.exec('cat /opt/rocm/.info/version')
+    orch.exec('hipconfig')
+    orch.exec('rocm_agent_enumerator')
     update_test_result()
 
 
-def test_collect_networkinfo(phdl):
+def test_collect_networkinfo(orch):
     """
-    Collect basic RDMA/verbs info from all nodes.
+    Collect basic RDMA/verbs info from all nodes using orchestrator.
 
     Behavior:
       - Executes 'rdma link' and 'ibv_devinfo' to snapshot network capabilities.
+      - Always executes on baremetal host regardless of orchestrator type.
       - Does not parse output; relies on update_test_result to finalize status.
     """
 
     globals.error_list = []
-    phdl.exec('rdma link')
-    phdl.exec('ibv_devinfo')
+    orch.all.exec('rdma link')
+    orch.all.exec('ibv_devinfo')
     update_test_result()
 
 
-def test_disable_firewall(phdl):
+def test_disable_firewall(orch):
     globals.error_list = []
     sudo_status = get_passwordless_sudo_status(phdl)
     no_sudo_nodes = [node for node, ok in sudo_status.items() if not ok]
@@ -237,7 +233,7 @@ def test_disable_firewall(phdl):
         return
     phdl.exec('sudo service ufw stop')
     time.sleep(2)
-    out_dict = phdl.exec('sudo service ufw status')
+    out_dict = orch.all.exec('sudo service ufw status')
     for node in out_dict.keys():
         if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
@@ -270,13 +266,12 @@ def test_print_env_once(phdl, shdl, config_dict):
         "broadcast_perf",
     ],
 )
-def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
+def test_rccl_perf(orch, cluster_dict, config_dict, rccl_collective):
     """
     Execute RCCL performance test across the cluster with given parameters.
 
     Parameters (from fixtures and config):
-      - phdl: parallel execution handle for nodes (expects exec/exec_cmd_list).
-      - shdl: switch or auxiliary handle used by rccl_lib (implementation-specific).
+      - orch: orchestrator for remote execution and MPI (baremetal, container, etc.).
       - cluster_dict: cluster topology and credentials (expects node_dict, username, etc.).
       - config_dict: test configuration with RCCL/MPI paths, env, and thresholds.
       - rccl_collective: which RCCL collective test to run (e.g., "all_reduce_perf").

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -13,9 +13,9 @@ import time
 import json
 import itertools
 
-from cvs.core import OrchestratorFactory, OrchestratorConfig
 from cvs.lib import rccl_lib
 from cvs.lib import html_lib
+from cvs.lib.parallel_ssh_lib import *
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 from cvs.lib import globals
@@ -116,27 +116,53 @@ def config_dict(config_file, cluster_dict):
 
 
 @pytest.fixture(scope="module")
-def orch(cluster_file, config_file):
+def phdl(cluster_dict):
     """
-    Create and return orchestrator instance for test execution.
+    Build and return a parallel SSH handle (Pssh) for all cluster nodes.
 
     Args:
-      cluster_file (str): Path to cluster configuration JSON
-      config_file (str): Path to test configuration JSON
+      cluster_dict (dict): Cluster metadata fixture containing:
+        - node_dict: dict of node_name -> node_details
+        - username: SSH username
+        - priv_key_file: path to SSH private key
 
     Returns:
-      Orchestrator: Orchestrator instance for running tests
+      Pssh: Handle configured for all nodes (for broadcast/parallel operations).
 
     Notes:
-      - Creates orchestrator using OrchestratorConfig.from_configs()
-      - Container setup is handled by test_launch_container
-      - Handles cleanup and container teardown automatically on teardown
+      - Prints the cluster_dict for quick debugging; consider replacing with log.debug.
+      - Module-scoped so a single shared handle is used across all tests in the module.
+      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
+      - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
     """
-    log.info("Creating orchestrator from config files")
-    config = OrchestratorConfig.from_configs(cluster_file, config_file)
-    orch = OrchestratorFactory.create_orchestrator(log, config)
-    yield orch
-    orch.cleanup(orch.hosts)
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return phdl
+
+
+@pytest.fixture(scope="module")
+def shdl(cluster_dict):
+    """
+    Build and return a parallel SSH handle (Pssh) for the head node only.
+
+    Args:
+      cluster_dict (dict): Cluster metadata fixture (see phdl docstring).
+
+    Returns:
+      Pssh: Handle configured for the first node (head node) in node_dict.
+
+    Notes:
+      - Useful when commands should be executed only from a designated head node.
+      - Module scope ensures a single connection context for the duration of the module.
+      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
+    """
+    node_list = list(cluster_dict['node_dict'].keys())
+    env_vars = cluster_dict.get("env_vars")
+    head_node = node_list[0]
+    shdl = Pssh(log, [head_node], user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return shdl
 
 
 @pytest.fixture(scope="module")
@@ -249,65 +275,41 @@ def pytest_generate_tests(metafunc):
 # Start of test cases.
 
 
-def test_launch_container(orch):
+def test_collect_hostinfo(phdl):
     """
-    Launch containers and validate setup - runs first due to definition order.
-
-    This test must run before any other tests that require containers.
-    If this test fails, subsequent container-dependent tests will also fail.
-
-    In baremetal mode (no containers configured), this test passes without action.
-    """
-    # Check orchestrator type
-    if orch.orchestrator_type == "baremetal":
-        log.info("Baremetal orchestrator detected - skipping container launch")
-        pytest.skip("Baremetal mode: no containers to launch")
-
-    log.info("Launching containers on cluster nodes")
-    success = orch.setup_containers()
-    assert success, "Container launch failed on one or more nodes"
-
-    log.info("Setting up SSH daemon in containers")
-    success = orch.setup_sshd()
-    assert success, "SSH daemon setup failed on one or more nodes"
-
-
-def test_collect_hostinfo(orch):
-    """
-    Collect basic ROCm/host info from all nodes using orchestrator.
+    Collect basic ROCm/host info from all nodes.
 
     Behavior:
       - Executes common ROCm commands to capture version and agent info.
-      - If container is enabled, executes inside container to get container ROCm version.
       - Does not parse output; relies on update_test_result to finalize status.
+
+    Notes:
+      - globals.error_list is reset before test (pattern used across tests).
     """
+
     globals.error_list = []
-
-    orch.exec('cat /opt/rocm/.info/version')
-    orch.exec('hipconfig')
-    orch.exec('rocm_agent_enumerator')
-
+    phdl.exec('cat /opt/rocm/.info/version')
+    phdl.exec('hipconfig')
+    phdl.exec('rocm_agent_enumerator')
     update_test_result()
 
 
-def test_collect_networkinfo(orch):
+def test_collect_networkinfo(phdl):
     """
-    Collect basic RDMA/verbs info from all nodes using orchestrator.
+    Collect basic RDMA/verbs info from all nodes.
 
     Behavior:
       - Executes 'rdma link' and 'ibv_devinfo' to snapshot network capabilities.
-      - Always executes on baremetal host regardless of orchestrator type.
       - Does not parse output; relies on update_test_result to finalize status.
     """
+
     globals.error_list = []
-
-    orch.all.exec('rdma link')
-    orch.all.exec('ibv_devinfo')
-
+    phdl.exec('rdma link')
+    phdl.exec('ibv_devinfo')
     update_test_result()
 
 
-def test_disable_firewall(orch):
+def test_disable_firewall(phdl):
     globals.error_list = []
     sudo_status = get_passwordless_sudo_status(phdl)
     no_sudo_nodes = [node for node, ok in sudo_status.items() if not ok]
@@ -319,7 +321,7 @@ def test_disable_firewall(orch):
         return
     phdl.exec('sudo service ufw stop')
     time.sleep(2)
-    out_dict = orch.all.exec('sudo service ufw status')
+    out_dict = phdl.exec('sudo service ufw status')
     for node in out_dict.keys():
         if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
@@ -342,7 +344,8 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     Execute RCCL regression test across the cluster with parametrized environment overrides.
 
     Parameters (from fixtures and config):
-      - orch: Orchestrator instance for test execution
+      - phdl: parallel execution handle for nodes (expects exec/exec_cmd_list).
+      - shdl: switch or auxiliary handle used by rccl_lib (implementation-specific).
       - cluster_dict: cluster topology and credentials (expects node_dict, username, etc.).
       - config_dict: test configuration with RCCL/MPI paths, env, and thresholds.
       - rccl_collective: which RCCL collective test to run (e.g., "all_reduce_perf").

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -13,9 +13,9 @@ import time
 import json
 import itertools
 
+from cvs.core import OrchestratorFactory, OrchestratorConfig
 from cvs.lib import rccl_lib
 from cvs.lib import html_lib
-from cvs.lib.parallel_ssh_lib import *
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 from cvs.lib import globals
@@ -116,53 +116,27 @@ def config_dict(config_file, cluster_dict):
 
 
 @pytest.fixture(scope="module")
-def phdl(cluster_dict):
+def orch(cluster_file, config_file):
     """
-    Build and return a parallel SSH handle (Pssh) for all cluster nodes.
+    Create and return orchestrator instance for test execution.
 
     Args:
-      cluster_dict (dict): Cluster metadata fixture containing:
-        - node_dict: dict of node_name -> node_details
-        - username: SSH username
-        - priv_key_file: path to SSH private key
+      cluster_file (str): Path to cluster configuration JSON
+      config_file (str): Path to test configuration JSON
 
     Returns:
-      Pssh: Handle configured for all nodes (for broadcast/parallel operations).
+      Orchestrator: Orchestrator instance for running tests
 
     Notes:
-      - Prints the cluster_dict for quick debugging; consider replacing with log.debug.
-      - Module-scoped so a single shared handle is used across all tests in the module.
-      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
-      - Assumes Pssh(log, node_list, user=..., pkey=...) is available in scope.
+      - Creates orchestrator using OrchestratorConfig.from_configs()
+      - Container setup is handled by test_launch_container
+      - Handles cleanup and container teardown automatically on teardown
     """
-    log.info("%s", cluster_dict)
-    env_vars = cluster_dict.get("env_vars")
-    node_list = list(cluster_dict['node_dict'].keys())
-    phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
-    return phdl
-
-
-@pytest.fixture(scope="module")
-def shdl(cluster_dict):
-    """
-    Build and return a parallel SSH handle (Pssh) for the head node only.
-
-    Args:
-      cluster_dict (dict): Cluster metadata fixture (see phdl docstring).
-
-    Returns:
-      Pssh: Handle configured for the first node (head node) in node_dict.
-
-    Notes:
-      - Useful when commands should be executed only from a designated head node.
-      - Module scope ensures a single connection context for the duration of the module.
-      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
-    """
-    node_list = list(cluster_dict['node_dict'].keys())
-    env_vars = cluster_dict.get("env_vars")
-    head_node = node_list[0]
-    shdl = Pssh(log, [head_node], user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
-    return shdl
+    log.info("Creating orchestrator from config files")
+    config = OrchestratorConfig.from_configs(cluster_file, config_file)
+    orch = OrchestratorFactory.create_orchestrator(log, config)
+    yield orch
+    orch.cleanup(orch.hosts)
 
 
 @pytest.fixture(scope="module")
@@ -275,41 +249,65 @@ def pytest_generate_tests(metafunc):
 # Start of test cases.
 
 
-def test_collect_hostinfo(phdl):
+def test_launch_container(orch):
     """
-    Collect basic ROCm/host info from all nodes.
+    Launch containers and validate setup - runs first due to definition order.
+
+    This test must run before any other tests that require containers.
+    If this test fails, subsequent container-dependent tests will also fail.
+
+    In baremetal mode (no containers configured), this test passes without action.
+    """
+    # Check orchestrator type
+    if orch.orchestrator_type == "baremetal":
+        log.info("Baremetal orchestrator detected - skipping container launch")
+        pytest.skip("Baremetal mode: no containers to launch")
+
+    log.info("Launching containers on cluster nodes")
+    success = orch.setup_containers()
+    assert success, "Container launch failed on one or more nodes"
+
+    log.info("Setting up SSH daemon in containers")
+    success = orch.setup_sshd()
+    assert success, "SSH daemon setup failed on one or more nodes"
+
+
+def test_collect_hostinfo(orch):
+    """
+    Collect basic ROCm/host info from all nodes using orchestrator.
 
     Behavior:
       - Executes common ROCm commands to capture version and agent info.
+      - If container is enabled, executes inside container to get container ROCm version.
       - Does not parse output; relies on update_test_result to finalize status.
-
-    Notes:
-      - globals.error_list is reset before test (pattern used across tests).
     """
-
     globals.error_list = []
-    phdl.exec('cat /opt/rocm/.info/version')
-    phdl.exec('hipconfig')
-    phdl.exec('rocm_agent_enumerator')
+
+    orch.exec('cat /opt/rocm/.info/version')
+    orch.exec('hipconfig')
+    orch.exec('rocm_agent_enumerator')
+
     update_test_result()
 
 
-def test_collect_networkinfo(phdl):
+def test_collect_networkinfo(orch):
     """
-    Collect basic RDMA/verbs info from all nodes.
+    Collect basic RDMA/verbs info from all nodes using orchestrator.
 
     Behavior:
       - Executes 'rdma link' and 'ibv_devinfo' to snapshot network capabilities.
+      - Always executes on baremetal host regardless of orchestrator type.
       - Does not parse output; relies on update_test_result to finalize status.
     """
-
     globals.error_list = []
-    phdl.exec('rdma link')
-    phdl.exec('ibv_devinfo')
+
+    orch.all.exec('rdma link')
+    orch.all.exec('ibv_devinfo')
+
     update_test_result()
 
 
-def test_disable_firewall(phdl):
+def test_disable_firewall(orch):
     globals.error_list = []
     sudo_status = get_passwordless_sudo_status(phdl)
     no_sudo_nodes = [node for node, ok in sudo_status.items() if not ok]
@@ -321,7 +319,7 @@ def test_disable_firewall(phdl):
         return
     phdl.exec('sudo service ufw stop')
     time.sleep(2)
-    out_dict = phdl.exec('sudo service ufw status')
+    out_dict = orch.all.exec('sudo service ufw status')
     for node in out_dict.keys():
         if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
@@ -344,8 +342,7 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     Execute RCCL regression test across the cluster with parametrized environment overrides.
 
     Parameters (from fixtures and config):
-      - phdl: parallel execution handle for nodes (expects exec/exec_cmd_list).
-      - shdl: switch or auxiliary handle used by rccl_lib (implementation-specific).
+      - orch: Orchestrator instance for test execution
       - cluster_dict: cluster topology and credentials (expects node_dict, username, etc.).
       - config_dict: test configuration with RCCL/MPI paths, env, and thresholds.
       - rccl_collective: which RCCL collective test to run (e.g., "all_reduce_perf").

--- a/docs/how-to/run-cvs-tests.rst
+++ b/docs/how-to/run-cvs-tests.rst
@@ -318,6 +318,10 @@ Use these scripts to start the test:
     
      cvs run rvs_cvs --cluster_file input/cluster_file/cluster.json --config_file input/config_file/health/mi300_health_config.json --html=/var/www/html/cvs/rvs.html --capture=tee-sys --self-contained-html --log-file=/tmp/test.log -vvv -s
 
+.. note::
+
+  RVS additionally supports running inside a per-host container instead of on the host filesystem. Pass a ``cluster_container.json`` cluster file with ``orchestrator: container`` to route ``rvs`` invocations through the container backend. See :doc:`/how-to/run-with-containers`.
+
 InfiniBand (IB Perf) test script
 --------------------------------
 

--- a/docs/how-to/run-with-containers.rst
+++ b/docs/how-to/run-with-containers.rst
@@ -1,0 +1,137 @@
+.. meta::
+  :description: Run CVS test suites against a per-host container backend
+  :keywords: CVS, container, docker, rvs, orchestrator, run
+
+****************************************
+Run CVS tests with the container backend
+****************************************
+
+CVS can route workload commands through a long-lived per-host container instead of running them directly on the host filesystem. This is useful when you want to validate the same image you ship to production, keep the host footprint minimal (Docker, GPU driver, and SSH only), or pin the test environment byte-for-byte.
+
+.. note::
+
+  **Scope today.** Of the test suites shipped with CVS, only ``rvs_cvs`` consumes the orchestrator and honors the ``orchestrator`` key in the cluster file. Other ``cvs run`` test suites and the ``cvs exec`` CLI run on the host regardless of the ``orchestrator`` value. See the Backends section in :doc:`/reference/configuration-files/cluster-file` for the full picture.
+
+Prerequisites
+=============
+
+On every cluster node:
+
+- **Docker** installed, with passwordless ``sudo docker`` for the SSH user.
+- **Host driver** loaded so ``/dev/kfd``, ``/dev/dri/*``, and ``/dev/infiniband/*`` (when RDMA is in scope) are present for passthrough.
+- **SSH user home directory** reachable. The orchestrator mounts ``~/.ssh`` as ``/host_ssh`` inside the container so that the in-container ``sshd`` on port ``2224`` can authenticate.
+- **Container image** either pre-loaded on every node (``docker load``) or pullable from a reachable registry. The image must contain ``openssh-server`` and the workload binaries the suite invokes (for example ``/opt/rocm/bin/rvs``).
+
+On the head node where you launch ``cvs run``:
+
+- CVS installed (see :doc:`/install/cvs-install`).
+- SSH key-based access to every cluster node as the SSH user.
+
+Step 1: Copy the cluster template
+=================================
+
+CVS ships a ``cluster_container.json`` template alongside the baremetal ``cluster.json``. Copy it to a working location:
+
+.. code:: bash
+
+  cvs copy-config cluster_container.json --output /tmp/cvs/input/cluster_file/cluster_container.json
+
+You can list every available template with:
+
+.. code:: bash
+
+  cvs copy-config --list
+
+Step 2: Edit the placeholders
+=============================
+
+Open the copied file and edit:
+
+- ``{user-id}``: your SSH user (or leave it for runtime resolution).
+- ``priv_key_file``: absolute path to your SSH private key.
+- ``head_node_dict.mgmt_ip`` and the keys of ``node_dict``: real IPs or hostnames of your cluster nodes. ``mgmt_ip`` must equal one of the keys in ``node_dict``.
+- ``container.image``: an image present on every node or pullable from a reachable registry. The image must include ``openssh-server`` and the workload binary (for example ``rvs``).
+- ``container.name``: container name on each host. For parallel runs make this per-iteration unique (for example ``cvs_iter_<run_id>``).
+- ``container.launch``: see the lifecycle note below.
+
+For the full schema and runtime argument reference, see :doc:`/reference/configuration-files/cluster-file`.
+
+Step 3: Run a test suite
+========================
+
+Run ``rvs_cvs`` the same way you run any CVS test suite, but with the container cluster file:
+
+.. code:: bash
+
+  cvs run rvs_cvs \
+      --cluster_file /tmp/cvs/input/cluster_file/cluster_container.json \
+      --config_file cvs/input/config_file/health/mi300_health_config.json \
+      --html=/var/www/html/cvs/rvs.html \
+      --self-contained-html \
+      --capture=tee-sys \
+      --log-file=/tmp/rvs.log \
+      -vvv -s
+
+What happens during the run:
+
+- The ``orch`` fixture in ``rvs_cvs`` reads ``orchestrator: container`` from the cluster file and constructs a ``ContainerOrchestrator``.
+- If ``container.launch`` is ``true``, CVS removes any container with the same name on each host, runs the configured image with the merged ``runtime.args``, and starts an in-container ``sshd`` on port ``2224``.
+- If ``container.launch`` is ``false``, CVS verifies that a container with the configured name is already running on every host and reuses it.
+- All ``rvs`` invocations are routed through the container via ``docker exec`` and the in-container ``sshd``.
+
+Step 4: Verify the run actually used the container
+==================================================
+
+Confirm that the workload ran inside the container, not on the host. From any node in the cluster, list running containers with the configured name:
+
+.. code:: bash
+
+  ssh <user>@<node> sudo docker ps --filter name=^cvs_container$
+
+You should see one running container per node with the configured name and image. You can fan this check out across every node from the head node:
+
+.. code:: bash
+
+  cvs exec --cluster_file /tmp/cvs/input/cluster_file/cluster_container.json \
+      --cmd "sudo docker ps --filter name=^cvs_container$ --format '{{.Names}} {{.Image}}'"
+
+.. note::
+
+  ``cvs exec`` always runs commands on the host regardless of the ``orchestrator`` value. That's exactly what you want for verification: it lets you observe the host's view of which containers are running.
+
+Lifecycle and teardown
+======================
+
+The ``container.launch`` flag controls who owns the container lifecycle:
+
+- ``launch: true`` - CVS starts the long-running container as part of test setup. Teardown is a no-op; CVS does not stop the container so that you can inspect it after the run. Stop and remove it manually when you are done.
+- ``launch: false`` - CVS does not start anything. It verifies that a container with the configured name is already running on every host and reuses it. Teardown is a no-op.
+
+When ``container.enabled`` is ``false``, both setup and teardown short-circuit to no-ops. See the launch truth table in :doc:`/reference/configuration-files/cluster-file` for the full state matrix.
+
+To stop and remove a container started with ``launch: true``, run on every node:
+
+.. code:: bash
+
+  cvs exec --cluster_file /tmp/cvs/input/cluster_file/cluster_container.json \
+      --cmd "sudo docker rm -f cvs_container"
+
+Replace ``cvs_container`` with the actual ``container.name`` from your cluster file.
+
+Common pitfalls
+===============
+
+- **Forgot ``enabled: true``.** The container block is present but the orchestrator silently no-ops every lifecycle call. The first ``orch.exec`` call then errors with "no container running".
+- **Image without ``openssh-server``.** ``setup_sshd`` cannot start ``sshd`` on port ``2224`` and ``orch.exec`` fails to connect. Make sure the image installs ``openssh-server`` and exposes the binary at ``/usr/sbin/sshd``.
+- **Image without the workload binary.** ``cvs run rvs_cvs`` invokes ``rvs`` inside the container; if the image lacks ``/opt/rocm/bin/rvs`` the test fails with a "command not found" style error.
+- **``launch: true`` plus a stale container with the same name.** On rerun, ``docker run`` would refuse to start because the name is taken. CVS's launch path issues ``docker rm -f`` before ``docker run`` to handle this; if you start a container outside CVS with the same name, stop it first.
+- **Port ``2224`` already bound on the host.** With ``network: host`` the in-container ``sshd`` binds to ``2224`` in the host's network namespace. If something else on the host already listens on ``2224`` the bind fails. Stop the conflicting service.
+- **Picked the wrong cluster template.** Use ``cluster_container.json`` (with ``orchestrator: container``) for container mode. Using ``cluster.json`` runs the suite on the host even when the image you wanted to test is sitting on every node.
+
+See also
+========
+
+- :doc:`/reference/configuration-files/cluster-file` - cluster file schema, container block reference, and ``runtime.args`` table.
+- `cvs/input/cluster_file/README.md <https://github.com/ROCm/cvs/blob/main/cvs/input/cluster_file/README.md>`_ - in-tree reference next to the templates.
+- :doc:`/how-to/run-cvs-tests` - general test running guide.
+- :doc:`/how-to/execute-cluster-commands` - ``cvs exec`` documentation.

--- a/docs/reference/configuration-files/cluster-file.rst
+++ b/docs/reference/configuration-files/cluster-file.rst
@@ -1,0 +1,248 @@
+.. meta::
+  :description: Configure the CVS cluster file and select the execution backend
+  :keywords: cluster, cluster_file, baremetal, container, docker, orchestrator, cvs
+
+***********************
+Cluster file
+***********************
+
+Each ``cvs run`` invocation is pointed at a cluster file via ``--cluster_file <path>``. The cluster file declares the SSH credentials, the node list, and the **execution backend** that runs the workload. CVS ships two starter templates:
+
+.. list-table::
+   :widths: 3 2 6
+   :header-rows: 1
+
+   * - Template
+     - Backend
+     - Use when
+   * - ``cluster.json``
+     - ``baremetal`` (default)
+     - ROCm, RVS, RCCL, and other workload binaries are installed on the host filesystem.
+   * - ``cluster_container.json``
+     - ``container``
+     - The workload runs inside a long-lived per-host container; the host only needs Docker, GPUs, and SSH.
+
+Copy the template that matches your cluster shape, edit the placeholders, and pass it to ``cvs run`` and ``cvs exec``. The choice of backend is made entirely in the cluster file. The ``cvs run`` invocation does not change.
+
+Backends
+========
+
+.. note::
+
+  **Scope today.** Of the test suites shipped with CVS, only ``rvs_cvs`` consumes the orchestrator and honors the ``orchestrator`` key in the cluster file. All other ``cvs run`` test suites and the ``cvs exec`` CLI run on the host regardless of the ``orchestrator`` value. Migrating additional suites to the orchestrator is tracked separately. Custom Python scripts can use the ``OrchestratorFactory`` API directly as an escape hatch.
+
+Baremetal
+---------
+
+Baremetal is the default. Workload commands are sent over SSH to each node and executed directly on the host filesystem. This is the path that has always been used by CVS and is consumed by every existing test suite.
+
+Container
+---------
+
+Container mode routes workload commands through a container runtime on each node. CVS uses host SSH to the node, then ``docker exec`` into a long-lived per-host container. Inside the container, an SSH daemon listens on port ``2224`` so that MPI-style workloads can fan out using the in-container SSH transport.
+
+The container backend is currently consumed by ``rvs_cvs`` only. The container lifecycle (start, verify, sshd setup, teardown) runs from the test fixture in `cvs/tests/health/rvs_cvs.py <https://github.com/ROCm/cvs/blob/main/cvs/tests/health/rvs_cvs.py>`_.
+
+Cluster file shape
+==================
+
+Both templates share the same top-level shape. The ``container`` block and the ``orchestrator`` key are only meaningful in container mode.
+
+.. note::
+
+  In the cluster file, ``{user-id}`` resolves to the current login user at runtime. Replace it with a literal username if you want to pin it. The placeholders ``{xx.xx.xx.xx|hostname-N}`` are example placeholders for real IPs or hostnames.
+
+.. dropdown:: ``cluster_container.json``
+
+  .. code:: json
+
+    {
+        "orchestrator": "container",
+        "username": "{user-id}",
+        "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
+
+        "head_node_dict": {
+            "mgmt_ip": "{xx.xx.xx.xx|hostname-1}"
+        },
+
+        "env_vars": {},
+
+        "node_dict": {
+            "{xx.xx.xx.xx|hostname-1}": {
+                "bmc_ip": "NA",
+                "vpc_ip": "{xx.xx.xx.xx|hostname-1}"
+            },
+            "{xx.xx.xx.xx|hostname-2}": {
+                "bmc_ip": "NA",
+                "vpc_ip": "{xx.xx.xx.xx|hostname-2}"
+            }
+        },
+
+        "container": {
+            "enabled": true,
+            "launch": true,
+            "image": "rocm/cvs:latest",
+            "name": "cvs_container",
+            "runtime": {
+                "name": "docker",
+                "args": {
+                    "network": "host",
+                    "ipc": "host",
+                    "privileged": true
+                }
+            }
+        }
+    }
+
+Top-level parameters
+--------------------
+
+.. list-table::
+   :widths: 3 3 5
+   :header-rows: 1
+
+   * - Configuration parameter
+     - Default value
+     - Description
+   * - ``orchestrator``
+     - ``baremetal``
+     - Execution backend. Set to ``container`` to route workload commands through the container runtime. Honored today only by ``rvs_cvs``; see the Backends section above.
+   * - ``username``
+     - ``{user-id}``
+     - SSH username for all hosts. ``{user-id}`` resolves to the current login user at runtime.
+   * - ``priv_key_file``
+     - ``/home/{user-id}/.ssh/id_rsa``
+     - Absolute path to the SSH private key used for every host.
+   * - ``head_node_dict.mgmt_ip``
+     - (required)
+     - Head node management IP or hostname. **Must equal one of the keys in ``node_dict``.**
+   * - ``env_vars``
+     - ``{}``
+     - Custom environment variables exported on every host before each command. Honored by the legacy parallel-SSH path; ``cvs exec`` does not export this block.
+   * - ``node_dict``
+     - (required)
+     - Cluster member nodes keyed by public IP or hostname. Each value is ``{"bmc_ip": "NA", "vpc_ip": "..."}``. ``vpc_ip`` is the address reachable from other nodes; set it equal to the public IP if there is no separate VPC.
+   * - ``container``
+     - ``{}``
+     - Container backend configuration. Required when ``orchestrator`` is ``container``. See the next section.
+
+Container block
+===============
+
+The ``container`` block configures the container backend. It is consumed by the ``ContainerOrchestrator`` defined in `cvs/core/orchestrators/container.py <https://github.com/ROCm/cvs/blob/main/cvs/core/orchestrators/container.py>`_.
+
+.. list-table::
+   :widths: 3 3 5
+   :header-rows: 1
+
+   * - Configuration parameter
+     - Default value
+     - Description
+   * - ``enabled``
+     - ``false``
+     - Master switch. Must be ``true`` for the container backend to do anything. When ``false``, ``setup_containers`` and ``teardown_containers`` short-circuit to no-ops.
+   * - ``launch``
+     - ``false``
+     - When ``true``, CVS starts the long-running containers on every host as part of test setup. When ``false``, CVS only verifies that containers with the configured name are already running on every host and never stops them.
+   * - ``image``
+     - (required)
+     - Image with the test dependencies (for example ``rvs``) pre-installed and an ``sshd`` you can start on port ``2224``. Must be present locally on each node or pullable from a reachable registry.
+   * - ``name``
+     - (required)
+     - Container name on each host. For parallel runs, make this per-iteration unique (for example ``cvs_iter_<run_id>``).
+   * - ``runtime.name``
+     - ``docker``
+     - Container runtime. Today only ``docker`` is implemented. ``enroot`` is registered as a stub and is not yet functional.
+   * - ``runtime.args``
+     - ``{}``
+     - Backend-specific runtime arguments (see the next section).
+
+Docker ``runtime.args`` reference
+=================================
+
+When ``runtime.name`` is ``docker``, the keys below configure the underlying ``docker run`` command. Defaults are merged from ``DEFAULT_CONTAINER_ARGS`` in `cvs/core/orchestrators/container.py <https://github.com/ROCm/cvs/blob/main/cvs/core/orchestrators/container.py>`_:
+
+- List arguments (``volumes``, ``devices``, ``cap_add``, ``security_opt``, ``group_add``, ``ulimit``) **append to** the baked-in defaults.
+- Scalar arguments (``network``, ``ipc``, ``privileged``) **override** the default when set, otherwise inherit it.
+- An empty ``args: {}`` already yields a working RDMA-ready container. The keys below are only needed to extend or override.
+
+.. list-table::
+   :widths: 3 3 5
+   :header-rows: 1
+
+   * - Argument
+     - Default value
+     - Description
+   * - ``network``
+     - ``host``
+     - ``--network`` mode. ``host`` for clusters sharing the host network stack.
+   * - ``ipc``
+     - ``host``
+     - ``--ipc`` mode. ``host`` enables cross-process IPC required for RDMA.
+   * - ``privileged``
+     - ``true``
+     - ``--privileged``. Required for device passthrough and RDMA.
+   * - ``volumes``
+     - Appended
+     - List of ``host:container[:ro]`` mounts. The container always also receives ``/home/$user:/workspace`` and ``/home/$user/.ssh:/host_ssh`` injected by the orchestrator.
+   * - ``devices``
+     - ``["/dev/kfd", "/dev/dri", "/dev/infiniband"]`` (appended)
+     - Device passthroughs. Per-host ``/dev/infiniband/*`` is also discovered at runtime.
+   * - ``cap_add``
+     - ``["SYS_PTRACE", "IPC_LOCK", "SYS_ADMIN"]`` (appended)
+     - Linux capabilities.
+   * - ``security_opt``
+     - ``["seccomp=unconfined", "apparmor=unconfined"]`` (appended)
+     - Security profile relaxations needed for RDMA and ptrace.
+   * - ``group_add``
+     - ``["video"]`` (appended)
+     - Supplementary groups inside the container.
+   * - ``ulimit``
+     - ``["memlock=-1"]`` (appended)
+     - Per-process resource limits. ``memlock=-1`` is required for RDMA.
+
+``launch`` truth table
+======================
+
+The ``launch`` flag interacts with ``enabled`` and the runtime-tracked ``container_id`` to decide whether ``teardown_containers`` actually stops anything. The behavior below is pinned by the unit test ``test_teardown_containers_short_circuits_when_launch_true`` in `cvs/core/orchestrators/unittests/test_container.py <https://github.com/ROCm/cvs/blob/main/cvs/core/orchestrators/unittests/test_container.py>`_.
+
+.. list-table::
+   :widths: 2 2 2 5
+   :header-rows: 1
+
+   * - ``enabled``
+     - ``launch``
+     - ``container_id``
+     - Behavior of ``teardown_containers``
+   * - ``false``
+     - any
+     - any
+     - Short-circuit (no-op, returns ``True``).
+   * - ``true``
+     - ``true``
+     - any
+     - Short-circuit. Containers are treated as externally managed; CVS does not stop them.
+   * - ``true``
+     - ``false``
+     - unset
+     - Short-circuit. Nothing was started.
+   * - ``true``
+     - ``false``
+     - set
+     - Calls the runtime's ``teardown_containers`` to stop and remove the container.
+
+Prerequisites on each cluster node
+==================================
+
+To use the container backend, every cluster node must have:
+
+- **Docker installed** with passwordless ``sudo docker`` for the SSH user.
+- **Host driver loaded** so ``/dev/kfd``, ``/dev/dri/*``, and ``/dev/infiniband/*`` (when RDMA is in scope) are present for passthrough.
+- **SSH user home directory accessible**. The orchestrator mounts ``~/.ssh`` as ``/host_ssh`` and copies keys into ``/root/.ssh`` inside the container so that the in-container ``sshd`` on port ``2224`` can authenticate.
+- **Container image** either pre-loaded on every node (``docker load``) or pullable from a reachable registry. The image must contain ``openssh-server`` (for the in-container ``sshd``) and the workload binaries the suite invokes (for example ``/opt/rocm/bin/rvs``).
+
+See also
+========
+
+- :doc:`/how-to/run-with-containers` - task-oriented walkthrough for running ``rvs_cvs`` in container mode.
+- `cvs/input/cluster_file/README.md <https://github.com/ROCm/cvs/blob/main/cvs/input/cluster_file/README.md>`_ - in-tree reference next to the templates.

--- a/docs/reference/configuration-files/configure-config.rst
+++ b/docs/reference/configuration-files/configure-config.rst
@@ -14,6 +14,14 @@ The test configuration files are in the ``cvs/input/config_file`` directory of t
 
   Ensure `ROCm <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>`_ is installed correctly, and the GPU drivers are loaded.
 
+Cluster file
+============
+
+In addition to a per-test ``--config_file``, every ``cvs run`` invocation needs a ``--cluster_file`` that declares the SSH credentials, the node list, and the **execution backend** (baremetal or container). See :doc:`/reference/configuration-files/cluster-file` for the full schema, the container block reference, and which suites consume the orchestrator today.
+
+Test configuration files
+========================
+
 The following list provides a link to code snippets and the parameters for each configuration file:
 
 - :doc:`Platform </reference/configuration-files/platform>`

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -17,6 +17,8 @@ subtrees:
   entries:
   - file: how-to/run-cvs-tests
     title: Run tests
+  - file: how-to/run-with-containers
+    title: Run tests with the container backend
   - file: how-to/run-cluster
     title: Monitor the health of GPU clusters
 
@@ -26,6 +28,8 @@ subtrees:
     title: Test configuration files
     subtrees:
     - entries:
+      - file: reference/configuration-files/cluster-file
+        title: Cluster file
       - file: reference/configuration-files/platform
         title: Platform
       - file: reference/configuration-files/health


### PR DESCRIPTION
> **Reviewer note:** the first two commits on this branch (`81a8ccb`, `7f44134`) were validated previously and are included for context only. **Please focus review on the 5 newer commits**: `040dacb`, `6decba7`, `7e176c3`, `14288b4`, `867f98f`. See the Commits section at the bottom for the breakdown.

## What this changes

Introduces a pluggable execution substrate under [`cvs/core/`](cvs/core/) so test suites
can run identically on baremetal hosts (SSH) or inside long-lived per-host containers
(`docker exec`), with the choice deferred to the cluster JSON. Migrates the RVS health
suite to the new ABC as the reference consumer.

Layered as:

- **`Orchestrator` ABC** ([`cvs/core/orchestrators/base.py`](cvs/core/orchestrators/base.py)) — `exec`, `exec_on_head`, `setup_env`, `cleanup`, `distribute_using_mpi`, plus the additive surface needed for backend-blind suites: `privileged_prefix()`, `prepare()`, `dispose()`, `host_all`, `host_head`.
- **`BaremetalOrchestrator`** ([`cvs/core/orchestrators/baremetal.py`](cvs/core/orchestrators/baremetal.py)) — runs commands over `Pssh` (paramiko); `host_all`/`host_head` alias `self.all`/`self.head` since the SSH namespace already targets the host.
- **`ContainerOrchestrator`** ([`cvs/core/orchestrators/container.py`](cvs/core/orchestrators/container.py)) — inherits the host-SSH plumbing and overlays a runtime; `prepare()` does `setup_containers` + `setup_sshd` with rollback on partial failure; `dispose()` tears down via the runtime directly to bypass the existing `launch:true` short-circuit.
- **`ContainerRuntime` Protocol** ([`cvs/core/runtimes/base.py`](cvs/core/runtimes/base.py)) with concrete [`DockerRuntime`](cvs/core/runtimes/docker.py) and stub [`EnrootRuntime`](cvs/core/runtimes/enroot.py).
- **Factories** ([`cvs/core/orchestrators/factory.py`](cvs/core/orchestrators/factory.py), [`cvs/core/runtimes/factory.py`](cvs/core/runtimes/factory.py)) instantiated from `OrchestratorConfig.from_configs(cluster_file, test_config)`.
- **Suite migration** — [`cvs/tests/health/rvs_cvs.py`](cvs/tests/health/rvs_cvs.py) is rewritten backend-blind (no `orchestrator_type` checks, no `isinstance`, no `"baremetal"`/`"container"` literals, no `/tmp/` literals — all scratch via `sealed_tmp(...)` keyed on `MULTIORCH_RUN_ID`). New conftest + helpers in [`cvs/tests/health/conftest.py`](cvs/tests/health/conftest.py) and [`cvs/tests/health/_rvs_orch_helpers.py`](cvs/tests/health/_rvs_orch_helpers.py).
- **Pssh** ([`cvs/lib/parallel_ssh_lib.py`](cvs/lib/parallel_ssh_lib.py)) gains an optional `detailed` mode on `exec()` returning per-host `{output, exit_code}`; covered by [`cvs/lib/unittests/test_parallel_ssh_lib.py`](cvs/lib/unittests/test_parallel_ssh_lib.py).
- **Tests** — 20-case ABC coverage in [`cvs/core/unittests/test_orchestrator_abc.py`](cvs/core/unittests/test_orchestrator_abc.py).
- **Contributor docs** — full architecture + extension guide in [`cvs/core/README.md`](cvs/core/README.md).

Sibling suites (`transferbench_cvs.py`, `agfhc_cvs.py`, `csp_qual_agfhc.py`) are
untouched and continue to work — every new fixture and hook is gated on the test
opting in via the `orch` fixture.

## Configuring the backend

Selection is via the `orchestrator` key in the cluster JSON. Two worked examples ship in this PR:

### Baremetal — [`cvs/input/cluster_file/cluster_baremetal.json`](cvs/input/cluster_file/cluster_baremetal.json)

```json
{
    "orchestrator": "baremetal",
    "username": "{user-id}",
    "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
    "head_node_dict": { "mgmt_ip": "{xx.xx.xx.xx|hostname-1}" },
    "node_dict": {
        "{xx.xx.xx.xx|hostname-1}": { "bmc_ip": "NA", "vpc_ip": "{xx.xx.xx.xx|hostname-1}" },
        "{xx.xx.xx.xx|hostname-2}": { "bmc_ip": "NA", "vpc_ip": "{xx.xx.xx.xx|hostname-2}" }
    }
}
```

`orchestrator` defaults to `"baremetal"` if omitted. Same shape as the existing
[`cluster.json`](cvs/input/cluster_file/cluster.json); 3-node variant in
[`cluster_3node.json`](cvs/input/cluster_file/cluster_3node.json).

### Container (Docker) — [`cvs/input/cluster_file/cluster_container.json`](cvs/input/cluster_file/cluster_container.json)

```json
{
    "orchestrator": "container",
    "username": "{user-id}",
    "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
    "head_node_dict": { "mgmt_ip": "{xx.xx.xx.xx|hostname-1}" },
    "node_dict": {
        "{xx.xx.xx.xx|hostname-1}": { "bmc_ip": "NA", "vpc_ip": "{xx.xx.xx.xx|hostname-1}" },
        "{xx.xx.xx.xx|hostname-2}": { "bmc_ip": "NA", "vpc_ip": "{xx.xx.xx.xx|hostname-2}" }
    },
    "container": {
        "enabled": true,
        "launch": true,
        "image": "rocm/cvs:latest",
        "name": "cvs_container",
        "runtime": {
            "name": "docker",
            "args": { "network": "host", "ipc": "host", "privileged": true }
        }
    }
}
```

Container-mode notes (full reference in [`cvs/core/README.md`](cvs/core/README.md)):

- `launch: true` → CVS owns the container lifecycle (started in `prepare()`, stopped in `dispose()`); `false` → externally managed, CVS only verifies and uses.
- `prepare()` starts the container and runs `sshd -p 2224` inside it; subsequent `orch.exec` SSHes into the container namespace as root, which is why `privileged_prefix()` is `""` for the container backend (vs `"sudo "` for baremetal).
- Host-namespace commands (kernel modules, firewall, RDMA, ROCm version probe) still hit the physical host via `orch.host_all` / `orch.host_head`.
- Defaults for any omitted `runtime.args` key come from `DEFAULT_CONTAINER_ARGS` in [`cvs/core/orchestrators/container.py`](cvs/core/orchestrators/container.py).
- The image must have the test deps (rvs, rccl, transferbench, etc.) and an sshd that can bind port 2224, and must be locally present on each host or pullable from a reachable registry.

## Commits

### Please focus review on these 5 commits (new in this PR)

- **`040dacb`** Extend Orchestrator ABC for backend-blind test suites
- **`6decba7`** Add multi-orch health conftest, helpers, and capstdout enrichment
- **`7e176c3`** Migrate `rvs_cvs.py` to the multi-orch backend
- **`14288b4`** Add developer documentation on adding more containers / orchestrators
- **`867f98f`** Add sample cluster configs (`cluster_baremetal.json`, `cluster_container.json`, `cluster_3node.json`)

### Already validated — included for context only (no re-review needed)

- `81a8ccb` Add cluster orchestrator layer and refactor RCCL to use it
- `7f44134` Revert RCCL lib and tests to origin/main

These two predate the new work, were validated previously, and the RCCL portion of `81a8ccb` was reverted by `7f44134` (so the net effect on RCCL is zero — only the orchestrator/runtime layer remains, which is then extended by the 5 commits above).
