### PR TITLE
fix(rccl): treat missing ufw as disabled in RCCL prechecks

### DIFF
--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -231,7 +231,7 @@ def test_disable_firewall(phdl):
     time.sleep(2)
     out_dict = phdl.exec('sudo service ufw status')
     for node in out_dict.keys():
-        if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
+        if not re.search('inactive|dead|stopped|disabled|not be found|unrecognized service', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
     update_test_result()
 

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -239,7 +239,7 @@ def test_disable_firewall(phdl):
     time.sleep(2)
     out_dict = phdl.exec('sudo service ufw status')
     for node in out_dict.keys():
-        if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
+        if not re.search('inactive|dead|stopped|disabled|not be found|unrecognized service', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
     update_test_result()
 

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -315,7 +315,7 @@ def test_disable_firewall(phdl):
     time.sleep(2)
     out_dict = phdl.exec('sudo service ufw status')
     for node in out_dict.keys():
-        if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
+        if not re.search('inactive|dead|stopped|disabled|not be found|unrecognized service', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
     update_test_result()
 

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -323,7 +323,7 @@ def test_disable_firewall(phdl):
     time.sleep(2)
     out_dict = phdl.exec('sudo service ufw status')
     for node in out_dict.keys():
-        if not re.search('inactive|dead|stopped|disabled', out_dict[node], re.I):
+        if not re.search('inactive|dead|stopped|disabled|not be found|unrecognized service', out_dict[node], re.I):
             fail_test(f'Service ufw not disabled properly on node {node}')
     update_test_result()
 


### PR DESCRIPTION
## Summary
- treat missing or unrecognized `ufw` service states as effectively disabled in RCCL perf and regression prechecks
- avoid false failures on clusters where `ufw` is not installed

## Test plan
- [x] `python -m compileall -q cvs/tests/rccl/rccl_perf.py cvs/tests/rccl/rccl_regression.py`

Made with [Cursor](https://cursor.com)