### PR TITLE
Port install_transferbench to the orch fixture; drop nfs_install [AIMVT-171]

### DIFF
--- a/cvs/input/config_file/health/mi300_health_config.json
+++ b/cvs/input/config_file/health/mi300_health_config.json
@@ -13,7 +13,6 @@
         "example_tests_path": "/home/{user-id}/INSTALL/TransferBench/examples",
         "git_install_path": "/home/{user-id}/INSTALL/",
         "git_url": "https://github.com/ROCm/TransferBench.git",
-        "nfs_install": "True",
         "_comment_rocm_path": "ROCm installation path. Set the placeholder changeme to auto-detect from /opt/rocm or /opt/rocm/core-*",
         "rocm_path": "<changeme>",
         "results": {

--- a/cvs/tests/health/install/install_transferbench.py
+++ b/cvs/tests/health/install/install_transferbench.py
@@ -11,7 +11,6 @@ import re
 import json
 
 
-from cvs.lib.parallel_ssh_lib import *
 from cvs.lib.utils_lib import *
 
 from cvs.lib import globals
@@ -22,12 +21,12 @@ log = globals.log
 # Importing additional cmd line args to script ..
 
 
-def detect_rocm_path(phdl, config_rocm_path):
+def detect_rocm_path(orch, config_rocm_path):
     """
     Detect the ROCm installation path, supporting both old (/opt/rocm) and new (/opt/rocm/core-X.Y) layouts.
 
     Args:
-        phdl: Parallel SSH handle
+        orch: Orchestrator instance
         config_rocm_path (str): Configured ROCm path from config file (empty string for auto-detect)
 
     Returns:
@@ -42,7 +41,7 @@ def detect_rocm_path(phdl, config_rocm_path):
     log.info('Auto-detecting ROCm path...')
 
     # Try new ROCm 7.x structure first (/opt/rocm/core-X.Y)
-    out_dict = phdl.exec('ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1')
+    out_dict = orch.exec('ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1')
     for node, output in out_dict.items():
         if output and '/opt/rocm/core-' in output:
             rocm_path = output.strip()
@@ -50,7 +49,7 @@ def detect_rocm_path(phdl, config_rocm_path):
             return rocm_path
 
     # Fall back to legacy /opt/rocm
-    out_dict = phdl.exec('test -d /opt/rocm && echo "/opt/rocm"')
+    out_dict = orch.exec('test -d /opt/rocm && echo "/opt/rocm"')
     for node, output in out_dict.items():
         if '/opt/rocm' in output:
             log.info('Detected ROCm path (legacy layout): /opt/rocm')
@@ -61,26 +60,26 @@ def detect_rocm_path(phdl, config_rocm_path):
     return '/opt/rocm'
 
 
-def detect_hip_compiler(phdl, rocm_path):
+def detect_hip_compiler(orch, rocm_path):
     """
     Detect the HIP compiler (hipcc or amdclang++) for the given ROCm installation.
 
     Args:
-        phdl: Parallel SSH handle
+        orch: Orchestrator instance
         rocm_path (str): ROCm installation path
 
     Returns:
         str: Full path to the HIP compiler
     """
     # Try hipcc first (ROCm 7.x)
-    out_dict = phdl.exec(f'test -f {rocm_path}/bin/hipcc && echo "{rocm_path}/bin/hipcc"')
+    out_dict = orch.exec(f'test -f {rocm_path}/bin/hipcc && echo "{rocm_path}/bin/hipcc"')
     for node, output in out_dict.items():
         if output and 'hipcc' in output:
             log.info(f'Detected HIP compiler: {rocm_path}/bin/hipcc')
             return f'{rocm_path}/bin/hipcc'
 
     # Fall back to amdclang++ (older ROCm versions)
-    out_dict = phdl.exec(f'test -f {rocm_path}/bin/amdclang++ && echo "{rocm_path}/bin/amdclang++"')
+    out_dict = orch.exec(f'test -f {rocm_path}/bin/amdclang++ && echo "{rocm_path}/bin/amdclang++"')
     for node, output in out_dict.items():
         if output and 'amdclang++' in output:
             log.info(f'Detected HIP compiler: {rocm_path}/bin/amdclang++')
@@ -170,72 +169,20 @@ def config_dict(config_file, cluster_dict):
     return config_dict
 
 
-@pytest.fixture(scope="module")
-def shdl(cluster_dict):
-    """
-    Build and return a parallel SSH handle (Pssh) for the head node only.
-
-    Args:
-      cluster_dict (dict): Cluster metadata fixture (see phdl docstring).
-
-    Returns:
-      Pssh: Handle configured for the first node (head node) in node_dict.
-
-    Notes:
-      - Useful when commands should be executed only from a designated head node.
-      - Module scope ensures a single connection context for the duration of the module.
-      - nhdl_dict is currently unused; it can be removed unless used elsewhere.
-    """
-    node_list = list(cluster_dict['node_dict'].keys())
-    env_vars = cluster_dict.get("env_vars")
-    head_node = node_list[0]
-    shdl = Pssh(log, [head_node], user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
-    return shdl
-
-
-# Create connection to DUT, MTPs, Switches and export for later use ..
-@pytest.fixture(scope="module")
-def phdl(cluster_dict):
-    """
-    Create a parallel SSH handle for all cluster nodes.
-
-    Args:
-      cluster_dict (dict): Loaded cluster configuration with at least:
-        - node_dict: mapping of node -> details
-        - username: SSH username
-        - priv_key_file: path to SSH key
-
-    Returns:
-      Pssh: Handle that executes commands on all nodes and returns dict[node] -> output.
-
-    """
-    log.info("%s", cluster_dict)
-    env_vars = cluster_dict.get("env_vars")
-    node_list = list(cluster_dict['node_dict'].keys())
-    phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
-    return phdl
-
-
-def test_install_transferbench(phdl, shdl, config_dict):
+def test_install_transferbench(orch, config_dict):
     """
     Install/Build TransferBench and verify installation on all nodes.
 
     Steps:
-      - Remove any stale working directory on the head node (if using shared/NFS paths).
-      - Clone TransferBench repo under git_install_path (via head-node hdl).
-      - Build on all nodes using CC=hipcc (via phdl).
-      - Verify '/opt/amd/transferbench' contains 'TransferBench' on each node.
+      - Ensure git_install_path exists on all nodes.
+      - Clone TransferBench repo under git_install_path on every node.
+      - Build on all nodes using detected ROCM_PATH and HIPCC.
+      - Verify the build artifact is present on each node.
 
-
-    Depending on the flag nfs_install in the config_file, decide if you want to use shdl (single node)
-    or all nodes (phdl)
-    If the nfs_install flag is set to True, then it assumes the install_dir is on a common file system
-    that is accessible from all the nodes and installs from just a single node, otherwise install on
-    all the nodes.
+    Clone, build, and verify all run on every node via ``orch.exec``.
 
     Args:
-      hdl: Head-node SSH handle
-      phdl: Parallel SSH handle for all nodes.
+      orch: Orchestrator instance.
       config_dict (dict): Includes:
         - git_install_path: directory to clone/build
         - git_url: repository URL
@@ -243,35 +190,29 @@ def test_install_transferbench(phdl, shdl, config_dict):
 
     globals.error_list = []
 
-    # For install case, if the systems are using NFS, use single connection to
-    if config_dict['nfs_install'] is True:
-        hdl = shdl
-    else:
-        hdl = phdl
-
     log.info('Testcase install transferbench')
     git_install_path = config_dict['git_install_path']
     git_url = config_dict['git_url']
 
-    out_dict = shdl.exec(f'ls -ld {git_install_path}')
+    out_dict = orch.exec(f'ls -ld {git_install_path}')
     for node in out_dict.keys():
         if re.search('No such file', out_dict[node]):
-            hdl.exec(f'mkdir -p {git_install_path}')
+            orch.exec(f'mkdir -p {git_install_path}')
 
-    out_dict = hdl.exec(f'rm -rf {git_install_path}/TransferBench')
-    out_dict = hdl.exec(f'cd {git_install_path};git clone {git_url}', timeout=120)
+    out_dict = orch.exec(f'rm -rf {git_install_path}/TransferBench')
+    out_dict = orch.exec(f'cd {git_install_path};git clone {git_url}', timeout=120)
 
     # Detect ROCm path and compiler
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    hip_compiler = detect_hip_compiler(phdl, rocm_path)
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    hip_compiler = detect_hip_compiler(orch, rocm_path)
 
     # Build with explicit ROCM_PATH and HIPCC
-    out_dict = hdl.exec(
+    out_dict = orch.exec(
         f'cd {git_install_path}/TransferBench;ROCM_PATH={rocm_path} HIPCC={hip_compiler} make', timeout=500
     )
 
     # Verify installation happened fine on all nodes
-    out_dict = phdl.exec(f'ls -l {git_install_path}/TransferBench')
+    out_dict = orch.exec(f'ls -l {git_install_path}/TransferBench')
     for node in out_dict.keys():
         if not re.search('TransferBench', out_dict[node]):
             fail_test(f'Transfer bench installation failed on node {node}')

--- a/cvs/tests/health/install/install_transferbench.py
+++ b/cvs/tests/health/install/install_transferbench.py
@@ -209,7 +209,8 @@ def test_install_transferbench(orch, config_dict):
     out_dict = orch.exec(f'rm -rf {git_install_path}/TransferBench')
     # Clone with explicit destination, no cwd dependency.
     out_dict = orch.exec(
-        f'git clone {git_url} {git_install_path}/TransferBench', timeout=120,
+        f'git clone {git_url} {git_install_path}/TransferBench',
+        timeout=120,
     )
 
     # Detect ROCm path and compiler

--- a/cvs/tests/health/install/install_transferbench.py
+++ b/cvs/tests/health/install/install_transferbench.py
@@ -40,18 +40,24 @@ def detect_rocm_path(orch, config_rocm_path):
     # Auto-detect ROCm path
     log.info('Auto-detecting ROCm path...')
 
-    # Try new ROCm 7.x structure first (/opt/rocm/core-X.Y)
-    out_dict = orch.exec('ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1')
+    # Try new ROCm 7.x structure first (/opt/rocm/core-X.Y). Wrapped in
+    # `bash -c` because we need glob expansion, stderr redirect and a pipeline
+    # to pick the highest-versioned core dir; ContainerOrchestrator's
+    # docker-exec transport does not spawn a shell on its own.
+    out_dict = orch.exec(
+        "bash -c 'ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1'",
+    )
     for node, output in out_dict.items():
         if output and '/opt/rocm/core-' in output:
             rocm_path = output.strip()
             log.info(f'Detected ROCm path (new layout): {rocm_path}')
             return rocm_path
 
-    # Fall back to legacy /opt/rocm
-    out_dict = orch.exec('test -d /opt/rocm && echo "/opt/rocm"')
-    for node, output in out_dict.items():
-        if '/opt/rocm' in output:
+    # Fall back to legacy /opt/rocm. One logical operation per orch.exec:
+    # use exit code rather than a `test ... && echo` shell short-circuit.
+    out_dict = orch.exec('test -d /opt/rocm', detailed=True)
+    for node, info in out_dict.items():
+        if info.get('exit_code') == 0:
             log.info('Detected ROCm path (legacy layout): /opt/rocm')
             return '/opt/rocm'
 
@@ -71,17 +77,18 @@ def detect_hip_compiler(orch, rocm_path):
     Returns:
         str: Full path to the HIP compiler
     """
-    # Try hipcc first (ROCm 7.x)
-    out_dict = orch.exec(f'test -f {rocm_path}/bin/hipcc && echo "{rocm_path}/bin/hipcc"')
-    for node, output in out_dict.items():
-        if output and 'hipcc' in output:
+    # Try hipcc first (ROCm 7.x). One logical operation per orch.exec:
+    # use the test(1) exit code rather than a `test ... && echo` chain.
+    out_dict = orch.exec(f'test -f {rocm_path}/bin/hipcc', detailed=True)
+    for node, info in out_dict.items():
+        if info.get('exit_code') == 0:
             log.info(f'Detected HIP compiler: {rocm_path}/bin/hipcc')
             return f'{rocm_path}/bin/hipcc'
 
-    # Fall back to amdclang++ (older ROCm versions)
-    out_dict = orch.exec(f'test -f {rocm_path}/bin/amdclang++ && echo "{rocm_path}/bin/amdclang++"')
-    for node, output in out_dict.items():
-        if output and 'amdclang++' in output:
+    # Fall back to amdclang++ (older ROCm versions).
+    out_dict = orch.exec(f'test -f {rocm_path}/bin/amdclang++', detailed=True)
+    for node, info in out_dict.items():
+        if info.get('exit_code') == 0:
             log.info(f'Detected HIP compiler: {rocm_path}/bin/amdclang++')
             return f'{rocm_path}/bin/amdclang++'
 
@@ -200,15 +207,23 @@ def test_install_transferbench(orch, config_dict):
             orch.exec(f'mkdir -p {git_install_path}')
 
     out_dict = orch.exec(f'rm -rf {git_install_path}/TransferBench')
-    out_dict = orch.exec(f'cd {git_install_path};git clone {git_url}', timeout=120)
+    # Clone with explicit destination, no cwd dependency.
+    out_dict = orch.exec(
+        f'git clone {git_url} {git_install_path}/TransferBench', timeout=120,
+    )
 
     # Detect ROCm path and compiler
     rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
     hip_compiler = detect_hip_compiler(orch, rocm_path)
 
-    # Build with explicit ROCM_PATH and HIPCC
+    # Build with explicit ROCM_PATH and HIPCC. The TransferBench Makefile
+    # uses cwd-relative paths so cwd MUST be the source tree; we wrap the
+    # build in `bash -c` explicitly to make the cwd dependency visible
+    # at the call site rather than via an implicit `cd X; cmd` chain.
+    tb_src = f'{git_install_path}/TransferBench'
     out_dict = orch.exec(
-        f'cd {git_install_path}/TransferBench;ROCM_PATH={rocm_path} HIPCC={hip_compiler} make', timeout=500
+        f"bash -c 'cd {tb_src} && ROCM_PATH={rocm_path} HIPCC={hip_compiler} make'",
+        timeout=500,
     )
 
     # Verify installation happened fine on all nodes

--- a/docs/reference/configuration-files/health.rst
+++ b/docs/reference/configuration-files/health.rst
@@ -36,7 +36,6 @@ Here's a code snippet of the ``mi300_health_config.json`` file for reference:
           "example_tests_path": "/home/{user-id}/INSTALL/TransferBench/examples",
           "git_install_path": "/home/{user-id}/INSTALL/",
           "git_url": "https://github.com/ROCm/TransferBench.git",
-          "nfs_install": "True",
           "_comment_rocm_path": "ROCm installation path. Set the placeholder changeme to auto-detect from /opt/rocm or /opt/rocm/core-*",
           "rocm_path": "<changeme>",
           "results":
@@ -212,9 +211,6 @@ TransferBench
    * - ``git_url``
      - `https://github.com/ROCm/TransferBench.git <https://github.com/ROCm/TransferBench.git>`_
      - URL for Git repo
-   * - ``nfs_install``
-     - True
-     - Set the flag to install nfs
    * - ``rocm_path``
      - ``<changeme>``
      - Set the path of rocm       


### PR DESCRIPTION
Tracking: [AIMVT-171](https://amd-hub.atlassian.net/browse/AIMVT-171).

## Changes

`cvs/tests/health/install/install_transferbench.py`:

- Delete `from cvs.lib.parallel_ssh_lib import *` and the local `phdl`/`shdl`
  fixtures. The test signature becomes
  `test_install_transferbench(orch, config_dict)`.
- Rename `phdl` → `orch` in the suite-local `detect_rocm_path` and
  `detect_hip_compiler` helpers (signatures, bodies, docstrings). Post-rename
  these match `install_rvs.py`'s helpers byte-for-byte.
- Remove the `nfs_install` head-vs-fleet conditional. Clone, build, and verify
  now run on every node via `orch.exec`.
- Split multi-statement shell strings into single-binary calls so each
  `orch.exec` works under `ContainerOrchestrator`'s docker-exec transport:
  - `detect_rocm_path`: glob+pipe pipeline wrapped in explicit `bash -c`.
  - `detect_hip_compiler`: probes both `hipcc` and `amdclang++` via the
    command's exit code (`detailed=True`) instead of
    `test -d X && echo Y`.
  - TransferBench clone: `git clone URL DEST` with explicit destination drops
    the `cd X; git clone URL` cwd dependency.
  - TransferBench Makefile build: Makefile genuinely needs cwd in the source
    tree, so the call is wrapped explicitly as
    `sudo bash -c 'cd X && ROCM_PATH=v make'`.

`cvs/input/config_file/health/mi300_health_config.json`:

- Remove `"nfs_install": "True"` from the `transferbench` block.

`docs/reference/configuration-files/health.rst`:

- Remove the matching `"nfs_install"` entry from the inline JSON dropdown and
  the `nfs_install` row from the TransferBench parameter table.