### PR TITLE
multiprocess_pssh: expose host_list in non-sharded init path (AIMVT-183)

### DIFF
--- a/cvs/lib/parallel/multiprocess_pssh.py
+++ b/cvs/lib/parallel/multiprocess_pssh.py
@@ -70,6 +70,10 @@ class MultiProcessPssh(ShardableSshInterface):
             self._use_process_sharding = False
             # Ensure attributes needed by _shard_init_kwargs are available
             self.env_vars = env_vars
+            # Expose host_list publicly so callers (e.g. megatron/jax training libs,
+            # workload tests doing phdl.host_list[0]) work regardless of which init
+            # path was taken. Mirrors _init_sharded.
+            self.host_list = list(host_list) if host_list is not None else []
 
     def _init_sharded(
         self,

--- a/cvs/lib/parallel/unittests/test_multiprocess_pssh.py
+++ b/cvs/lib/parallel/unittests/test_multiprocess_pssh.py
@@ -32,6 +32,11 @@ class TestMultiProcessPsshInitialization(unittest.TestCase):
         self.assertFalse(pssh._use_process_sharding)
         # But pssh instance should always exist
         self.assertTrue(hasattr(pssh, 'pssh'))
+        # Regression guard for AIMVT-183: the non-sharded branch must expose
+        # host_list on the wrapper, matching _init_sharded. Callers like
+        # megatron_training_lib / jax_training_lib / mori_lib / inference.base
+        # read phdl.host_list directly.
+        self.assertEqual(pssh.host_list, small_host_list)
 
     @patch('cvs.lib.parallel.multiprocess_pssh.MultiProcessPssh._init_sharded')
     @patch('cvs.lib.parallel.multiprocess_pssh.PsshSharder')


### PR DESCRIPTION
Fixes [AIMVT-183](https://amd-hub.atlassian.net/browse/AIMVT-183).

## Change

In `cvs/lib/parallel/multiprocess_pssh.py`, mirror `host_list` on the wrapper in the non-sharded init branch so it matches what `_init_sharded` already does:

```python
self._use_process_sharding = False
self.env_vars = env_vars
self.host_list = list(host_list) if host_list is not None else []  # NEW
```

Also add one assertion to `test_init_no_sharding_small_host_list` in `cvs/lib/parallel/unittests/test_multiprocess_pssh.py` as a regression guard.

## Why

Callers across `megatron_training_lib`, `jax_training_lib`, `mori_lib`, `inference/base`, and every workload test's `gpu_type` fixture read `phdl.host_list` directly. The sharded init path sets it; the non-sharded path (taken when `len(host_list) <= hosts_per_shard`, default 32) didn't. Every <= 32-node workload run failed with `AttributeError: 'MultiProcessPssh' object has no attribute 'host_list'` at fixture setup before any container started. Large-cluster runs (> 32 nodes) hit the sharded path and were unaffected, which is why this went unnoticed in 28n / 32n smoke runs.

Full reproduction, traceback, blast-radius enumeration, and proof-of-detection output are on [AIMVT-183](https://amd-hub.atlassian.net/browse/AIMVT-183).

## Not changed

- `reachable_hosts` / `unreachable_hosts` on the wrapper -- no external readers in the non-sharded path (which delegates everything else to `self.pssh`). Worth a separate cleanup PR if we ever want to fully unify the wrapper surface.
