### PR TITLE
feat(megatron_training_lib): make HCA-id verification regex configurable [AIMVT-160]

### DIFF
--- a/cvs/input/config_file/training/megatron/mi3xx_megatron_llama_distributed.json
+++ b/cvs/input/config_file/training/megatron/mi3xx_megatron_llama_distributed.json
@@ -22,6 +22,8 @@
         "gloo_socket_ifname": "<changeme>",
         "_example_nccl_ib_gid_index": "3",
         "nccl_ib_gid_index": "<changeme>",
+        "_example_hca_id_pattern": "bnxt_|rocep|mlx5_",
+        "hca_id_pattern": "bnxt_|rocep",
         "nccl_debug": "ERROR",
         "hf_token_file": "/home/{user-id}/.hf_token",
         "shm_size": "128G",

--- a/cvs/lib/megatron_training_lib.py
+++ b/cvs/lib/megatron_training_lib.py
@@ -162,6 +162,7 @@ class MegatronLlamaTrainingJob:
         tdict.setdefault('training_iterations', 10)
         tdict.setdefault('nnodes', 2)
         tdict.setdefault('nic_type', 'thor2')
+        tdict.setdefault('hca_id_pattern', 'bnxt_|rocep')
         tdict.setdefault('nccl_ib_hca_list', 'bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re6,bnxt_re7')
         tdict.setdefault('nccl_ib_hca', 'bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re6,bnxt_re7')
         tdict.setdefault('nccl_socket_ifname', 'ensf1np1')
@@ -180,6 +181,7 @@ class MegatronLlamaTrainingJob:
         self.iterations = int(tdict['training_iterations'])
         self.nnodes = tdict['nnodes']
         self.nic_type = tdict['nic_type']
+        self.hca_id_pattern = tdict['hca_id_pattern']
         self.nccl_ib_hca_list = tdict['nccl_ib_hca_list']
         self.nccl_ib_hca = tdict['nccl_ib_hca']
         self.nccl_socket_ifname = tdict['nccl_socket_ifname']
@@ -299,7 +301,7 @@ class MegatronLlamaTrainingJob:
                     sleep 2;ibv_devinfo;sleep 2;"'
                 )
                 for node in out_dict.keys():
-                    if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
+                    if not re.search(rf'hca_id:\s+({self.hca_id_pattern})', out_dict[node], re.I):
                         log.info("%s", out_dict[node])
                         fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
 

--- a/cvs/lib/megatron_training_lib.py
+++ b/cvs/lib/megatron_training_lib.py
@@ -307,6 +307,11 @@ class MegatronLlamaTrainingJob:
                 # For the default `bnxt_|rocep`, the emitted regex is
                 # byte-identical to the prior raw-interpolation behavior.
                 segments = [re.escape(s.strip()) for s in self.hca_id_pattern.split('|') if s.strip()]
+                if not segments:
+                    fail_test(
+                        f'hca_id_pattern parsed to zero non-empty segments, got: {self.hca_id_pattern!r}. '
+                        f'Expected a `|`-separated list of NIC-name prefixes, e.g. "bnxt_|rocep".'
+                    )
                 hca_id_regex = rf'hca_id:\s+({"|".join(segments)})'
                 for node in out_dict.keys():
                     if not re.search(hca_id_regex, out_dict[node], re.I):

--- a/cvs/lib/megatron_training_lib.py
+++ b/cvs/lib/megatron_training_lib.py
@@ -300,8 +300,16 @@ class MegatronLlamaTrainingJob:
                     /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so; \
                     sleep 2;ibv_devinfo;sleep 2;"'
                 )
+                # Treat `hca_id_pattern` as a `|`-separated list of literal
+                # NIC-name prefixes. Each segment is `re.escape`d so users
+                # can't accidentally inject regex syntax (e.g. `mlx5+` is a
+                # literal 5-char prefix, not `mlx` + `5+` quantifier).
+                # For the default `bnxt_|rocep`, the emitted regex is
+                # byte-identical to the prior raw-interpolation behavior.
+                segments = [re.escape(s.strip()) for s in self.hca_id_pattern.split('|') if s.strip()]
+                hca_id_regex = rf'hca_id:\s+({"|".join(segments)})'
                 for node in out_dict.keys():
-                    if not re.search(rf'hca_id:\s+({self.hca_id_pattern})', out_dict[node], re.I):
+                    if not re.search(hca_id_regex, out_dict[node], re.I):
                         log.info("%s", out_dict[node])
                         fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
 

--- a/cvs/lib/unittests/test_megatron_training_lib.py
+++ b/cvs/lib/unittests/test_megatron_training_lib.py
@@ -96,5 +96,30 @@ class TestMegatronJobConstructor(unittest.TestCase):
         self.assertTrue(job.training_script.endswith('train_llama3.sh'))
 
 
+class TestExecNicSetupHcaIdPattern(unittest.TestCase):
+    """AIMVT-160: hca_id_pattern config key flows from training_dict into the
+    in-container HCA-id verification regex inside exec_nic_setup_scripts."""
+
+    @patch('cvs.lib.megatron_training_lib.fail_test')
+    def test_default_pattern_matches_rocep(self, mock_fail):
+        # Default pattern 'bnxt_|rocep' must match 'rocep1s0f0' so the
+        # workaround verification doesn't fire fail_test on Mellanox/RoCE NICs.
+        job = _make_megatron_job(phdl_exec_returns='hca_id:\trocep1s0f0\n')
+        job.exec_nic_setup_scripts()
+        mock_fail.assert_not_called()
+
+    @patch('cvs.lib.megatron_training_lib.fail_test')
+    def test_override_pattern_matches_mlx5(self, mock_fail):
+        # Custom hca_id_pattern from config must propagate through to the regex
+        # in exec_nic_setup_scripts (catches missing setdefault, missing
+        # f-string interpolation, or a stale hardcoded literal).
+        job = _make_megatron_job(
+            training_overrides={'hca_id_pattern': 'mlx5_'},
+            phdl_exec_returns='hca_id:\tmlx5_0\n',
+        )
+        job.exec_nic_setup_scripts()
+        mock_fail.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/cvs/lib/unittests/test_megatron_training_lib.py
+++ b/cvs/lib/unittests/test_megatron_training_lib.py
@@ -152,6 +152,21 @@ class TestExecNicSetupHcaIdPattern(unittest.TestCase):
         job.exec_nic_setup_scripts()
         mock_fail.assert_called_once()
 
+    @patch('cvs.lib.megatron_training_lib.fail_test')
+    def test_empty_pattern_aborts_with_fail_test(self, mock_fail):
+        # Empty (or all-separator/whitespace) input parses to zero segments,
+        # which would yield the degenerate regex `hca_id:\s+()` that matches
+        # every devinfo line. The inline guard must call fail_test instead.
+        # Without the guard: the empty-capture regex matches whatever devinfo
+        # is supplied, the for-loop's `if not re.search(...)` is False, and
+        # mock_fail is never called -- assert_called_once raises.
+        job = _make_megatron_job(
+            training_overrides={'hca_id_pattern': ''},
+            phdl_exec_returns='hca_id:\twhatever\n',
+        )
+        job.exec_nic_setup_scripts()
+        mock_fail.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cvs/lib/unittests/test_megatron_training_lib.py
+++ b/cvs/lib/unittests/test_megatron_training_lib.py
@@ -98,7 +98,13 @@ class TestMegatronJobConstructor(unittest.TestCase):
 
 class TestExecNicSetupHcaIdPattern(unittest.TestCase):
     """AIMVT-160: hca_id_pattern config key flows from training_dict into the
-    in-container HCA-id verification regex inside exec_nic_setup_scripts."""
+    in-container HCA-id verification regex inside exec_nic_setup_scripts.
+
+    The lib splits the `|`-separated value into segments, `re.escape`s each,
+    and rejoins with `|`. For the default `bnxt_|rocep` the emitted regex
+    is byte-identical to the prior raw-interpolation behavior; the change
+    only affects pathological inputs (whitespace around segments, regex
+    special chars inside a segment)."""
 
     @patch('cvs.lib.megatron_training_lib.fail_test')
     def test_default_pattern_matches_rocep(self, mock_fail):
@@ -119,6 +125,32 @@ class TestExecNicSetupHcaIdPattern(unittest.TestCase):
         )
         job.exec_nic_setup_scripts()
         mock_fail.assert_not_called()
+
+    @patch('cvs.lib.megatron_training_lib.fail_test')
+    def test_whitespace_around_segments_is_stripped(self, mock_fail):
+        # User-typed `|` lists often have surrounding whitespace per segment;
+        # the lib must strip so 'bnxt_| rocep | mlx5_' still matches
+        # 'rocep1s0f0'. Catches a refactor that drops the .strip() call.
+        job = _make_megatron_job(
+            training_overrides={'hca_id_pattern': 'bnxt_| rocep | mlx5_'},
+            phdl_exec_returns='hca_id:\trocep1s0f0\n',
+        )
+        job.exec_nic_setup_scripts()
+        mock_fail.assert_not_called()
+
+    @patch('cvs.lib.megatron_training_lib.fail_test')
+    def test_special_regex_chars_in_segment_are_escaped(self, mock_fail):
+        # Proof-of-detection for the re.escape fix: a segment 'mlx5+' must be
+        # treated as the LITERAL 5-char string, not 'mlx' followed by 'one or
+        # more 5s'. Under the prior raw-interpolation, '5+' would have falsely
+        # matched 'mlx5550000' and fail_test would NOT fire -- silently
+        # passing the libbnxt-copy verification on the wrong NIC.
+        job = _make_megatron_job(
+            training_overrides={'hca_id_pattern': 'mlx5+'},
+            phdl_exec_returns='hca_id:\tmlx5550000\n',
+        )
+        job.exec_nic_setup_scripts()
+        mock_fail.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/docs/reference/configuration-files/megatron.rst
+++ b/docs/reference/configuration-files/megatron.rst
@@ -915,6 +915,8 @@ This is the multi-node ``mi3xx_megatron_llama_distributed.json`` configuration f
             "gloo_socket_ifname": "<changeme>",
             "_example_nccl_ib_gid_index": "3",
             "nccl_ib_gid_index": "<changeme>",
+            "_example_hca_id_pattern": "bnxt_|rocep|mlx5_",
+            "hca_id_pattern": "bnxt_|rocep",
             "nccl_debug": "ERROR",
             "hf_token_file": "/home/{user-id}/.hf_token",
             "shm_size": "128G",
@@ -1120,6 +1122,12 @@ Use the parameters in these tables to configure the training file.
    * - ``_example_nccl_ib_gid_index``
      - 3
      - Example of  GID index used for IB addressing (selects which GID entry on the HCA to use)
+   * - ``_example_hca_id_pattern``
+     - ``bnxt_|rocep|mlx5_``
+     - Example of HCA-id regex used to verify the libbnxt copy succeeded inside the container
+   * - ``hca_id_pattern``
+     - ``bnxt_|rocep``
+     - Regex matched against ``ibv_devinfo`` ``hca_id:`` lines after libbnxt copy; must match a per-rail HCA-id like ``bnxt_re0`` or ``rocep1s0f0``. Extend (e.g. add ``|mlx5_``) for other RDMA NIC vendors.
    * - ``nccl_debug``
      - ERROR
      - NCCL log level

--- a/docs/reference/configuration-files/megatron.rst
+++ b/docs/reference/configuration-files/megatron.rst
@@ -1124,10 +1124,10 @@ Use the parameters in these tables to configure the training file.
      - Example of  GID index used for IB addressing (selects which GID entry on the HCA to use)
    * - ``_example_hca_id_pattern``
      - ``bnxt_|rocep|mlx5_``
-     - Example of HCA-id regex used to verify the libbnxt copy succeeded inside the container
+     - Example of HCA-id pattern used to verify the libbnxt copy succeeded inside the container
    * - ``hca_id_pattern``
      - ``bnxt_|rocep``
-     - Regex matched against ``ibv_devinfo`` ``hca_id:`` lines after libbnxt copy; must match a per-rail HCA-id like ``bnxt_re0`` or ``rocep1s0f0``. Extend (e.g. add ``|mlx5_``) for other RDMA NIC vendors.
+     - ``|``-separated list of NIC-name prefixes (e.g. ``bnxt_``, ``rocep``, ``mlx5_``) checked against ``ibv_devinfo`` ``hca_id:`` lines after the libbnxt copy. Each segment is treated as a literal prefix (regex special chars are escaped by the lib), so use ``|`` only as the separator -- not as part of a regex pattern within a segment. Add ``|mlx5_`` for Mellanox/RoCE NICs.
    * - ``nccl_debug``
      - ERROR
      - NCCL log level


### PR DESCRIPTION
## Summary

Closes [AIMVT-160]. Makes the in-container HCA-id verification regex inside `exec_nic_setup_scripts` configurable via a new optional `hca_id_pattern` key in the training config (default `bnxt_|rocep`). Replaces the previously hardcoded `bnxt_` literal so users with Mellanox/RoCE or other RDMA NICs can extend the match without patching the lib.

## Why

`exec_nic_setup_scripts` runs a Broadcom-specific libbnxt copy inside each container, then verifies the copy by `re.search(r'hca_id:\s+bnxt_', ibv_devinfo_output)`. On clusters running different nics, that regex never matches. Today the only fix is editing the lib; this PR moves the pattern into config.

## What changed

- [`cvs/lib/megatron_training_lib.py`](cvs/lib/megatron_training_lib.py)
  - Add `tdict.setdefault('hca_id_pattern', 'bnxt_|rocep')` next to the existing `nic_type` setdefault.
  - Store on `self.hca_id_pattern` and thread it into the `re.search` call:

    ```python
    if not re.search(rf'hca_id:\s+({self.hca_id_pattern})', out_dict[node], re.I):
    ```

- [`cvs/input/config_file/training/megatron/mi3xx_megatron_llama_distributed.json`](cvs/input/config_file/training/megatron/mi3xx_megatron_llama_distributed.json) — add `_example_hca_id_pattern: "bnxt_|rocep|mlx5_"` and `hca_id_pattern: "bnxt_|rocep"` after the `nccl_ib_gid_index` block. **Distributed only** — the libbnxt workaround never runs in single-node mode, so the single-node JSONs intentionally don't get the key.

- [`docs/reference/configuration-files/megatron.rst`](docs/reference/configuration-files/megatron.rst) — distributed section only:
  - Update the embedded JSON dropdown to match the JSON above.
  - Add two rows to the distributed `config` parameters table.

- [`cvs/lib/unittests/test_megatron_training_lib.py`](cvs/lib/unittests/test_megatron_training_lib.py) — append `TestExecNicSetupHcaIdPattern` with two cases:
  - `test_default_pattern_matches_rocep` — default config + `hca_id:\trocep1s0f0`, asserts `fail_test` is *not* called. Catches a regression where the default value loses `rocep`.
  - `test_override_pattern_matches_mlx5` — `hca_id_pattern='mlx5_'` + `hca_id:\tmlx5_0`, asserts `fail_test` is *not* called. Catches missing `setdefault`, missing f-string interpolation, and a stale hardcoded literal.