### PR TITLE
Update documentation for new RCCL test suite structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,19 +254,19 @@ Once your configuration files are set up, you can run CVS tests using the conven
 cvs list
 
 # List sub-tests within a specific test suite
-cvs list rccl_multinode_cvs
+cvs list rccl_perf
 
 # Run all tests from a specific test suite
-cvs run rccl_multinode_cvs --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_test_report.html --self-contained-html --capture=tee-sys
+cvs run rccl_perf --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_test_report.html --self-contained-html --capture=tee-sys
 
 # Run a specific test from a test suite
-cvs run rccl_multinode_cvs test_collect_hostinfo --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_test_report.html --self-contained-html --capture=tee-sys
+cvs run rccl_perf test_collect_hostinfo --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_test_report.html --self-contained-html --capture=tee-sys
 
 # Run multiple specific tests from a test suite
-cvs run rccl_multinode_cvs test_collect_hostinfo test_basic_ring --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_test_report.html --self-contained-html --capture=tee-sys
+cvs run rccl_perf test_collect_hostinfo "test_rccl_perf[all_reduce_perf]" --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_test_report.html --self-contained-html --capture=tee-sys
 
 # Run without HTML reporting
-cvs run rccl_multinode_cvs --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json
+cvs run rccl_perf --cluster_file /tmp/cvs/input/cluster_file/cluster.json --config_file /tmp/cvs/input/config_file/rccl/rccl_config.json
 ```
 
 ## Executing Commands on Cluster Nodes
@@ -365,7 +365,7 @@ All other pytest arguments are supported and passed transparently to pytest. For
 ## Complete CVS Run Example
 
 ```bash
-cvs run rccl_multinode_cvs \
+cvs run rccl_perf \
   --cluster_file ./input/cluster_file/cluster.json \
   --config_file ./input/config_file/rccl_config.json \
   --html=/var/www/html/cvs/rccl_test_report.html \

--- a/cvs/tests/rccl/README.md
+++ b/cvs/tests/rccl/README.md
@@ -15,8 +15,7 @@ RCCL tests in CVS are split into a small set of focused workflows:
 2. `rccl_regression`  
    Regression suite with Cartesian product sweep. Uses `regression` object in JSON for NCCL/RCCL env variable combinations, or internal defaults.
 
-3. `rccl_singlenode_cvs`  
-   Single-node RCCL suite for local collective checks.
+**Single-node testing:** Configure a single-node cluster in your cluster JSON file and use the main suites above for single-node testing.
 
 4. `heatmap`  
    Standalone result-comparison suite. It generates a heatmap from two result JSON files and is reusable beyond RCCL-only flows.
@@ -36,7 +35,7 @@ All RCCL execution suites still collect host/network info and validate firewall 
 ```bash
 cvs list rccl_perf
 cvs list rccl_regression
-cvs list rccl_singlenode_cvs
+# Single-node testing via cluster config
 cvs list heatmap
 ```
 
@@ -86,22 +85,16 @@ cvs run rccl_regression \
 
 - **Keys** are real NCCL/RCCL environment variable names
 - **Values** are lists; CVS builds the Cartesian product
-- **Tree + collective rule**: `tree` is skipped for collectives other than `all_reduce_perf` (same as main's old `rccl_multinode_cvs`)
+- **Tree + collective rule**: `tree` is skipped for collectives other than `all_reduce_perf`
 - Missing `regression` or `{}` → single default case
 
 Example internal config: [`rccl_regression_internal.json`](rccl_regression_internal.json).
 
 Full design notes and a **from `main` rebuild** checklist: [RCCL_HANDOFF_FROM_MAIN.md](RCCL_HANDOFF_FROM_MAIN.md).
 
-### Single-node
+### Single-node testing
 
-```bash
-cvs run rccl_singlenode_cvs \
-  --cluster_file input/cluster_file/cluster.json \
-  --config_file input/config_file/rccl/single_node_mi355_rccl.json \
-  --html=/var/www/html/cvs/rccl_singlenode.html --capture=tee-sys --self-contained-html \
-  --log-file=/tmp/rccl_singlenode.log -vvv -s
-```
+Single-node RCCL testing is achieved by using either `rccl_perf` or `rccl_regression` with a cluster configuration that contains only one node. The tests automatically adapt to single-node execution.
 
 ### Heatmap
 
@@ -166,4 +159,4 @@ The RCCL config keeps benchmark intent and validation settings, while RCCL/NCCL/
 - **Env staging**: `run_rccl` stages env scripts to `/tmp/cvs_rccl_env/` on all nodes with optional per-case overrides
 - **Regression cases**: Each combination in the Cartesian product gets its own result file suffix
 - **Single env dump**: Only `test_print_env_once` prints the environment; other tests focus on performance
-- **Tree filter**: Matches main's `rccl_multinode_cvs.py` behavior for algorithm restrictions
+- **Tree filter**: Algorithm restrictions apply to maintain compatibility

--- a/docs/how-to/copy-to-cluster.rst
+++ b/docs/how-to/copy-to-cluster.rst
@@ -1,0 +1,166 @@
+.. meta::
+  :description: Copy files and directories to cluster nodes using CVS
+  :keywords: CVS, cluster, copy, scp, files, directories, parallel
+
+*******************************
+Copy Files and Directories to Cluster Nodes
+*******************************
+
+CVS provides an ``scp`` command to copy files and directories to all nodes in the cluster simultaneously using parallel SCP operations. This is useful for distributing configuration files, scripts, data files, or software packages across all cluster nodes at once.
+
+The ``scp`` command uses the same cluster configuration files as other CVS commands and supports both command-line arguments and environment variables for configuration.
+
+Copy files
+==========
+
+To copy a file to all cluster nodes:
+
+.. code:: bash
+
+  cvs scp --file /path/to/local/file --cluster_file input/cluster_file/cluster.json
+
+You can also use the ``CLUSTER_FILE`` environment variable:
+
+.. code:: bash
+
+  CLUSTER_FILE=input/cluster_file/cluster.json cvs scp --file /path/to/local/file
+
+Copy directories
+================
+
+To copy a directory recursively to all cluster nodes:
+
+.. code:: bash
+
+  cvs scp --file /path/to/local/directory --recurse --cluster_file input/cluster_file/cluster.json
+
+Command options
+===============
+
+The ``scp`` command supports these options:
+
+- ``--file``: Local file or directory to copy to all nodes (required)
+- ``--dest``: Remote destination path (optional, defaults to same path as source)
+- ``--recurse``: Copy directories recursively (required for directories)
+- ``--cluster_file``: Path to cluster configuration JSON file (optional if ``CLUSTER_FILE`` environment variable is set)
+- ``--parallel``: Number of parallel SCP operations (default: 20)
+
+Performance tuning
+==================
+
+The ``--parallel`` option controls how many SCP operations run simultaneously:
+
+.. code:: bash
+
+  # Use more parallel operations for faster copying (if network allows)
+  cvs scp --file ./large_file --parallel 50 --cluster_file input/cluster_file/cluster.json
+
+  # Use fewer parallel operations to reduce network load
+  cvs scp --file ./sensitive_data --parallel 5 --cluster_file input/cluster_file/cluster.json
+
+.. note::
+
+  The default parallel setting is 20, which works well for most clusters. Increase this value if you have high network bandwidth and want faster transfers. Decrease it if you experience network congestion or timeouts.
+
+File paths and permissions
+==========================
+
+Destination paths
+-----------------
+
+When ``--dest`` is not specified, files are copied to the same path on remote nodes:
+
+.. code:: bash
+
+  # This copies /home/user/file.txt to /home/user/file.txt on all nodes
+  cvs scp --file /home/user/file.txt --cluster_file input/cluster_file/cluster.json
+
+When ``--dest`` is specified, files are copied to that exact path:
+
+.. code:: bash
+
+  # This copies local file.txt to /tmp/remote_file.txt on all nodes
+  cvs scp --file ./file.txt --dest /tmp/remote_file.txt --cluster_file input/cluster_file/cluster.json
+
+Permissions and ownership
+-------------------------
+
+Files are copied with the permissions of the remote user specified in the cluster configuration. To set specific permissions after copying, combine with the ``exec`` command:
+
+.. code:: bash
+
+  # Copy a script and make it executable
+  cvs scp --file ./setup.sh --dest /tmp/setup.sh --cluster_file input/cluster_file/cluster.json
+  cvs exec --cmd "chmod +x /tmp/setup.sh" --cluster_file input/cluster_file/cluster.json
+
+  # Copy configuration and set ownership
+  cvs scp --file ./app.conf --dest /etc/app.conf --cluster_file input/cluster_file/cluster.json
+  cvs exec --cmd "sudo chown root:root /etc/app.conf" --cluster_file input/cluster_file/cluster.json
+
+Working with directories
+========================
+
+Directory structure
+-------------------
+
+When copying directories with ``--recurse``, the entire directory structure is preserved:
+
+.. code:: bash
+
+  # This will create /opt/myapp/ with all subdirectories and files
+  cvs scp --file ./myapp --dest /opt/myapp --recurse --cluster_file input/cluster_file/cluster.json
+
+To copy only the contents of a directory, adjust your source path:
+
+.. code:: bash
+
+  # Copy contents of ./config/ to /etc/myapp/
+  cvs scp --file ./config/ --dest /etc/myapp/ --recurse --cluster_file input/cluster_file/cluster.json
+
+Large directories
+-----------------
+
+For very large directories, consider:
+
+1. Using tar compression locally first:
+
+.. code:: bash
+
+  # Compress first, then copy and extract
+  tar czf myapp.tar.gz ./myapp/
+  cvs scp --file myapp.tar.gz --dest /tmp/myapp.tar.gz --cluster_file input/cluster_file/cluster.json
+  cvs exec --cmd "cd /opt && sudo tar xzf /tmp/myapp.tar.gz" --cluster_file input/cluster_file/cluster.json
+
+2. Reducing parallelism to avoid overwhelming the network:
+
+.. code:: bash
+
+  cvs scp --file ./large_directory --dest /opt/data --recurse --parallel 5 --cluster_file input/cluster_file/cluster.json
+
+Common use cases
+================
+
+RCCL testing without shared storage
+------------------------------------
+
+When cluster nodes don't have shared mount/storage, you need to copy MPI, RCCL-tests build artifacts, and environment scripts to all nodes. Use compressed archives for efficient transfer:
+
+.. code:: bash
+
+  # Copy environment scripts for RCCL tests (required when no shared storage)
+  cvs scp --file ~/cvs/cvs/input/env_file/rccl/ainic_env_script.sh --dest /tmp/ainic_env_script.sh --cluster_file input/cluster_file/cluster.json
+
+  # Create compressed archives including all components (build artifacts, .so files, headers)
+  tar czf openmpi.tar.gz -C /opt openmpi
+  tar czf rccl-tests.tar.gz -C /opt rccl-tests
+
+  # Copy compressed archives to all nodes
+  cvs scp --file openmpi.tar.gz --dest /tmp/openmpi.tar.gz --cluster_file input/cluster_file/cluster.json
+  cvs scp --file rccl-tests.tar.gz --dest /tmp/rccl-tests.tar.gz --cluster_file input/cluster_file/cluster.json
+
+  # Extract archives on all nodes
+  cvs exec --cmd "sudo tar xzf /tmp/openmpi.tar.gz -C /opt" --cluster_file input/cluster_file/cluster.json
+  cvs exec --cmd "sudo tar xzf /tmp/rccl-tests.tar.gz -C /opt" --cluster_file input/cluster_file/cluster.json
+
+  # Clean up temporary archives
+  cvs exec --cmd "rm /tmp/*.tar.gz" --cluster_file input/cluster_file/cluster.json

--- a/docs/how-to/run-cvs-tests.rst
+++ b/docs/how-to/run-cvs-tests.rst
@@ -64,11 +64,9 @@ You can list available tests using either `cvs run` (with no arguments) or `cvs 
     cvs.tests.platform (1 test suite)
       • host_configs_cvs
   
-    cvs.tests.rccl (4 test suites)
-      • rccl_heatmap_cvs
-      • rccl_multinode_cvs
-      • rccl_multinode_default_cvs
-      • rccl_singlenode_cvs
+    cvs.tests.rccl (2 test suites)
+      • rccl_perf
+      • rccl_regression
   
     cvs.tests.training.jax (3 test suites)
       • jax_llama3_1_405b_distributed
@@ -361,144 +359,70 @@ Note: Atleast two nodes are required to run IB Perf installation and tests.
 ROCm Communication Collectives Library (RCCL) test script
 ---------------------------------------------------------
 
-
-You can list all available RCCL multinode test cases using the CLI:
+You can list all available RCCL test cases using the CLI:
 
 .. code:: bash
 
-  cvs list rccl_multinode_cvs
+  cvs list rccl_perf
 
 .. code:: text
 
-  Available tests in rccl_multinode_cvs:
+  Available tests in rccl_perf:
     - test_collect_hostinfo
     - test_collect_networkinfo
     - test_disable_firewall
+    - test_gen_graph
+    - test_print_env_once
+    - test_rccl_perf[all_gather_perf]
+    - test_rccl_perf[all_reduce_perf]
+    - test_rccl_perf[alltoall_perf]
+    - test_rccl_perf[alltoallv_perf]
+    - test_rccl_perf[broadcast_perf]
+    - test_rccl_perf[gather_perf]
+    - test_rccl_perf[reduce_scatter_perf]
+    - test_rccl_perf[scatter_perf]
+    - test_rccl_perf[sendrecv_perf]
+
+.. code:: bash
+
+  cvs list rccl_regression
+
+.. code:: text
+
+  Available tests in rccl_regression:
+    - test_collect_hostinfo
+    - test_collect_networkinfo
+    - test_disable_firewall
+    - test_gen_graph
+    - test_print_env_once
     - test_rccl_perf
-    - test_gen_graph
-
-.. code:: bash
-
-  cvs list rccl_singlenode_cvs
-
-.. code:: text
-
-  Available tests in rccl_singlenode_cvs:
-    - test_collect_hostinfo
-    - test_collect_networkinfo
-    - test_disable_firewall
-    - test_gen_graph
-    - test_singlenode_perf[all_gather_perf]
-    - test_singlenode_perf[all_reduce_perf]
-    - test_singlenode_perf[alltoall_perf]
-    - test_singlenode_perf[alltoallv_perf]
-    - test_singlenode_perf[broadcast_perf]
-    - test_singlenode_perf[gather_perf]
-    - test_singlenode_perf[reduce_scatter_perf]
-    - test_singlenode_perf[scatter_perf]
-    - test_singlenode_perf[sendrecv_perf]
-
-.. code:: bash
-
-  cvs list rccl_multinode_default_cvs
-
-.. code:: text
-
-  Available tests in rccl_multinode_default_cvs:
-    - test_collect_hostinfo
-    - test_collect_networkinfo
-    - test_disable_firewall
-    - test_singlenode_perf[all_gather_perf]
-    - test_singlenode_perf[all_reduce_perf]
-    - test_singlenode_perf[alltoall_perf]
-    - test_singlenode_perf[alltoallv_perf]
-    - test_singlenode_perf[broadcast_perf]
-    - test_singlenode_perf[gather_perf]
-    - test_singlenode_perf[reduce_scatter_perf]
-    - test_singlenode_perf[scatter_perf]
-    - test_singlenode_perf[sendrecv_perf]
-    - test_gen_graph
-
-
-.. code:: bash
-
-  cvs list rccl_heatmap_cvs
-
-.. code:: text
-
-  Available tests in rccl_heatmap_cvs:
-
-    - test_collect_hostinfo
-    - test_collect_networkinfo
-    - test_disable_firewall
-    - test_rccl_perf
-    - test_gen_graph
-    - test_gen_heatmap  
-
-.. code:: bash
-
-  cvs list rccl_multinode_default_cvs
-
-.. code:: text
-
-  Available tests in rccl_multinode_default_cvs:
-    - test_collect_hostinfo
-    - test_collect_networkinfo
-    - test_disable_firewall
-    - test_rccl_perf
-    - test_gen_graph
-
-.. code:: bash
-
-  cvs list rccl_heatmap_cvs
-
-.. code:: text
-
-  Available tests in rccl_heatmap_cvs:
-    - test_collect_hostinfo
-    - test_collect_networkinfo
-    - test_disable_firewall
-    - test_rccl_perf
-    - test_gen_graph
-    - test_gen_heatmap
 
 Use these scripts to start RCCL tests with CVS:
 
-1. Run RCCL multinode parameter sweep:
+**Prerequisites: Environment Script Staging**
+
+Before running RCCL tests, ensure the environment script specified in ``env_source_script`` is available on all cluster nodes:
+
+- **With shared storage**: Place the environment script in a shared directory accessible from all nodes
+- **Without shared storage**: Use ``cvs scp`` to copy the environment script to all nodes. See :doc:`Copy files and directories to cluster nodes <copy-to-cluster>` for detailed instructions and examples.
+
+1. Run RCCL performance suite:
 
 .. code:: bash
 
-  cvs run rccl_multinode_cvs --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_multinode.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_multinode.log -vvv -s
+  cvs run rccl_perf --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_perf.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_perf.log -vvv -s
 
-2. Run RCCL multinode with RCCL defaults:
-
-.. code:: bash
-
-  cvs run rccl_multinode_default_cvs --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_multinode_default.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_multinode_default.log -vvv -s
-
-3. Run RCCL single-node:
+2. Run RCCL regression suite:
 
 .. code:: bash
 
-  cvs run rccl_singlenode_cvs --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/single_node_mi355_rccl.json --html=/var/www/html/cvs/rccl_singlenode.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_singlenode.log -vvv -s
+  cvs run rccl_regression --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/rccl_regression.json --html=/var/www/html/cvs/rccl_regression.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_regression.log -vvv -s
 
-4. Run RCCL heatmap:
-
-.. code:: bash
-
-  cvs run rccl_heatmap_cvs --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/rccl_config.json --html=/var/www/html/cvs/rccl_heatmap.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_heatmap.log -vvv -s
-
-You can run all RCCL multinode default tests using the CVS CLI:
+3. Generate RCCL performance heatmap:
 
 .. code:: bash
 
- cvs list rccl_multinode_default_cvs --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/rccl_singlenode_config.json --html=/var/www/html/cvs/rccl_singlenode.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_singlenode.log -vvv -s
-
-You can run all RCCL heatmap tests using the CVS CLI:
-
-.. code:: bash
-
- cvs list rccl_heatmap_cvs --cluster_file input/cluster_file/cluster.json --config_file input/config_file/rccl/rccl_singlenode_config.json --html=/var/www/html/cvs/rccl_singlenode.html --capture=tee-sys --self-contained-html --log-file=/tmp/rccl_singlenode.log -vvv -s
+  cvs generate heatmap --actual /tmp/rccl_perf_results.json --reference /path/to/golden_reference.json --output /var/www/html/cvs/rccl_heatmap.html --title "RCCL Performance Comparison"
 
 
 JAX training test scripts

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ The component public repository is located at `https://github.com/ROCm/cvs <http
 
     * :doc:`Run tests <how-to/run-cvs-tests>`
     * :doc:`Execute arbitrary commands on cluster nodes <how-to/execute-cluster-commands>`
+    * :doc:`Copy files and directories to cluster nodes <how-to/copy-to-cluster>`
     * :doc:`Monitor the health of GPU clusters <how-to/run-cluster>`
 
   .. grid-item-card:: Reference

--- a/docs/reference/configuration-files/rccl.rst
+++ b/docs/reference/configuration-files/rccl.rst
@@ -19,14 +19,10 @@ CVS provides the following RCCL suites:
 
    * - Test suite
      - What it does
-   * - ``rccl_multinode_cvs``
-     - Runs multinode RCCL with a parameter sweep over collective, algorithm, protocol, queue-pair scale, and PXN setting.
-   * - ``rccl_multinode_default_cvs``
-     - Runs multinode RCCL collectives using RCCL default algorithm/protocol behavior.
-   * - ``rccl_singlenode_cvs``
-     - Runs single-node RCCL collectives and validates output against configured expectations.
-   * - ``rccl_heatmap_cvs``
-     - Runs a sweep over collective, GPU count, data type, and channel configuration; then generates a heatmap against a golden reference JSON.
+   * - ``rccl_perf``
+     - User-facing performance suite that runs configured collectives with environment script staging.
+   * - ``rccl_regression``
+     - Regression suite with Cartesian product sweep using environment variable combinations from JSON configuration.
 
 All suites also collect host/network information and check firewall state before performance runs.
 
@@ -37,50 +33,38 @@ From the CVS repo root (directory containing ``cvs`` and ``input``):
 
 .. code-block:: bash
 
-  cvs list rccl_multinode_cvs
-  cvs list rccl_multinode_default_cvs
-  cvs list rccl_singlenode_cvs
-  cvs list rccl_heatmap_cvs
+  cvs list rccl_perf
+  cvs list rccl_regression
 
-Run the multinode sweep:
+Run the performance suite:
 
 .. code-block:: bash
 
-  cvs run rccl_multinode_cvs \
+  cvs run rccl_perf \
       --cluster_file input/cluster_file/cluster.json \
       --config_file input/config_file/rccl/rccl_config.json \
-      --html=/var/www/html/cvs/rccl_multinode.html --capture=tee-sys --self-contained-html \
-      --log-file=/tmp/rccl_multinode.log -vvv -s
+      --html=/var/www/html/cvs/rccl_perf.html --capture=tee-sys --self-contained-html \
+      --log-file=/tmp/rccl_perf.log -vvv -s
 
-Run multinode with RCCL defaults:
+Run the regression suite:
 
 .. code-block:: bash
 
-  cvs run rccl_multinode_default_cvs \
-      --cluster_file input/cluster_file/cluster.json \
+  cvs run rccl_regression \
+      --cluster_file input/cluster_file/rccl/rccl_regression.json \
       --config_file input/config_file/rccl/rccl_config.json \
-      --html=/var/www/html/cvs/rccl_multinode_default.html --capture=tee-sys --self-contained-html \
-      --log-file=/tmp/rccl_multinode_default.log -vvv -s
+      --html=/var/www/html/cvs/rccl_regression.html --capture=tee-sys --self-contained-html \
+      --log-file=/tmp/rccl_regression.log -vvv -s
 
-Run the single-node suite:
-
-.. code-block:: bash
-
-  cvs run rccl_singlenode_cvs \
-      --cluster_file input/cluster_file/cluster.json \
-      --config_file input/config_file/rccl/single_node_mi355_rccl.json \
-      --html=/var/www/html/cvs/rccl_singlenode.html --capture=tee-sys --self-contained-html \
-      --log-file=/tmp/rccl_singlenode.log -vvv -s
-
-Run the heatmap suite:
+Generate heatmap from results:
 
 .. code-block:: bash
 
-  cvs run rccl_heatmap_cvs \
-      --cluster_file input/cluster_file/cluster.json \
-      --config_file input/config_file/rccl/rccl_config.json \
-      --html=/var/www/html/cvs/rccl_heatmap.html --capture=tee-sys --self-contained-html \
-      --log-file=/tmp/rccl_heatmap.log -vvv -s
+  cvs generate heatmap \
+      --actual /tmp/rccl_perf_results.json \
+      --reference /path/to/reference.json \
+      --output /var/www/html/cvs/rccl_heatmap.html \
+      --title "RCCL Performance Heatmap"
 
 .. note::
 
@@ -90,7 +74,7 @@ Run the heatmap suite:
 ``rccl_config.json``
 ====================
 
-Main config file used by ``rccl_multinode_cvs``, ``rccl_multinode_default_cvs``, and ``rccl_heatmap_cvs``:
+Main config file used by ``rccl_perf`` and ``rccl_regression``:
 
 .. dropdown:: ``rccl_config.json`` (example)
 
@@ -98,31 +82,71 @@ Main config file used by ``rccl_multinode_cvs``, ``rccl_multinode_default_cvs``,
 
     {
       "rccl": {
-        "no_of_nodes": "2",
-        "no_of_global_ranks": "16",
-        "no_of_local_ranks": "8",
-        "rccl_dir": "/opt/rccl-tests/",
-        "rccl_tests_dir": "/opt/rccl-tests/build",
-        "mpi_dir": "/usr/bin",
-        "mpi_path_var": "/usr",
-        "rocm_path_var": "/opt/rocm/",
-        "rccl_collective": ["all_reduce_perf", "all_gather_perf", "broadcast_perf"],
-        "rccl_algo": ["ring", "tree"],
-        "rccl_protocol": ["simple"],
-        "qp_scale": ["1", "2"],
-        "gpu_count_list": ["8", "16", "32"],
-        "data_type_list": ["float", "bfloat16"],
-        "channel_config_list": ["default"],
-        "golden_reference_json_file": "/home/{user-id}/JSONS/mi300_reference.json",
-        "start_msg_size": "1024",
-        "end_msg_size": "16g",
-        "step_function": "2",
-        "warmup_iterations": "10",
-        "no_of_iterations": "20",
-        "verify_bus_bw": "False",
-        "verify_bw_dip": "True",
-        "verify_lat_dip": "True",
-        "env_source_script": "/root/env_source_file.sh",
+        "env_source_script": "/home/{user-id}/thor2_env_script.sh",
+        "mpi_params": {
+          "no_of_nodes": "2",
+          "no_of_local_ranks": "8",
+          "mpi_pml": "auto",
+          "mpi_dir": "/home/{user-id}/openmpi/bin",
+          "mpi_oob_port": "eth0"
+        },
+        "rccl_test_params": {
+          "rccl_collective": ["all_reduce_perf", "all_gather_perf", "broadcast_perf"],
+          "rccl_tests_dir": "/home/{user-id}/rccl-tests/build",
+          "start_msg_size": "1024",
+          "end_msg_size": "16g",
+          "step_function": "2",
+          "warmup_iterations": "10",
+          "no_of_iterations": "20",
+          "data_types": ["float"]
+        },
+        "cvs_params": {
+          "verify_bus_bw": "False",
+          "verify_bw_dip": "True",
+          "verify_lat_dip": "True",
+          "cluster_snapshot_debug": "False",
+          "rccl_result_file": "/home/{user-id}/rccl_result_file.json"
+        },
+        "results": {}
+      }
+    }
+
+.. dropdown:: ``rccl_config.json`` with regression (example)
+
+  .. code:: json
+
+    {
+      "rccl": {
+        "env_source_script": "/home/{user-id}/thor2_env_script.sh",
+        "mpi_params": {
+          "no_of_nodes": "2",
+          "no_of_local_ranks": "8",
+          "mpi_pml": "auto",
+          "mpi_dir": "/home/{user-id}/openmpi/bin"
+        },
+        "rccl_test_params": {
+          "rccl_collective": ["all_reduce_perf"],
+          "rccl_tests_dir": "/home/{user-id}/rccl-tests/build",
+          "start_msg_size": "1024",
+          "end_msg_size": "16g",
+          "step_function": "2",
+          "warmup_iterations": "10",
+          "no_of_iterations": "20"
+        },
+        "regression": {
+          "NCCL_ALGO": ["Ring", "Tree"],
+          "NCCL_PROTO": ["Simple"],
+          "NCCL_IB_QPS_PER_CONNECTION": ["1", "2"],
+          "NCCL_PXN_DISABLE": ["0", "1"],
+          "NCCL_MIN_NCHANNELS": ["8", "16"],
+          "NCCL_MAX_NCHANNELS": ["8", "16"]
+        },
+        "cvs_params": {
+          "verify_bus_bw": "False",
+          "verify_bw_dip": "True", 
+          "verify_lat_dip": "True",
+          "rccl_result_file": "/home/{user-id}/rccl_result_file.json"
+        },
         "results": {}
       }
     }
@@ -130,7 +154,9 @@ Main config file used by ``rccl_multinode_cvs``, ``rccl_multinode_default_cvs``,
 Parameters
 ----------
 
-Exhaustive parameter list for ``rccl_config.json``:
+Configuration parameters for RCCL suites:
+
+**Core Configuration:**
 
 .. list-table::
    :widths: 3 3 5
@@ -139,164 +165,80 @@ Exhaustive parameter list for ``rccl_config.json``:
    * - Configuration parameter
      - Example/default
      - Description
-   * - ``no_of_nodes``
-     - ``2``
-     - Number of nodes participating in multinode runs.
-   * - ``no_of_global_ranks``
-     - ``16``
-     - Total MPI ranks across all nodes.
-   * - ``no_of_local_ranks``
-     - ``8``
-     - MPI ranks per node.
-   * - ``ranks_per_node``
-     - ``8``
-     - GPU/rank density per node (topology reference).
-   * - ``rccl_dir``
-     - ``/opt/rccl-tests/``
-     - RCCL test install root.
-   * - ``rccl_tests_dir``
-     - ``/opt/rccl-tests/build``
-     - Directory containing RCCL test binaries.
-   * - ``mpi_dir``
-     - ``/usr/bin``
-     - MPI executable directory.
-   * - ``mpi_path_var``
-     - ``/usr``
-     - MPI root path used when constructing runtime environment.
-   * - ``mpi_pml``
-     - ``auto``
-     - MPI point-to-point messaging layer (`auto`, `ucx`, `ob1`).
-   * - ``rocm_path_var``
-     - ``/opt/rocm/``
-     - ROCm installation path.
-   * - ``rccl_path_var``
-     - ``/opt/rccl-tests/``
-     - RCCL path exported to runtime environment.
-   * - ``gpu_count_list``
-     - ``["8", "16", "32"]``
-     - GPU-count sweep list for ``rccl_heatmap_cvs``.
-   * - ``data_type_list``
-     - ``["float", "bfloat16"]``
-     - Data-type sweep list for ``rccl_heatmap_cvs``.
-   * - ``nic_model``
-     - ``thor``
-     - NIC model tag used in validation logic/reporting.
-   * - ``heatmap_title``
-     - ``RCCL heatmap comparison between MI300s``
-     - Title rendered in heatmap HTML.
-   * - ``golden_reference_json_file``
-     - ``/home/{user-id}/JSONS/mi300_reference.json``
-     - Baseline reference JSON for heatmap comparison.
-   * - ``cluster_snapshot_debug``
-     - ``False``
-     - Enables before/after cluster metric snapshots around tests.
    * - ``env_source_script``
-     - ``/root/env_source_file.sh``
-     - Optional script sourced before test execution.
+     - ``"/home/{user-id}/thor2_env_script.sh"``
+     - Environment script sourced before test execution (contains RCCL/NCCL/UCX tuning parameters).
    * - ``rccl_collective``
-     - ``["all_reduce_perf", ..., "broadcast_perf"]``
+     - ``["all_reduce_perf", "all_gather_perf"]``
      - RCCL collectives to execute.
-   * - ``rccl_algo``
-     - ``["ring", "tree"]``
-     - RCCL algorithm sweep values.
-   * - ``rccl_protocol``
-     - ``["simple"]``
-     - RCCL protocol sweep values.
-   * - ``qp_scale``
-     - ``["1", "2"]``
-     - Queue-pair scaling sweep values.
-   * - ``ib_hca_list``
-     - ``bnxt_re0,...,bnxt_re7``
-     - RDMA HCA device list used by launch/runtime setup.
-   * - ``net_dev_list``
-     - ``ens28np0,...,ens22np0``
-     - Network interface list aligned with IB devices.
-   * - ``oob_port``
-     - ``eth0``
-     - Out-of-band control interface.
-   * - ``nccl_socket_ifname``
-     - ``""``
-     - Optional NCCL bootstrap/socket fallback interface.
-   * - ``gid_index``
-     - ``1``
-     - GID index for RDMA/IB communication.
+   * - ``rccl_result_file``
+     - ``"/tmp/rccl_result.json"``
+     - Output file path for RCCL parsed results.
    * - ``start_msg_size``
-     - ``1024``
+     - ``"1024"``
      - Start message size for sweep.
    * - ``end_msg_size``
-     - ``16g``
+     - ``"16g"``
      - End message size for sweep.
-   * - ``step_function``
-     - ``2``
-     - Message-size progression rule.
-   * - ``threads_per_gpu``
-     - ``1``
-     - Worker threads per GPU for RCCL test binaries.
+   * - ``regression``
+     - ``{"NCCL_ALGO": ["Ring", "Tree"], "NCCL_PROTO": ["Simple"]}``
+     - Cartesian product sweep using NCCL/RCCL environment variable combinations (rccl_regression only).
+
+**MPI Parameters (mpi_params):**
+
+.. list-table::
+   :widths: 3 3 5
+   :header-rows: 1
+
+   * - Configuration parameter
+     - Example/default
+     - Description
+   * - ``mpi_pml``
+     - ``"auto"``
+     - MPI point-to-point messaging layer (auto, ucx, ob1).
+
+**RCCL Test Parameters (rccl_test_params):**
+
+.. list-table::
+   :widths: 3 3 5
+   :header-rows: 1
+
+   * - Configuration parameter
+     - Example/default
+     - Description
    * - ``warmup_iterations``
-     - ``10``
+     - ``"10"``
      - Warmup iteration count before measured iterations.
    * - ``no_of_iterations``
-     - ``20``
+     - ``"20"``
      - Number of measured iterations.
-   * - ``no_of_cycles``
-     - ``1``
-     - Number of full run cycles.
-   * - ``check_iteration_count``
-     - ``1``
-     - Validation/check iteration count used by parsers.
-   * - ``nccl_ib_timeout``
-     - ``30``
-     - NCCL/RCCL IB timeout.
-   * - ``ib_rx_queue_len``
-     - ``8192``
-     - IB receive queue length.
-   * - ``ucx_tls``
-     - ``tcp``
-     - UCX transport selection.
-   * - ``hcoll_enable_mcast_all``
-     - ``0``
-     - HCOLL multicast setting.
-   * - ``nccl_cumem_enable``
-     - ``0``
-     - NCCL memory behavior control.
-   * - ``nccl_ib_sl``
-     - ``0``
-     - IB service level.
-   * - ``nccl_ib_tc``
-     - ``0``
-     - IB traffic class.
-   * - ``nccl_ib_split_data_on_qps``
-     - ``0``
-     - Split-data policy across queue pairs.
-   * - ``nccl_pxn_disable``
-     - ``["0", "1"]``
-     - PXN enable/disable sweep values.
-   * - ``nccl_net_plugin``
-     - ``none``
-     - NCCL/RCCL network plugin selection.
-   * - ``channel_config_list``
-     - ``["default"]``
-     - Channel sweep list (for example ``"16-16"``, ``"64-64"``, ``"default"``).
+   * - ``step_function``
+     - ``"2"``
+     - Message-size progression rule.
+
+**CVS Parameters (cvs_params):**
+
+.. list-table::
+   :widths: 3 3 5
+   :header-rows: 1
+
+   * - Configuration parameter
+     - Example/default
+     - Description
    * - ``verify_bus_bw``
-     - ``False``
+     - ``"False"``
      - Enable bus-bandwidth threshold validation.
    * - ``verify_bw_dip``
-     - ``True``
+     - ``"True"``
      - Enable bandwidth-dip validation.
    * - ``verify_lat_dip``
-     - ``True``
+     - ``"True"``
      - Enable latency-dip validation.
-   * - ``debug_level``
-     - ``ERROR``
-     - RCCL/NCCL test debug verbosity.
-   * - ``rccl_result_file``
-     - ``/tmp/rccl_result_file.json``
-     - Base output file path for RCCL parsed results.
-   * - ``_comments_results``
-     - informational text
-     - Notes that expected results vary by cluster size and hardware.
+   * - ``cluster_snapshot_debug``
+     - ``"False"``
+     - Enables before/after cluster metric snapshots around tests.
    * - ``results``
-     - per-collective threshold map
+     - ``{}``
      - Expected threshold values used for pass/fail validation.
 
 Expected results format
@@ -330,110 +272,77 @@ Collective meanings
 - ``alltoallv_perf``: variable-sized all-to-all exchange.
 - ``broadcast_perf``: one-to-all data broadcast.
 
-``single_node_mi355_rccl.json``
-===============================
+Regression testing
+==================
 
-This file is tuned for ``rccl_singlenode_cvs`` and keeps only single-node relevant fields (collective list, message sweep, iteration controls, and expected thresholds).
+The ``rccl_regression`` suite performs Cartesian product sweeps using the ``regression`` object in the configuration. Each key-value pair represents an NCCL/RCCL environment variable and its possible values:
 
-Parameters
-----------
+.. code:: json
 
-Exhaustive parameter list for ``single_node_mi355_rccl.json``:
+  "regression": {
+    "NCCL_ALGO": ["Ring", "Tree"],
+    "NCCL_PROTO": ["Simple"],
+    "NCCL_IB_QPS_PER_CONNECTION": ["1", "2"],
+    "NCCL_PXN_DISABLE": ["0", "1"],
+    "NCCL_MIN_NCHANNELS": ["8", "16"],
+    "NCCL_MAX_NCHANNELS": ["8", "16"]
+  }
 
-.. list-table::
-   :widths: 3 3 5
-   :header-rows: 1
+**Key features:**
 
-   * - Configuration parameter
-     - Example/default
-     - Description
-   * - ``no_of_local_ranks``
-     - ``8``
-     - Local ranks (GPU processes) used for single-node tests.
-   * - ``rccl_dir``
-     - ``/opt/rccl-tests/``
-     - RCCL test install root.
-   * - ``rccl_tests_dir``
-     - ``/opt/rccl-tests/build``
-     - Directory containing RCCL test binaries.
-   * - ``rocm_path_var``
-     - ``/opt/rocm/``
-     - ROCm installation path.
-   * - ``rccl_path_var``
-     - ``/opt/rccl-tests/``
-     - RCCL runtime path.
-   * - ``env_source_script``
-     - ``/root/env_source_file.sh``
-     - Optional script sourced before test execution.
-   * - ``rccl_collective``
-     - ``["all_reduce_perf", ..., "broadcast_perf"]``
-     - Collectives executed in single-node sweep.
-   * - ``start_msg_size``
-     - ``1024``
-     - Start message size for sweep.
-   * - ``end_msg_size``
-     - ``16g``
-     - End message size for sweep.
-   * - ``step_function``
-     - ``2``
-     - Message-size progression rule.
-   * - ``warmup_iterations``
-     - ``10``
-     - Warmup iteration count before measured iterations.
-   * - ``no_of_iterations``
-     - ``1``
-     - Number of measured iterations.
-   * - ``check_iteration_count``
-     - ``1``
-     - Validation/check iteration count used by parsers.
-   * - ``verify_bus_bw``
-     - ``False``
-     - Enable bus-bandwidth threshold validation.
-   * - ``verify_bw_dip``
-     - ``True``
-     - Enable bandwidth-dip validation.
-   * - ``verify_lat_dip``
-     - ``True``
-     - Enable latency-dip validation.
-   * - ``debug_level``
-     - ``ERROR``
-     - RCCL/NCCL test debug verbosity.
-   * - ``rccl_result_file``
-     - ``/tmp/rccl_result_file.json``
-     - Output file path for parsed results.
-   * - ``_comments_results``
-     - informational text
-     - Notes that expected results vary by system and test profile.
-   * - ``results``
-     - per-collective threshold map
-     - Expected threshold values used for pass/fail validation.
+- **Cartesian product**: All combinations of the environment variables are tested
+- **Paired channels**: ``NCCL_MIN_NCHANNELS`` and ``NCCL_MAX_NCHANNELS`` are paired (not Cartesian)
+- **Tree filtering**: Tree algorithm only runs with ``all_reduce_perf`` collective
+- **Environment variables**: Use actual NCCL/RCCL environment variable names as keys
 
-Use this command:
+Single-node testing
+===================
+
+Single-node RCCL testing can be achieved by configuring a single-node cluster in your cluster JSON file and running either ``rccl_perf`` or ``rccl_regression`` suites. The tests will automatically adapt to single-node execution when only one node is present in the cluster configuration.
+
+Heatmap generation
+==================
+
+Generate performance heatmaps by comparing actual test results against a golden reference:
 
 .. code-block:: bash
 
-  cvs run rccl_singlenode_cvs \
-      --cluster_file input/cluster_file/cluster.json \
-      --config_file input/config_file/rccl/single_node_mi355_rccl.json \
-      --html=/var/www/html/cvs/rccl_singlenode.html --capture=tee-sys --self-contained-html \
-      --log-file=/tmp/rccl_singlenode.log -vvv -s
+  cvs generate heatmap \
+      --actual /tmp/rccl_perf_results.json \
+      --reference /path/to/golden_reference.json \
+      --output /var/www/html/cvs/rccl_heatmap.html \
+      --title "RCCL Performance Comparison" \
+      --metadata
 
-AINIC/ANP net plugin setup (optional)
-=====================================
+**Options:**
 
-To run with AINIC + ANP plugin:
+- ``--actual``: Path to actual test results JSON file (required)
+- ``--reference``: Path to golden reference JSON file (required)  
+- ``--output``: Output HTML file path (optional, defaults to /tmp)
+- ``--title``: Custom heatmap title (optional)
+- ``--metadata``: Include metadata table if actual JSON has 'metadata' key
+- ``--no-data-table``: Exclude data table from output
 
-1. Ensure AMD ANP is installed and available on all target nodes.
-2. Edit ``input/config_file/rccl/ainic_env_script.sh`` and set ``ANP_HOME_DIR`` to your ANP install path.
-3. Set ``env_source_script`` in RCCL JSON config to that script path.
+Environment script setup
+=========================
+
+All cluster configurations require an environment script to be sourced before RCCL tests, regardless of NIC type (Broadcom/ConnectX/AINIC):
+
+1. **For AINIC clusters:** Ensure AMD ANP is installed and available on all target nodes, then edit ``input/config_file/rccl/ainic_env_script.sh`` and set ``ANP_HOME_DIR`` to your ANP install path.
+
+2. **For other NIC types:** Use the appropriate environment script (``thor2_env_script.sh`` for Broadcom, ``cx7_env_script.sh`` for ConnectX-7, etc.).
+
+3. Set ``env_source_script`` in RCCL JSON config to the correct script path for your hardware.
+
 4. Run RCCL using ``cvs run ...`` commands; CVS sources the script automatically.
 
-If AINIC/ANP is not used, set ``env_source_script`` to your standard environment script or ``"None"`` to skip script sourcing.
+The environment script contains essential RCCL/NCCL/UCX tuning parameters and paths required for proper test execution.
 
 Validation and artifacts
 ========================
 
 - Test-level pass/fail is based on command execution plus enabled validations (``results``, bandwidth checks, dip checks).
-- Graph reports are generated under ``/tmp/rccl_perf_report_*.html`` (or ``/tmp/rccl_singlenode_perf_report_*.html``).
-- Heatmap runs produce ``/tmp/rccl_heatmap_*.html`` and JSON result artifacts, and may copy them to ``output_dir`` when configured.
-- Artifacts generated under ``/tmp`` can be copied to a web server path (for example ``/var/www/html/cvs``) for browser access.
+- Performance reports are generated under ``/tmp/rccl_perf_report_*.html``.
+- Regression reports are generated under ``/tmp/rccl_perf_report_*.html`` with "RCCL Multi Node Performance Report" title.
+- Heatmaps are generated using ``cvs generate heatmap`` with customizable output paths.
+- All artifacts generated under ``/tmp`` can be copied to a web server path (for example ``/var/www/html/cvs``) for browser access.


### PR DESCRIPTION
- Replace old RCCL test suites (rccl_multinode_cvs, rccl_multinode_default_cvs, rccl_singlenode_cvs, rccl_heatmap_cvs) with new ones (rccl_perf, rccl_regression)
- Update configuration format to reflect new structure with mpi_params, rccl_test_params, and cvs_params sections
- Document cvs generate heatmap command for performance comparison
- Add comprehensive cvs scp command documentation for cluster file distribution
- Update all examples and command references across documentation files

Changes:
- docs/reference/configuration-files/rccl.rst: Updated test suite descriptions and config format
- docs/how-to/run-cvs-tests.rst: Updated RCCL section with correct suite names
- docs/how-to/copy-to-cluster.rst: New documentation for cvs scp command
- docs/index.rst: Added copy-to-cluster documentation to index
- README.md: Updated RCCL examples to use rccl_perf
- cvs/tests/rccl/README.md: Removed references to non-existent singlenode suite

Made-with: Cursor

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
