### PR TITLE
fix(rccl): classify connectx NICs correctly

### DIFF
--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -865,7 +865,7 @@ def rccl_perf(
         nic_type = 'ainic'
     elif re.search('broadcom|thor|bnxt', nic_model, re.I):
         nic_type = 'thor'
-    elif re.search('mellanox|cx|nvidia', nic_model, re.I):
+    elif re.search('mellanox|connectx|cx|nvidia', nic_model, re.I):
         nic_type = 'connectx'
     else:
         nic_type = 'ainic'

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -983,7 +983,7 @@ def rccl_perf(
         nic_type = 'ainic'
     elif re.search('broadcom|thor|bnxt', nic_model, re.I):
         nic_type = 'thor'
-    elif re.search('mellanox|cx|nvidia', nic_model, re.I):
+    elif re.search('mellanox|connectx|cx|nvidia', nic_model, re.I):
         nic_type = 'connectx'
     else:
         nic_type = 'ainic'


### PR DESCRIPTION
## Summary
- recognize `connectx` explicitly in RCCL NIC classification
- route validation to the ConnectX bucket when users provide `nic_model: connectx`

## Test plan
- [x] `python -m compileall -q cvs/lib/rccl_lib.py`

Made with [Cursor](https://cursor.com)