### PR TITLE
refactor(conftest): lift orch fixture into cvs/tests/conftest.py + fix report_plugins   JSON-escape regression [AIMVT-172]

### DIFF
--- a/cvs/lib/report_plugins.py
+++ b/cvs/lib/report_plugins.py
@@ -331,7 +331,11 @@ class HtmlReportManager:
             updated_json = json.dumps(data)
             encoded_json = html.escape(updated_json, quote=True)
 
-            html_content = re.sub(json_pattern, f'data-jsonblob="{encoded_json}"', html_content)
+            # Function-form replacement avoids re.sub's backslash-escape
+            # processing on string replacements (which would convert JSON's
+            # 2-char `\n` / `\t` escapes into raw 0x0A / 0x09 bytes, breaking
+            # the data-jsonblob and emptying the results table in the browser).
+            html_content = re.sub(json_pattern, lambda _m: f'data-jsonblob="{encoded_json}"', html_content)
 
         except json.JSONDecodeError as e:
             log.error("Failed to parse JSON data: %s", e)

--- a/cvs/tests/conftest.py
+++ b/cvs/tests/conftest.py
@@ -1,0 +1,38 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import pytest
+
+from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFactory
+from cvs.lib import globals
+
+log = globals.log
+
+
+@pytest.fixture(scope="module")
+def orch(pytestconfig):
+    cluster_file = pytestconfig.getoption("cluster_file")
+    config_file = pytestconfig.getoption("config_file")
+    if not cluster_file or not config_file:
+        pytest.fail("orch fixture requires --cluster_file and --config_file")
+
+    cfg = OrchestratorConfig.from_configs(cluster_file, config_file)
+    orch = OrchestratorFactory.create_orchestrator(log, cfg)
+
+    if cfg.orchestrator == "container":
+        if not orch.setup_containers():
+            pytest.fail(
+                f"Failed to launch container : "
+                f"{orch.get_container_name(orch.container_config, orch.container_config['image'])}"
+            )
+        if not orch.setup_sshd():
+            pytest.fail("Failed to setup sshd in container")
+
+    yield orch
+
+    if cfg.orchestrator == "container":
+        orch.teardown_containers()

--- a/cvs/tests/health/rvs_cvs.py
+++ b/cvs/tests/health/rvs_cvs.py
@@ -12,7 +12,6 @@ import re
 import json
 from packaging import version
 
-from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFactory
 from cvs.lib.utils_lib import *
 
 from cvs.lib import globals
@@ -55,24 +54,6 @@ def config_dict(config_file, cluster_dict):
 
     log.info("%s", config_dict)
     return config_dict
-
-
-@pytest.fixture(scope="module")
-def orch(pytestconfig, request):
-    cluster_file = pytestconfig.getoption("cluster_file")
-    config_file = pytestconfig.getoption("config_file")
-    cfg = OrchestratorConfig.from_configs(cluster_file, config_file)
-    orch = OrchestratorFactory.create_orchestrator(log, cfg)
-
-    if cfg.orchestrator == "container":
-        container_name = orch.get_container_name(orch.container_config, orch.container_config['image'])
-        if not orch.setup_containers():
-            pytest.fail(f"Failed to launch container : {container_name}")
-        if not orch.setup_sshd():
-            pytest.fail(f"Failed to setup sshd in container : {container_name}")
-        request.addfinalizer(orch.teardown_containers)
-
-    return orch
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
  Jira: [AIMVT-172](https://amd-hub.atlassian.net/browse/AIMVT-172)
  ## Summary
  - Lift the canonical `orch` pytest fixture into a new [`cvs/tests/conftest.py`](cvs/tests/conftest.py). Pytest walks the conftest hierarchy upward, so suites under `cvs/tests/` pick it up automatically with zero per-suiteboilerplate.
  - Delete the module-local `orch` fixture and its now-unused `OrchestratorConfig` /`OrchestratorFactory` imports from [`cvs/tests/health/rvs_cvs.py`](cvs/tests/health/rvs_cvs.py); the conftest one takesover.
  - Replace a string-form `re.sub` replacement in [`cvs/lib/report_plugins.py`](cvs/lib/report_plugins.py) with a function-form lambda so JSON `\n` / `\t` escapes inside `data-jsonblob` are preserved verbatim. Without this, the rvs_cvs HTML report in container mode renders with an empty results table.
  ## Why
  The `orch` fixture is the single seam between a pytest suite and the orchestrator factory introduced by [#135](https://github.com/ROCm/cvs/pull/135). As `transferbench_cvs`, `agfhc_cvs`, and friends migrate off `phdl` / `Pssh` (AIMVT-168 through AIMVT-171), every one of them would otherwise copy-paste the same ~15-line fixture body + the same two imports + the same container setup/teardown wiring. Lifting it once keeps that surface single-sourced; subsequent suite migrations become a mechanical `phdl` → `orch` rename. The lifted fixture is identical to the original except it gains an explicit CLI-arg guard:
  ```16:38:cvs/tests/conftest.py
  @pytest.fixture(scope="module")
  def orch(pytestconfig):
      cluster_file = pytestconfig.getoption("cluster_file")
      config_file = pytestconfig.getoption("config_file")
      if not cluster_file or not config_file:
          pytest.fail("orch fixture requires --cluster_file and --config_file")
      cfg = OrchestratorConfig.from_configs(cluster_file, config_file)
      orch = OrchestratorFactory.create_orchestrator(log, cfg)
      if cfg.orchestrator == "container":
          if not orch.setup_containers():
              pytest.fail(
                  f"Failed to launch container : "
                  f"{orch.get_container_name(orch.container_config,
  orch.container_config['image'])}"
              )
          if not orch.setup_sshd():
              pytest.fail("Failed to setup sshd in container")
      yield orch
      if cfg.orchestrator == "container":
          orch.teardown_containers()
  ```
  The previous local fixture raised a NoneType deep inside `OrchestratorConfig.from_configs` when invoked without `--cluster_file` /`--config_file`; the explicit `pytest.fail(...)` turns that into an actionable message  at the fixture boundary.

The `report_plugins` change addresses a latent regression in [`_update_environment_config_links`](cvs/lib/report_plugins.py): the function mutates pytest-html's embedded `data-jsonblob` dict to inject clickable cluster/config-file links, then re-serializes via `re.sub(pattern, replacement_string, html_content)`. Per the [`re` docs](https://docs.python.org/3/library/re.html#re.sub), string-form replacements have backslash escapes processed, which collapses the JSON-encoded `\n` / `\t` 2-char escapes into raw `0x0A` / `0x09` bytes inside JSON string values, breaking `JSON.parse` in the browser. Function-form (lambda) replacements skip that processing.
  ## What is NOT changed
  - No new CLI options. `--cluster_file` / `--config_file` are still registered in `cvs/conftest.py:31-53`; the new `cvs/tests/conftest.py` inherits them via pytest's conftest walk.
  - No other suite under `cvs/tests/` is touched. `transferbench_cvs` / `agfhc_cvs` /others are queued under AIMVT-168 through AIMVT-171.
  - No L1 doc changes (`docs/how-to/run-with-containers.rst`, `docs/reference/configuration-files/cluster-file.rst`, `cvs/input/cluster_file/README.md`).
  - No `addfinalizer`, no eager `get_container_name`, no `detailed=True` / `hosts=` /exit-code-check additions on `orch.exec(...)`.
  - `cluster_file` / `config_file` fixtures in `rvs_cvs.py:24-31` left alone —`cluster_dict` / `config_dict` still consume them.
  ## Verification
  - `python -m pytest cvs/core/orchestrators/unittests/ cvs/core/runtimes/unittests/ -q` — green.
  - `rg -n '\bdef orch\b|OrchestratorConfig|OrchestratorFactory' cvs/tests/health/rvs_cvs.py` — 0 hits.
  - `cvs run rvs_cvs` level-4 on an 8x MI300X node, both `orchestrator: baremetal` and `orchestrator: container` —both `2 passed, 6 skipped`, HTML reports render cleanly. Run zips (auto-bundles) are attached to [AIMVT-172](https://amd-hub.atlassian.net/browse/AIMVT-172).
  ## Commits
  1. `053fe60` `test: lift orch fixture into cvs/tests/conftest.py`
  2. `2e7bcb4` `test(rvs_cvs): consume conftest-lifted orch fixture`
  3. `79cab56` `fix(report_plugins): use function-form re.sub replacement to preserve JSON escapes`

