### PR TITLE
fix(install_rvs): single-command strings for container-mode source build [AIMVT-168]

### DIFF
--- a/cvs/tests/health/install/install_rvs.py
+++ b/cvs/tests/health/install/install_rvs.py
@@ -298,28 +298,29 @@ def test_install_rvs(orch, config_dict):
                     orch.exec(f'mkdir -p {git_install_path}')
 
             # Remove any existing RVS directory and clone fresh
-            out_dict = orch.exec(f'rm -rf {git_install_path}/ROCmValidationSuite')
-            out_dict = orch.exec(f'cd {git_install_path};git clone {git_url}', timeout=300)
+            src_dir = f'{git_install_path}/ROCmValidationSuite'
+            build_dir = f'{src_dir}/build'
+            out_dict = orch.exec(f'rm -rf {src_dir}')
+            out_dict = orch.exec(f'git clone {git_url} {src_dir}', timeout=300)
 
-            # Build and install RVS (using rocm_path detected earlier)
+            # Build and install RVS (using rocm_path detected earlier).
+            # Each orch.exec is a single command (no shell operators) so the
+            # docker exec / SSH transport doesn't have to interpret a pipeline.
+            # RVS_BUILD_TESTS=OFF skips the bundled googletest, whose old
+            # cmake_minimum_required(<3.5) breaks on newer cmakes.
             try:
                 out_dict = orch.exec(
-                    f'cd {git_install_path}/ROCmValidationSuite; cmake -B ./build -DROCM_PATH={rocm_path} -DCMAKE_INSTALL_PREFIX={rocm_path} -DCPACK_PACKAGING_INSTALL_PREFIX={rocm_path} -DHIP_PLATFORM=amd',
+                    f'cmake -S {src_dir} -B {build_dir} -DROCM_PATH={rocm_path} -DCMAKE_INSTALL_PREFIX={rocm_path} -DCPACK_PACKAGING_INSTALL_PREFIX={rocm_path} -DHIP_PLATFORM=amd -DRVS_BUILD_TESTS=OFF',
                     timeout=1200,
                 )
-                out_dict = orch.exec(f'cd {git_install_path}/ROCmValidationSuite/build; make -j$(nproc)', timeout=1200)
-
+                out_dict = orch.exec(f'cmake --build {build_dir} --parallel', timeout=1200)
                 out_dict = orch.exec(
-                    f'cd {git_install_path}/ROCmValidationSuite/build; make -j$(nproc) package', timeout=1200
+                    f'cmake --build {build_dir} --target package --parallel', timeout=1200
                 )
-                out_dict = orch.exec(
-                    f'cd {git_install_path}/ROCmValidationSuite/build; sudo make install; echo "RVS_INSTALL_STATUS:$?"',
-                    timeout=1200,
-                )
-
-                for node in out_dict.keys():
-                    if not re.search(r'RVS_INSTALL_STATUS:0', out_dict[node]):
-                        fail_test(f'RVS build/installation failed on node {node}')
+                out_dict = orch.exec(f'sudo cmake --install {build_dir}', timeout=1200)
+                # Install success is verified by the `which rvs` / config-file
+                # checks below; cmake --install exits non-zero on failure and
+                # the verification block will fail the test.
 
             except Exception as e:
                 fail_test(f'RVS installation failed with exception: {e}')

--- a/cvs/tests/health/install/install_rvs.py
+++ b/cvs/tests/health/install/install_rvs.py
@@ -314,9 +314,7 @@ def test_install_rvs(orch, config_dict):
                     timeout=1200,
                 )
                 out_dict = orch.exec(f'cmake --build {build_dir} --parallel', timeout=1200)
-                out_dict = orch.exec(
-                    f'cmake --build {build_dir} --target package --parallel', timeout=1200
-                )
+                out_dict = orch.exec(f'cmake --build {build_dir} --target package --parallel', timeout=1200)
                 out_dict = orch.exec(f'sudo cmake --install {build_dir}', timeout=1200)
                 # Install success is verified by the `which rvs` / config-file
                 # checks below; cmake --install exits non-zero on failure and

--- a/cvs/tests/health/install/install_rvs.py
+++ b/cvs/tests/health/install/install_rvs.py
@@ -331,9 +331,12 @@ def test_install_rvs(orch, config_dict):
         if re.search('not found|No such file', out_dict[node], re.I) and not re.search('rvs', out_dict[node]):
             fail_test(f'RVS installation verification failed on node {node}')
 
-    # Verify config files are accessible
+    # Verify config files are accessible. Suppress per-clause stderr so a
+    # missing MI300X subdir (which is optional - some packagings only ship
+    # the default conf dir) doesn't leak "No such file" into the captured
+    # output and trip the regex below when the default-path fallback succeeded.
     out_dict = orch.exec(
-        f'ls -l {config_dict["config_path_mi300x"]}/gst_single.conf || ls -l {config_dict["config_path_default"]}/gst_single.conf',
+        f'ls -l {config_dict["config_path_mi300x"]}/gst_single.conf 2>/dev/null || ls -l {config_dict["config_path_default"]}/gst_single.conf 2>/dev/null',
         timeout=60,
     )
     for node in out_dict.keys():


### PR DESCRIPTION
## Summary

In container orchestrator mode, `install_rvs.test_install_rvs`'s source-build path passes multi-command shell strings like `cd X; cmd Y` to `orch.exec`. The docker runtime (`docker.py:196`) expands that to `sudo docker exec <name> cd X; cmd Y`, the host shell parses `;` first, so `docker exec ... cd X` runs and dies with `OCI runtime exec failed: "cd": executable file not found in $PATH` (`cd` is a shell builtin, not an executable), and `cmd Y` then runs on the host instead of inside the container.

Rewrites each affected `orch.exec` call in the source-build branch (`install_rvs.py:302-318`) as a single command:

| Old | New |
|---|---|
| `cd X; git clone Y` | `git clone <url> <dest>` |
| `cd X; cmake -B ./build` | `cmake -S <src> -B <build>` |
| `cd X; make -j$(nproc)` | `cmake --build <build> --parallel` |
| `cd X; make -j$(nproc) package` | `cmake --build <build> --target package --parallel` |
| `cd X; sudo make install; echo "RVS_INSTALL_STATUS:$?"` | `sudo cmake --install <build>` |

Also adds `-DRVS_BUILD_TESTS=OFF` to the cmake invocation: the bundled googletest in `release/rocm-rel-7.2` declares `cmake_minimum_required(VERSION 2.6.4)`, which newer cmake versions reject. RVS's own unit tests are not needed for `install_rvs`'s verification.

The `RVS_INSTALL_STATUS:0` regex check on the old install line is dropped: `cmake --install` exits non-zero on failure, and the existing `which rvs` + `gst_single.conf` existence checks below (lines 326-340) already gate install success.