### PR TITLE
Fix RCCL post-test JSON save for payloads >30 KB by replacing libssh2 heredoc with scp

### DIFF
--- a/cvs/lib/parallel_ssh_lib.py
+++ b/cvs/lib/parallel_ssh_lib.py
@@ -299,9 +299,7 @@ class Pssh:
         Raises:
           IOError: If transfer fails on any host. Message lists offending hosts.
         """
-        self.log.info(
-            'SFTP upload %s -> %s on %s', local_file, remote_file, self.reachable_hosts
-        )
+        self.log.info('SFTP upload %s -> %s on %s', local_file, remote_file, self.reachable_hosts)
         cmds = self.client.copy_file(local_file, remote_file, recurse=recurse)
         self.client.pool.join()
         errors = []
@@ -343,12 +341,8 @@ class Pssh:
         Raises:
           IOError: If transfer fails on any host. Message lists offending hosts.
         """
-        self.log.info(
-            'SFTP download %s -> %s from %s', remote_file, local_file, self.reachable_hosts
-        )
-        cmds = self.client.copy_remote_file(
-            remote_file, local_file, recurse=recurse, suffix_separator=suffix_separator
-        )
+        self.log.info('SFTP download %s -> %s from %s', remote_file, local_file, self.reachable_hosts)
+        cmds = self.client.copy_remote_file(remote_file, local_file, recurse=recurse, suffix_separator=suffix_separator)
         self.client.pool.join()
         errors = []
         result = {}

--- a/cvs/lib/parallel_ssh_lib.py
+++ b/cvs/lib/parallel_ssh_lib.py
@@ -269,19 +269,19 @@ class Pssh:
         return cmd_output
 
     def scp_file(self, local_file, remote_file, recurse=False):
+        """
+        Backward-compatible alias for upload_file.
+
+        Kept so existing callers (and log-grep tooling looking for the legacy
+        "About to copy local file..." line) keep working. New code should call
+        upload_file directly.
+        """
         self.log.info('About to copy local file {} to remote {} on all Hosts'.format(local_file, remote_file))
-        cmds = self.client.copy_file(local_file, remote_file, recurse=recurse)
-        self.client.pool.join()
-        for cmd in cmds:
-            try:
-                cmd.get()
-            except IOError as e:
-                raise IOError(f"scp '{local_file}' -> '{remote_file}' failed: {e}") from e
-        return
+        self.upload_file(local_file, remote_file, recurse=recurse)
 
     def upload_file(self, local_file, remote_file, recurse=False):
         """
-        SFTP-upload a local file from the conductor to `remote_file` on every host
+        SFTP-upload a local file from the runner node to `remote_file` on every host
         in this Pssh's reachable_hosts. Wraps ParallelSSHClient.copy_file.
 
         Use this instead of embedding file contents in `exec()` command strings
@@ -289,10 +289,10 @@ class Pssh:
         cap. SFTP transfers go over a separate channel with no such limit and
         auto-create missing parent directories when recurse=True.
 
-        For a 1:1 conductor->head_node push, construct the Pssh with [head_node].
+        For a 1:1 runner->head_node push, construct the Pssh with [head_node].
 
         Parameters:
-          local_file: Path on the conductor to read from.
+          local_file: Path on the runner node to read from.
           remote_file: Absolute destination path on each remote host.
           recurse: If True, copy a directory tree (parent dirs auto-created).
 
@@ -312,13 +312,14 @@ class Pssh:
                 errors.append((host, e))
         if errors:
             raise IOError(
-                f'upload_file failed on {len(errors)}/{len(self.reachable_hosts)} hosts: {errors}'
-            )
+                f"upload_file '{local_file}' -> '{remote_file}' failed on "
+                f"{len(errors)}/{len(self.reachable_hosts)} hosts: {errors}"
+            ) from errors[0][1]
 
     def download_file(self, remote_file, local_file, recurse=False, suffix_separator='_'):
         """
         SFTP-download `remote_file` from every host in this Pssh's reachable_hosts
-        to the conductor. Wraps ParallelSSHClient.copy_remote_file.
+        to the runner node. Wraps ParallelSSHClient.copy_remote_file.
 
         Use this instead of `exec('cat <file>')` + parsing stdout when the file
         may exceed a few KB. `cat`-over-exec reassembles bytes through the
@@ -332,7 +333,7 @@ class Pssh:
 
         Parameters:
           remote_file: Absolute path on each remote host.
-          local_file: Local path prefix on the conductor (host name will be appended).
+          local_file: Local path prefix on the runner node (host name will be appended).
           recurse: If True, recursively download a directory tree.
           suffix_separator: Separator placed between local_file and host. Default '_'.
 
@@ -359,8 +360,9 @@ class Pssh:
                 errors.append((host, e))
         if errors:
             raise IOError(
-                f'download_file failed on {len(errors)}/{len(self.reachable_hosts)} hosts: {errors}'
-            )
+                f"download_file '{remote_file}' -> '{local_file}' failed on "
+                f"{len(errors)}/{len(self.reachable_hosts)} hosts: {errors}"
+            ) from errors[0][1]
         return result
 
     def reboot_connections(self):

--- a/cvs/lib/parallel_ssh_lib.py
+++ b/cvs/lib/parallel_ssh_lib.py
@@ -279,6 +279,90 @@ class Pssh:
                 raise IOError(f"scp '{local_file}' -> '{remote_file}' failed: {e}") from e
         return
 
+    def upload_file(self, local_file, remote_file, recurse=False):
+        """
+        SFTP-upload a local file from the conductor to `remote_file` on every host
+        in this Pssh's reachable_hosts. Wraps ParallelSSHClient.copy_file.
+
+        Use this instead of embedding file contents in `exec()` command strings
+        (e.g. heredoc cat>EOF), which is bounded by libssh2's ~30 KB exec_request
+        cap. SFTP transfers go over a separate channel with no such limit and
+        auto-create missing parent directories when recurse=True.
+
+        For a 1:1 conductor->head_node push, construct the Pssh with [head_node].
+
+        Parameters:
+          local_file: Path on the conductor to read from.
+          remote_file: Absolute destination path on each remote host.
+          recurse: If True, copy a directory tree (parent dirs auto-created).
+
+        Raises:
+          IOError: If transfer fails on any host. Message lists offending hosts.
+        """
+        self.log.info(
+            'SFTP upload %s -> %s on %s', local_file, remote_file, self.reachable_hosts
+        )
+        cmds = self.client.copy_file(local_file, remote_file, recurse=recurse)
+        self.client.pool.join()
+        errors = []
+        for cmd, host in zip(cmds, self.reachable_hosts):
+            try:
+                cmd.get()
+            except Exception as e:
+                errors.append((host, e))
+        if errors:
+            raise IOError(
+                f'upload_file failed on {len(errors)}/{len(self.reachable_hosts)} hosts: {errors}'
+            )
+
+    def download_file(self, remote_file, local_file, recurse=False, suffix_separator='_'):
+        """
+        SFTP-download `remote_file` from every host in this Pssh's reachable_hosts
+        to the conductor. Wraps ParallelSSHClient.copy_remote_file.
+
+        Use this instead of `exec('cat <file>')` + parsing stdout when the file
+        may exceed a few KB. `cat`-over-exec reassembles bytes through the
+        line-oriented stdout pipeline of `_process_output`, which is fragile for
+        binary content and unnecessary work for any text payload of nontrivial
+        size.
+
+        Note: parallel-ssh suffixes the local filename with `<suffix_separator><host>`
+        to avoid collisions when downloading the same path from multiple hosts.
+        Use the returned dict to look up the actual on-disk path per host.
+
+        Parameters:
+          remote_file: Absolute path on each remote host.
+          local_file: Local path prefix on the conductor (host name will be appended).
+          recurse: If True, recursively download a directory tree.
+          suffix_separator: Separator placed between local_file and host. Default '_'.
+
+        Returns:
+          dict: {host: actual_local_path} for each host in reachable_hosts.
+
+        Raises:
+          IOError: If transfer fails on any host. Message lists offending hosts.
+        """
+        self.log.info(
+            'SFTP download %s -> %s from %s', remote_file, local_file, self.reachable_hosts
+        )
+        cmds = self.client.copy_remote_file(
+            remote_file, local_file, recurse=recurse, suffix_separator=suffix_separator
+        )
+        self.client.pool.join()
+        errors = []
+        result = {}
+        for cmd, host in zip(cmds, self.reachable_hosts):
+            try:
+                cmd.get()
+                result[host] = f'{local_file}{suffix_separator}{host}'
+            except Exception as e:
+                errors.append((host, e))
+        if errors:
+            raise IOError(
+                f'download_file failed on {len(errors)}/{len(self.reachable_hosts)} hosts: {errors}'
+            )
+        return result
+
     def reboot_connections(self):
         self.log.info('Rebooting Connections')
         self.client.run_command('reboot -f', stop_on_errors=self.stop_on_errors)

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -9,7 +9,6 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 import os
 import re
 import json
-import subprocess
 import tempfile
 from typing import List
 from pathlib import Path
@@ -52,40 +51,29 @@ def _is_severe_wrong_corruption_error(err: ValidationError) -> bool:
     return 'SEVERE DATA CORRUPTION' in s or "'#wrong'" in s
 
 
-def _push_json_to_remote_head(
-    head_node: str,
-    remote_path: str,
-    json_string: str,
-    ssh_user: str,
-    ssh_key: str,
-    log_label: str,
-) -> bool:
+def _save_json_to_head_node(shdl, head_node, remote_path, payload_obj, log_label):
     """
-    Push a JSON payload from the conductor (login) node to the MPI head node via OpenSSH scp.
+    Serialize `payload_obj` to JSON and SFTP-upload it from the conductor to
+    `remote_path` on `head_node` via the existing single-host Pssh handle `shdl`.
 
-    The previous implementation embedded the JSON in a `cat > path << 'EOF' ... EOF` heredoc
-    sent over an ssh2-python (libssh2) exec channel. libssh2 rejects exec requests whose
-    command string grows past ~30 KB with InvalidRequestError, which broke saves of combined
-    raw and aggregated RCCL result files. Writing to a temp file and shelling out to OpenSSH
-    `scp` lifts that limit; OpenSSH does not have the same channel-payload constraint.
+    Replaces an earlier implementation that embedded the JSON in a `cat > path << 'EOF'`
+    heredoc over `shdl.exec`. libssh2 caps exec_request command strings at ~30 KB,
+    which broke saves on clusters of ~30+ nodes (combined raw files routinely
+    30-550 KB). SFTP transfers go over a separate channel with no such limit.
+
+    Failure is non-fatal: the benchmark and schema validation have already
+    completed before this is called and raw data remains in test.log. The caller
+    logs and continues.
 
     Parameters:
-      head_node: Hostname or IP of the MPI head node (target of the scp).
-      remote_path: Absolute destination path on the head node.
-      json_string: Serialized JSON to upload.
-      ssh_user: SSH username (must match the cluster JSON / passwordless key access).
-      ssh_key: Filesystem path to the SSH private key on the conductor.
-      log_label: Short label used in log lines for context (e.g. 'combined_rccl_results').
+      shdl: Pssh handle scoped to [head_node]. Credentials are reused from the handle.
+      head_node: Hostname/IP, used only for log context.
+      remote_path: Absolute destination path on head_node.
+      payload_obj: Any json.dumps-able Python object.
+      log_label: Short label used in log lines (e.g. 'combined_rccl_results').
 
     Returns:
-      bool: True on success, False on any scp-side failure (network, auth, missing binary,
-        non-zero exit). Failure is non-fatal to the test: the benchmark and schema validation
-        have already completed before this is called, and raw data remains in test.log; the
-        caller logs an error and continues.
-
-    Raises:
-      OSError: If the temporary file on the conductor cannot be created (e.g. /tmp full or
-        unwritable). This is a setup error and is left to propagate.
+      bool: True on success, False on transfer failure.
     """
     tmp_path = None
     try:
@@ -97,36 +85,21 @@ def _push_json_to_remote_head(
             suffix='.json',
             dir='/tmp',
         ) as tf:
-            tf.write(json_string)
+            json.dump(payload_obj, tf, indent=2)
             tmp_path = tf.name
 
-        scp_args = [
-            'scp',
-            '-i', ssh_key,
-            '-o', 'BatchMode=yes',
-            '-o', 'StrictHostKeyChecking=no',
-            tmp_path,
-            f'{ssh_user}@{head_node}:{remote_path}',
-        ]
         try:
-            subprocess.run(scp_args, check=True, capture_output=True, text=True)
-            log.info('scp push succeeded for %s -> %s:%s', log_label, head_node, remote_path)
+            shdl.upload_file(tmp_path, remote_path)
+            log.info('SFTP upload succeeded for %s -> %s:%s', log_label, head_node, remote_path)
             return True
-        except subprocess.CalledProcessError as e:
+        except IOError as e:
             log.error(
-                'scp push failed for %s -> %s:%s (exit %s): stderr=%r stdout=%r',
-                log_label, head_node, remote_path, e.returncode, e.stderr, e.stdout,
-            )
-            return False
-        except FileNotFoundError:
-            log.error(
-                'scp binary not found on conductor while pushing %s -> %s:%s',
-                log_label, head_node, remote_path,
+                'SFTP upload failed for %s -> %s:%s: %r', log_label, head_node, remote_path, e
             )
             return False
         except Exception as e:
             log.error(
-                'scp push unexpected error for %s -> %s:%s: %r',
+                'SFTP upload unexpected error for %s -> %s:%s: %r',
                 log_label, head_node, remote_path, e,
             )
             return False
@@ -136,6 +109,38 @@ def _push_json_to_remote_head(
                 os.unlink(tmp_path)
             except OSError as e:
                 log.warning('Failed to remove temp file %s: %r', tmp_path, e)
+
+
+def _read_json_from_head_node(shdl, head_node, remote_path, log_label):
+    """
+    SFTP-download a JSON file from `remote_path` on `head_node` to a conductor
+    tempfile and return the parsed object.
+
+    Replaces an earlier `shdl.exec(f'cat {remote_path}')` + line-oriented stdout
+    reassembly + `.replace('\\n','').replace('\\r','')` hack. That approach was
+    fragile for any text payload of nontrivial size and architecturally the
+    receive-direction sibling of the 30 KB exec-request bug.
+
+    Parameters:
+      shdl: Pssh handle scoped to [head_node].
+      head_node: Hostname/IP key used to look up the per-host download path.
+      remote_path: Absolute path on head_node to fetch.
+      log_label: Short label used in log lines (e.g. 'all_reduce_perf_float').
+
+    Returns:
+      The parsed JSON object.
+
+    Raises:
+      IOError: If the SFTP transfer fails.
+      json.JSONDecodeError: If the downloaded file is not valid JSON.
+    """
+    with tempfile.TemporaryDirectory(prefix='cvs_rccl_dl_') as tmpdir:
+        local_prefix = os.path.join(tmpdir, os.path.basename(remote_path))
+        paths = shdl.download_file(remote_path, local_prefix)
+        local_path = paths[head_node]
+        log.info('SFTP download succeeded for %s <- %s:%s', log_label, head_node, remote_path)
+        with open(local_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
 
 
 def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
@@ -707,9 +712,9 @@ def rccl_regression(
         log.error(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
         fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
 
-    # Read the JSON results emitted by the RCCL test binary
-    result_dict_out = shdl.exec(f'cat {rccl_result_file}')
-    result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
+    # Read the JSON results emitted by the RCCL test binary via SFTP
+    # (avoids fragile cat-over-exec stdout reassembly for large payloads)
+    result_out = _read_json_from_head_node(shdl, head_node, rccl_result_file, test_name)
 
     # Collect basic GPU information via rocm-smi
     smi_out_dict = shdl.exec('rocm-smi -a | head -30')
@@ -750,7 +755,6 @@ def rccl_perf(
     cvs_params,
     cluster_node_list,
     vpc_node_list,
-    cluster_dict,
 ):
     """
     Run an RCCL collective test across a cluster via MPI and verify results.
@@ -886,9 +890,11 @@ def rccl_perf(
             log.error(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
             fail_test(f'Hit Exceptions with rccl cmd {cmd} - exception {repr(e)}')
 
-        # Read the JSON results emitted by the RCCL test binary
-        result_dict_out = shdl.exec(f'cat {dtype_result_file}')
-        dtype_result_out = json.loads(result_dict_out[head_node].replace('\n', '').replace('\r', ''))
+        # Read the JSON results emitted by the RCCL test binary via SFTP
+        # (avoids fragile cat-over-exec stdout reassembly for large payloads)
+        dtype_result_out = _read_json_from_head_node(
+            shdl, head_node, dtype_result_file, f'{test_name}_{dtype}'
+        )
         # Validate the results against the schema fail if results are not valid
         try:
             validated = [RcclTestsMultinodeRaw.model_validate(test_result) for test_result in dtype_result_out]
@@ -919,22 +925,11 @@ def rccl_perf(
             # IMPORTANT: schema validation failures should stop further iterations/data types
             raise RuntimeError(f'RCCL Test {dtype} schema validation failed') from e
 
-    if not isinstance(cluster_dict, dict):
-        raise ValueError('rccl_perf: cluster_dict must be a dict containing SSH credentials')
-    ssh_user = cluster_dict.get('username')
-    ssh_key = cluster_dict.get('priv_key_file')
-    if not ssh_user or not ssh_key:
-        raise ValueError(
-            "rccl_perf: cluster_dict missing required 'username' and/or 'priv_key_file' "
-            'needed to scp result JSON to the head node'
-        )
-
-    # Save the combined raw results to the head node via scp.
+    # Save the combined raw results to the head node via SFTP through `shdl`.
     # This is non-fatal: the benchmark and schema validation have already passed by this point;
     # raw data also lives in test.log. A save failure logs an ERROR but does not fail the test.
-    json_string = json.dumps(all_raw_results, indent=2)
-    if _push_json_to_remote_head(
-        head_node, rccl_result_file, json_string, ssh_user, ssh_key, 'combined_rccl_results'
+    if _save_json_to_head_node(
+        shdl, head_node, rccl_result_file, all_raw_results, 'combined_rccl_results'
     ):
         log.info(f'Saved combined results from all data types to {rccl_result_file}')
     else:
@@ -948,9 +943,9 @@ def rccl_perf(
             log.info(f'Aggregation passed: {len(aggregated_rccl_tests)} RcclTestsAggregated schema validation passed')
             # Note: currently we are saving the aggregated results, but we could instead use this for final report generation
             aggregated_path = f'{base_path.parent}/{base_path.stem}_aggregated.json'
-            json_string = json.dumps([result.model_dump() for result in aggregated_rccl_tests], indent=2)
-            if _push_json_to_remote_head(
-                head_node, aggregated_path, json_string, ssh_user, ssh_key, 'aggregated_rccl_results'
+            aggregated_payload = [result.model_dump() for result in aggregated_rccl_tests]
+            if _save_json_to_head_node(
+                shdl, head_node, aggregated_path, aggregated_payload, 'aggregated_rccl_results'
             ):
                 log.info(f'Saved aggregated results to {aggregated_path}')
             else:

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -93,14 +93,15 @@ def _save_json_to_head_node(shdl, head_node, remote_path, payload_obj, log_label
             log.info('SFTP upload succeeded for %s -> %s:%s', log_label, head_node, remote_path)
             return True
         except IOError as e:
-            log.error(
-                'SFTP upload failed for %s -> %s:%s: %r', log_label, head_node, remote_path, e
-            )
+            log.error('SFTP upload failed for %s -> %s:%s: %r', log_label, head_node, remote_path, e)
             return False
         except Exception as e:
             log.error(
                 'SFTP upload unexpected error for %s -> %s:%s: %r',
-                log_label, head_node, remote_path, e,
+                log_label,
+                head_node,
+                remote_path,
+                e,
             )
             return False
     finally:
@@ -892,9 +893,7 @@ def rccl_perf(
 
         # Read the JSON results emitted by the RCCL test binary via SFTP
         # (avoids fragile cat-over-exec stdout reassembly for large payloads)
-        dtype_result_out = _read_json_from_head_node(
-            shdl, head_node, dtype_result_file, f'{test_name}_{dtype}'
-        )
+        dtype_result_out = _read_json_from_head_node(shdl, head_node, dtype_result_file, f'{test_name}_{dtype}')
         # Validate the results against the schema fail if results are not valid
         try:
             validated = [RcclTestsMultinodeRaw.model_validate(test_result) for test_result in dtype_result_out]
@@ -928,9 +927,7 @@ def rccl_perf(
     # Save the combined raw results to the head node via SFTP through `shdl`.
     # This is non-fatal: the benchmark and schema validation have already passed by this point;
     # raw data also lives in test.log. A save failure logs an ERROR but does not fail the test.
-    if _save_json_to_head_node(
-        shdl, head_node, rccl_result_file, all_raw_results, 'combined_rccl_results'
-    ):
+    if _save_json_to_head_node(shdl, head_node, rccl_result_file, all_raw_results, 'combined_rccl_results'):
         log.info(f'Saved combined results from all data types to {rccl_result_file}')
     else:
         log.error('Failed to save combined results to %s on head node %s', rccl_result_file, head_node)
@@ -944,9 +941,7 @@ def rccl_perf(
             # Note: currently we are saving the aggregated results, but we could instead use this for final report generation
             aggregated_path = f'{base_path.parent}/{base_path.stem}_aggregated.json'
             aggregated_payload = [result.model_dump() for result in aggregated_rccl_tests]
-            if _save_json_to_head_node(
-                shdl, head_node, aggregated_path, aggregated_payload, 'aggregated_rccl_results'
-            ):
+            if _save_json_to_head_node(shdl, head_node, aggregated_path, aggregated_payload, 'aggregated_rccl_results'):
                 log.info(f'Saved aggregated results to {aggregated_path}')
             else:
                 log.error('Failed to save aggregated results to %s on head node %s', aggregated_path, head_node)

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -53,7 +53,7 @@ def _is_severe_wrong_corruption_error(err: ValidationError) -> bool:
 
 def _save_json_to_head_node(shdl, head_node, remote_path, payload_obj, log_label):
     """
-    Serialize `payload_obj` to JSON and SFTP-upload it from the conductor to
+    Serialize `payload_obj` to JSON and SFTP-upload it from the runner node to
     `remote_path` on `head_node` via the existing single-host Pssh handle `shdl`.
 
     Replaces an earlier implementation that embedded the JSON in a `cat > path << 'EOF'`
@@ -113,7 +113,7 @@ def _save_json_to_head_node(shdl, head_node, remote_path, payload_obj, log_label
 
 def _read_json_from_head_node(shdl, head_node, remote_path, log_label):
     """
-    SFTP-download a JSON file from `remote_path` on `head_node` to a conductor
+    SFTP-download a JSON file from `remote_path` on `head_node` to a runner-node
     tempfile and return the parsed object.
 
     Replaces an earlier `shdl.exec(f'cat {remote_path}')` + line-oriented stdout

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -6,8 +6,11 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 '''
 
 # Standard libraries
+import os
 import re
 import json
+import subprocess
+import tempfile
 from typing import List
 from pathlib import Path
 
@@ -47,6 +50,92 @@ def _is_severe_wrong_corruption_error(err: ValidationError) -> bool:
     # Fallback to string search
     s = str(err)
     return 'SEVERE DATA CORRUPTION' in s or "'#wrong'" in s
+
+
+def _push_json_to_remote_head(
+    head_node: str,
+    remote_path: str,
+    json_string: str,
+    ssh_user: str,
+    ssh_key: str,
+    log_label: str,
+) -> bool:
+    """
+    Push a JSON payload from the conductor (login) node to the MPI head node via OpenSSH scp.
+
+    The previous implementation embedded the JSON in a `cat > path << 'EOF' ... EOF` heredoc
+    sent over an ssh2-python (libssh2) exec channel. libssh2 rejects exec requests whose
+    command string grows past ~30 KB with InvalidRequestError, which broke saves of combined
+    raw and aggregated RCCL result files. Writing to a temp file and shelling out to OpenSSH
+    `scp` lifts that limit; OpenSSH does not have the same channel-payload constraint.
+
+    Parameters:
+      head_node: Hostname or IP of the MPI head node (target of the scp).
+      remote_path: Absolute destination path on the head node.
+      json_string: Serialized JSON to upload.
+      ssh_user: SSH username (must match the cluster JSON / passwordless key access).
+      ssh_key: Filesystem path to the SSH private key on the conductor.
+      log_label: Short label used in log lines for context (e.g. 'combined_rccl_results').
+
+    Returns:
+      bool: True on success, False on any scp-side failure (network, auth, missing binary,
+        non-zero exit). Failure is non-fatal to the test: the benchmark and schema validation
+        have already completed before this is called, and raw data remains in test.log; the
+        caller logs an error and continues.
+
+    Raises:
+      OSError: If the temporary file on the conductor cannot be created (e.g. /tmp full or
+        unwritable). This is a setup error and is left to propagate.
+    """
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode='w',
+            encoding='utf-8',
+            delete=False,
+            prefix='cvs_rccl_json_',
+            suffix='.json',
+            dir='/tmp',
+        ) as tf:
+            tf.write(json_string)
+            tmp_path = tf.name
+
+        scp_args = [
+            'scp',
+            '-i', ssh_key,
+            '-o', 'BatchMode=yes',
+            '-o', 'StrictHostKeyChecking=no',
+            tmp_path,
+            f'{ssh_user}@{head_node}:{remote_path}',
+        ]
+        try:
+            subprocess.run(scp_args, check=True, capture_output=True, text=True)
+            log.info('scp push succeeded for %s -> %s:%s', log_label, head_node, remote_path)
+            return True
+        except subprocess.CalledProcessError as e:
+            log.error(
+                'scp push failed for %s -> %s:%s (exit %s): stderr=%r stdout=%r',
+                log_label, head_node, remote_path, e.returncode, e.stderr, e.stdout,
+            )
+            return False
+        except FileNotFoundError:
+            log.error(
+                'scp binary not found on conductor while pushing %s -> %s:%s',
+                log_label, head_node, remote_path,
+            )
+            return False
+        except Exception as e:
+            log.error(
+                'scp push unexpected error for %s -> %s:%s: %r',
+                log_label, head_node, remote_path, e,
+            )
+            return False
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError as e:
+                log.warning('Failed to remove temp file %s: %r', tmp_path, e)
 
 
 def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
@@ -661,6 +750,7 @@ def rccl_perf(
     cvs_params,
     cluster_node_list,
     vpc_node_list,
+    cluster_dict,
 ):
     """
     Run an RCCL collective test across a cluster via MPI and verify results.
@@ -829,11 +919,26 @@ def rccl_perf(
             # IMPORTANT: schema validation failures should stop further iterations/data types
             raise RuntimeError(f'RCCL Test {dtype} schema validation failed') from e
 
-    # Save the results to a main result file
+    if not isinstance(cluster_dict, dict):
+        raise ValueError('rccl_perf: cluster_dict must be a dict containing SSH credentials')
+    ssh_user = cluster_dict.get('username')
+    ssh_key = cluster_dict.get('priv_key_file')
+    if not ssh_user or not ssh_key:
+        raise ValueError(
+            "rccl_perf: cluster_dict missing required 'username' and/or 'priv_key_file' "
+            'needed to scp result JSON to the head node'
+        )
+
+    # Save the combined raw results to the head node via scp.
+    # This is non-fatal: the benchmark and schema validation have already passed by this point;
+    # raw data also lives in test.log. A save failure logs an ERROR but does not fail the test.
     json_string = json.dumps(all_raw_results, indent=2)
-    cmd = f"cat > {rccl_result_file} << 'EOF'\n{json_string}\nEOF"
-    shdl.exec(cmd)
-    log.info(f'Saved combined results from all data types to {rccl_result_file}')
+    if _push_json_to_remote_head(
+        head_node, rccl_result_file, json_string, ssh_user, ssh_key, 'combined_rccl_results'
+    ):
+        log.info(f'Saved combined results from all data types to {rccl_result_file}')
+    else:
+        log.error('Failed to save combined results to %s on head node %s', rccl_result_file, head_node)
 
     # Validate the results against the schema and aggregate if multiple results are found, fail if results are not valid
     aggregated_rccl_tests = None
@@ -844,9 +949,12 @@ def rccl_perf(
             # Note: currently we are saving the aggregated results, but we could instead use this for final report generation
             aggregated_path = f'{base_path.parent}/{base_path.stem}_aggregated.json'
             json_string = json.dumps([result.model_dump() for result in aggregated_rccl_tests], indent=2)
-            cmd = f"cat > {aggregated_path} << 'EOF'\n{json_string}\nEOF"
-            shdl.exec(cmd)
-            log.info(f'Saved aggregated results to {aggregated_path}')
+            if _push_json_to_remote_head(
+                head_node, aggregated_path, json_string, ssh_user, ssh_key, 'aggregated_rccl_results'
+            ):
+                log.info(f'Saved aggregated results to {aggregated_path}')
+            else:
+                log.error('Failed to save aggregated results to %s on head node %s', aggregated_path, head_node)
         else:
             log.warning('Aggregation skipped: only one run found')
     except ValidationError as e:

--- a/cvs/lib/unittests/test_parallel_ssh_lib.py
+++ b/cvs/lib/unittests/test_parallel_ssh_lib.py
@@ -957,9 +957,7 @@ class TestPsshFileTransfer(unittest.TestCase):
 
         self.pssh.upload_file("/tmp/local.json", "/remote/dest.json")
 
-        self.mock_client.copy_file.assert_called_once_with(
-            "/tmp/local.json", "/remote/dest.json", recurse=False
-        )
+        self.mock_client.copy_file.assert_called_once_with("/tmp/local.json", "/remote/dest.json", recurse=False)
         self.mock_client.pool.join.assert_called_once()
 
     def test_upload_file_recurse_passes_through(self):
@@ -1038,9 +1036,7 @@ class TestPsshFileTransfer(unittest.TestCase):
             self._ok_greenlet(),
         ]
 
-        result = self.pssh.download_file(
-            "/remote/file.json", "/tmp/local.json", suffix_separator="."
-        )
+        result = self.pssh.download_file("/remote/file.json", "/tmp/local.json", suffix_separator=".")
 
         self.assertEqual(
             result,
@@ -1099,9 +1095,7 @@ class TestPsshFileTransfer(unittest.TestCase):
         # to confirm delegation rather than reimplementing the underlying mock.
         with patch.object(Pssh, "upload_file") as mock_upload:
             self.pssh.scp_file("/tmp/local.json", "/remote/dest.json", recurse=True)
-            mock_upload.assert_called_once_with(
-                "/tmp/local.json", "/remote/dest.json", recurse=True
-            )
+            mock_upload.assert_called_once_with("/tmp/local.json", "/remote/dest.json", recurse=True)
 
     def test_scp_file_propagates_ioerror_from_upload_file(self):
         # When upload_file raises, scp_file lets it propagate (no swallowing)

--- a/cvs/lib/unittests/test_parallel_ssh_lib.py
+++ b/cvs/lib/unittests/test_parallel_ssh_lib.py
@@ -921,13 +921,210 @@ class TestPsshExecCmdList(unittest.TestCase):
             self.assertNotIn("host2 output line1", call)
 
 
+class TestPsshFileTransfer(unittest.TestCase):
+    """
+    Unit tests for upload_file / download_file / scp_file.
+
+    Strategy: mock ParallelSSHClient.copy_file and copy_remote_file. Each call
+    returns a list of greenlet-like objects whose .get() either returns or
+    raises. We verify the {host: local_path} dict contract and the IOError
+    aggregation message format on partial/full failure.
+    """
+
+    @patch("cvs.lib.parallel_ssh_lib.ParallelSSHClient")
+    def setUp(self, mock_pssh_client):
+        self.mock_client = MagicMock()
+        mock_pssh_client.return_value = self.mock_client
+        self.host_list = ["host1", "host2"]
+        self.mock_log = MagicMock()
+        self.pssh = Pssh(self.mock_log, self.host_list, user="user", password="pass")
+
+    def _ok_greenlet(self):
+        g = MagicMock()
+        g.get.return_value = None
+        return g
+
+    def _fail_greenlet(self, exc):
+        g = MagicMock()
+        g.get.side_effect = exc
+        return g
+
+    # -------------------- upload_file --------------------
+
+    def test_upload_file_success_multi_host(self):
+        # Both hosts succeed -> no exception, copy_file called with right args
+        self.mock_client.copy_file.return_value = [self._ok_greenlet(), self._ok_greenlet()]
+
+        self.pssh.upload_file("/tmp/local.json", "/remote/dest.json")
+
+        self.mock_client.copy_file.assert_called_once_with(
+            "/tmp/local.json", "/remote/dest.json", recurse=False
+        )
+        self.mock_client.pool.join.assert_called_once()
+
+    def test_upload_file_recurse_passes_through(self):
+        # recurse=True must be propagated to copy_file
+        self.mock_client.copy_file.return_value = [self._ok_greenlet(), self._ok_greenlet()]
+
+        self.pssh.upload_file("/tmp/dir", "/remote/dir", recurse=True)
+
+        self.mock_client.copy_file.assert_called_once_with("/tmp/dir", "/remote/dir", recurse=True)
+
+    def test_upload_file_partial_failure_raises_ioerror(self):
+        # host1 ok, host2 raises -> IOError listing offending host
+        boom = IOError("permission denied")
+        self.mock_client.copy_file.return_value = [self._ok_greenlet(), self._fail_greenlet(boom)]
+
+        with self.assertRaises(IOError) as cm:
+            self.pssh.upload_file("/tmp/local.json", "/remote/dest.json")
+
+        msg = str(cm.exception)
+        self.assertIn("upload_file '/tmp/local.json' -> '/remote/dest.json'", msg)
+        self.assertIn("failed on 1/2 hosts", msg)
+        self.assertIn("host2", msg)
+        self.assertIn("permission denied", msg)
+
+    def test_upload_file_all_hosts_fail(self):
+        # Every host fails -> N/N in the message
+        self.mock_client.copy_file.return_value = [
+            self._fail_greenlet(IOError("disk full")),
+            self._fail_greenlet(IOError("disk full")),
+        ]
+
+        with self.assertRaises(IOError) as cm:
+            self.pssh.upload_file("/tmp/local.json", "/remote/dest.json")
+
+        self.assertIn("upload_file '/tmp/local.json' -> '/remote/dest.json'", str(cm.exception))
+        self.assertIn("failed on 2/2 hosts", str(cm.exception))
+
+    def test_upload_file_non_ioerror_exception_aggregated(self):
+        # Any Exception (not just IOError) from cmd.get() is caught and
+        # surfaced through the IOError aggregation. This locks in the
+        # broad `except Exception` we use deliberately.
+        self.mock_client.copy_file.return_value = [
+            self._ok_greenlet(),
+            self._fail_greenlet(RuntimeError("libssh2 channel closed")),
+        ]
+
+        with self.assertRaises(IOError) as cm:
+            self.pssh.upload_file("/tmp/local.json", "/remote/dest.json")
+
+        self.assertIn("libssh2 channel closed", str(cm.exception))
+
+    # -------------------- download_file --------------------
+
+    def test_download_file_success_returns_host_to_path_dict(self):
+        # On success returns {host: local_file<sep>host} for every host
+        self.mock_client.copy_remote_file.return_value = [
+            self._ok_greenlet(),
+            self._ok_greenlet(),
+        ]
+
+        result = self.pssh.download_file("/remote/file.json", "/tmp/local.json")
+
+        self.assertEqual(
+            result,
+            {"host1": "/tmp/local.json_host1", "host2": "/tmp/local.json_host2"},
+        )
+        self.mock_client.copy_remote_file.assert_called_once_with(
+            "/remote/file.json", "/tmp/local.json", recurse=False, suffix_separator="_"
+        )
+        self.mock_client.pool.join.assert_called_once()
+
+    def test_download_file_custom_suffix_separator(self):
+        # Honors a non-default suffix_separator both in the API call and the returned paths
+        self.mock_client.copy_remote_file.return_value = [
+            self._ok_greenlet(),
+            self._ok_greenlet(),
+        ]
+
+        result = self.pssh.download_file(
+            "/remote/file.json", "/tmp/local.json", suffix_separator="."
+        )
+
+        self.assertEqual(
+            result,
+            {"host1": "/tmp/local.json.host1", "host2": "/tmp/local.json.host2"},
+        )
+        self.mock_client.copy_remote_file.assert_called_once_with(
+            "/remote/file.json", "/tmp/local.json", recurse=False, suffix_separator="."
+        )
+
+    def test_download_file_partial_failure_raises_ioerror(self):
+        # Failed host -> IOError lists it; succeeded host's path is NOT returned
+        # (we raise before constructing a partial return value)
+        boom = IOError("file not found")
+        self.mock_client.copy_remote_file.return_value = [
+            self._ok_greenlet(),
+            self._fail_greenlet(boom),
+        ]
+
+        with self.assertRaises(IOError) as cm:
+            self.pssh.download_file("/remote/file.json", "/tmp/local.json")
+
+        msg = str(cm.exception)
+        self.assertIn("download_file '/remote/file.json' -> '/tmp/local.json'", msg)
+        self.assertIn("failed on 1/2 hosts", msg)
+        self.assertIn("host2", msg)
+        self.assertIn("file not found", msg)
+
+    def test_download_file_all_hosts_fail(self):
+        self.mock_client.copy_remote_file.return_value = [
+            self._fail_greenlet(IOError("nope")),
+            self._fail_greenlet(IOError("nope")),
+        ]
+
+        with self.assertRaises(IOError) as cm:
+            self.pssh.download_file("/remote/file.json", "/tmp/local.json")
+
+        self.assertIn("download_file '/remote/file.json' -> '/tmp/local.json'", str(cm.exception))
+        self.assertIn("failed on 2/2 hosts", str(cm.exception))
+
+    def test_download_file_recurse_passes_through(self):
+        self.mock_client.copy_remote_file.return_value = [
+            self._ok_greenlet(),
+            self._ok_greenlet(),
+        ]
+
+        self.pssh.download_file("/remote/dir", "/tmp/local", recurse=True)
+
+        self.mock_client.copy_remote_file.assert_called_once_with(
+            "/remote/dir", "/tmp/local", recurse=True, suffix_separator="_"
+        )
+
+    # -------------------- scp_file (alias) --------------------
+
+    def test_scp_file_delegates_to_upload_file(self):
+        # scp_file must call upload_file with the same args. We patch upload_file
+        # to confirm delegation rather than reimplementing the underlying mock.
+        with patch.object(Pssh, "upload_file") as mock_upload:
+            self.pssh.scp_file("/tmp/local.json", "/remote/dest.json", recurse=True)
+            mock_upload.assert_called_once_with(
+                "/tmp/local.json", "/remote/dest.json", recurse=True
+            )
+
+    def test_scp_file_propagates_ioerror_from_upload_file(self):
+        # When upload_file raises, scp_file lets it propagate (no swallowing)
+        with patch.object(Pssh, "upload_file", side_effect=IOError("boom")):
+            with self.assertRaises(IOError):
+                self.pssh.scp_file("/tmp/local.json", "/remote/dest.json")
+
+
 class TestPsshScpFile(unittest.TestCase):
+    """
+    Regression test from main (commit 79d7b20) covering scp_file's exception
+    semantics. With our PR, scp_file is a backward-compatible alias for
+    upload_file, so this test exercises upload_file's IOError contract via
+    scp_file: type is IOError (not bare Exception), message includes both
+    file paths, and the original exception is chained via __cause__.
+    """
+
     @patch("cvs.lib.parallel_ssh_lib.ParallelSSHClient")
     def setUp(self, mock_pssh_client):
         self.mock_client = MagicMock()
         mock_pssh_client.return_value = self.mock_client
         self.mock_log = MagicMock()
-        self.pssh = Pssh(self.mock_log, ["host1", "host2"], user="user", password="pass")
+        self.pssh = Pssh(self.mock_log, ["host1"], user="user", password="pass")
 
     def test_scp_file_preserves_original_io_error(self):
         # Regression (B3): scp_file's exception handler used to read:

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -337,6 +337,7 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
         config_dict['cvs_params'],
         node_list,
         vpc_node_list,
+        cluster_dict,
     )
 
     log.info("%s", result_dict)

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -337,7 +337,6 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
         config_dict['cvs_params'],
         node_list,
         vpc_node_list,
-        cluster_dict,
     )
 
     log.info("%s", result_dict)


### PR DESCRIPTION
The post-test combined raw and aggregated RCCL JSON files are written to the
MPI head node by `rccl_lib.rccl_perf` via a `cat > path << 'EOF' ... EOF`
heredoc over an `ssh2-python` (libssh2) exec channel.

Above roughly 30 KB, libssh2 rejects the exec request with
`InvalidRequestError`, which propagates out of `Pssh.exec` and causes pytest
to mark the entire collective FAILED even though the benchmark itself ran
clean and its results were already schema-validated. At cluster scales of
~30+ nodes (combined files routinely 30-550 KB, aggregated 90-250 KB), every
collective hits this. A 62-node overnight run on Apr 30 reproduced the issue
deterministically across all 6 collectives.

This change replaces the heredoc save with an OpenSSH `scp` subprocess from
the conductor (login) node to the head node, reusing the SSH credentials
already loaded in the `cluster_dict` fixture (`username`, `priv_key_file`):

- New private helper `_push_json_to_remote_head(...)` writes the JSON to a
  temp file on the conductor and `scp -i <key> -o BatchMode=yes -o
  StrictHostKeyChecking=no <tmp> <user>@<head>:<path>`.
- `rccl_perf(...)` gains a required `cluster_dict` positional argument and
  validates it carries `username` and `priv_key_file` (`ValueError` otherwise).
  No env-var fallback, no hardcoded defaults.
- Save failure logs `log.error(...)` and continues. Benchmark and schema
  validation have already completed by this point and raw data is in
  `test.log`; this matches the file's convention of reserving `fail_test()`
  for real benchmark/validation problems.
- `tests/rccl/rccl_perf.py::test_rccl_perf` passes the existing `cluster_dict`
  fixture to `rccl_lib.rccl_perf(...)`.

Validated:
- 4-node smoke: pytest exit 0, 2 `scp push succeeded` INFO lines, 0
  `InvalidRequestError`, JSONs land on head and parse cleanly.
- 62-node overnight: 12/12 saves succeeded across 6 collectives x 2 files,
  0 failures, payloads up to ~550 KB.

Made with [Cursor](https://cursor.com)