### PR TITLE
cvs/rccl: surface oversubscription as WARN, per-test dmesg window, per-user hostfile

### DIFF
--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -643,10 +643,11 @@ def rccl_regression(
     for node in vpc_node_list:
         host_file_params = f'{host_file_params}{node} slots={proc_per_node}\n'
 
-    cmd = 'rm -f /tmp/rccl_hosts_file.txt'
+    hosts_file_path = f'/tmp/rccl_hosts_file_{os.environ.get("USER", "cvs")}.txt'
+    cmd = f'rm -f {hosts_file_path}'
     shdl.exec(cmd)
 
-    cmd = f'echo "{host_file_params}" > /tmp/rccl_hosts_file.txt'
+    cmd = f'echo "{host_file_params}" > {hosts_file_path}'
     shdl.exec(cmd)
 
     # Determine PML (Point-to-Point Messaging Layer) based on user config or auto-detection
@@ -700,7 +701,7 @@ def rccl_regression(
     cmd = f'''{mpi_dir}/bin/mpirun \
         --allow-run-as-root \
         -np {no_of_global_ranks} \
-        --hostfile /tmp/rccl_hosts_file.txt \
+        --hostfile {hosts_file_path} \
         --bind-to numa \
         {ucx_params} \
         --mca btl ^vader,openib \
@@ -826,10 +827,11 @@ def rccl_perf(
     for node in vpc_node_list:
         host_file_params = f'{host_file_params}' + f'{node} slots={proc_per_node}\n'
 
-    cmd = 'rm -f /tmp/rccl_hosts_file.txt'
+    hosts_file_path = f'/tmp/rccl_hosts_file_{os.environ.get("USER", "cvs")}.txt'
+    cmd = f'rm -f {hosts_file_path}'
     shdl.exec(cmd)
 
-    cmd = f'echo "{host_file_params}" > /tmp/rccl_hosts_file.txt'
+    cmd = f'echo "{host_file_params}" > {hosts_file_path}'
     shdl.exec(cmd)
 
     # Determine PML (Point-to-Point Messaging Layer) based on user config or auto-detection
@@ -887,7 +889,7 @@ def rccl_perf(
         # Build mpirun command
         cmd = f'''{mpi_dir}/bin/mpirun --np {no_of_global_ranks} \
         --allow-run-as-root \
-        --hostfile /tmp/rccl_hosts_file.txt \
+        --hostfile {hosts_file_path} \
         --bind-to numa \
         {ucx_params} \
         --mca btl ^vader,openib \

--- a/cvs/lib/verify_lib.py
+++ b/cvs/lib/verify_lib.py
@@ -19,7 +19,11 @@ err_patterns_dict = {
     'crash': 'crashed|Traceback|cut here|Bug:|Call Trace|RIP:|end trace|amdgpu: Fatal error|segfault|show_stack|dump_stack|fault ',
     'test_fail': 'Test failure',
     'fault': 'no-retry page fault|Illegal register access|PROTECTION_FAULT_STATUS',
-    'driver': 'Queue preemption failed for queue|Failed to evict process queues|Runlist is getting oversubscribed|No more SDMA queue to allocate|Expect reduced ROCm performance|amdgpu: process pid',
+    # Note: 'Runlist is getting oversubscribed' and 'Expect reduced ROCm performance'
+    # are amdgpu kernel info-level messages (not errors). They fire routinely on
+    # large multi-rank RCCL runs whenever HSA queue count exceeds the runlist
+    # size, even when the run itself is healthy. Excluded from failure matching.
+    'driver': 'Queue preemption failed for queue|Failed to evict process queues|No more SDMA queue to allocate|amdgpu: process pid',
     'hardware': 'hardware error|hardware fail|ras error|uncorrectable|correctable err',
     'network': 'NIC Link is Down|link is down|ib_uverb|CQE|queue catastrophic|CQ error',
 }

--- a/cvs/lib/verify_lib.py
+++ b/cvs/lib/verify_lib.py
@@ -19,13 +19,28 @@ err_patterns_dict = {
     'crash': 'crashed|Traceback|cut here|Bug:|Call Trace|RIP:|end trace|amdgpu: Fatal error|segfault|show_stack|dump_stack|fault ',
     'test_fail': 'Test failure',
     'fault': 'no-retry page fault|Illegal register access|PROTECTION_FAULT_STATUS',
-    # Note: 'Runlist is getting oversubscribed' and 'Expect reduced ROCm performance'
-    # are amdgpu kernel info-level messages (not errors). They fire routinely on
-    # large multi-rank RCCL runs whenever HSA queue count exceeds the runlist
-    # size, even when the run itself is healthy. Excluded from failure matching.
+    # Note: amdgpu oversubscription messages ('Runlist is getting oversubscribed',
+    # 'Expect reduced ROCm performance') are perf-degrading but not test failures —
+    # they're matched as warnings via warn_patterns_dict below. See AMD docs:
+    # https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/conceptual/oversubscription.html
     'driver': 'Queue preemption failed for queue|Failed to evict process queues|No more SDMA queue to allocate|amdgpu: process pid',
     'hardware': 'hardware error|hardware fail|ras error|uncorrectable|correctable err',
     'network': 'NIC Link is Down|link is down|ib_uverb|CQE|queue catastrophic|CQ error',
+}
+
+
+# warn_patterns_dict captures kernel events that indicate the GPU entered a
+# perf-degrading state but the workload itself still completes correctly. Matches
+# emit a WARN to the run log (no fail_test) so reviewers know the perf numbers
+# from this run were measured under a degraded HW state and should not be trusted
+# blindly for regression comparisons.
+warn_patterns_dict = {
+    # GPU runlist / VM context oversubscription. Per AMD docs, when this fires the
+    # HW scheduler is round-robining queues and inactive queues can block the GPU
+    # for millisecond-scale windows. Triggers: >24 user-mode compute queues per
+    # GPU, >11 VM context slots, or >1 process using cooperative workgroups.
+    # https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/conceptual/oversubscription.html
+    'oversubscribed': 'Runlist is getting oversubscribed|Expect reduced ROCm performance',
 }
 
 
@@ -199,7 +214,8 @@ def verify_gpu_pcie_errors(phdl):
 def verify_dmesg_for_errors(phdl, start_time_dict, end_time_dict, till_end_flag=True):
     """
     Scan kernel logs (dmesg) between given start and end timestamps across nodes
-    and fail if any known error patterns are detected.
+    and fail if any known error patterns are detected. Lines matching warn-only
+    patterns are logged via log.warning but do not fail the test.
 
     Parameters:
       phdl: pssh handle that can execute remote shell commands via .exec(cmd) -> dict.
@@ -210,17 +226,19 @@ def verify_dmesg_for_errors(phdl, start_time_dict, end_time_dict, till_end_flag=
       - Extracts a human-readable timestamp prefix (e.g., 'Mon Jan  2 03:04:05') from provided times.
       - Uses dmesg -T (human-readable timestamps) piped to awk to slice the log from start to end.
       - Filters out lines containing 'ALLOWED' or 'DENIED' (non-fatal/noisy) via egrep -v.
-      - Scans each line against a set of known error regex patterns (err_patterns_dict).
-      - Immediately fails the test via fail_test if any error pattern is seen.
+      - Scans each line against err_patterns_dict (fail_test on match) and warn_patterns_dict
+        (log.warning only on match; test still passes but run carries a visible WARN).
 
     Assumptions:
-      - err_patterns_dict is defined in scope: {name: regex_pattern, ...}.
+      - err_patterns_dict and warn_patterns_dict are defined in scope: {name: regex_pattern, ...}.
       - phdl.exec(cmd) returns a dict: { node: stdout_str }.
       - Input timestamps contain a prefix matching the regex used here.
       - sudo is available and does not prompt for a password when running dmesg.
 
     Notes:
       - This function fails fast on the first detected error to shorten feedback cycles.
+      - Warn-bucket matches are non-fatal but should be reviewed before trusting any
+        perf measurements from the run (e.g. RCCL bandwidth, training step time).
       - If start/end times are not aligned with dmesg -T formatting, the awk range may be empty.
       - Consider handling cases where regex extraction fails (no match) to avoid attribute errors.
     """
@@ -258,13 +276,23 @@ def verify_dmesg_for_errors(phdl, start_time_dict, end_time_dict, till_end_flag=
     for node in output_dict.keys():
         err_dict[node] = []
 
-    # Iterate through each node's sliced dmesg and scan for known error patterns
+    # Iterate through each node's sliced dmesg and scan for known error/warn patterns.
+    # err patterns -> fail_test (existing behavior).
+    # warn patterns -> log.warning only; the test still passes but the run carries a
+    # visible WARN so callers / reviewers know the GPU was in a degraded state and
+    # any perf numbers from this run should not be trusted blindly.
     for node in output_dict.keys():
         for line in output_dict[node].split("\n"):
             for err_key in err_patterns_dict.keys():
                 if re.search(f'{err_patterns_dict[err_key]}', line, re.I):
                     fail_test(f'ERROR - Failue pattern ** {line} ** seen in Dmesg')
                     err_dict[node].append(line)
+            for warn_key in warn_patterns_dict.keys():
+                if re.search(f'{warn_patterns_dict[warn_key]}', line, re.I):
+                    log.warning(
+                        f'WARN - GPU in degraded state ({warn_key}) on {node}: {line.strip()} '
+                        f'-- perf numbers from this run may not be trustworthy'
+                    )
 
     return err_dict
 

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -350,7 +350,11 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
 
     end_time = phdl.exec('date +"%a %b %e %H:%M"')
     if can_use_sudo:
-        verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=True)
+        # Bound dmesg scan to this test's own start..end window (per-test).
+        # till_end_flag=True scans from start_time to the end of the dmesg
+        # buffer, which causes earlier-test kernel events (e.g. a scatter_perf
+        # segfault) to repeatedly fail every subsequent parametrized test.
+        verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=False)
 
     # Get new cluster snapshot and compare ..
     if can_use_sudo and re.search(

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -309,7 +309,10 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
         phdl.exec(f'sudo echo "Starting Test {rccl_collective}" | sudo tee /dev/kmsg')
 
     # start_time = phdl.exec('date')
-    start_time = phdl.exec('date +"%a %b %e %H:%M"')
+    # Seconds precision matters: verify_dmesg_for_errors' node-scraper path
+    # treats analysis_range_end as an exclusive cutoff, so a minute-truncated
+    # end time silently drops the final minute of this test's dmesg window.
+    start_time = phdl.exec('date +"%a %b %e %H:%M:%S"')
 
     # Build list of nodes and their VPC IPs (used by the RCCL test)
     # make sure the VPC IPs are reachable from all nodes for passwordless ssh
@@ -348,7 +351,7 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
     if can_use_sudo:
         phdl.exec(f'sudo echo "End of Test {rccl_collective}" | sudo tee /dev/kmsg')
 
-    end_time = phdl.exec('date +"%a %b %e %H:%M"')
+    end_time = phdl.exec('date +"%a %b %e %H:%M:%S"')
     if can_use_sudo:
         # Bound dmesg scan to this test's own start..end window (per-test).
         # till_end_flag=True scans from start_time to the end of the dmesg

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -424,7 +424,11 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
 
     end_time = phdl.exec('date +"%a %b %e %H:%M"')
     if can_use_sudo:
-        verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=True)
+        # Bound dmesg scan to this test's own start..end window (per-test).
+        # till_end_flag=True scans from start_time to the end of the dmesg
+        # buffer, which causes earlier-test kernel events (e.g. a scatter_perf
+        # segfault) to repeatedly fail every subsequent parametrized test.
+        verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=False)
 
     # Get new cluster snapshot and compare ..
     if can_use_sudo and re.search(

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -380,7 +380,10 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
         phdl.exec(f'sudo echo "Starting Test {rccl_collective} {params_str}" | sudo tee /dev/kmsg')
 
     # start_time = phdl.exec('date')
-    start_time = phdl.exec('date +"%a %b %e %H:%M"')
+    # Seconds precision matters: verify_dmesg_for_errors' node-scraper path
+    # treats analysis_range_end as an exclusive cutoff, so a minute-truncated
+    # end time silently drops the final minute of this test's dmesg window.
+    start_time = phdl.exec('date +"%a %b %e %H:%M:%S"')
     node_list = list(cluster_dict['node_dict'].keys())
 
     # Build list of nodes and their VPC IPs (used by the RCCL test)
@@ -422,7 +425,7 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     if can_use_sudo:
         phdl.exec(f'sudo echo "End of Test {rccl_collective} {params_str}" | sudo tee /dev/kmsg')
 
-    end_time = phdl.exec('date +"%a %b %e %H:%M"')
+    end_time = phdl.exec('date +"%a %b %e %H:%M:%S"')
     if can_use_sudo:
         # Bound dmesg scan to this test's own start..end window (per-test).
         # till_end_flag=True scans from start_time to the end of the dmesg


### PR DESCRIPTION
## Summary

Three small fixes from debugging a 28-node `rccl_perf` run on a shared cluster:

- **`cvs/lib/verify_lib.py`** — surface amdgpu runlist oversubscription as a non-fatal **WARN**. Per [AMD docs](https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/conceptual/oversubscription.html) (`Runlist is getting oversubscribed`, `Expect reduced ROCm performance`), this is a real perf-degrading state — the HW scheduler round-robins queues and inactive queues can block the GPU for ms-scale windows. The collective itself completes correctly, so we don't fail the test, but we do log a `WARN` line so reviewers know the perf numbers from this run were measured under a degraded HW state and shouldn't be trusted blindly. Implemented via a new module-level `warn_patterns_dict` scanned alongside `err_patterns_dict` inside `verify_dmesg_for_errors`. Backward-compatible — function signature and return shape unchanged, all 7+ existing callers untouched.

- **`cvs/tests/rccl/rccl_perf.py`** — flip `verify_dmesg_for_errors(..., till_end_flag=False)` so the dmesg scan is bounded by each parametrized test's own `start_time`/`end_time` window. With `till_end_flag=True` the scan ran from `start_time` to the end of the dmesg buffer, so a kernel event from one test (e.g. a `scatter_perf` segfault) was re-flagged as a failure for every subsequent parametrized test in the run.

- **`cvs/lib/rccl_lib.py`** — write the mpirun hostfile to `/tmp/rccl_hosts_file_<USER>.txt` instead of the shared `/tmp/rccl_hosts_file.txt`. A leftover hostfile owned by another user blocks the run with `Operation not permitted` / `Permission denied` on shared cluster nodes.

## Why the WARN approach (not drop-from-failures)

Earlier rev of this PR dropped the oversubscription patterns from the failure regex outright. That made the run "green" but threw away the signal — a perf run in a degraded HW state would now be marked PASS and its bandwidth deltas silently trusted. Demoting to a WARN bucket separates the two questions:
- _Did the collective complete correctly?_ → still a PASS (correct behavior).
- _Is this a valid perf measurement?_ → flagged via WARN in `std.log`.

Real driver-side errors (`Queue preemption failed`, `Failed to evict process queues`, `No more SDMA queue to allocate`, `amdgpu: process pid`) still match the FAIL regex and behave as before.

## Test plan

- [x] 28-node validation on RCCL 2.27.7 / ROCm 7.2 and RCCL 2.28.3 / ROCm 7.13: previously 7-9 false-positive failures per run, now 14/14 collectives PASS, oversubscription events emit `WARN` lines in `std.log`.
- [x] Confirmed `Test failure` and segfault still fail the correct (and only the correct) test after the per-test window change.
- [x] Confirmed two concurrent users on the same nodes no longer collide on the hostfile.

Refs: AIMVT-175