### PR TITLE
fixed namings for rccl results files

### DIFF
--- a/cvs/input/config_file/rccl/rccl_config.json
+++ b/cvs/input/config_file/rccl/rccl_config.json
@@ -26,6 +26,7 @@
             "data_types": ["float"]
         },
 
+        "_comment_cvs_params": "The rccl_result_file.json will be appended by rccl_test_params.data_types. When it's float the file name will be rccl_result_file_float.json on the head node.",
         "cvs_params": {
             "cluster_snapshot_debug": "False",
             "_comment_nic_model": "Set nic_model for validations (eg., 'thor' , 'ainic', 'connectx')",

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -830,8 +830,9 @@ def rccl_perf(
             raise RuntimeError(f'RCCL Test {dtype} schema validation failed') from e
 
     # Save the results to a main result file
-    with open(rccl_result_file, 'w') as f:
-        json.dump(all_raw_results, f, indent=2)
+    json_string = json.dumps(all_raw_results, indent=2)
+    cmd = f"cat > {rccl_result_file} << 'EOF'\n{json_string}\nEOF"
+    shdl.exec(cmd)
     log.info(f'Saved combined results from all data types to {rccl_result_file}')
 
     # Validate the results against the schema and aggregate if multiple results are found, fail if results are not valid
@@ -842,8 +843,9 @@ def rccl_perf(
             log.info(f'Aggregation passed: {len(aggregated_rccl_tests)} RcclTestsAggregated schema validation passed')
             # Note: currently we are saving the aggregated results, but we could instead use this for final report generation
             aggregated_path = f'{base_path.parent}/{base_path.stem}_aggregated.json'
-            with open(aggregated_path, 'w') as f:
-                json.dump([result.model_dump() for result in aggregated_rccl_tests], f, indent=2)
+            json_string = json.dumps([result.model_dump() for result in aggregated_rccl_tests], indent=2)
+            cmd = f"cat > {aggregated_path} << 'EOF'\n{json_string}\nEOF"
+            shdl.exec(cmd)
             log.info(f'Saved aggregated results to {aggregated_path}')
         else:
             log.warning('Aggregation skipped: only one run found')


### PR DESCRIPTION
## Motivation

In the rccl config json file, user provides path to a file where rccl result is supposed to be saved. CVS also allows to run collectives for various data types, for example float. This file name is appended by "_float.json" when data type is json. Besides, without this patch the CVS wrongfully tries to save the result in the controller's filesystem not on the head node.

## Technical Details

CVS uses with open syntax of python to save result file. It assumes /home/"userid" to be present, where userid is provided in cluster file. But then again it was meant for head node. CVS wronfully tries to open the file on the controller's filesystem and not on the headnode.
## Test Plan

It is tested on a 2N SuperMicro MI350 systems.

## Test Result

Without this patch the rccl_perf test case was failing.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
