### PR TITLE
test(megatron_training_lib): add `_make_megatron_job` helper + smoke …

### DIFF
--- a/cvs/lib/unittests/test_megatron_training_lib.py
+++ b/cvs/lib/unittests/test_megatron_training_lib.py
@@ -1,0 +1,100 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+# Unit tests for cvs/lib/megatron_training_lib.py: helper builds a fully-mocked
+# MegatronLlamaTrainingJob so subsequent tests can target individual methods
+# without SSH or real time.sleep waits.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from cvs.lib import megatron_training_lib  # noqa: F401  (referenced by name in subsequent PRs)
+from cvs.lib.megatron_training_lib import MegatronLlamaTrainingJob
+
+
+def _make_megatron_job(
+    *,
+    training_overrides=None,
+    distributed_training=True,
+    model_name='llama3_1_8b',
+    gpu_type='mi300',
+    phdl_exec_returns=None,
+):
+    """Construct a MegatronLlamaTrainingJob with all heavyweight init paths mocked.
+
+    Args:
+        training_overrides: dict shallow-merged onto a minimal default training_dict.
+        distributed_training: passed straight to the constructor.
+        model_name: key in model_params_dict[topology].
+        gpu_type: key in model_params_dict[topology][model_name].
+        phdl_exec_returns: string returned by every phdl.exec(...) call (mapped
+            per-host via host_list). Default '' which forces detect_rocm_path's
+            legacy /opt/rocm fallback.
+
+    Notes:
+        - time.sleep is patched out so the constructor's two 2-second sleeps
+          and detect_rocm_path are zero-cost.
+        - phdl.exec is a MagicMock returning {'n0': phdl_exec_returns}, so
+          ibv_devinfo / cat training.log / etc. all see the same fixture.
+    """
+    phdl = MagicMock()
+    phdl.host_list = ['n0']
+    phdl.user = 'tester'
+    phdl.exec = MagicMock(return_value={'n0': phdl_exec_returns or ''})
+    phdl.exec_cmd_list = MagicMock(return_value=None)
+
+    training_dict = {'training_iterations': 2, 'nnodes': 1, 'nic_type': 'thor2'}
+    if training_overrides:
+        training_dict.update(training_overrides)
+
+    topology = 'multi_node' if distributed_training else 'single_node'
+    model_params_dict = {
+        topology: {
+            model_name: {
+                gpu_type: {
+                    'tokenizer_model': 'NousResearch/Meta-Llama-3-8B',
+                    'model_size': '8',
+                    'batch_size': '128',
+                    'micro_batch_size': '2',
+                    'precision': 'TE_FP8',
+                    'sequence_length': '8192',
+                    'tensor_parallelism': '1',
+                    'pipeline_parallelism': '1',
+                    'recompute': '0',
+                    'fsdp': '0',
+                    'result_dict': {'throughput_per_gpu': '0.0', 'tokens_per_gpu': '0.0'},
+                }
+            }
+        }
+    }
+
+    with patch('cvs.lib.megatron_training_lib.time.sleep'):
+        return MegatronLlamaTrainingJob(
+            phdl,
+            model_name,
+            training_dict,
+            model_params_dict,
+            hf_token='dummy',
+            gpu_type=gpu_type,
+            distributed_training=distributed_training,
+            tune_model_params=False,
+        )
+
+
+class TestMegatronJobConstructor(unittest.TestCase):
+    """Smoke test that _make_megatron_job actually constructs a job with default config."""
+
+    def test_init_constructs_with_default_config(self):
+        job = _make_megatron_job()
+        self.assertEqual(int(job.nnodes), 1)
+        self.assertEqual(job.nic_type, 'thor2')
+        # tokenizer_model contains 'Llama-3', so __init__ picks the train_llama3.sh branch.
+        self.assertTrue(job.training_script.endswith('train_llama3.sh'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the first unit-test scaffolding for [`cvs/lib/megatron_training_lib.py`](cvs/lib/megatron_training_lib.py): a `_make_megatron_job(**overrides)` helper that mocks `phdl`, `time.sleep`, and the `detect_rocm_path` `phdl.exec` calls, plus one smoke test that exercises the constructor end-to-end. No production-code changes.

## Why split this out

`MegatronLlamaTrainingJob.__init__` is heavyweight: ~4 `phdl.exec` calls (incl. `detect_rocm_path`'s probes), an in-`__init__` `rm -rf` / `mkdir` / `chmod` sequence, and two `time.sleep(2)` calls (4s of dead time per construction). Until now the only tests for this lib were the integration tests under [`cvs/tests/training/megatron/`](cvs/tests/training/megatron/), which require a multi-node cluster + Megatron Docker image + HF token to run.

This PR adds the first hardware-free, sub-second test surface for the lib so subsequent PRs can land focused unit tests for individual methods. It's intentionally small (one new file, ~100 lines) and reviewable on its own merits.

## What's in this PR

New file [`cvs/lib/unittests/test_megatron_training_lib.py`](cvs/lib/unittests/test_megatron_training_lib.py):

- `_make_megatron_job(**overrides)` — module-level helper that:
  - Builds a `MagicMock` `phdl` with `host_list`, `user`, `exec`, `exec_cmd_list`.
  - Supplies a minimal `training_dict` (overridable per-test via `training_overrides`).
  - Supplies a properly-nested `model_params_dict` keyed by topology / model_name / gpu_type.
  - Patches `cvs.lib.megatron_training_lib.time.sleep` to zero out the 4 seconds of `__init__` sleeps.
  - Returns a constructed `MegatronLlamaTrainingJob`.
- `TestMegatronJobConstructor.test_init_constructs_with_default_config` — smoke test asserting `job.nnodes`, `job.nic_type`, and `job.training_script.endswith('train_llama3.sh')` (default Llama-3 tokenizer branch).

Convention follows [`cvs/lib/unittests/test_parallel_ssh_lib.py`](cvs/lib/unittests/test_parallel_ssh_lib.py) and [`cvs/core/orchestrators/unittests/test_baremetal.py`](cvs/core/orchestrators/unittests/test_baremetal.py): `unittest.TestCase`, `@patch("cvs.lib.megatron_training_lib.<symbol>")` decorators per test, no shared `conftest.py`.

## Not changed

- [`cvs/lib/megatron_training_lib.py`](cvs/lib/megatron_training_lib.py) — purely additive test scaffolding; the lib itself is untouched.
- No JSON config or `.rst` changes.
- No CI workflow changes.

## Verification

```bash
# Same path CI takes via `make test`:
.test_venv/bin/python run_all_unittests.py
# or, just this file:
.test_venv/bin/python -m unittest discover -s cvs/lib/unittests \
    -p "test_megatron_training_lib.py" -v