### PR TITLE
exec-plumbing fixes: DockerRuntime shell-wrap + BaremetalOrchestrator detailed kwarg

### DIFF
--- a/cvs/core/orchestrators/baremetal.py
+++ b/cvs/core/orchestrators/baremetal.py
@@ -71,7 +71,7 @@ class BaremetalOrchestrator(Orchestrator):
             stop_on_errors=self.stop_on_errors,
         )
 
-    def exec(self, cmd, hosts=None, timeout=None):
+    def exec(self, cmd, hosts=None, timeout=None, detailed=False):
         """
         Execute command across hosts via SSH (baremetal execution).
 
@@ -79,6 +79,8 @@ class BaremetalOrchestrator(Orchestrator):
             cmd: Command to execute
             hosts: Target hosts (if None, uses all hosts)
             timeout: Command timeout
+            detailed: If True, return detailed execution info including
+                exit_code (mirrors ContainerOrchestrator.exec).
 
         Returns:
             Dictionary mapping hosts to execution results
@@ -88,7 +90,7 @@ class BaremetalOrchestrator(Orchestrator):
 
         # Use appropriate handle based on target hosts
         if set(hosts) == set(self.hosts):
-            return self.all.exec(cmd, timeout=timeout)
+            return self.all.exec(cmd, timeout=timeout, detailed=detailed)
         else:
             # For arbitrary subset (including head node), create temporary handle
             pssh = Pssh(
@@ -100,20 +102,21 @@ class BaremetalOrchestrator(Orchestrator):
                 host_key_check=False,
                 stop_on_errors=self.stop_on_errors,
             )
-            return pssh.exec(cmd, timeout=timeout)
+            return pssh.exec(cmd, timeout=timeout, detailed=detailed)
 
-    def exec_on_head(self, cmd, timeout=None):
+    def exec_on_head(self, cmd, timeout=None, detailed=False):
         """
         Execute command on head node only via SSH.
 
         Args:
             cmd: Command to execute
             timeout: Command timeout
+            detailed: See exec().
 
         Returns:
             Dictionary mapping head node to execution result
         """
-        return self.head.exec(cmd, timeout=timeout)
+        return self.head.exec(cmd, timeout=timeout, detailed=detailed)
 
     def setup_env(self, hosts, env_script=None):
         """Set up environment on hosts."""

--- a/cvs/core/orchestrators/unittests/test_baremetal.py
+++ b/cvs/core/orchestrators/unittests/test_baremetal.py
@@ -54,7 +54,7 @@ class TestBaremetalOrchestrator(unittest.TestCase):
         orch.all = MagicMock()
         orch.all.exec.return_value = {"10.0.0.1": "ok", "10.0.0.2": "ok"}
         result = orch.exec("ls", timeout=5)
-        orch.all.exec.assert_called_once_with("ls", timeout=5)
+        orch.all.exec.assert_called_once_with("ls", timeout=5, detailed=False)
         self.assertEqual(result, {"10.0.0.1": "ok", "10.0.0.2": "ok"})
 
     @patch("cvs.core.orchestrators.baremetal.Pssh")
@@ -63,7 +63,7 @@ class TestBaremetalOrchestrator(unittest.TestCase):
         orch.head = MagicMock()
         orch.head.exec.return_value = {"10.0.0.1": "ok"}
         result = orch.exec_on_head("hostname", timeout=10)
-        orch.head.exec.assert_called_once_with("hostname", timeout=10)
+        orch.head.exec.assert_called_once_with("hostname", timeout=10, detailed=False)
         self.assertEqual(result, {"10.0.0.1": "ok"})
 
     @patch("cvs.core.orchestrators.baremetal.Pssh")

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -5,6 +5,8 @@ The year included in the foregoing notice is the year of creation of the work.
 All code contained here is Property of Advanced Micro Devices, Inc.
 '''
 
+import shlex
+
 
 class DockerRuntime:
     """Docker container runtime implementation."""
@@ -191,21 +193,35 @@ class DockerRuntime:
         return success
 
     def exec(self, container_name, cmd, hosts=None, timeout=None, detailed=False):
-        """Execute command in running Docker containers."""
-        # Use docker exec to run command in existing container
-        exec_cmd = f"sudo docker exec {container_name} {cmd}"
+        """Execute command in running Docker containers.
+
+        cmd is wrapped in `bash -c` so shell features (cd, ;, &&, |, globs,
+        redirects) run inside the container -- docker exec uses execve with
+        no implicit shell.
+        """
+        exec_cmd = f"sudo docker exec {container_name} bash -c {shlex.quote(cmd)}"
         if hosts:
-            # Execute on specific hosts
-            results = {}
-            for host in hosts:
-                results.update(self.orchestrator.all.exec_on_host(exec_cmd, host, timeout=timeout, detailed=detailed))
-            return results
-        else:
-            return self.orchestrator.all.exec(exec_cmd, timeout=timeout, detailed=detailed)
+            # Build a fresh Pssh for the host subset, mirroring
+            # BaremetalOrchestrator.exec's subset branch.
+            from cvs.lib.parallel_ssh_lib import Pssh
+
+            pssh = Pssh(
+                self.orchestrator.log,
+                hosts,
+                user=self.orchestrator.user,
+                password=self.orchestrator.password,
+                pkey=self.orchestrator.pkey,
+                host_key_check=False,
+                stop_on_errors=self.orchestrator.stop_on_errors,
+            )
+            return pssh.exec(exec_cmd, timeout=timeout, detailed=detailed)
+
+        return self.orchestrator.all.exec(exec_cmd, timeout=timeout, detailed=detailed)
 
     def exec_on_head(self, container_name, cmd, timeout=None):
-        """Execute command directly on head node (container)."""
-        exec_cmd = f"sudo docker exec {container_name} {cmd}"
+        """Execute command directly on head node (container). See exec() for
+        the bash -c wrap rationale."""
+        exec_cmd = f"sudo docker exec {container_name} bash -c {shlex.quote(cmd)}"
         return self.orchestrator.head.exec(exec_cmd, timeout=timeout)
 
     @staticmethod


### PR DESCRIPTION
## Summary

Two pre-existing defects in the orchestrator/runtime exec layer, surfaced by the in-flight orch-port branches. Each is its own commit so they can be reviewed independently.

### `286e173` runtimes/docker: fix two defects in DockerRuntime.exec

Both surface only under `ContainerOrchestrator` and were inert before the orch-port branches started exercising container mode end-to-end against non-pre-baked images.

- **No shell wrap around `cmd`.** `exec_cmd = f"sudo docker exec {container_name} {cmd}"` -- `docker exec` runs argv via `execve` with no implicit shell, so any `cmd` containing `cd`, `;`, `&&`, `||`, `|`, globs or redirects gets parsed by the host SSH shell first. Empirical proof: `install_agfhc.py:118`'s `cd {install_dir}; cp {tar} . && tar -xvf {tar}` extracted AGFHC ONTO THE HOST (`/home/atnair/agfhc-mi300...`) instead of inside the container; the install output even printed the host's ROCm 7.2.0 instead of the container's 7.13.0 as a smoking gun. Fix: wrap with `bash -c` using `shlex.quote` so shell semantics are evaluated inside the container and embedded quotes survive the SSH-host shell unwrap.
- **Phantom `exec_on_host` call on the `hosts=` branch.** `results.update(self.orchestrator.all.exec_on_host(exec_cmd, host, ...))` -- `MultiProcessPssh` (the type behind `self.orchestrator.all`) has no `exec_on_host` method. Any test passing `hosts=[...]` raises `AttributeError`. Empirical proof: `csp_qual_agfhc`'s per-host log collection via `orch.exec(cmd, hosts=[host])` failed on `test_agfhc_xgmi_lvl1` / `test_agfhc_pcie_lvl2` after the AGFHC run itself succeeded. Fix: build a fresh `Pssh` handle for the requested host subset, mirroring `BaremetalOrchestrator.exec`'s subset branch. Cannot reuse `self.orchestrator.exec()` because that re-enters `ContainerOrchestrator` and recurses through `self.runtime.exec`.

`exec_on_head` gets the same `bash -c` wrap for symmetry.

### `3aa4a03` orchestrators/baremetal: forward `detailed` kwarg in `exec` / `exec_on_head`

`BaremetalOrchestrator.exec` and `exec_on_head` omit the `detailed` kwarg that the underlying `Pssh.exec` already supports and that `ContainerOrchestrator.exec` already accepts. Callers that branch on `output['exit_code']` work under the container orchestrator but raise

```
TypeError: BaremetalOrchestrator.exec() got an unexpected keyword argument 'detailed'
```

under the baremetal orchestrator. Surfaced by the `port-install-transferbench` branch (`AIMVT-171`, commit `0aca15c`) which switched `detect_rocm_path` / `detect_hip_compiler` from the legacy `test ... && echo Y` pattern to `orch.exec('test ...', detailed=True)`. That commit was validated container-only on a06u43; the baremetal path failed at the first `detailed=True` call site (`install_transferbench.py:58`).

Fix: add `detailed=False` to both methods, forward to the Pssh handle on all three branches (`self.all`, `self.head`, and the subset-hosts fresh `Pssh`). No new behavior in Pssh -- that layer already handles `detailed` end-to-end.

## Sequencing

These fixes are independent of the orch-port branches by design. After this lands on `main`, the port branches (`port-install-transferbench`, `port-install-agfhc`, `port-csp-qual-agfhc`, `port-agfhc-cvs`, `port-transferbench-cvs`) rebase on top to pick up correct container-mode + baremetal-mode `detailed` support.