### PR TITLE
fix(rccl_lib): use --prtemca for PRRTE-layer mpirun params on OpenMPI 5.x

### DIFF
--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -179,6 +179,69 @@ def is_ucx_available_in_mpi(shdl, mpi_path, head_node):
         return False
 
 
+def get_ompi_major_version(shdl, mpi_path, head_node):
+    """
+    Return the OpenMPI major version (int) on the head node, or None if it
+    cannot be determined.
+
+    Used by :func:`get_prte_mca_prefix` to decide which CLI prefix to use
+    for PRRTE-layer MCA params (``oob_tcp_if_include`` etc.). In OpenMPI
+    5.0+, PRRTE is a standalone runtime and PRRTE-layer params must be
+    passed with ``--prtemca``; passing them via ``--mca`` routes them to
+    the OMPI layer where PRRTE never sees them, which on multi-NIC hosts
+    causes prted to pick the wrong control-plane interface and crash
+    inside ``prte_ess_base_prted_setup`` ("PRTE has lost communication
+    with a remote daemon" within ~3s of launch).
+
+    See:
+      https://docs.open-mpi.org/en/v5.0.x/mca.html#command-line-parameters
+      https://github.com/openpmix/prrte/issues/1731
+    """
+    try:
+        out_dict = shdl.exec(f'{mpi_path}/bin/ompi_info --version | head -1')
+        version_line = out_dict[head_node].strip()
+        # Examples we want to match:
+        #   "Open MPI v5.0.8"
+        #   "mpirun (Open MPI) 4.1.6"
+        match = re.search(r'(\d+)\.\d+(?:\.\d+)?', version_line)
+        if match:
+            major = int(match.group(1))
+            log.info(f"Detected OpenMPI major version: {major} (from: {version_line!r})")
+            return major
+        log.warning(f"Could not parse OpenMPI version from ompi_info output: {version_line!r}")
+        return None
+    except Exception as e:
+        log.warning(f"ompi_info --version probe failed: {e}; OpenMPI major version unknown")
+        return None
+
+
+def get_prte_mca_prefix(shdl, mpi_path, head_node):
+    """
+    Return the correct mpirun CLI prefix for PRRTE-layer MCA params on the
+    target OpenMPI install.
+
+    - OpenMPI >= 5.0: use ``--prtemca`` (PRRTE is a separate project; its
+      params must be explicitly addressed, otherwise the OMPI schizo
+      parser keeps them on the OMPI side and PRRTE never sees them).
+    - OpenMPI <= 4.x: use ``--mca`` (ORTE is built in; there is no
+      separate PRRTE layer to address).
+    - Unknown version (probe failed): fall back to single-dash ``-mca``.
+      It is accepted by both OMPI 4.x and 5.x argv parsers and, on 5.x,
+      happens to be routed through PRRTE's schizo before the OMPI-side
+      dispatch, which avoids the silent mis-route. This is intentionally
+      a conservative fallback rather than ``--mca``.
+    """
+    major = get_ompi_major_version(shdl, mpi_path, head_node)
+    if major is None:
+        log.info("Using '-mca' prefix for PRRTE-layer params (OpenMPI version unknown)")
+        return '-mca'
+    if major >= 5:
+        log.info("Using '--prtemca' prefix for PRRTE-layer params (OpenMPI 5.x)")
+        return '--prtemca'
+    log.info("Using '--mca' prefix for PRRTE-layer params (OpenMPI <= 4.x)")
+    return '--mca'
+
+
 def detect_rccl_output_flag(shdl, rccl_test_binary_path, head_node):
     """
     Detect which output file argument is supported by the RCCL test binary.
@@ -696,7 +759,9 @@ def rccl_regression(
     if env_overrides:
         env_override_params = ' '.join([f'-x {k}={v}' for k, v in env_overrides.items()])
 
-    # Build mpirun command
+    # Build mpirun command. PRRTE-layer params (oob/btl_tcp_if_include)
+    # need the version-correct prefix; see get_prte_mca_prefix() docstring.
+    prte_mca = get_prte_mca_prefix(shdl, mpi_dir, head_node)
     cmd = f'''{mpi_dir}/bin/mpirun \
         --allow-run-as-root \
         -np {no_of_global_ranks} \
@@ -704,8 +769,8 @@ def rccl_regression(
         --bind-to numa \
         {ucx_params} \
         --mca btl ^vader,openib \
-        --mca btl_tcp_if_include {mpi_oob_port} \
-        --mca oob_tcp_if_include {mpi_oob_port} \
+        {prte_mca} btl_tcp_if_include {mpi_oob_port} \
+        {prte_mca} oob_tcp_if_include {mpi_oob_port} \
         {pml_param} \
         {env_override_params} \
         {test_cmd}'''
@@ -884,15 +949,17 @@ def rccl_perf(
             # Always wrap in bash to interpret && shell operator
             test_cmd = f'bash -c "{test_cmd}"'
 
-        # Build mpirun command
+        # Build mpirun command. PRRTE-layer params (oob/btl_tcp_if_include)
+        # need the version-correct prefix; see get_prte_mca_prefix() docstring.
+        prte_mca = get_prte_mca_prefix(shdl, mpi_dir, head_node)
         cmd = f'''{mpi_dir}/bin/mpirun --np {no_of_global_ranks} \
         --allow-run-as-root \
         --hostfile /tmp/rccl_hosts_file.txt \
         --bind-to numa \
         {ucx_params} \
         --mca btl ^vader,openib \
-        --mca btl_tcp_if_include {mpi_oob_port} \
-        --mca oob_tcp_if_include {mpi_oob_port} \
+        {prte_mca} btl_tcp_if_include {mpi_oob_port} \
+        {prte_mca} oob_tcp_if_include {mpi_oob_port} \
         {pml_param} \
         {test_cmd}
         '''


### PR DESCRIPTION
## Summary
`rccl_regression()` and `rccl_perf()` build their `mpirun` line passing `oob_tcp_if_include` and `btl_tcp_if_include` via `--mca`. These are PRRTE-layer parameters: on OpenMPI 5.0+ (where PRRTE is a standalone runtime), `--mca` keeps them on the OMPI side and PRRTE never sees them. On multi-NIC hosts that defaults `prted` to the wrong control-plane interface, the daemon-to-daemon handshake fails, and `prted` crashes inside `prte_ess_base_prted_setup` — observed as `"PRTE has lost communication with a remote daemon"` within ~3s of `mpirun` launch.

This PR detects the head node's OpenMPI major version via `ompi_info --version` (reusing the existing `shdl` handle, same pattern as `is_ucx_available_in_mpi`) and picks the right prefix for PRRTE-layer params:

| OpenMPI version | Prefix used | Why |
|---|---|---|
| `>= 5.0`  | `--prtemca` | Documented PRRTE prefix (`docs.open-mpi.org/en/v5.0.x/mca.html`). |
| `<= 4.x`  | `--mca`     | ORTE is built into OMPI 4.x; preserves prior behavior exactly. |
| Probe fails | `-mca`    | Single-dash is accepted by both 4.x and 5.x argv parsers; on 5.x it's routed through PRRTE's schizo before OMPI dispatch, which avoids the silent mis-route. Conservative fallback. |

`--mca btl ^vader,openib` and `--mca pml ob1` are intentionally unchanged — those are OMPI-layer params and `--mca` is correct on every version.

### Background refs
- OMPI 5 MCA command-line semantics: https://docs.open-mpi.org/en/v5.0.x/mca.html#command-line-parameters
- PRRTE upstream discussion of generic `--mca` mis-routing: https://github.com/openpmix/prrte/issues/1731

### Bisect evidence
Reproduced and isolated on a 4×8 MI355X cluster running OMPI 5.0.8 / ROCm 7.0.2:
- Status quo (`--mca oob_tcp_if_include …`): deterministic prted GPF in ~3s.
- After this PR (auto-selects `--prtemca` on OMPI 5.0.8): full `rccl_perf` sweep `14 passed in 2441.74s`, plus 5×5 chained smokes all green, zero PRTE traps.

## Test plan
- [x] Multi-node `rccl_perf` and `rccl_regression` on OpenMPI 5.0.x — verify `--prtemca …` appears in the logged `mpirun` line and no PRTE GPF.
- [x] Multi-node `rccl_perf` on OpenMPI 4.1.x — verify `--mca …` is still emitted for the OOB params (no behavior change for 4.x users).
- [ ] Simulated probe failure (e.g. broken `mpi_dir`) — verify the run falls back to `-mca` and a warning is logged, instead of bailing out.


Made with [Cursor](https://cursor.com)