### PR TITLE
[cherry-pick] Add configurable cvs_exec_timeout, rccl-tests -T, and -A algoproto output (#153)

### DIFF
--- a/cvs/input/config_file/rccl/rccl_config.json
+++ b/cvs/input/config_file/rccl/rccl_config.json
@@ -23,6 +23,9 @@
             "no_of_iterations": "20",
             "no_of_cycles": "1",
             "check_iteration_count": "1",
+            "_comment_rccl_test_flags": "Optional rccl-tests binary flags. rccl_timeout = rccl-tests internal timer passed as -T (seconds; omit to not set). output_algo_proto_channels = boolean toggle for rccl-tests' -A 1 algorithm/protocol/channels diagnostic output.",
+            "rccl_timeout": "1800",
+            "output_algo_proto_channels": false,
             "data_types": ["float"]
         },
 
@@ -34,6 +37,8 @@
             "verify_bus_bw": "False",
             "verify_bw_dip": "True",
             "verify_lat_dip": "True",
+            "_comment_cvs_exec_timeout": "Optional. CVS-side outer cap on the SSH-exec call wrapping mpirun (seconds, default 2400).",
+            "cvs_exec_timeout": "2400",
             "rccl_result_file": "/home/{user-id}/rccl_result_file.json"
         },
 

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -569,16 +569,25 @@ def rccl_regression(
     no_of_iterations = rccl_test_params.get('no_of_iterations', 20)
     no_of_cycles = rccl_test_params.get('no_of_cycles', 1)
     check_iteration_count = rccl_test_params.get('check_iteration_count', 1)
+    rccl_timeout = rccl_test_params.get('rccl_timeout', None)
+    output_algo_proto_channels = bool(rccl_test_params.get('output_algo_proto_channels', False))
 
     rccl_result_file = cvs_params.get('rccl_result_file', '/tmp/rccl_result_output.json')
+    cvs_exec_timeout = int(cvs_params.get('cvs_exec_timeout', 2400))
 
     # Detect which output file argument is supported by the RCCL test binary
     rccl_test_binary_path = f'{rccl_tests_dir}/{test_name}'
     output_flag = detect_rccl_output_flag(shdl, rccl_test_binary_path, head_node)
 
+    extra_flags = ''
+    if rccl_timeout is not None:
+        extra_flags += f' -T {rccl_timeout}'
+    if output_algo_proto_channels:
+        extra_flags += ' -A 1'
+
     test_cmd = f'{rccl_tests_dir}/{test_name} -b {start_msg_size} -e {end_msg_size} -f {step_function} \
         -t {threads_per_gpu} -w {warmup_iterations} -n {no_of_iterations} \
-        -N {no_of_cycles} -c {check_iteration_count} -Z json {output_flag} {rccl_result_file}'
+        -N {no_of_cycles} -c {check_iteration_count}{extra_flags} -Z json {output_flag} {rccl_result_file}'
 
     # Wrap with env file sourcing
     if env_file and str(env_file).lower() != 'none':
@@ -611,7 +620,7 @@ def rccl_regression(
     log.info('%%%%%%%%%%%%%%%%')
 
     try:
-        out_dict = shdl.exec(cmd, timeout=500)
+        out_dict = shdl.exec(cmd, timeout=cvs_exec_timeout)
         output = out_dict[head_node]
         scan_rccl_logs(output)
     except Exception as e:
@@ -744,8 +753,11 @@ def rccl_perf(
     no_of_cycles = rccl_test_params.get('no_of_cycles', 1)
     check_iteration_count = rccl_test_params.get('check_iteration_count', 1)
     data_types = rccl_test_params.get('data_types', ['float'])
+    rccl_timeout = rccl_test_params.get('rccl_timeout', None)
+    output_algo_proto_channels = bool(rccl_test_params.get('output_algo_proto_channels', False))
 
     rccl_result_file = cvs_params.get('rccl_result_file', '/tmp/rccl_result_output.json')
+    cvs_exec_timeout = int(cvs_params.get('cvs_exec_timeout', 2400))
 
     all_raw_results = []
     all_validated_results = []
@@ -755,6 +767,12 @@ def rccl_perf(
     rccl_test_binary_path = f'{rccl_tests_dir}/{test_name}'
     output_flag = detect_rccl_output_flag(shdl, rccl_test_binary_path, head_node)
 
+    extra_flags = ''
+    if rccl_timeout is not None:
+        extra_flags += f' -T {rccl_timeout}'
+    if output_algo_proto_channels:
+        extra_flags += ' -A 1'
+
     for dtype in data_types:
         # Create a unique result file for each data type
         dtype_result_file = f'{base_path.parent}/{base_path.stem}_{dtype}.json'
@@ -763,7 +781,7 @@ def rccl_perf(
         # Wrap test binary in shell to source env script if provided
         test_cmd = f'{rccl_tests_dir}/{test_name} -b {start_msg_size} -e {end_msg_size} -f {step_function} \
             -g {threads_per_gpu} -c {check_iteration_count} -w {warmup_iterations} \
-            -d {dtype} -n {no_of_iterations} -N {no_of_cycles} -Z json {output_flag} {dtype_result_file}'
+            -d {dtype} -n {no_of_iterations} -N {no_of_cycles}{extra_flags} -Z json {output_flag} {dtype_result_file}'
 
         if env_file and str(env_file).lower() != 'none':
             test_cmd = f'bash -c "source {env_file} && {test_cmd}"'
@@ -788,7 +806,7 @@ def rccl_perf(
         log.info("%s", cmd)
         log.info('%%%%%%%%%%%%%%%%')
         try:
-            out_dict = shdl.exec(cmd, timeout=500)
+            out_dict = shdl.exec(cmd, timeout=cvs_exec_timeout)
             output = out_dict[head_node]
             # print(output)
             scan_rccl_logs(output)


### PR DESCRIPTION
Cherry-pick of #153 into `release/cvs-0.2.0`.

Adds three optional `rccl_test_params` keys applied symmetrically to `rccl_regression` and `rccl_perf`:
- `cvs_exec_timeout` (default 2400s) replaces the hardcoded `shdl.exec` 500s timeout
- `rccl_timeout` appends `-T <value>` when set
- `output_algo_proto_channels` appends `-A 1` when truthy

Commit:
- `e470ab4` Add configurable cvs_exec_timeout, rccl-tests -T timeout, and -A algoproto output to rccl_perf and rccl_regression (#153)

Made with [Cursor](https://cursor.com)