### PR TITLE
fix(rccl): accept Reduce and HyperCube RCCL collectives

### DIFF
--- a/cvs/schema/rccl.py
+++ b/cvs/schema/rccl.py
@@ -9,7 +9,8 @@ NonNegativeInt = Annotated[int, Field(ge=0)]
 PositiveInt = Annotated[int, Field(gt=0)]
 NonNegativeFloat = Annotated[float, Field(ge=0.0)]
 Collective = Literal[
-    'AllReduce', 'AllGather', 'Scatter', 'Gather', 'ReduceScatter', 'SendRecv', 'AllToAll', 'AllToAllV', 'Broadcast'
+    'AllReduce', 'AllGather', 'Scatter', 'Gather', 'ReduceScatter', 'SendRecv', 'AllToAll', 'AllToAllV', 'Broadcast',
+    'Reduce', 'HyperCube'
 ]
 Type = Literal[
     'int8', 'int32', 'int64', 'uint8', 'uint32', 'uint64', 'float', 'double', 'half', 'bfloat16', 'fp8_e4m3', 'fp8_e5m2'
@@ -42,6 +43,8 @@ class RcclTests(BaseModel):
             'alltoall': 'AllToAll',  # Maps "AlltoAll" -> "AllToAll"
             'alltoallv': 'AllToAllV',
             'broadcast': 'Broadcast',
+            'reduce': 'Reduce',
+            'hypercube': 'HyperCube',
         }
 
         # Try exact match first
@@ -55,6 +58,8 @@ class RcclTests(BaseModel):
             'AllToAll',
             'AllToAllV',
             'Broadcast',
+            'Reduce',
+            'HyperCube',
         ]:
             return v
 

--- a/cvs/schema/rccl.py
+++ b/cvs/schema/rccl.py
@@ -9,8 +9,17 @@ NonNegativeInt = Annotated[int, Field(ge=0)]
 PositiveInt = Annotated[int, Field(gt=0)]
 NonNegativeFloat = Annotated[float, Field(ge=0.0)]
 Collective = Literal[
-    'AllReduce', 'AllGather', 'Scatter', 'Gather', 'ReduceScatter', 'SendRecv', 'AllToAll', 'AllToAllV', 'Broadcast',
-    'Reduce', 'HyperCube'
+    'AllReduce',
+    'AllGather',
+    'Scatter',
+    'Gather',
+    'ReduceScatter',
+    'SendRecv',
+    'AllToAll',
+    'AllToAllV',
+    'Broadcast',
+    'Reduce',
+    'HyperCube',
 ]
 Type = Literal[
     'int8', 'int32', 'int64', 'uint8', 'uint32', 'uint64', 'float', 'double', 'half', 'bfloat16', 'fp8_e4m3', 'fp8_e5m2'


### PR DESCRIPTION
## Summary
- extend the RCCL schema to accept `Reduce` and `HyperCube`
- add normalization support so these valid collective names pass post-processing validation

## Test plan
- [x] `python -m compileall -q cvs/schema/rccl.py`
- [x] `pytest cvs/unittests/test_rccl_schema_validation.py -q --cluster_file cvs/input/cluster_file/cluster.json --config_file cvs/input/config_file/rccl/rccl_config.json`

Made with [Cursor](https://cursor.com)