### PR TITLE
fix(rccl): surface clearer RCCL result-file failures

### DIFF
--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -49,6 +49,22 @@ def _is_severe_wrong_corruption_error(err: ValidationError) -> bool:
     return 'SEVERE DATA CORRUPTION' in s or "'#wrong'" in s
 
 
+def _load_rccl_json_result(shdl, head_node, result_file):
+    """Read and parse a rccl-tests JSON result file with a clearer failure mode."""
+    result_dict_out = shdl.exec(f'cat {result_file}')
+    raw_output = result_dict_out[head_node].strip()
+    try:
+        return json.loads(raw_output.replace('\n', '').replace('\r', ''))
+    except json.JSONDecodeError:
+        msg = (
+            f'Unable to parse RCCL JSON result file {result_file}. '
+            f'Raw output from {head_node}: {raw_output or "<empty>"}'
+        )
+        log.error(msg)
+        fail_test(msg)
+        return []
+
+
 def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
     """
     Check if UCX is available in the OpenMPI build.
@@ -619,8 +635,7 @@ def rccl_regression(
         fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
 
     # Read the JSON results emitted by the RCCL test binary
-    result_dict_out = shdl.exec(f'cat {rccl_result_file}')
-    result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
+    result_out = _load_rccl_json_result(shdl, head_node, rccl_result_file)
 
     # Collect basic GPU information via rocm-smi
     smi_out_dict = shdl.exec('rocm-smi -a | head -30')
@@ -797,8 +812,7 @@ def rccl_perf(
             fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
 
         # Read the JSON results emitted by the RCCL test binary
-        result_dict_out = shdl.exec(f'cat {dtype_result_file}')
-        dtype_result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
+        dtype_result_out = _load_rccl_json_result(shdl, head_node, dtype_result_file)
         # Validate the results against the schema fail if results are not valid
         try:
             validated = [RcclTestsMultinodeRaw.model_validate(test_result) for test_result in dtype_result_out]

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -129,11 +129,11 @@ def _read_json_from_head_node(shdl, head_node, remote_path, log_label):
       log_label: Short label used in log lines (e.g. 'all_reduce_perf_float').
 
     Returns:
-      The parsed JSON object.
+      The parsed JSON object, or [] if the downloaded file is not valid JSON
+      (a clear diagnostic is logged and the test is failed in that case).
 
     Raises:
       IOError: If the SFTP transfer fails.
-      json.JSONDecodeError: If the downloaded file is not valid JSON.
     """
     with tempfile.TemporaryDirectory(prefix='cvs_rccl_dl_') as tmpdir:
         local_prefix = os.path.join(tmpdir, os.path.basename(remote_path))
@@ -141,7 +141,17 @@ def _read_json_from_head_node(shdl, head_node, remote_path, log_label):
         local_path = paths[head_node]
         log.info('SFTP download succeeded for %s <- %s:%s', log_label, head_node, remote_path)
         with open(local_path, 'r', encoding='utf-8') as f:
-            return json.load(f)
+            raw_output = f.read()
+        try:
+            return json.loads(raw_output)
+        except json.JSONDecodeError:
+            msg = (
+                f'Unable to parse RCCL JSON result file {remote_path} on {head_node}. '
+                f'Raw content: {raw_output.strip() or "<empty>"}'
+            )
+            log.error(msg)
+            fail_test(msg)
+            return []
 
 
 def is_ucx_available_in_mpi(shdl, mpi_path, head_node):

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -925,7 +925,7 @@ def rccl_perf(
         # Validate the results against the schema fail if results are not valid
         try:
             validated = [RcclTestsMultinodeRaw.model_validate(test_result) for test_result in dtype_result_out]
-            log.info(f'Validation passed: {len(validated)} RcclTests schema validation passed')
+            log.info(f'{dtype}: {len(validated)} rccl-tests row(s) passed schema validation')
             all_validated_results.extend(validated)
             all_raw_results.extend(dtype_result_out)
         except ValidationError as e:


### PR DESCRIPTION
## Summary
- add a dedicated RCCL result-file loader that reports the unreadable path and raw head-node output
- use that helper in both regression and perf result parsing paths so missing or empty JSON files fail with a clearer message

## Test plan
- [x] `python -m compileall -q cvs/lib/rccl_lib.py`
- [x] `pytest cvs/lib/unittests/test_rccl_lib.py -q --cluster_file cvs/input/cluster_file/cluster.json --config_file cvs/input/config_file/rccl/rccl_config.json`

Made with [Cursor](https://cursor.com)