### PR TITLE
Port transferbench_cvs.py to the orch fixture [AIMVT-171]

### DIFF
--- a/cvs/tests/health/transferbench_cvs.py
+++ b/cvs/tests/health/transferbench_cvs.py
@@ -11,7 +11,6 @@ import re
 import json
 
 
-from cvs.lib.parallel_ssh_lib import *
 from cvs.lib.utils_lib import *
 
 from cvs.lib import globals
@@ -56,11 +55,11 @@ def config_dict(config_file, cluster_dict):
     return config_dict
 
 
-def detect_rocm_path(phdl, config_rocm_path):
+def detect_rocm_path(orch, config_rocm_path):
     """
     Detect the ROCm installation path, supporting both old (/opt/rocm) and new (/opt/rocm/core-X.Y) layouts.
     Args:
-        phdl: Parallel SSH handle
+        orch: Orchestrator instance
         config_rocm_path (str): Configured ROCm path from config file (empty string for auto-detect)
     Returns:
         str: Detected ROCm path
@@ -68,7 +67,7 @@ def detect_rocm_path(phdl, config_rocm_path):
     # If rocm_path is explicitly configured, validate and use it
     if config_rocm_path and config_rocm_path != '<changeme>':
         # Validate the configured path exists
-        out_dict = phdl.exec(
+        out_dict = orch.exec(
             f'test -d {config_rocm_path}/lib && ls {config_rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'
         )
         for node, output in out_dict.items():
@@ -84,12 +83,12 @@ def detect_rocm_path(phdl, config_rocm_path):
     log.info('Auto-detecting ROCm path...')
 
     # Try new ROCm 7.x structure first (/opt/rocm/core-X.Y)
-    out_dict = phdl.exec('ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1')
+    out_dict = orch.exec('ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1')
     for node, output in out_dict.items():
         if output and '/opt/rocm/core-' in output:
             rocm_path = output.strip()
             # Validate it has the library
-            validate_dict = phdl.exec(
+            validate_dict = orch.exec(
                 f'test -d {rocm_path}/lib && ls {rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'
             )
             for _, lib_output in validate_dict.items():
@@ -98,7 +97,7 @@ def detect_rocm_path(phdl, config_rocm_path):
                     return rocm_path
 
     # Fall back to legacy /opt/rocm
-    out_dict = phdl.exec('test -d /opt/rocm/lib && ls /opt/rocm/lib/libamdhip64.so* 2>/dev/null | head -1')
+    out_dict = orch.exec('test -d /opt/rocm/lib && ls /opt/rocm/lib/libamdhip64.so* 2>/dev/null | head -1')
     for node, output in out_dict.items():
         if output.strip() and 'libamdhip64.so' in output:
             log.info('Detected ROCm path (legacy layout): /opt/rocm')
@@ -301,23 +300,14 @@ def parse_tb_example_test_results(out_dict, exp_dict):
             )
 
 
-@pytest.fixture(scope="module")
-def phdl(cluster_dict):
-    log.info("%s", cluster_dict)
-    env_vars = cluster_dict.get("env_vars")
-    node_list = list(cluster_dict['node_dict'].keys())
-    phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
-    return phdl
-
-
-def test_transfer_bench_example_tests_1_6_t(phdl, config_dict):
+def test_transfer_bench_example_tests_1_6_t(orch, config_dict):
     globals.error_list = []
     log.info('Testcase Run TransferBench example tests 1-6')
     path = config_dict['path']
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
     log.info("%s", config_dict)
     example_path = config_dict['example_tests_path']
-    out_dict = phdl.exec(
+    out_dict = orch.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench {example_path}/example.cfg'",
         timeout=(60 * 5),
     )
@@ -328,14 +318,14 @@ def test_transfer_bench_example_tests_1_6_t(phdl, config_dict):
 
 
 def test_transfer_bench_a2a(
-    phdl,
+    orch,
     config_dict,
 ):
     globals.error_list = []
     log.info('Testcase Run Transferbench a2a')
     path = config_dict['path']
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    out_dict = phdl.exec(
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    out_dict = orch.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench a2a'",
         timeout=(60 * 5),
     )
@@ -347,14 +337,14 @@ def test_transfer_bench_a2a(
 
 
 def test_transfer_bench_p2p(
-    phdl,
+    orch,
     config_dict,
 ):
     globals.error_list = []
     log.info('Testcase Run Transferbench p2p')
     path = config_dict['path']
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    out_dict = phdl.exec(
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    out_dict = orch.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench p2p'",
         timeout=(60 * 5),
     )
@@ -365,14 +355,14 @@ def test_transfer_bench_p2p(
 
 
 def test_transfer_bench_healthcheck(
-    phdl,
+    orch,
     config_dict,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench healthcheck')
     path = config_dict['path']
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    out_dict = phdl.exec(
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    out_dict = orch.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench healthcheck'",
         timeout=(60 * 3),
     )
@@ -382,14 +372,14 @@ def test_transfer_bench_healthcheck(
 
 
 def test_transfer_bench_a2asweep(
-    phdl,
+    orch,
     config_dict,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench a2asweep')
     path = config_dict['path']
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    out_dict = phdl.exec(
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    out_dict = orch.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench a2asweep'",
         timeout=(60 * 10),
     )
@@ -399,14 +389,14 @@ def test_transfer_bench_a2asweep(
 
 
 def test_transfer_bench_scaling(
-    phdl,
+    orch,
     config_dict,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench scaling')
     path = config_dict['path']
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    out_dict = phdl.exec(
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    out_dict = orch.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench scaling'",
         timeout=(60 * 10),
     )
@@ -417,14 +407,14 @@ def test_transfer_bench_scaling(
 
 
 def test_transfer_bench_schmoo(
-    phdl,
+    orch,
     config_dict,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench schmoo')
     path = config_dict['path']
-    rocm_path = detect_rocm_path(phdl, config_dict.get('rocm_path', ''))
-    out_dict = phdl.exec(
+    rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    out_dict = orch.exec(
         f"sudo bash -c 'export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH && echo \"LD_LIBRARY_PATH: $LD_LIBRARY_PATH\" && {path}/TransferBench schmoo'",
         timeout=(60 * 5),
     )

--- a/cvs/tests/health/transferbench_cvs.py
+++ b/cvs/tests/health/transferbench_cvs.py
@@ -87,16 +87,13 @@ def detect_rocm_path(orch, config_rocm_path):
 
     # Try new ROCm 7.x structure first (/opt/rocm/core-X.Y). Glob+pipe wrapped
     # in explicit `bash -c`; same rationale as the configured-path probe above.
-    out_dict = orch.exec(
-        "bash -c 'ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1'"
-    )
+    out_dict = orch.exec("bash -c 'ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1'")
     for node, output in out_dict.items():
         if output and '/opt/rocm/core-' in output:
             rocm_path = output.strip()
             # Validate it has the library
             validate_dict = orch.exec(
-                f"bash -c 'test -d {rocm_path}/lib"
-                f" && ls {rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'"
+                f"bash -c 'test -d {rocm_path}/lib && ls {rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'"
             )
             for _, lib_output in validate_dict.items():
                 if lib_output.strip() and 'libamdhip64.so' in lib_output:
@@ -104,10 +101,7 @@ def detect_rocm_path(orch, config_rocm_path):
                     return rocm_path
 
     # Fall back to legacy /opt/rocm
-    out_dict = orch.exec(
-        "bash -c 'test -d /opt/rocm/lib"
-        " && ls /opt/rocm/lib/libamdhip64.so* 2>/dev/null | head -1'"
-    )
+    out_dict = orch.exec("bash -c 'test -d /opt/rocm/lib && ls /opt/rocm/lib/libamdhip64.so* 2>/dev/null | head -1'")
     for node, output in out_dict.items():
         if output.strip() and 'libamdhip64.so' in output:
             log.info('Detected ROCm path (legacy layout): /opt/rocm')

--- a/cvs/tests/health/transferbench_cvs.py
+++ b/cvs/tests/health/transferbench_cvs.py
@@ -64,11 +64,14 @@ def detect_rocm_path(orch, config_rocm_path):
     Returns:
         str: Detected ROCm path
     """
-    # If rocm_path is explicitly configured, validate and use it
+    # If rocm_path is explicitly configured, validate and use it. The validation
+    # is a glob+pipe pipeline (does {path}/lib exist AND does it contain a
+    # libamdhip64.so*?), wrapped in explicit `bash -c` because
+    # ContainerOrchestrator's docker-exec transport does not spawn a shell.
     if config_rocm_path and config_rocm_path != '<changeme>':
-        # Validate the configured path exists
         out_dict = orch.exec(
-            f'test -d {config_rocm_path}/lib && ls {config_rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'
+            f"bash -c 'test -d {config_rocm_path}/lib"
+            f" && ls {config_rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'"
         )
         for node, output in out_dict.items():
             if output.strip() and 'libamdhip64.so' in output:
@@ -82,14 +85,18 @@ def detect_rocm_path(orch, config_rocm_path):
     # Auto-detect ROCm path
     log.info('Auto-detecting ROCm path...')
 
-    # Try new ROCm 7.x structure first (/opt/rocm/core-X.Y)
-    out_dict = orch.exec('ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1')
+    # Try new ROCm 7.x structure first (/opt/rocm/core-X.Y). Glob+pipe wrapped
+    # in explicit `bash -c`; same rationale as the configured-path probe above.
+    out_dict = orch.exec(
+        "bash -c 'ls -d /opt/rocm/core-* 2>/dev/null | sort -V | tail -1'"
+    )
     for node, output in out_dict.items():
         if output and '/opt/rocm/core-' in output:
             rocm_path = output.strip()
             # Validate it has the library
             validate_dict = orch.exec(
-                f'test -d {rocm_path}/lib && ls {rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'
+                f"bash -c 'test -d {rocm_path}/lib"
+                f" && ls {rocm_path}/lib/libamdhip64.so* 2>/dev/null | head -1'"
             )
             for _, lib_output in validate_dict.items():
                 if lib_output.strip() and 'libamdhip64.so' in lib_output:
@@ -97,7 +104,10 @@ def detect_rocm_path(orch, config_rocm_path):
                     return rocm_path
 
     # Fall back to legacy /opt/rocm
-    out_dict = orch.exec('test -d /opt/rocm/lib && ls /opt/rocm/lib/libamdhip64.so* 2>/dev/null | head -1')
+    out_dict = orch.exec(
+        "bash -c 'test -d /opt/rocm/lib"
+        " && ls /opt/rocm/lib/libamdhip64.so* 2>/dev/null | head -1'"
+    )
     for node, output in out_dict.items():
         if output.strip() and 'libamdhip64.so' in output:
             log.info('Detected ROCm path (legacy layout): /opt/rocm')


### PR DESCRIPTION
Tracking: [AIMVT-171](https://amd-hub.atlassian.net/browse/AIMVT-171).

## Changes

`cvs/tests/health/transferbench_cvs.py`:

- Delete `from cvs.lib.parallel_ssh_lib import *` and the local `phdl` fixture
  (the only `Pssh(...)` constructor in the file). `orch` is auto-injected from
  `cvs/tests/conftest.py`.
- Rename `phdl` → `orch` in the suite-local `detect_rocm_path` helper
  (signature, body, and the `phdl: Parallel SSH handle` →
  `orch: Orchestrator instance` docstring entry, matching the convention in
  `rvs_cvs.py`).
- Rename `phdl` → `orch` and rewrite each `phdl.exec(...)` call as
  `orch.exec(...)` across all 7 test functions
  (`test_transfer_bench_example_tests_1_6_t`, `test_transfer_bench_a2a`,
  `test_transfer_bench_p2p`, `test_transfer_bench_healthcheck`,
  `test_transfer_bench_a2asweep`, `test_transfer_bench_scaling`,
  `test_transfer_bench_schmoo`).