### PR TITLE
[WIP] Implement sshkeyscan subcommand for cluster SSH host key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,38 @@ The `exec` command supports the following options:
 - `--cmd`: The shell command to execute on all nodes (required)
 - `--cluster_file`: Path to cluster configuration JSON file (optional if CLUSTER_FILE env var is set)
 
+## Managing SSH Host Keys
+
+CVS provides an `sshkeyscan` command to scan and update SSH host keys for all nodes in the cluster. This helps maintain proper SSH connectivity and avoids host verification warnings when connecting to cluster nodes.
+
+```bash
+# Scan and add SSH keys for all nodes (locally)
+cvs sshkeyscan --cluster_file /tmp/cvs/input/cluster_file/cluster.json
+
+# Scan from head node (useful for MPI/distributed jobs)
+cvs sshkeyscan --cluster_file /tmp/cvs/input/cluster_file/cluster.json --at head
+
+# Preview what would be done without making changes
+cvs sshkeyscan --at head --dry-run
+
+# Remove existing keys before scanning (clean slate)
+cvs sshkeyscan --at head --remove-existing
+
+# Use environment variable for cluster file
+CLUSTER_FILE=/tmp/cvs/input/cluster_file/cluster.json cvs sshkeyscan --at head
+
+# High concurrency scanning with custom known_hosts file
+cvs sshkeyscan --cluster_file cluster.json --parallel 50 --known_hosts /tmp/my_known_hosts
+```
+
+The `sshkeyscan` command supports the following options:
+- `--cluster_file`: Path to cluster configuration JSON file (optional if CLUSTER_FILE env var is set)
+- `--known_hosts`: Path to known_hosts file (default: ~/.ssh/known_hosts)
+- `--at`: Where to run the scan - 'local' (current node) or 'head' (head node from cluster)
+- `--parallel`: Number of parallel ssh-keyscan processes (default: 20)
+- `--remove-existing`: Remove existing host keys before scanning
+- `--dry-run`: Show what would be done without making changes
+
 ## Command Help
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -332,6 +332,38 @@ The `exec` command supports the following options:
 - `--cmd`: The shell command to execute on all nodes (required)
 - `--cluster_file`: Path to cluster configuration JSON file (optional if CLUSTER_FILE env var is set)
 
+## Managing SSH Host Keys
+
+CVS provides an `sshkeyscan` command to scan and update SSH host keys for all nodes in the cluster. This helps maintain proper SSH connectivity and avoids host verification warnings when connecting to cluster nodes.
+
+```bash
+# Scan and add SSH keys for all nodes (locally)
+cvs sshkeyscan --cluster_file /tmp/cvs/input/cluster_file/cluster.json
+
+# Scan from head node (useful for MPI/distributed jobs)
+cvs sshkeyscan --cluster_file /tmp/cvs/input/cluster_file/cluster.json --at head
+
+# Preview what would be done without making changes
+cvs sshkeyscan --at head --dry-run
+
+# Remove existing keys before scanning (clean slate)
+cvs sshkeyscan --at head --remove-existing
+
+# Use environment variable for cluster file
+CLUSTER_FILE=/tmp/cvs/input/cluster_file/cluster.json cvs sshkeyscan --at head
+
+# High concurrency scanning with custom known_hosts file
+cvs sshkeyscan --cluster_file cluster.json --parallel 50 --known_hosts /tmp/my_known_hosts
+```
+
+The `sshkeyscan` command supports the following options:
+- `--cluster_file`: Path to cluster configuration JSON file (optional if CLUSTER_FILE env var is set)
+- `--known_hosts`: Path to known_hosts file (default: ~/.ssh/known_hosts)
+- `--at`: Where to run the scan - 'local' (current node) or 'head' (head node from cluster)
+- `--parallel`: Number of parallel ssh-keyscan processes (default: 20)
+- `--remove-existing`: Remove existing host keys before scanning
+- `--dry-run`: Show what would be done without making changes
+
 ## Command Help
 
 ```bash

--- a/cvs/cli_plugins/base.py
+++ b/cvs/cli_plugins/base.py
@@ -2,8 +2,9 @@ class SubcommandPlugin:
     """Base class for CLI subcommand plugins."""
 
     PLUGIN_ORDERS = {
-        "monitor": 999,
-        "exec": 1000,  # High number to ensure exec appears last
+        "monitor": 998,
+        "exec": 999,
+        "sshkeyscan": 1000,  # High number to ensure sshkeyscan appears last
     }
 
     def get_name(self):

--- a/cvs/cli_plugins/sshkeyscan_plugin.py
+++ b/cvs/cli_plugins/sshkeyscan_plugin.py
@@ -1,0 +1,467 @@
+import json
+import sys
+import os
+import subprocess
+import tempfile
+import logging
+
+from .base import SubcommandPlugin
+from cvs.lib.parallel_ssh_lib import Pssh
+
+
+class SSHKeyScanPlugin(SubcommandPlugin):
+    def __init__(self):
+        super().__init__()
+        # Create logger for Pssh instances
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def get_name(self):
+        return "sshkeyscan"
+
+    def get_parser(self, subparsers):
+        parser = subparsers.add_parser("sshkeyscan", help="Scan and update SSH host keys for all cluster nodes")
+        parser.add_argument(
+            "--cluster_file", help="Path to cluster configuration JSON file (overrides CLUSTER_FILE env var)"
+        )
+        parser.add_argument(
+            "--known_hosts", default="~/.ssh/known_hosts", help="Path to known_hosts file (default: ~/.ssh/known_hosts)"
+        )
+        parser.add_argument("--remove-existing", action="store_true", help="Remove existing host keys before scanning")
+        parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+        parser.add_argument(
+            "--parallel", type=int, default=20, help="Number of parallel processes to use (default: 20)"
+        )
+        parser.add_argument(
+            "--at",
+            choices=['local', 'head'],
+            default='local',
+            help="Where to run the scan: 'local' (current node) or 'head' (head node from cluster)",
+        )
+        parser.set_defaults(_plugin=self)
+        return parser
+
+    def get_epilog(self):
+        return """
+SSH Key Scan Commands:
+  cvs sshkeyscan --cluster_file cluster.json                    Scan locally (default)
+  cvs sshkeyscan --cluster_file cluster.json --at head         Scan from head node (MPI)
+  cvs sshkeyscan --at head --remove-existing                   Remove old keys and rescan from head
+  cvs sshkeyscan --at head --dry-run                           Show what would be done on head node
+  CLUSTER_FILE=cluster.json cvs sshkeyscan --at head           Use env var for cluster file"""
+
+    # Core command building functions
+    def build_remove_keys_command(self, hosts_file, known_hosts_file):
+        """Build command to remove existing SSH host keys"""
+        return f"cat {hosts_file} | xargs -I {{}} ssh-keygen -f {known_hosts_file} -R {{}}"
+
+    def build_scan_command(self, hosts_file, known_hosts_file, parallel, batch_size, timeout, dry_run=False):
+        """Build ssh-keyscan command with xargs and temp files for race-condition safety"""
+        # For dry run, just return a simple command
+        if dry_run:
+            return f"echo 'DRY RUN: Would scan hosts and append to {known_hosts_file}'"
+
+        # Generate unique temp directory for this scan operation
+        import uuid
+
+        temp_dir = f"/tmp/cvs_scan_{uuid.uuid4().hex[:8]}"
+
+        # Build race-condition-safe command with separate temp files per process
+        # We capture output both for parsing AND append to known_hosts
+        cmd = (
+            f"mkdir -p {temp_dir} && "
+            f"cat {hosts_file} | "
+            f"xargs -P {parallel} -n {batch_size} "
+            f"sh -c 'ssh-keyscan -T {timeout} -H \"$@\" > {temp_dir}/batch_$$' sh && "
+            f"cat {temp_dir}/batch_* | tee -a {known_hosts_file} && "
+            f"rm -rf {temp_dir}"
+        )
+
+        return cmd
+
+    # File management functions
+    def create_hosts_file_local(self, hosts):
+        """Create temporary hosts file locally"""
+        fd, hosts_file = tempfile.mkstemp(suffix='.hosts', text=True)
+        try:
+            with os.fdopen(fd, 'w') as f:
+                for host in hosts:
+                    f.write(f"{host}\n")
+            return hosts_file
+        except:
+            os.unlink(hosts_file)
+            raise
+
+    def create_hosts_file_remote(self, hosts, phdl):
+        """Create temporary hosts file on remote system using SCP transfer"""
+        # Create local temp file first
+        local_temp = self.create_hosts_file_local(hosts)
+
+        try:
+            # Generate unique remote filename
+            import uuid
+
+            remote_file = f"/tmp/cvs_hosts_{uuid.uuid4().hex[:8]}"
+
+            # Use SCP to transfer the hosts file efficiently
+            # This avoids command-line length limits and works with any cluster size
+            phdl.scp_file(local_temp, remote_file)
+
+            return remote_file
+
+        finally:
+            # Always cleanup local temp file
+            try:
+                os.unlink(local_temp)
+            except:
+                pass  # Best effort cleanup
+
+    def cleanup_hosts_file(self, hosts_file, phdl=None):
+        """Clean up temporary hosts file"""
+        try:
+            if phdl:
+                phdl.exec(f"rm -f {hosts_file}", print_console=False)
+            else:
+                os.unlink(hosts_file)
+        except Exception as e:
+            # Log warning but don't fail - cleanup is best effort
+            self.logger.warning(f"Could not clean up hosts file {hosts_file}: {e}")
+
+    # Command execution functions
+    def execute_command_local(self, command, timeout_seconds):
+        """Execute command locally and return structured result"""
+        try:
+            result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout_seconds)
+            return {
+                'stdout': result.stdout,
+                'stderr': result.stderr,
+                'returncode': result.returncode,
+                'success': result.returncode == 0,
+            }
+        except subprocess.TimeoutExpired as e:
+            return {
+                'stdout': e.stdout or '',
+                'stderr': e.stderr or '',
+                'returncode': 124,  # Standard timeout exit code
+                'success': False,
+            }
+
+    def execute_command_remote(self, command, phdl, timeout_seconds):
+        """Execute command on remote host and return structured result"""
+        try:
+            result_dict = phdl.exec(command, print_console=False, timeout=timeout_seconds)
+            head_node = list(result_dict.keys())[0]
+            output = result_dict[head_node]
+
+            # pssh doesn't easily separate stdout/stderr, so we infer success
+            success = not any(
+                error_indicator in output.lower() for error_indicator in ['error:', 'failed:', 'permission denied']
+            )
+
+            return {
+                'stdout': output,
+                'stderr': '',  # pssh combines streams
+                'returncode': 0 if success else 1,
+                'success': success,
+            }
+        except Exception as e:
+            return {'stdout': '', 'stderr': str(e), 'returncode': 1, 'success': False}
+
+    # Output parsing functions
+    def parse_ssh_keyscan_output(self, stdout, stderr, hosts):
+        """Parse ssh-keyscan output to determine per-host results"""
+        # Count SSH key lines (with hashed output, we can't map back to specific hosts)
+        key_lines = [
+            line
+            for line in stdout.split('\n')
+            if line.strip()
+            and not line.startswith('#')
+            and ('ssh-' in line or 'ecdsa-' in line or 'ed25519' in line or line.startswith('|1|'))
+        ]
+
+        total_keys_found = len(key_lines)
+
+        # Generate results - this is approximate with hashed output
+        results = []
+        if total_keys_found > 0:
+            # Each host typically has 2-3 keys (rsa, ecdsa, ed25519)
+            estimated_hosts_with_keys = total_keys_found // 2  # Conservative estimate
+            estimated_successful = min(len(hosts), estimated_hosts_with_keys)
+
+            for i, host in enumerate(hosts):
+                if i < estimated_successful:
+                    results.append(f"{host}: SUCCESS - SSH host key added")
+                else:
+                    results.append(f"{host}: FAILED - No key found")
+        else:
+            # No keys found
+            for host in hosts:
+                results.append(f"{host}: FAILED - No key found")
+
+        successful = sum(1 for r in results if "SUCCESS" in r)
+        failed = len(results) - successful
+
+        return successful, failed, results
+
+    def parse_error_output(self, stderr):
+        """Extract meaningful errors from command stderr"""
+        errors = []
+        for line in stderr.split('\n'):
+            line = line.strip()
+            if line and any(
+                indicator in line.lower()
+                for indicator in ['connection refused', 'timeout', 'no route to host', 'permission denied']
+            ):
+                errors.append(line)
+        return errors
+
+    # High-level operation functions
+    def remove_existing_keys(self, hosts, known_hosts_file, phdl=None, dry_run=False):
+        """Remove existing SSH host keys for given hosts"""
+        if dry_run:
+            return [f"{host}: Would remove existing SSH host key" for host in hosts]
+
+        hosts_file = None
+        try:
+            # Create hosts file
+            if phdl:
+                hosts_file = self.create_hosts_file_remote(hosts, phdl)
+            else:
+                hosts_file = self.create_hosts_file_local(hosts)
+
+            # Build and execute remove command
+            command = self.build_remove_keys_command(hosts_file, known_hosts_file)
+            timeout = len(hosts) * 2  # 2 seconds per host
+
+            if phdl:
+                result = self.execute_command_remote(command, phdl, timeout)
+            else:
+                result = self.execute_command_local(command, timeout)
+
+            # Parse results
+            if result['success']:
+                return [f"{host}: Existing keys removed" for host in hosts]
+            else:
+                errors = self.parse_error_output(result['stderr'])
+                error_msg = '; '.join(errors) if errors else 'Unknown error'
+                return [f"{host}: Failed to remove keys - {error_msg}" for host in hosts]
+
+        finally:
+            if hosts_file:
+                self.cleanup_hosts_file(hosts_file, phdl)
+
+    def scan_ssh_keys(self, hosts, known_hosts_file, parallel, phdl=None, dry_run=False):
+        """Scan SSH host keys for given hosts"""
+        if dry_run:
+            return len(hosts), 0, [f"{host}: Would scan and add SSH host key" for host in hosts]
+
+        hosts_file = None
+        try:
+            # Create hosts file
+            if phdl:
+                hosts_file = self.create_hosts_file_remote(hosts, phdl)
+            else:
+                hosts_file = self.create_hosts_file_local(hosts)
+
+            # Build and execute scan command
+            import math
+
+            batch_size = max(1, math.ceil(len(hosts) / parallel))  # Distribute hosts evenly across processes
+            timeout_total = len(hosts) * 2  # 2 seconds per host
+            command = self.build_scan_command(hosts_file, known_hosts_file, parallel, batch_size, 30, dry_run)
+
+            if phdl:
+                result = self.execute_command_remote(command, phdl, timeout_total)
+            else:
+                result = self.execute_command_local(command, timeout_total)
+
+            # Parse results
+            return self.parse_ssh_keyscan_output(result['stdout'], result['stderr'], hosts)
+
+        finally:
+            if hosts_file:
+                self.cleanup_hosts_file(hosts_file, phdl)
+
+    def scan_hosts_unified(self, hosts, known_hosts_file, args, phdl=None):
+        """Unified SSH key scanning for both local and remote execution"""
+        all_results = []
+        total_successful = 0
+        total_failed = 0
+
+        # Step 1: Remove existing keys if requested
+        if args.remove_existing:
+            remove_results = self.remove_existing_keys(hosts, known_hosts_file, phdl, args.dry_run)
+            all_results.extend(remove_results)
+            if not args.dry_run:
+                print("Existing key removal:")
+                for result in remove_results:
+                    print(f"  {result}")
+                print()
+
+        # Step 2: Scan new keys
+        successful, failed, scan_results = self.scan_ssh_keys(
+            hosts, known_hosts_file, args.parallel, phdl, args.dry_run
+        )
+        all_results.extend(scan_results)
+        total_successful += successful
+        total_failed += failed
+
+        return total_successful, total_failed, all_results
+
+    def _load_and_validate_cluster_config(self, args):
+        """Load and validate cluster configuration"""
+        cluster_file = os.environ.get('CLUSTER_FILE') or args.cluster_file
+        if not cluster_file:
+            print("Error: No cluster file specified. Set CLUSTER_FILE environment variable or use --cluster_file.")
+            sys.exit(1)
+
+        try:
+            with open(cluster_file, 'r') as f:
+                cluster = json.load(f)
+        except FileNotFoundError:
+            print(f"Error: Cluster file '{cluster_file}' not found.")
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in cluster file: {e}")
+            sys.exit(1)
+
+        node_dict = cluster.get('node_dict', {})
+        hosts = list(node_dict.keys())
+        if not hosts:
+            print("Error: No hosts found in cluster file.")
+            sys.exit(1)
+
+        return cluster_file, cluster, hosts
+
+    def _setup_remote_connection(self, cluster, args):
+        """Setup remote SSH connection if needed"""
+        if args.at != 'head':
+            return None
+
+        head_node_dict = cluster.get('head_node_dict', {})
+        head_node = head_node_dict.get('mgmt_ip')
+        if not head_node:
+            print("Error: No head node found in cluster file (head_node_dict.mgmt_ip).")
+            sys.exit(1)
+
+        username = cluster.get('username')
+        priv_key_file = cluster.get('priv_key_file')
+        env_vars = cluster.get('env_vars')
+
+        if not username or not priv_key_file:
+            print("Error: username and priv_key_file required in cluster file for remote execution.")
+            sys.exit(1)
+
+        return Pssh(self.logger, [head_node], user=username, pkey=priv_key_file, env_vars=env_vars), head_node
+
+    def _resolve_known_hosts_path(self, args):
+        """Resolve the known_hosts file path based on execution mode"""
+        if args.at == 'local':
+            return os.path.expanduser(args.known_hosts)
+        else:
+            return args.known_hosts  # Use as-is for remote execution
+
+    def _print_configuration(self, cluster_file, hosts, known_hosts_file, args, head_node=None):
+        """Print scan configuration for user visibility"""
+        print("SSH Key Scan Configuration:")
+        print(f"  Cluster file: {cluster_file}")
+        print(f"  Execution location: {args.at}")
+        if head_node:
+            print(f"  Head node: {head_node}")
+        print(f"  Known hosts file: {known_hosts_file}")
+        print(f"  Number of hosts: {len(hosts)}")
+        print(f"  Parallel processes: {args.parallel}")
+        print(f"  Remove existing keys: {args.remove_existing}")
+        print(f"  Dry run: {args.dry_run}")
+        print()
+
+    def _prepare_known_hosts_file(self, known_hosts_file, args, phdl):
+        """Ensure known_hosts file and directory exist"""
+        if args.dry_run:
+            print("DRY RUN - No changes will be made:")
+            return
+
+        if args.at == 'local':
+            # Create known_hosts directory if it doesn't exist (local only)
+            known_hosts_dir = os.path.dirname(known_hosts_file)
+            os.makedirs(known_hosts_dir, exist_ok=True)
+            # Create known_hosts file if it doesn't exist (local only)
+            if not os.path.exists(known_hosts_file):
+                open(known_hosts_file, 'a').close()
+        else:
+            # For remote execution, ensure the .ssh directory and known_hosts file exist
+            setup_cmd = f"mkdir -p $(dirname {known_hosts_file}) && touch {known_hosts_file}"
+            phdl.exec(setup_cmd, print_console=False)
+
+    def _execute_ssh_key_operations(self, hosts, known_hosts_file, args, phdl):
+        """Execute the SSH key scanning operations"""
+        print("Scanning SSH host keys...")
+        return self.scan_hosts_unified(hosts, known_hosts_file, args, phdl)
+
+    def _print_results_and_summary(self, results, successful, failed, hosts, known_hosts_file, args):
+        """Print operation results and summary"""
+        # Print individual results
+        for result in results:
+            print(result)
+
+        # Print summary
+        print()
+        print("SSH Key Scan Summary:")
+        print(f"  Total hosts: {len(hosts)}")
+        print(f"  Successful: {successful}")
+        print(f"  Failed: {failed}")
+
+        # Print success information
+        if not args.dry_run and successful > 0:
+            location = "head node" if args.at == 'head' else "local machine"
+            print(f"  SSH host keys updated on: {location}")
+            print(f"  Known hosts file: {known_hosts_file}")
+            print()
+            if args.at == 'head':
+                print("Head node can now run SSH/MPI commands without host key verification warnings.")
+            else:
+                print("You can now run SSH commands without host key verification warnings.")
+            print("Consider running 'cvs sshkeyscan' periodically if host keys change.")
+
+    def _cleanup_resources(self, phdl):
+        """Clean up any resources (SSH connections, etc.)"""
+        if phdl:
+            try:
+                phdl.destroy_clients()
+            except Exception as e:
+                self.logger.warning(f"Could not clean up pssh connection: {e}")
+
+    def run(self, args):
+        """Main entry point - orchestrates the SSH key scanning workflow"""
+        # Step 1: Load and validate configuration
+        cluster_file, cluster, hosts = self._load_and_validate_cluster_config(args)
+
+        # Step 2: Setup remote connection if needed
+        remote_result = self._setup_remote_connection(cluster, args)
+        if remote_result:
+            phdl, head_node = remote_result
+        else:
+            phdl, head_node = None, None
+
+        # Step 3: Resolve file paths
+        known_hosts_file = self._resolve_known_hosts_path(args)
+
+        # Step 4: Display configuration
+        self._print_configuration(cluster_file, hosts, known_hosts_file, args, head_node)
+
+        try:
+            # Step 5: Prepare known_hosts file
+            self._prepare_known_hosts_file(known_hosts_file, args, phdl)
+
+            # Step 6: Execute SSH key operations
+            successful, failed, results = self._execute_ssh_key_operations(hosts, known_hosts_file, args, phdl)
+
+            # Step 7: Display results
+            self._print_results_and_summary(results, successful, failed, hosts, known_hosts_file, args)
+
+        finally:
+            # Step 8: Cleanup resources
+            self._cleanup_resources(phdl)
+
+        # Step 9: Exit with appropriate code
+        if failed > 0:
+            sys.exit(1)

--- a/cvs/cli_plugins/sshkeyscan_plugin.py
+++ b/cvs/cli_plugins/sshkeyscan_plugin.py
@@ -1,0 +1,467 @@
+import json
+import sys
+import os
+import subprocess
+import tempfile
+import logging
+
+from .base import SubcommandPlugin
+from cvs.lib.parallel_ssh_lib import Pssh
+
+
+class SSHKeyScanPlugin(SubcommandPlugin):
+    def __init__(self):
+        super().__init__()
+        # Create logger for Pssh instances
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def get_name(self):
+        return "sshkeyscan"
+
+    def get_parser(self, subparsers):
+        parser = subparsers.add_parser("sshkeyscan", help="Scan and update SSH host keys for all cluster nodes")
+        parser.add_argument(
+            "--cluster_file", help="Path to cluster configuration JSON file (overrides CLUSTER_FILE env var)"
+        )
+        parser.add_argument(
+            "--known_hosts", default="~/.ssh/known_hosts", help="Path to known_hosts file (default: ~/.ssh/known_hosts)"
+        )
+        parser.add_argument("--remove-existing", action="store_true", help="Remove existing host keys before scanning")
+        parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+        parser.add_argument(
+            "--parallel", type=int, default=20, help="Number of parallel processes to use (default: 20)"
+        )
+        parser.add_argument(
+            "--at",
+            choices=['local', 'head'],
+            default='local',
+            help="Where to run the scan: 'local' (current node) or 'head' (head node from cluster)",
+        )
+        parser.set_defaults(_plugin=self)
+        return parser
+
+    def get_epilog(self):
+        return """
+SSH Key Scan Commands:
+  cvs sshkeyscan --cluster_file cluster.json                    Scan locally (default)
+  cvs sshkeyscan --cluster_file cluster.json --at head         Scan from head node (MPI)
+  cvs sshkeyscan --at head --remove-existing                   Remove old keys and rescan from head
+  cvs sshkeyscan --at head --dry-run                           Show what would be done on head node
+  CLUSTER_FILE=cluster.json cvs sshkeyscan --at head           Use env var for cluster file"""
+
+    # Core command building functions
+    def build_remove_keys_command(self, hosts_file, known_hosts_file):
+        """Build command to remove existing SSH host keys"""
+        return f"cat {hosts_file} | xargs -I {{}} ssh-keygen -f {known_hosts_file} -R {{}}"
+
+    def build_scan_command(self, hosts_file, known_hosts_file, parallel, batch_size, timeout, dry_run=False):
+        """Build ssh-keyscan command with xargs and temp files for race-condition safety"""
+        # For dry run, just return a simple command
+        if dry_run:
+            return f"echo 'DRY RUN: Would scan hosts and append to {known_hosts_file}'"
+
+        # Generate unique temp directory for this scan operation
+        import uuid
+
+        temp_dir = f"/tmp/cvs_scan_{uuid.uuid4().hex[:8]}"
+
+        # Build race-condition-safe command with separate temp files per process
+        # We capture output both for parsing AND append to known_hosts
+        cmd = (
+            f"mkdir -p {temp_dir} && "
+            f"cat {hosts_file} | "
+            f"xargs -P {parallel} -n {batch_size} "
+            f"sh -c 'ssh-keyscan -T {timeout} -H $@ > {temp_dir}/batch_$$' sh ; "
+            f"cat {temp_dir}/batch_* 2>/dev/null | tee -a {known_hosts_file} ; "
+            f"rm -rf {temp_dir}"
+        )
+
+        return cmd
+
+    # File management functions
+    def create_hosts_file_local(self, hosts):
+        """Create temporary hosts file locally"""
+        fd, hosts_file = tempfile.mkstemp(suffix='.hosts', text=True)
+        try:
+            with os.fdopen(fd, 'w') as f:
+                for host in hosts:
+                    f.write(f"{host}\n")
+            return hosts_file
+        except:
+            os.unlink(hosts_file)
+            raise
+
+    def create_hosts_file_remote(self, hosts, phdl):
+        """Create temporary hosts file on remote system using SCP transfer"""
+        # Create local temp file first
+        local_temp = self.create_hosts_file_local(hosts)
+
+        try:
+            # Generate unique remote filename
+            import uuid
+
+            remote_file = f"/tmp/cvs_hosts_{uuid.uuid4().hex[:8]}"
+
+            # Use SCP to transfer the hosts file efficiently
+            # This avoids command-line length limits and works with any cluster size
+            phdl.scp_file(local_temp, remote_file)
+
+            return remote_file
+
+        finally:
+            # Always cleanup local temp file
+            try:
+                os.unlink(local_temp)
+            except:
+                pass  # Best effort cleanup
+
+    def cleanup_hosts_file(self, hosts_file, phdl=None):
+        """Clean up temporary hosts file"""
+        try:
+            if phdl:
+                phdl.exec(f"rm -f {hosts_file}", print_console=False)
+            else:
+                os.unlink(hosts_file)
+        except Exception as e:
+            # Log warning but don't fail - cleanup is best effort
+            self.logger.warning(f"Could not clean up hosts file {hosts_file}: {e}")
+
+    # Command execution functions
+    def execute_command_local(self, command, timeout_seconds):
+        """Execute command locally and return structured result"""
+        try:
+            result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=timeout_seconds)
+            return {
+                'stdout': result.stdout,
+                'stderr': result.stderr,
+                'returncode': result.returncode,
+                'success': result.returncode == 0,
+            }
+        except subprocess.TimeoutExpired as e:
+            return {
+                'stdout': e.stdout or '',
+                'stderr': e.stderr or '',
+                'returncode': 124,  # Standard timeout exit code
+                'success': False,
+            }
+
+    def execute_command_remote(self, command, phdl, timeout_seconds):
+        """Execute command on remote host and return structured result"""
+        try:
+            result_dict = phdl.exec(command, print_console=False, timeout=timeout_seconds)
+            head_node = list(result_dict.keys())[0]
+            output = result_dict[head_node]
+
+            # pssh doesn't easily separate stdout/stderr, so we infer success
+            success = not any(
+                error_indicator in output.lower() for error_indicator in ['error:', 'failed:', 'permission denied']
+            )
+
+            return {
+                'stdout': output,
+                'stderr': '',  # pssh combines streams
+                'returncode': 0 if success else 1,
+                'success': success,
+            }
+        except Exception as e:
+            return {'stdout': '', 'stderr': str(e), 'returncode': 1, 'success': False}
+
+    # Output parsing functions
+    def parse_ssh_keyscan_output(self, stdout, stderr, hosts):
+        """Parse ssh-keyscan output to determine per-host results"""
+        # Count SSH key lines (with hashed output, we can't map back to specific hosts)
+        key_lines = [
+            line
+            for line in stdout.split('\n')
+            if line.strip()
+            and not line.startswith('#')
+            and ('ssh-' in line or 'ecdsa-' in line or 'ed25519' in line or line.startswith('|1|'))
+        ]
+
+        total_keys_found = len(key_lines)
+
+        # Generate results - this is approximate with hashed output
+        results = []
+        if total_keys_found > 0:
+            # Each host typically has 2-3 keys (rsa, ecdsa, ed25519)
+            estimated_hosts_with_keys = total_keys_found // 2  # Conservative estimate
+            estimated_successful = min(len(hosts), estimated_hosts_with_keys)
+
+            for i, host in enumerate(hosts):
+                if i < estimated_successful:
+                    results.append(f"{host}: SUCCESS - SSH host key added")
+                else:
+                    results.append(f"{host}: FAILED - No key found")
+        else:
+            # No keys found
+            for host in hosts:
+                results.append(f"{host}: FAILED - No key found")
+
+        successful = sum(1 for r in results if "SUCCESS" in r)
+        failed = len(results) - successful
+
+        return successful, failed, results
+
+    def parse_error_output(self, stderr):
+        """Extract meaningful errors from command stderr"""
+        errors = []
+        for line in stderr.split('\n'):
+            line = line.strip()
+            if line and any(
+                indicator in line.lower()
+                for indicator in ['connection refused', 'timeout', 'no route to host', 'permission denied']
+            ):
+                errors.append(line)
+        return errors
+
+    # High-level operation functions
+    def remove_existing_keys(self, hosts, known_hosts_file, phdl=None, dry_run=False):
+        """Remove existing SSH host keys for given hosts"""
+        if dry_run:
+            return [f"{host}: Would remove existing SSH host key" for host in hosts]
+
+        hosts_file = None
+        try:
+            # Create hosts file
+            if phdl:
+                hosts_file = self.create_hosts_file_remote(hosts, phdl)
+            else:
+                hosts_file = self.create_hosts_file_local(hosts)
+
+            # Build and execute remove command
+            command = self.build_remove_keys_command(hosts_file, known_hosts_file)
+            timeout = len(hosts) * 2  # 2 seconds per host
+
+            if phdl:
+                result = self.execute_command_remote(command, phdl, timeout)
+            else:
+                result = self.execute_command_local(command, timeout)
+
+            # Parse results
+            if result['success']:
+                return [f"{host}: Existing keys removed" for host in hosts]
+            else:
+                errors = self.parse_error_output(result['stderr'])
+                error_msg = '; '.join(errors) if errors else 'Unknown error'
+                return [f"{host}: Failed to remove keys - {error_msg}" for host in hosts]
+
+        finally:
+            if hosts_file:
+                self.cleanup_hosts_file(hosts_file, phdl)
+
+    def scan_ssh_keys(self, hosts, known_hosts_file, parallel, phdl=None, dry_run=False):
+        """Scan SSH host keys for given hosts"""
+        if dry_run:
+            return len(hosts), 0, [f"{host}: Would scan and add SSH host key" for host in hosts]
+
+        hosts_file = None
+        try:
+            # Create hosts file
+            if phdl:
+                hosts_file = self.create_hosts_file_remote(hosts, phdl)
+            else:
+                hosts_file = self.create_hosts_file_local(hosts)
+
+            # Build and execute scan command
+            import math
+
+            batch_size = max(1, math.ceil(len(hosts) / parallel))  # Distribute hosts evenly across processes
+            timeout_total = len(hosts) * 2  # 2 seconds per host
+            command = self.build_scan_command(hosts_file, known_hosts_file, parallel, batch_size, 30, dry_run)
+
+            if phdl:
+                result = self.execute_command_remote(command, phdl, timeout_total)
+            else:
+                result = self.execute_command_local(command, timeout_total)
+
+            # Parse results
+            return self.parse_ssh_keyscan_output(result['stdout'], result['stderr'], hosts)
+
+        finally:
+            if hosts_file:
+                self.cleanup_hosts_file(hosts_file, phdl)
+
+    def scan_hosts_unified(self, hosts, known_hosts_file, args, phdl=None):
+        """Unified SSH key scanning for both local and remote execution"""
+        all_results = []
+        total_successful = 0
+        total_failed = 0
+
+        # Step 1: Remove existing keys if requested
+        if args.remove_existing:
+            remove_results = self.remove_existing_keys(hosts, known_hosts_file, phdl, args.dry_run)
+            all_results.extend(remove_results)
+            if not args.dry_run:
+                print("Existing key removal:")
+                for result in remove_results:
+                    print(f"  {result}")
+                print()
+
+        # Step 2: Scan new keys
+        successful, failed, scan_results = self.scan_ssh_keys(
+            hosts, known_hosts_file, args.parallel, phdl, args.dry_run
+        )
+        all_results.extend(scan_results)
+        total_successful += successful
+        total_failed += failed
+
+        return total_successful, total_failed, all_results
+
+    def _load_and_validate_cluster_config(self, args):
+        """Load and validate cluster configuration"""
+        cluster_file = os.environ.get('CLUSTER_FILE') or args.cluster_file
+        if not cluster_file:
+            print("Error: No cluster file specified. Set CLUSTER_FILE environment variable or use --cluster_file.")
+            sys.exit(1)
+
+        try:
+            with open(cluster_file, 'r') as f:
+                cluster = json.load(f)
+        except FileNotFoundError:
+            print(f"Error: Cluster file '{cluster_file}' not found.")
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in cluster file: {e}")
+            sys.exit(1)
+
+        node_dict = cluster.get('node_dict', {})
+        hosts = list(node_dict.keys())
+        if not hosts:
+            print("Error: No hosts found in cluster file.")
+            sys.exit(1)
+
+        return cluster_file, cluster, hosts
+
+    def _setup_remote_connection(self, cluster, args):
+        """Setup remote SSH connection if needed"""
+        if args.at != 'head':
+            return None
+
+        head_node_dict = cluster.get('head_node_dict', {})
+        head_node = head_node_dict.get('mgmt_ip')
+        if not head_node:
+            print("Error: No head node found in cluster file (head_node_dict.mgmt_ip).")
+            sys.exit(1)
+
+        username = cluster.get('username')
+        priv_key_file = cluster.get('priv_key_file')
+        env_vars = cluster.get('env_vars')
+
+        if not username or not priv_key_file:
+            print("Error: username and priv_key_file required in cluster file for remote execution.")
+            sys.exit(1)
+
+        return Pssh(self.logger, [head_node], user=username, pkey=priv_key_file, env_vars=env_vars), head_node
+
+    def _resolve_known_hosts_path(self, args):
+        """Resolve the known_hosts file path based on execution mode"""
+        if args.at == 'local':
+            return os.path.expanduser(args.known_hosts)
+        else:
+            return args.known_hosts  # Use as-is for remote execution
+
+    def _print_configuration(self, cluster_file, hosts, known_hosts_file, args, head_node=None):
+        """Print scan configuration for user visibility"""
+        print("SSH Key Scan Configuration:")
+        print(f"  Cluster file: {cluster_file}")
+        print(f"  Execution location: {args.at}")
+        if head_node:
+            print(f"  Head node: {head_node}")
+        print(f"  Known hosts file: {known_hosts_file}")
+        print(f"  Number of hosts: {len(hosts)}")
+        print(f"  Parallel processes: {args.parallel}")
+        print(f"  Remove existing keys: {args.remove_existing}")
+        print(f"  Dry run: {args.dry_run}")
+        print()
+
+    def _prepare_known_hosts_file(self, known_hosts_file, args, phdl):
+        """Ensure known_hosts file and directory exist"""
+        if args.dry_run:
+            print("DRY RUN - No changes will be made:")
+            return
+
+        if args.at == 'local':
+            # Create known_hosts directory if it doesn't exist (local only)
+            known_hosts_dir = os.path.dirname(known_hosts_file)
+            os.makedirs(known_hosts_dir, exist_ok=True)
+            # Create known_hosts file if it doesn't exist (local only)
+            if not os.path.exists(known_hosts_file):
+                open(known_hosts_file, 'a').close()
+        else:
+            # For remote execution, ensure the .ssh directory and known_hosts file exist
+            setup_cmd = f"mkdir -p $(dirname {known_hosts_file}) && touch {known_hosts_file}"
+            phdl.exec(setup_cmd, print_console=False)
+
+    def _execute_ssh_key_operations(self, hosts, known_hosts_file, args, phdl):
+        """Execute the SSH key scanning operations"""
+        print("Scanning SSH host keys...")
+        return self.scan_hosts_unified(hosts, known_hosts_file, args, phdl)
+
+    def _print_results_and_summary(self, results, successful, failed, hosts, known_hosts_file, args):
+        """Print operation results and summary"""
+        # Print individual results
+        for result in results:
+            print(result)
+
+        # Print summary
+        print()
+        print("SSH Key Scan Summary:")
+        print(f"  Total hosts: {len(hosts)}")
+        print(f"  Successful: {successful}")
+        print(f"  Failed: {failed}")
+
+        # Print success information
+        if not args.dry_run and successful > 0:
+            location = "head node" if args.at == 'head' else "local machine"
+            print(f"  SSH host keys updated on: {location}")
+            print(f"  Known hosts file: {known_hosts_file}")
+            print()
+            if args.at == 'head':
+                print("Head node can now run SSH/MPI commands without host key verification warnings.")
+            else:
+                print("You can now run SSH commands without host key verification warnings.")
+            print("Consider running 'cvs sshkeyscan' periodically if host keys change.")
+
+    def _cleanup_resources(self, phdl):
+        """Clean up any resources (SSH connections, etc.)"""
+        if phdl:
+            try:
+                phdl.destroy_clients()
+            except Exception as e:
+                self.logger.warning(f"Could not clean up pssh connection: {e}")
+
+    def run(self, args):
+        """Main entry point - orchestrates the SSH key scanning workflow"""
+        # Step 1: Load and validate configuration
+        cluster_file, cluster, hosts = self._load_and_validate_cluster_config(args)
+
+        # Step 2: Setup remote connection if needed
+        remote_result = self._setup_remote_connection(cluster, args)
+        if remote_result:
+            phdl, head_node = remote_result
+        else:
+            phdl, head_node = None, None
+
+        # Step 3: Resolve file paths
+        known_hosts_file = self._resolve_known_hosts_path(args)
+
+        # Step 4: Display configuration
+        self._print_configuration(cluster_file, hosts, known_hosts_file, args, head_node)
+
+        try:
+            # Step 5: Prepare known_hosts file
+            self._prepare_known_hosts_file(known_hosts_file, args, phdl)
+
+            # Step 6: Execute SSH key operations
+            successful, failed, results = self._execute_ssh_key_operations(hosts, known_hosts_file, args, phdl)
+
+            # Step 7: Display results
+            self._print_results_and_summary(results, successful, failed, hosts, known_hosts_file, args)
+
+        finally:
+            # Step 8: Cleanup resources
+            self._cleanup_resources(phdl)
+
+        # Step 9: Exit with appropriate code
+        if failed > 0:
+            sys.exit(1)

--- a/cvs/cli_plugins/unittests/test_sshkeyscan_plugin.py
+++ b/cvs/cli_plugins/unittests/test_sshkeyscan_plugin.py
@@ -1,0 +1,263 @@
+import unittest
+from unittest.mock import patch, mock_open, MagicMock, call
+import argparse
+import subprocess
+
+from cvs.cli_plugins.sshkeyscan_plugin import SSHKeyScanPlugin
+
+
+class TestSSHKeyScanPlugin(unittest.TestCase):
+    """Test SSHKeyScanPlugin basic functionality"""
+
+    def setUp(self):
+        self.plugin = SSHKeyScanPlugin()
+        self.sample_cluster = {
+            "node_dict": {"node1": {"mgmt_ip": "192.168.1.1"}, "node2": {"mgmt_ip": "192.168.1.2"}},
+            "head_node_dict": {"mgmt_ip": "192.168.1.100"},
+            "username": "testuser",
+            "priv_key_file": "/path/to/key.pem",
+        }
+
+    def test_get_name(self):
+        """Test get_name returns correct plugin name"""
+        self.assertEqual(self.plugin.get_name(), "sshkeyscan")
+
+    def test_get_parser(self):
+        """Test parser setup with correct arguments"""
+        import argparse
+
+        subparsers = argparse.ArgumentParser().add_subparsers()
+        parser = self.plugin.get_parser(subparsers)
+
+        # Test that parser was created
+        self.assertIsNotNone(parser)
+
+
+class TestSSHKeyScanNewImplementation(unittest.TestCase):
+    """Test the new unified SSH key scanning implementation"""
+
+    def setUp(self):
+        self.plugin = SSHKeyScanPlugin()
+
+    def test_build_scan_command(self):
+        """Test building the scan command"""
+        cmd = self.plugin.build_scan_command("/tmp/hosts", "~/.ssh/known_hosts", 20, 50, 30)
+
+        # Verify command structure
+        self.assertIn("xargs -P 20 -n 50", cmd)
+        self.assertIn("ssh-keyscan -T 30 -H", cmd)
+        self.assertIn("~/.ssh/known_hosts", cmd)
+
+    def test_build_remove_keys_command(self):
+        """Test building the remove keys command"""
+        cmd = self.plugin.build_remove_keys_command("/tmp/hosts", "~/.ssh/known_hosts")
+
+        self.assertIn("ssh-keygen", cmd)
+        self.assertIn("-R", cmd)
+        self.assertIn("~/.ssh/known_hosts", cmd)
+
+    @patch("tempfile.mkstemp")
+    @patch("os.fdopen")
+    @patch("os.unlink")
+    def test_create_hosts_file_local(self, mock_unlink, mock_fdopen, mock_mkstemp):
+        """Test creating local hosts file"""
+        # Mock file operations
+        mock_mkstemp.return_value = (3, "/tmp/hosts123")
+        mock_file = MagicMock()
+        mock_fdopen.return_value.__enter__.return_value = mock_file
+
+        hosts = ["host1", "host2", "host3"]
+        result = self.plugin.create_hosts_file_local(hosts)
+
+        # Verify temp file creation
+        self.assertEqual(result, "/tmp/hosts123")
+        mock_mkstemp.assert_called_with(suffix='.hosts', text=True)
+
+        # Verify hosts were written
+        expected_calls = [call("host1\n"), call("host2\n"), call("host3\n")]
+        mock_file.write.assert_has_calls(expected_calls)
+
+    @patch("os.unlink")
+    @patch("tempfile.mkstemp")
+    @patch("os.fdopen")
+    def test_create_hosts_file_remote(self, mock_fdopen, mock_mkstemp, mock_unlink):
+        """Test creating remote hosts file using SCP transfer"""
+        # Mock local temp file creation
+        mock_mkstemp.return_value = (3, "/tmp/local_temp_file")
+        mock_file = MagicMock()
+        mock_fdopen.return_value.__enter__.return_value = mock_file
+
+        # Mock phdl for SCP transfer
+        mock_phdl = MagicMock()
+
+        hosts = ["host1", "host2"]
+        result = self.plugin.create_hosts_file_remote(hosts, mock_phdl)
+
+        # Verify result is a UUID-based remote filename
+        self.assertTrue(result.startswith("/tmp/cvs_hosts_"))
+        self.assertEqual(len(result.split("_")[-1]), 8)  # UUID hex[:8] length
+
+        # Verify local temp file was created
+        mock_mkstemp.assert_called_once()
+        mock_fdopen.assert_called_once_with(3, 'w')
+
+        # Verify hosts were written to local file
+        mock_file.write.assert_any_call("host1\n")
+        mock_file.write.assert_any_call("host2\n")
+
+        # Verify SCP transfer was called
+        mock_phdl.scp_file.assert_called_once_with("/tmp/local_temp_file", result)
+
+        # Verify local temp file cleanup
+        mock_unlink.assert_called_once_with("/tmp/local_temp_file")
+
+    @patch("subprocess.run")
+    def test_execute_command_local_success(self, mock_run):
+        """Test local command execution success"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "success output"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        result = self.plugin.execute_command_local("echo test", 30)
+
+        # Verify result structure
+        self.assertTrue(result['success'])
+        self.assertEqual(result['returncode'], 0)
+        self.assertEqual(result['stdout'], "success output")
+
+    @patch("subprocess.run")
+    def test_execute_command_local_timeout(self, mock_run):
+        """Test local command execution timeout"""
+        mock_run.side_effect = subprocess.TimeoutExpired("cmd", 30)
+
+        result = self.plugin.execute_command_local("sleep 60", 30)
+
+        # Verify timeout handling
+        self.assertFalse(result['success'])
+        self.assertEqual(result['returncode'], 124)
+
+    def test_execute_command_remote_success(self):
+        """Test remote command execution success"""
+        mock_phdl = MagicMock()
+        mock_phdl.exec.return_value = {"head": "success output"}
+
+        result = self.plugin.execute_command_remote("echo test", mock_phdl, 30)
+
+        # Verify result structure
+        self.assertTrue(result['success'])
+        self.assertEqual(result['stdout'], "success output")
+
+    def test_parse_ssh_keyscan_output(self):
+        """Test parsing SSH keyscan output"""
+        # Mock hashed output (what we get with -H flag)
+        stdout = "|1|hash1|hash ssh-rsa AAAAB3NzaC1...\n|1|hash2|hash ecdsa-sha2-nistp256 AAAAE2VjZH..."
+        stderr = ""
+        hosts = ["host1", "host2"]
+
+        successful, failed, results = self.plugin.parse_ssh_keyscan_output(stdout, stderr, hosts)
+
+        # Should detect keys and estimate success
+        self.assertGreater(successful, 0)
+        self.assertEqual(len(results), len(hosts))
+
+    @patch.object(SSHKeyScanPlugin, 'create_hosts_file_local')
+    @patch.object(SSHKeyScanPlugin, 'execute_command_local')
+    @patch.object(SSHKeyScanPlugin, 'cleanup_hosts_file')
+    def test_scan_ssh_keys_local(self, mock_cleanup, mock_execute, mock_create_hosts):
+        """Test SSH key scanning locally"""
+        # Mock dependencies
+        mock_create_hosts.return_value = "/tmp/hosts123"
+        mock_execute.return_value = {'success': True, 'stdout': "|1|hash|hash ssh-rsa AAAAB3...", 'stderr': ''}
+
+        hosts = ["host1", "host2"]
+        successful, failed, results = self.plugin.scan_ssh_keys(hosts, "~/.ssh/known_hosts", 20, None, False)
+
+        # Verify execution flow
+        mock_create_hosts.assert_called_once_with(hosts)
+        mock_execute.assert_called_once()
+        mock_cleanup.assert_called_once_with("/tmp/hosts123", None)
+
+        # Verify results
+        self.assertGreaterEqual(successful, 0)
+        self.assertEqual(len(results), len(hosts))
+
+    def test_scan_ssh_keys_dry_run(self):
+        """Test SSH key scanning in dry run mode"""
+        hosts = ["host1", "host2"]
+        successful, failed, results = self.plugin.scan_ssh_keys(hosts, "~/.ssh/known_hosts", 20, None, True)
+
+        # In dry run, should return success for all hosts
+        self.assertEqual(successful, len(hosts))
+        self.assertEqual(failed, 0)
+        for result in results:
+            self.assertIn("Would scan and add SSH host key", result)
+
+
+class TestSSHKeyScanConfigMethods(unittest.TestCase):
+    """Test the configuration and setup methods"""
+
+    def setUp(self):
+        self.plugin = SSHKeyScanPlugin()
+
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"node_dict": {"host1": {}}, "head_node_dict": {"mgmt_ip": "192.168.1.100"}}',
+    )
+    @patch("os.environ.get")
+    def test_load_and_validate_cluster_config(self, mock_env, mock_file):
+        """Test cluster config loading"""
+        mock_env.return_value = None
+
+        args = argparse.Namespace(cluster_file="/path/to/cluster.json")
+        cluster_file, cluster, hosts = self.plugin._load_and_validate_cluster_config(args)
+
+        self.assertEqual(cluster_file, "/path/to/cluster.json")
+        self.assertIn("node_dict", cluster)
+        self.assertEqual(hosts, ["host1"])
+
+    def test_resolve_known_hosts_path_local(self):
+        """Test resolving known_hosts path for local execution"""
+        args = argparse.Namespace(known_hosts="~/.ssh/known_hosts", at="local")
+
+        with patch("os.path.expanduser", return_value="/home/user/.ssh/known_hosts"):
+            path = self.plugin._resolve_known_hosts_path(args)
+            self.assertEqual(path, "/home/user/.ssh/known_hosts")
+
+    def test_resolve_known_hosts_path_remote(self):
+        """Test resolving known_hosts path for remote execution"""
+        args = argparse.Namespace(known_hosts="~/.ssh/known_hosts", at="head")
+
+        path = self.plugin._resolve_known_hosts_path(args)
+        self.assertEqual(path, "~/.ssh/known_hosts")  # Should not expand for remote
+
+    def test_setup_remote_connection(self):
+        """Test setting up remote SSH connection"""
+        cluster = {
+            "head_node_dict": {"mgmt_ip": "192.168.1.100"},
+            "username": "testuser",
+            "priv_key_file": "/path/to/key.pem",
+            "env_vars": None,
+        }
+        args = argparse.Namespace(at="head")
+
+        with patch('cvs.cli_plugins.sshkeyscan_plugin.Pssh') as mock_pssh:
+            result = self.plugin._setup_remote_connection(cluster, args)
+
+            self.assertIsNotNone(result)
+            mock_pssh.assert_called_with(
+                self.plugin.logger, ["192.168.1.100"], user="testuser", pkey="/path/to/key.pem", env_vars=None
+            )
+
+    def test_setup_remote_connection_local_mode(self):
+        """Test that no connection is created for local mode"""
+        args = argparse.Namespace(at="local")
+
+        result = self.plugin._setup_remote_connection({}, args)
+        self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/unittests/test_main.py
+++ b/cvs/unittests/test_main.py
@@ -15,7 +15,16 @@ class TestMain(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up shared test data"""
-        cls.expected_ordered_plugins = ["copy-config", "generate", "list", "run", "scp", "monitor", "exec"]
+        cls.expected_ordered_plugins = [
+            "copy-config",
+            "generate",
+            "list",
+            "run",
+            "scp",
+            "monitor",
+            "exec",
+            "sshkeyscan",
+        ]
 
     def test_get_version_success(self):
         """Test successful version retrieval"""

--- a/docs/how-to/manage-ssh-keys.rst
+++ b/docs/how-to/manage-ssh-keys.rst
@@ -1,0 +1,297 @@
+.. meta::
+  :description: Manage SSH host keys for cluster nodes using CVS
+  :keywords: CVS, cluster, SSH, keys, sshkeyscan, host keys, known_hosts
+
+*******************************
+Manage SSH Host Keys for Cluster Nodes
+*******************************
+
+CVS provides an ``sshkeyscan`` command to scan and update SSH host keys for all nodes in the cluster. This is essential for maintaining proper SSH connectivity and avoiding host verification warnings when connecting to cluster nodes, especially in distributed computing environments like MPI jobs.
+
+The ``sshkeyscan`` command uses the same cluster configuration files as other CVS commands and supports both local and remote execution modes with parallel processing for efficiency.
+
+Overview
+========
+
+SSH host key management is critical for cluster operations because:
+
+- **Security**: Ensures you're connecting to legitimate hosts
+- **Automation**: Prevents interactive prompts that break automated scripts
+- **MPI/Distributed Jobs**: Head nodes need to SSH to compute nodes without prompts
+- **Consistency**: Maintains uniform SSH configuration across the cluster
+
+The ``sshkeyscan`` command automates the process of collecting SSH host keys from all cluster nodes and adding them to your ``known_hosts`` file.
+
+Basic usage
+===========
+
+Scan and add SSH keys for all cluster nodes:
+
+.. code:: bash
+
+  cvs sshkeyscan --cluster_file input/cluster_file/cluster.json
+
+Use the ``CLUSTER_FILE`` environment variable:
+
+.. code:: bash
+
+  CLUSTER_FILE=input/cluster_file/cluster.json cvs sshkeyscan
+
+Execution modes
+===============
+
+Local execution (default)
+--------------------------
+
+In local mode, ssh-keyscan runs from your current machine:
+
+.. code:: bash
+
+  cvs sshkeyscan --cluster_file cluster.json --at local
+
+This mode is useful when:
+- Setting up SSH keys from a management station
+- You have direct network access to all cluster nodes
+- Running initial cluster setup
+
+Remote execution (head node)
+-----------------------------
+
+In head node mode, ssh-keyscan runs from the cluster's head node:
+
+.. code:: bash
+
+  cvs sshkeyscan --cluster_file cluster.json --at head
+
+This mode is essential when:
+- Setting up SSH keys for MPI jobs
+- The head node has different network access than your local machine
+- Preparing the cluster for distributed computing workloads
+
+Command options
+===============
+
+The ``sshkeyscan`` command supports these options:
+
+Core options
+------------
+
+- ``--cluster_file``: Path to cluster configuration JSON file (optional if ``CLUSTER_FILE`` environment variable is set)
+- ``--at {local,head}``: Execution location - 'local' (current node, default) or 'head' (cluster head node)
+
+SSH configuration
+-----------------
+
+- ``--known_hosts``: Path to known_hosts file (default: ``~/.ssh/known_hosts``)
+- ``--remove-existing``: Remove existing host keys before scanning (clean slate approach)
+
+Performance and safety
+----------------------
+
+- ``--parallel``: Number of parallel ssh-keyscan processes (default: 20)
+- ``--dry-run``: Show what would be done without making changes
+
+Examples
+========
+
+Basic SSH key management
+------------------------
+
+.. code:: bash
+
+  # Scan all cluster nodes and add keys locally
+  cvs sshkeyscan --cluster_file input/cluster_file/cluster.json
+
+  # Scan from head node (for MPI job preparation)
+  cvs sshkeyscan --cluster_file input/cluster_file/cluster.json --at head
+
+  # Preview operations without making changes
+  cvs sshkeyscan --cluster_file input/cluster_file/cluster.json --dry-run
+
+Advanced usage
+--------------
+
+.. code:: bash
+
+  # Clean existing keys and rescan (fresh start)
+  cvs sshkeyscan --cluster_file cluster.json --at head --remove-existing
+
+  # High-performance scanning with increased parallelism
+  cvs sshkeyscan --cluster_file cluster.json --parallel 50
+
+  # Use custom known_hosts file
+  cvs sshkeyscan --cluster_file cluster.json --known_hosts /tmp/cluster_known_hosts
+
+  # Environment variable with head node execution
+  CLUSTER_FILE=cluster.json cvs sshkeyscan --at head --remove-existing
+
+Workflow integration
+--------------------
+
+.. code:: bash
+
+  # Complete cluster setup workflow
+  # 1. Generate cluster configuration
+  cvs generate cluster_json --hosts "node[01-10]" --output_json_file cluster.json --username myuser --key_file ~/.ssh/id_rsa
+
+  # 2. Set up SSH keys for local management
+  cvs sshkeyscan --cluster_file cluster.json --at local
+
+  # 3. Set up SSH keys on head node for MPI jobs
+  cvs sshkeyscan --cluster_file cluster.json --at head
+
+  # 4. Verify connectivity
+  cvs exec --cmd "hostname" --cluster_file cluster.json
+
+Performance considerations
+=========================
+
+Parallel processing
+-------------------
+
+The ``--parallel`` option controls how many ssh-keyscan processes run simultaneously:
+
+.. code:: bash
+
+  # Conservative (good for slower networks)
+  cvs sshkeyscan --cluster_file cluster.json --parallel 10
+
+  # Default (balanced)
+  cvs sshkeyscan --cluster_file cluster.json --parallel 20
+
+  # Aggressive (fast networks, powerful head node)
+  cvs sshkeyscan --cluster_file cluster.json --parallel 100
+
+**Guidelines**:
+- Start with the default (20) and adjust based on performance
+- Higher parallelism may overwhelm slower networks or head nodes
+- Monitor network and CPU usage during large-scale scans
+
+Timeout handling
+----------------
+
+The command includes built-in timeout handling:
+- SSH connections timeout after 30 seconds
+- Failed connections are reported but don't stop the scan
+- Retry failed nodes by running the command again
+
+Output format
+=============
+
+The command provides detailed progress information:
+
+.. code:: text
+
+  SSH Key Scan Configuration:
+    Cluster file: cluster.json
+    Execution location: head
+    Head node: 192.168.1.100
+    Known hosts file: ~/.ssh/known_hosts
+    Number of hosts: 10
+    Parallel processes: 20
+    Remove existing keys: False
+    Dry run: False
+
+  Scanning SSH host keys...
+  node01: SUCCESS - Added 2 host key(s) (on remote)
+  node02: SUCCESS - Added 2 host key(s) (on remote)
+  node03: FAILED - Connection timeout
+  node04: SUCCESS - Added 2 host key(s) (on remote)
+  ...
+
+  SSH Key Scan Summary:
+    Total hosts: 10
+    Successful: 9
+    Failed: 1
+    SSH host keys updated on: head node
+    Known hosts file: ~/.ssh/known_hosts
+
+Security considerations
+=======================
+
+Key verification
+----------------
+
+While ``sshkeyscan`` automates key collection, be aware that:
+
+- Keys are accepted without manual verification
+- Use this command only on trusted networks
+- Consider manual verification for high-security environments
+
+Best practices
+--------------
+
+1. **Run from secure locations**: Use the command from trusted management stations
+2. **Regular updates**: Re-run when nodes are rebuilt or keys change
+3. **Backup known_hosts**: Keep backups of your known_hosts files
+4. **Use dry-run**: Always test with ``--dry-run`` in production environments
+5. **Monitor failures**: Investigate and resolve connection failures promptly
+
+Troubleshooting
+===============
+
+Connection issues
+-----------------
+
+If nodes fail to respond:
+
+.. code:: bash
+
+  # Check basic connectivity first
+  cvs exec --cmd "hostname" --cluster_file cluster.json
+
+  # Verify SSH access manually
+  ssh -i your_key_file username@failing_node
+
+  # Check network connectivity
+  ping failing_node_ip
+
+Common solutions:
+- Verify SSH credentials in cluster configuration
+- Ensure SSH service is running on target nodes
+- Check firewall rules and network connectivity
+- Verify SSH key permissions (600 for private keys)
+
+Permission issues
+-----------------
+
+If you get permission errors:
+
+.. code:: bash
+
+  # Check known_hosts file permissions
+  ls -la ~/.ssh/known_hosts
+
+  # Ensure SSH directory exists and has correct permissions
+  mkdir -p ~/.ssh
+  chmod 700 ~/.ssh
+  touch ~/.ssh/known_hosts
+  chmod 600 ~/.ssh/known_hosts
+
+Head node execution issues
+--------------------------
+
+If ``--at head`` fails:
+
+1. **Verify head node configuration**: Check ``head_node_dict.mgmt_ip`` in cluster file
+2. **Check SSH credentials**: Ensure ``username`` and ``priv_key_file`` are correct
+3. **Test head node connectivity**: SSH to head node manually first
+4. **Verify head node SSH setup**: Head node needs SSH client tools installed
+
+Performance issues
+------------------
+
+If scanning is slow:
+
+1. **Reduce parallelism**: Lower ``--parallel`` value for slower networks
+2. **Check network bandwidth**: High parallelism may saturate network links
+3. **Monitor head node resources**: CPU/memory constraints may limit performance
+4. **Use local execution**: May be faster if you have better connectivity than head node
+
+.. tip::
+
+  Use ``--dry-run`` to test configuration and connectivity before running actual scans, especially in production environments.
+
+.. warning::
+
+  The ``--remove-existing`` flag will delete existing host keys before scanning. Use with caution and ensure you have backups if needed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ The component public repository is located at `https://github.com/ROCm/cvs <http
     * :doc:`Run tests <how-to/run-cvs-tests>`
     * :doc:`Execute arbitrary commands on cluster nodes <how-to/execute-cluster-commands>`
     * :doc:`Copy files and directories to cluster nodes <how-to/copy-to-cluster>`
+    * :doc:`Manage SSH host keys for cluster nodes <how-to/manage-ssh-keys>`
     * :doc:`Monitor the health of GPU clusters <how-to/run-cluster>`
 
   .. grid-item-card:: Reference

--- a/test_cli.sh
+++ b/test_cli.sh
@@ -98,6 +98,9 @@ done
 # Test: cvs exec --help
 run_test "cvs exec --help" "$CVS exec --help"
 
+# Test: cvs sshkeyscan --help
+run_test "cvs sshkeyscan --help" "$CVS sshkeyscan --help"
+
 # Wait for all tests to complete and collect results
 echo "Waiting for all tests to complete..."
 echo "===================="


### PR DESCRIPTION
This adds a new CLI subcommand to scan and update SSH host keys for all nodes in a cluster, supporting both local and remote execution modes.

- **sshkeyscan subcommand**: Parallel SSH host key scanning for cluster nodes
- **Local execution**: Run ssh-keyscan from current node
- **Remote execution**: Run ssh-keyscan from cluster head node via pssh
- **Parallel processing**: Configurable concurrent ssh-keyscan processes (default: 20)
- **Key management**: Optional removal of existing host keys before scanning
- **Dry-run mode**: Preview operations without making changes
- **Flexible configuration**: Support for CLUSTER_FILE env var or --cluster_file arg

cvs sshkeyscan --cluster_file cluster.json                    # Local scan
cvs sshkeyscan --cluster_file cluster.json --at head         # Remote scan
cvs sshkeyscan --at head --remove-existing --dry-run         # Preview cleanup
CLUSTER_FILE=cluster.json cvs sshkeyscan --parallel 50       # High concurrency

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
