### PR TITLE
factory: resolve {user-id} placeholders at OrchestratorConfig.from_configs boundary

### DIFF
--- a/cvs/core/orchestrators/factory.py
+++ b/cvs/core/orchestrators/factory.py
@@ -84,7 +84,10 @@ class OrchestratorConfig:
         Create config from multiple configuration sources.
 
         Merges cluster_config.json and <testsuite>_config.json configurations, with testsuite_config
-        taking precedence for overlapping keys.
+        taking precedence for overlapping keys. After merging, the {user-id} placeholder is
+        resolved recursively (via cvs.lib.utils_lib.resolve_cluster_config_placeholders) so SSH
+        credentials and any nested container fields carry real values when consumed by Pssh /
+        docker run. Unresolved <changeme> tokens trigger sys.exit(1) at this boundary.
 
         Args:
             cluster_config: Cluster configuration (dict or path to cluster_config.json)
@@ -115,6 +118,13 @@ class OrchestratorConfig:
         merged_config = cluster_config.copy()
         if testsuite_config:
             merged_config.update(testsuite_config)
+
+        # Resolve {user-id} recursively so SSH credentials (username, priv_key_file) and any
+        # nested container fields carry real values when consumed by Pssh / docker run. Applied
+        # AFTER the merge so testsuite overrides containing placeholders are also resolved.
+        from cvs.lib.utils_lib import resolve_cluster_config_placeholders  # Lazy: avoids core->lib import at module load
+
+        merged_config = resolve_cluster_config_placeholders(merged_config)
 
         # Extract only required keys for orchestrators
         required_config = {

--- a/cvs/core/orchestrators/factory.py
+++ b/cvs/core/orchestrators/factory.py
@@ -122,7 +122,9 @@ class OrchestratorConfig:
         # Resolve {user-id} recursively so SSH credentials (username, priv_key_file) and any
         # nested container fields carry real values when consumed by Pssh / docker run. Applied
         # AFTER the merge so testsuite overrides containing placeholders are also resolved.
-        from cvs.lib.utils_lib import resolve_cluster_config_placeholders  # Lazy: avoids core->lib import at module load
+        from cvs.lib.utils_lib import (
+            resolve_cluster_config_placeholders,
+        )  # Lazy: avoids core->lib import at module load
 
         merged_config = resolve_cluster_config_placeholders(merged_config)
 

--- a/cvs/core/orchestrators/unittests/test_factory.py
+++ b/cvs/core/orchestrators/unittests/test_factory.py
@@ -127,14 +127,16 @@ class TestOrchestratorConfig(unittest.TestCase):
             )
         self.assertIn("priv_key_file", str(ctx.exception))
 
+    @patch.dict(os.environ, {"USER": "alice", "LOGNAME": "", "USERNAME": ""}, clear=False)
     def test_from_configs_reads_from_file_path(self):
         # Round-trip a real JSON file through from_configs to exercise the
         # path-handling branch (the rvs_cvs.py orch fixture goes through this).
+        # Also pins that {user-id} placeholders are resolved when input came from disk.
         cluster = {
             "orchestrator": "baremetal",
             "node_dict": {"1.1.1.1": {}, "1.1.1.2": {}},
-            "username": "u",
-            "priv_key_file": "/dev/null",
+            "username": "{user-id}",
+            "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
         }
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
             json.dump(cluster, f)
@@ -143,8 +145,85 @@ class TestOrchestratorConfig(unittest.TestCase):
             cfg = OrchestratorConfig.from_configs(path)
             self.assertEqual(cfg.orchestrator, "baremetal")
             self.assertEqual(len(cfg.node_dict), 2)
+            self.assertEqual(cfg.username, "alice")
+            self.assertEqual(cfg.priv_key_file, "/home/alice/.ssh/id_rsa")
         finally:
             os.unlink(path)
+
+    # ------------------------------------------------------------------
+    # Placeholder resolution at the from_configs boundary.
+    #
+    # Pins that {user-id} in the cluster file (and any merged testsuite
+    # overrides) is substituted before the values reach BaremetalOrchestrator /
+    # Pssh / docker run. Env is patched so the substituted value is
+    # deterministic regardless of host $USER (CI / sudo / containers).
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"USER": "alice", "LOGNAME": "", "USERNAME": ""}, clear=False)
+    def test_from_configs_resolves_user_id_in_username_and_priv_key(self):
+        cluster = {
+            "node_dict": {"1.1.1.1": {}},
+            "username": "{user-id}",
+            "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
+        }
+        cfg = OrchestratorConfig.from_configs(cluster)
+        self.assertEqual(cfg.username, "alice")
+        self.assertEqual(cfg.priv_key_file, "/home/alice/.ssh/id_rsa")
+
+    @patch.dict(os.environ, {"USER": "alice", "LOGNAME": "", "USERNAME": ""}, clear=False)
+    def test_from_configs_resolves_user_id_throughout_container_block(self):
+        # The recursive walk must descend into container at every nesting shape:
+        # top-level string scalar (image, name), and list item under a nested dict
+        # (runtime.args.volumes).
+        cluster = {
+            "orchestrator": "container",
+            "node_dict": {"1.1.1.1": {}},
+            "username": "{user-id}",
+            "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
+            "container": {
+                "enabled": True,
+                "image": "rocm/{user-id}:test",
+                "name": "{user-id}_cvs",
+                "runtime": {
+                    "name": "docker",
+                    "args": {"volumes": ["/home/{user-id}/data:/data"]},
+                },
+            },
+        }
+        cfg = OrchestratorConfig.from_configs(cluster)
+        self.assertEqual(cfg.container["image"], "rocm/alice:test")
+        self.assertEqual(cfg.container["name"], "alice_cvs")
+        self.assertEqual(
+            cfg.container["runtime"]["args"]["volumes"],
+            ["/home/alice/data:/data"],
+        )
+
+    @patch.dict(os.environ, {"USER": "alice", "LOGNAME": "", "USERNAME": ""}, clear=False)
+    def test_from_configs_resolves_user_id_in_testsuite_override(self):
+        # Pins that resolution runs AFTER the cluster+testsuite merge. If a future
+        # refactor moves the resolver call before the merge, the testsuite override
+        # would leak {user-id} verbatim and this test would fail.
+        cluster = {
+            "node_dict": {"1.1.1.1": {}},
+            "username": "literal_user",
+            "priv_key_file": "/dev/null",
+        }
+        testsuite = {"username": "{user-id}"}
+        cfg = OrchestratorConfig.from_configs(cluster, testsuite)
+        self.assertEqual(cfg.username, "alice")
+
+    def test_from_configs_exits_on_unresolved_changeme(self):
+        # Pins that the resolver's <changeme> guard propagates through from_configs.
+        # Defends against a future change that disables the guard and silently leaks
+        # <changeme> into Pssh / docker run.
+        cluster = {
+            "node_dict": {"1.1.1.1": {}},
+            "username": "<changeme>",
+            "priv_key_file": "/dev/null",
+        }
+        with self.assertRaises(SystemExit) as ctx:
+            OrchestratorConfig.from_configs(cluster)
+        self.assertEqual(ctx.exception.code, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves [AIMVT-191](https://amd-hub.atlassian.net/browse/AIMVT-191).

## Motivation

`cluster.json` ships `{user-id}` placeholders in `username`, `priv_key_file`, and any nested `container.*` field so the same config travels across users. Before this PR, `OrchestratorConfig.from_configs` merged cluster + testsuite configs and fed the merged dict into `OrchestratorConfig` **without ever calling the resolver** (`cvs.lib.utils_lib.resolve_cluster_config_placeholders`). Every orch-port suite that used the shipped template's `{user-id}` form therefore tried to SSH as a literal user named `{user-id}` and failed at the `orch` fixture's setup with `Permission denied (publickey)`, before any test code ran.

Suites affected (orch fixture in `cvs/tests/conftest.py::orch`):

- `cvs/tests/health/rvs_cvs.py` (8 tests)
- `cvs/tests/health/install/install_rvs.py::test_install_rvs`
- `cvs/tests/health/install/install_transferbench.py::test_install_transferbench`
- `cvs/tests/health/transferbench_cvs.py::test_transfer_bench_example_tests_1_6_t`

Legacy (non-orch) suites were unaffected — their per-suite `cluster_dict` fixture calls the resolver itself.

## Technical Details

In `OrchestratorConfig.from_configs`, after the cluster + testsuite merge and before the required-keys extraction, call `resolve_cluster_config_placeholders` on the merged dict:

```python
merged_config = cluster_config.copy()
if testsuite_config:
    merged_config.update(testsuite_config)

from cvs.lib.utils_lib import resolve_cluster_config_placeholders  # lazy: avoids core -> lib import at module load
merged_config = resolve_cluster_config_placeholders(merged_config)
```

Three properties this preserves:

- **Recursive substitution**: `{user-id}` in nested fields (`container.image`, `container.name`, `container.runtime.args.volumes`, etc.) is also resolved.
- **Resolution after merge**: any `{user-id}` in a testsuite-side override is substituted (would leak if resolution ran before the merge). Pinned by `test_from_configs_resolves_user_id_in_testsuite_override`.
- **Existing `<changeme>` fail-fast**: the resolver's `sys.exit(1)` guard for unresolved `<changeme>` propagates up through `from_configs`, so unresolved tokens fail at config load instead of producing confusing downstream errors. Pinned by `test_from_configs_exits_on_unresolved_changeme`.

Diff: +94 / -3 across `cvs/core/orchestrators/factory.py` and `cvs/core/orchestrators/unittests/test_factory.py`.

## Test Plan

### Unit tests (`cvs/core/orchestrators/unittests/test_factory.py`)

Five tests; all patch `os.environ` so the substituted username is deterministic regardless of host `$USER`:

| Test | Pins |
| --- | --- |
| `test_from_configs_resolves_user_id_in_username_and_priv_key` | Standard SSH credential substitution. |
| `test_from_configs_resolves_user_id_throughout_container_block` | Recursive descent at every nesting shape (top-level scalar, list under nested dict): `image`, `name`, `runtime.args.volumes`. |
| `test_from_configs_resolves_user_id_in_testsuite_override` | Resolution runs after the merge. |
| `test_from_configs_exits_on_unresolved_changeme` | `<changeme>` guard still aborts via `SystemExit(1)`. |
| `test_from_configs_reads_from_file_path` (modified) | Disk-loaded path used by the orch fixture asserts resolved values, not just parse success. |

### Commands

```bash
python -m unittest cvs.core.orchestrators.unittests.test_factory -v
python -m unittest cvs.core.orchestrators.unittests cvs.core.runtimes.unittests -v
```

### End-to-end

Container-mode `install_rvs` on a Core42 Group D node (`g20u43`, 10.245.135.31) with a fully-templated `cluster.json` exercising the fix (`username: "{user-id}"`, `priv_key_file: "/data/{user-id}/.ssh/id_ed25519"`, `container.name: "{user-id}_install_rvs_iter"`).

## Test Result

- `test_factory.py`: 18 / 18 pass (5 new/modified + 13 pre-existing).
- `cvs.core.orchestrators.unittests` + `cvs.core.runtimes.unittests`: 36 / 36 pass.
- End-to-end run on g20u43:

  ```
  2026-05-26 17:55:20 INFO Resolving cluster config placeholders: {user-id}=atnair
  2026-05-26 17:55:20 INFO Starting long-running containers on 1 nodes: atnair_install_rvs_iter
  ============================== 1 passed in 44.92s ==============================
  ```

  Run bundle (HTML report + per-test log + cluster + config): `install_rvs_2026-05-26T175605.zip` attached to [AIMVT-191](https://amd-hub.atlassian.net/browse/AIMVT-191).

## Submission Checklist

- [x] Reviewed contributing guidelines: https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests
