### PR TITLE
Add IFoE L2 connectivity preflight check [AIMVT-180]

### DIFF
--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -4,12 +4,14 @@ This document explains how to configure the GPU cluster preflight checks system.
 
 ## Overview
 
-The preflight checks system validates essential cluster health before running performance tests like IB performance tests, RCCL training, and inference workloads. It performs four key validations:
+The preflight checks system validates essential cluster health before running performance tests like IB performance tests, RCCL training, and inference workloads. It performs the following validations:
 
 1. **GID Consistency** - Ensures RDMA interfaces have valid GID entries
 2. **RDMA Connectivity** - Tests node-to-node RDMA communication using ibv_rc_pingpong
 3. **ROCm Version Consistency** - Verifies consistent ROCm versions across nodes
 4. **Interface Name Consistency** - Validates RDMA interface naming patterns
+5. **IFoE L2 Connectivity (AIMVT-180; opt-in)** - Runs `afmctl test ping`
+   on each node and enforces per-port and Summary pass/fail accounting
 
 ## Configuration File Structure
 
@@ -55,8 +57,8 @@ preflight/
 ├── debug/                # Debug and troubleshooting options  
 ├── node_check/           # Individual node validation parameters
 ├── connectivity_check/   # Inter-node connectivity tests
-│   └── rdma/             # RDMA-specific parameters (including nodes_per_full_mesh_group)
-│   └── ifoe/            # (Future: IFoE parameters)
+│   ├── rdma/             # RDMA-specific parameters (including nodes_per_full_mesh_group)
+│   └── ifoe/             # IFoE L2 ping parameters (AIMVT-180; opt-in)
 └── reporting/           # Output and report generation
 ```
 
@@ -162,6 +164,40 @@ All parameters below are optional and have sensible defaults. The sample configu
 - **`exclude_failed_interface_nodes`** (default: "true")
   - Legacy hint for reporting: preflight now prunes interface/GID-failed nodes automatically
   - Interface failures are excluded from mesh testing regardless of this flag
+
+#### IFoE Settings (`connectivity_check.ifoe`) — opt-in (AIMVT-180)
+
+Runs `afmctl test ping` on each reachable node and validates the per-port
+pass/fail table plus the aggregate `Summary:` block in afmctl's output.
+
+- **`connectivity_mode`** (default: `"skip"`)
+  - `"run"` — execute the L2 ping on every reachable node
+  - `"skip"` — preflight records a SKIPPED result and does not invoke afmctl
+- **`afmctl_path`** (default: `"afmctl"`)
+  - Absolute path or PATH-resolved binary name on each node
+- **`use_sudo`** (default: `false`)
+  - Prepend `sudo` to the afmctl invocation when the cluster image requires root
+- **`bdf_discovery`** (default: `"auto"`)
+  - `"auto"` — run `afmctl show device` on each node and use the reported BDFs
+  - `"config"` — use only the `bdfs` list below; nodes with no matching BDFs FAIL
+- **`bdfs`** (default: `[]`)
+  - Optional explicit list of accelerator BDFs to test on every node
+  - Example: `["0001:01:00.1"]`
+- **`dst_accelerators`** (default: `[0]`)
+  - One afmctl invocation is issued per `(bdf, dst_accelerator)` combination
+- **`ports`** (default: `"all"`)
+  - `"all"` (omit `-p`), a string like `"0-7"` or `"0,1,2"`, or a list `[0, 1, 2]`
+- **`pings_per_port`** (default: `1`)
+  - Passed to afmctl as `-c <count>`
+- **`per_ping_timeout`** (default: `null`)
+  - Optional afmctl `-t <seconds>` value; omitted when `null`
+- **`traffic_types`** (default: `["ifoe_req", "ifoe_resp", "non_ifoe"]`)
+  - Determines which afmctl traffic categories are required to pass
+  - When all three are selected, `--traffic-type` is omitted so afmctl runs them all
+- **`loss_threshold_pct`** (default: `0.0`)
+  - Maximum tolerated loss percentage per traffic type (Summary line)
+- **`ssh_timeout`** (default: `180`)
+  - Per-invocation SSH timeout (seconds); raise for high `pings_per_port`
 
 ### Reporting Settings (`reporting`)
 

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -48,6 +48,47 @@
         
         "exclude_failed_interface_nodes": "true",
         "_comment_exclude_failed_interface_nodes": "Legacy hint for reporting: preflight now prunes interface/GID-failed nodes from the SSH host list automatically. Interface failures are excluded from mesh testing regardless of this flag."
+      },
+
+      "ifoe": {
+        "_comment": "IFoE L2 connectivity testing via 'afmctl test ping' (AIMVT-180). Opt-in: defaults to 'skip'.",
+
+        "connectivity_mode": "skip",
+        "_comment_connectivity_mode": "IFoE L2 ping mode. Options: 'run' (execute afmctl L2 ping on every reachable node) or 'skip' (default; preflight will not invoke afmctl). Enable once afmctl and the IFoE driver are available on every node.",
+
+        "afmctl_path": "afmctl",
+        "_comment_afmctl_path": "Absolute path or PATH-resolved name of the afmctl binary on each cluster node. Examples: 'afmctl', '/usr/local/bin/afmctl'.",
+
+        "use_sudo": false,
+        "_comment_use_sudo": "When true, afmctl is invoked with sudo. Enable if afmctl needs root on the cluster image.",
+
+        "bdf_discovery": "auto",
+        "_comment_bdf_discovery": "How to determine which accelerator BDFs to ping on each node. 'auto' runs 'afmctl show device' on each node and uses the BDFs reported there. 'config' uses only the explicit 'bdfs' list below.",
+
+        "_example_bdfs": ["0001:01:00.1"],
+        "bdfs": [],
+        "_comment_bdfs": "Optional explicit list of accelerator BDFs (e.g. ['0001:01:00.1']) shared across the cluster. Leave empty to defer to bdf_discovery='auto'.",
+
+        "dst_accelerators": [0],
+        "_comment_dst_accelerators": "Destination accelerator IDs passed to --dst-accelerator. One afmctl ping is issued per (bdf, dst_accelerator). Use [0] for a single-accelerator destination; use a list like [0, 1] to ping multiple peers.",
+
+        "ports": "all",
+        "_comment_ports": "Ports passed to -p. Use 'all' (default; omits -p so afmctl tests every port), a string like '0,1,2' or '0-7', or a list [0,1,2].",
+
+        "pings_per_port": 1,
+        "_comment_pings_per_port": "Value for -c (pings per port pair). Larger values smooth over transient losses.",
+
+        "per_ping_timeout": null,
+        "_comment_per_ping_timeout": "Optional value for afmctl's -t flag (per-ping timeout). Leave null to use afmctl's default.",
+
+        "traffic_types": ["ifoe_req", "ifoe_resp", "non_ifoe"],
+        "_comment_traffic_types": "Traffic categories to enforce when evaluating PASS/FAIL. Maps to afmctl's --traffic-type (request, response, non-ifoe). When all three are selected (default) --traffic-type is omitted so afmctl exercises every category.",
+
+        "loss_threshold_pct": 0.0,
+        "_comment_loss_threshold_pct": "Maximum tolerated packet loss percentage per traffic type. Defaults to 0.0 (any failure marks the node as FAIL).",
+
+        "ssh_timeout": 180,
+        "_comment_ssh_timeout": "Overall SSH timeout (seconds) for each afmctl invocation. Increase for large port counts or high pings_per_port values."
       }
     },
     

--- a/cvs/lib/preflight/ifoe_l2_connectivity.py
+++ b/cvs/lib/preflight/ifoe_l2_connectivity.py
@@ -186,9 +186,7 @@ class AfmctlPingParser:
                     }
 
         if not result["ports"] and not result["summary"]:
-            result["parse_errors"].append(
-                "Could not locate afmctl ping result table or Summary section in output"
-            )
+            result["parse_errors"].append("Could not locate afmctl ping result table or Summary section in output")
 
         return result
 
@@ -237,9 +235,7 @@ def parse_afmctl_show_device(output: str) -> List[Dict]:
         if lm:
             raw_list = lm.group(1).strip()
             if raw_list and raw_list != "-":
-                cur["local_accelerators"] = [
-                    int(tok) for tok in re.split(r"[,\s]+", raw_list) if tok.isdigit()
-                ]
+                cur["local_accelerators"] = [int(tok) for tok in re.split(r"[,\s]+", raw_list) if tok.isdigit()]
             continue
         nm = re.match(r"^No\.\s*of\s*network\s*ports\s*:\s*(\d+)\s*$", line, re.IGNORECASE)
         if nm:
@@ -368,9 +364,7 @@ class IfoeL2ConnectivityCheck(PreflightCheck):
         self.dst_accelerators: List[int] = _coerce_int_list(dst_accelerators) or [0]
         self.ports = ports if ports not in ("", None) else "all"
         self.pings_per_port: int = int(pings_per_port) if pings_per_port else self.DEFAULT_PINGS_PER_PORT
-        self.per_ping_timeout: Optional[int] = (
-            int(per_ping_timeout) if per_ping_timeout not in (None, "", 0) else None
-        )
+        self.per_ping_timeout: Optional[int] = int(per_ping_timeout) if per_ping_timeout not in (None, "", 0) else None
 
         tt = _coerce_str_list(traffic_types) or list(self.DEFAULT_TRAFFIC_TYPES)
         canonical: List[str] = []
@@ -466,10 +460,7 @@ class IfoeL2ConnectivityCheck(PreflightCheck):
             for port, port_result in (parsed.get("ports") or {}).items():
                 rr = port_result.get(ttype)
                 if rr and rr.get("status") == "FAIL":
-                    errors.append(
-                        f"Port {port} {TRAFFIC_LABELS[ttype]}: "
-                        f"{rr['pass']}/{rr['total']} (FAIL)"
-                    )
+                    errors.append(f"Port {port} {TRAFFIC_LABELS[ttype]}: {rr['pass']}/{rr['total']} (FAIL)")
                     status = "FAIL"
         return status, errors
 

--- a/cvs/lib/preflight/ifoe_l2_connectivity.py
+++ b/cvs/lib/preflight/ifoe_l2_connectivity.py
@@ -1,0 +1,572 @@
+"""
+IFoE L2 Connectivity Check (AIMVT-180).
+
+Validates L2 connectivity by invoking ``afmctl test ping`` on each
+reachable node and parsing the per-port pass/fail counts and the
+aggregate ``Summary:`` section that ``afmctl`` emits.
+
+This is a *per-node* preflight check: each node runs one
+``afmctl test ping`` invocation per configured ``(bdf, dst_accelerator)``
+pairing. The check requires no pairwise SSH coordination because
+``afmctl`` drives the request/response state machine in the device and
+reports a per-port pass/fail table plus an aggregate Summary that we
+surface to the operator.
+
+Example command issued on each node::
+
+    afmctl test ping -b 0001:01:00.1 -c 1 --dst-accelerator 0
+
+Example output parsed by :class:`AfmctlPingParser`::
+
+    0001:01:00.1                   : Ping test results (1 pings per port pair)
+    Accel ID    Port#     IFoE Req        IFoE Rsp        Non-IFoE
+    --------    -----     --------        ---------       --------
+    0           0         1/1 PASS        1/1 PASS        1/1 PASS
+
+    Summary:
+      IFoE Request    : 1/1 PASS, 0/1 fail (0.00% loss)
+      IFoE Response   : 1/1 PASS, 0/1 fail (0.00% loss)
+      Non-IFoE        : 1/1 PASS, 0/1 fail (0.00% loss)
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from cvs.lib.preflight.base import PreflightCheck
+
+TRAFFIC_TYPES: Tuple[str, str, str] = ("ifoe_req", "ifoe_resp", "non_ifoe")
+
+TRAFFIC_LABELS: Dict[str, str] = {
+    "ifoe_req": "IFoE Request",
+    "ifoe_resp": "IFoE Response",
+    "non_ifoe": "Non-IFoE",
+}
+
+_BDF_PATTERN = re.compile(r"^([0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])\s*:")
+
+_PER_PORT_PATTERN = re.compile(
+    r"""^\s*
+        (?P<accel>\d+)\s+
+        (?P<port>\d+)\s+
+        (?P<req_pass>\d+)/(?P<req_total>\d+)\s+(?P<req_status>PASS|FAIL)\s+
+        (?P<resp_pass>\d+)/(?P<resp_total>\d+)\s+(?P<resp_status>PASS|FAIL)\s+
+        (?P<non_pass>\d+)/(?P<non_total>\d+)\s+(?P<non_status>PASS|FAIL)\s*$
+    """,
+    re.VERBOSE,
+)
+
+_SUMMARY_LINE_PATTERN = re.compile(
+    r"""^\s*
+        (?P<label>IFoE\s+Request|IFoE\s+Response|Non-IFoE)\s*:\s*
+        (?P<pass>\d+)/(?P<total>\d+)\s+PASS\s*,\s*
+        (?P<fail>\d+)/(?P<total2>\d+)\s+fail\s*
+        \(\s*(?P<loss>[0-9]+(?:\.[0-9]+)?)\s*%\s+loss\s*\)\s*$
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+_LABEL_TO_KEY: Dict[str, str] = {
+    "ifoe request": "ifoe_req",
+    "ifoe response": "ifoe_resp",
+    "non-ifoe": "non_ifoe",
+}
+
+
+def _normalize_label(label: str) -> str:
+    """Map a Summary section label to our canonical traffic-type key."""
+    key = " ".join(label.strip().split()).lower()
+    return _LABEL_TO_KEY.get(key, key)
+
+
+class AfmctlPingParser:
+    """Parse the output of ``afmctl test ping`` into structured results.
+
+    The parser is intentionally tolerant of extra log/banner lines that
+    afmctl may emit before/after the table (it locates the header by the
+    ``Accel ID  Port#`` line and the Summary section by the literal
+    ``Summary:`` marker).
+    """
+
+    HEADER_RE = re.compile(r"^\s*Accel\s*ID\s+Port#\s+IFoE\s+Req", re.IGNORECASE)
+
+    @classmethod
+    def parse(cls, output: str) -> Dict:
+        """Parse one ``afmctl test ping`` invocation's stdout.
+
+        Args:
+            output: Full stdout (and stderr if merged) from one afmctl run.
+
+        Returns:
+            dict with keys:
+              * ``bdf``: BDF reported on the first results line (or ``None``).
+              * ``pings_per_port``: declared count from the banner (or ``None``).
+              * ``ports``: ``{port_str: {traffic_key: {pass, total, status}}}``.
+              * ``summary``: ``{traffic_key: {pass, total, fail, loss_pct, status}}``.
+              * ``parse_errors``: list of human-readable parse error strings.
+        """
+        result: Dict = {
+            "bdf": None,
+            "pings_per_port": None,
+            "ports": {},
+            "summary": {},
+            "parse_errors": [],
+        }
+        if not output:
+            result["parse_errors"].append("Empty afmctl output")
+            return result
+
+        lines = output.splitlines()
+
+        for line in lines:
+            m = _BDF_PATTERN.match(line)
+            if m and "Ping test results" in line:
+                result["bdf"] = m.group(1)
+                count_match = re.search(r"\((\d+)\s+pings?\s+per\s+port\s+pair\)", line, re.IGNORECASE)
+                if count_match:
+                    result["pings_per_port"] = int(count_match.group(1))
+                break
+
+        in_table = False
+        in_summary = False
+        for line in lines:
+            stripped = line.rstrip()
+            if cls.HEADER_RE.match(stripped):
+                in_table = True
+                continue
+            if in_table and re.match(r"^\s*-{3,}\s+-{3,}", stripped):
+                continue
+            if stripped.strip().startswith("Summary"):
+                in_table = False
+                in_summary = True
+                continue
+
+            if in_table:
+                if not stripped.strip():
+                    in_table = False
+                    continue
+                pm = _PER_PORT_PATTERN.match(stripped)
+                if pm:
+                    port = pm.group("port")
+                    result["ports"][port] = {
+                        "accelerator_id": int(pm.group("accel")),
+                        "ifoe_req": {
+                            "pass": int(pm.group("req_pass")),
+                            "total": int(pm.group("req_total")),
+                            "status": pm.group("req_status").upper(),
+                        },
+                        "ifoe_resp": {
+                            "pass": int(pm.group("resp_pass")),
+                            "total": int(pm.group("resp_total")),
+                            "status": pm.group("resp_status").upper(),
+                        },
+                        "non_ifoe": {
+                            "pass": int(pm.group("non_pass")),
+                            "total": int(pm.group("non_total")),
+                            "status": pm.group("non_status").upper(),
+                        },
+                    }
+
+            if in_summary:
+                sm = _SUMMARY_LINE_PATTERN.match(stripped)
+                if sm:
+                    key = _normalize_label(sm.group("label"))
+                    p = int(sm.group("pass"))
+                    t = int(sm.group("total"))
+                    f = int(sm.group("fail"))
+                    loss = float(sm.group("loss"))
+                    result["summary"][key] = {
+                        "pass": p,
+                        "total": t,
+                        "fail": f,
+                        "loss_pct": loss,
+                        "status": "PASS" if f == 0 and p == t and t > 0 else "FAIL",
+                    }
+
+        if not result["ports"] and not result["summary"]:
+            result["parse_errors"].append(
+                "Could not locate afmctl ping result table or Summary section in output"
+            )
+
+        return result
+
+
+def parse_afmctl_show_device(output: str) -> List[Dict]:
+    """Parse one or more ``afmctl show device`` blocks into device descriptors.
+
+    The output of ``afmctl show device`` is a multi-line block per device::
+
+        BDF                              : 0001:01:00.1
+        Spec:
+          Accelerator id                 : 0
+          Local accelerators             : 0, 1
+          ...
+            No. of network ports         : 72
+
+    Args:
+        output: Combined stdout from running ``afmctl show device``.
+
+    Returns:
+        List of dicts with keys ``bdf``, ``accelerator_id``,
+        ``local_accelerators`` (list[int]), ``num_network_ports`` (int|None).
+    """
+    devices: List[Dict] = []
+    cur: Optional[Dict] = None
+    for raw in output.splitlines():
+        line = raw.strip()
+        m = re.match(r"^BDF\s*:\s*([0-9a-fA-F:.\-]+)\s*$", line)
+        if m:
+            if cur:
+                devices.append(cur)
+            cur = {
+                "bdf": m.group(1),
+                "accelerator_id": None,
+                "local_accelerators": [],
+                "num_network_ports": None,
+            }
+            continue
+        if cur is None:
+            continue
+        am = re.match(r"^Accelerator\s+id\s*:\s*(\d+)\s*$", line)
+        if am:
+            cur["accelerator_id"] = int(am.group(1))
+            continue
+        lm = re.match(r"^Local\s+accelerators\s*:\s*(.+)$", line)
+        if lm:
+            raw_list = lm.group(1).strip()
+            if raw_list and raw_list != "-":
+                cur["local_accelerators"] = [
+                    int(tok) for tok in re.split(r"[,\s]+", raw_list) if tok.isdigit()
+                ]
+            continue
+        nm = re.match(r"^No\.\s*of\s*network\s*ports\s*:\s*(\d+)\s*$", line, re.IGNORECASE)
+        if nm:
+            cur["num_network_ports"] = int(nm.group(1))
+            continue
+    if cur:
+        devices.append(cur)
+    return devices
+
+
+def _coerce_int_list(value) -> List[int]:
+    """Best-effort conversion of config values to a list of ints."""
+    if value is None:
+        return []
+    if isinstance(value, int):
+        return [value]
+    if isinstance(value, str):
+        return [int(t) for t in re.split(r"[,\s]+", value.strip()) if t.strip().isdigit()]
+    if isinstance(value, (list, tuple)):
+        out: List[int] = []
+        for item in value:
+            if isinstance(item, bool):
+                continue
+            if isinstance(item, int):
+                out.append(item)
+            elif isinstance(item, str) and item.strip().isdigit():
+                out.append(int(item.strip()))
+        return out
+    return []
+
+
+def _coerce_str_list(value) -> List[str]:
+    """Best-effort conversion of config values to a list of non-empty strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [tok.strip() for tok in re.split(r"[,\s]+", value.strip()) if tok.strip()]
+    if isinstance(value, (list, tuple)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _format_ports_arg(ports) -> Optional[str]:
+    """Render a ports spec for the ``-p`` flag.
+
+    Accepts ``None``/``"all"`` (returns ``None`` meaning *all ports*), a list
+    of port numbers, or a pre-formatted string like ``"0,1,2"`` or ``"0-7"``.
+    """
+    if ports is None:
+        return None
+    if isinstance(ports, str):
+        normalized = ports.strip()
+        if not normalized or normalized.lower() == "all":
+            return None
+        return normalized
+    if isinstance(ports, (list, tuple)):
+        if not ports:
+            return None
+        return ",".join(str(p) for p in ports)
+    return str(ports)
+
+
+class IfoeL2ConnectivityCheck(PreflightCheck):
+    """Validate IFoE L2 connectivity via ``afmctl test ping`` (AIMVT-180).
+
+    Each reachable cluster node runs one ``afmctl test ping`` invocation per
+    configured ``(bdf, dst_accelerator)`` pairing. The check reports a node
+    as PASS only when **every** invocation completes and every enabled
+    traffic type meets the configured ``loss_threshold_percent``.
+    """
+
+    DEFAULT_AFMCTL_PATH = "afmctl"
+    DEFAULT_PINGS_PER_PORT = 1
+    DEFAULT_PER_PING_TIMEOUT_SEC = 10
+    DEFAULT_SSH_TIMEOUT_SEC = 180
+    DEFAULT_LOSS_THRESHOLD_PCT = 0.0
+    DEFAULT_TRAFFIC_TYPES: Tuple[str, ...] = TRAFFIC_TYPES
+
+    def __init__(
+        self,
+        phdl,
+        afmctl_path: Optional[str] = None,
+        bdfs: Optional[Iterable[str]] = None,
+        dst_accelerators: Optional[Iterable[int]] = None,
+        ports=None,
+        pings_per_port: Optional[int] = None,
+        per_ping_timeout: Optional[int] = None,
+        traffic_types: Optional[Iterable[str]] = None,
+        loss_threshold_pct: Optional[float] = None,
+        ssh_timeout: Optional[int] = None,
+        use_sudo: bool = False,
+        bdf_discovery: str = "auto",
+        config_dict: Optional[Dict] = None,
+    ):
+        """Initialize the IFoE L2 connectivity check.
+
+        Args:
+            phdl: Parallel SSH handle.
+            afmctl_path: Absolute path or command name for the ``afmctl``
+                binary. Defaults to ``"afmctl"`` (PATH lookup).
+            bdfs: Iterable of accelerator BDFs (e.g. ``"0001:01:00.1"``) to
+                test on each node. If empty and ``bdf_discovery == "auto"``,
+                BDFs are auto-discovered per-node via ``afmctl show device``.
+            dst_accelerators: Iterable of destination accelerator IDs passed
+                to ``--dst-accelerator``. Defaults to ``[0]``.
+            ports: Port spec for ``-p``: ``"all"``/``None`` for all ports,
+                a list ``[0,1,2]``, or a string ``"0,1,2"`` / ``"0-7"``.
+            pings_per_port: Value for ``-c`` (per-port-pair ping count).
+            per_ping_timeout: Value for ``-t`` (per-ping timeout). Omitted
+                from the command line if ``None``.
+            traffic_types: Subset of ``("ifoe_req", "ifoe_resp", "non_ifoe")``
+                used both to filter ``--traffic-type`` and to gate pass/fail
+                evaluation. Defaults to all three.
+            loss_threshold_pct: Maximum acceptable loss percentage for any
+                enabled traffic type (default ``0.0``).
+            ssh_timeout: Overall SSH timeout for each ``afmctl`` invocation.
+            use_sudo: Prepend ``sudo`` when calling ``afmctl``.
+            bdf_discovery: ``"auto"`` (run ``afmctl show device`` if ``bdfs``
+                is empty) or ``"config"`` (require ``bdfs`` to be supplied).
+            config_dict: Optional full preflight config block (passed through
+                to the base class for reporting purposes).
+        """
+        super().__init__(phdl, config_dict)
+        self.afmctl_path = afmctl_path or self.DEFAULT_AFMCTL_PATH
+        self.bdfs: List[str] = _coerce_str_list(bdfs)
+        self.dst_accelerators: List[int] = _coerce_int_list(dst_accelerators) or [0]
+        self.ports = ports if ports not in ("", None) else "all"
+        self.pings_per_port: int = int(pings_per_port) if pings_per_port else self.DEFAULT_PINGS_PER_PORT
+        self.per_ping_timeout: Optional[int] = (
+            int(per_ping_timeout) if per_ping_timeout not in (None, "", 0) else None
+        )
+
+        tt = _coerce_str_list(traffic_types) or list(self.DEFAULT_TRAFFIC_TYPES)
+        canonical: List[str] = []
+        for raw in tt:
+            t = raw.strip().lower().replace("-", "_")
+            if t in ("request", "ifoe_request"):
+                t = "ifoe_req"
+            elif t in ("response", "ifoe_response"):
+                t = "ifoe_resp"
+            elif t in ("non_ifoe", "nonifoe"):
+                t = "non_ifoe"
+            if t in TRAFFIC_TYPES:
+                canonical.append(t)
+        self.traffic_types: Tuple[str, ...] = tuple(canonical) if canonical else self.DEFAULT_TRAFFIC_TYPES
+
+        self.loss_threshold_pct: float = (
+            float(loss_threshold_pct) if loss_threshold_pct is not None else self.DEFAULT_LOSS_THRESHOLD_PCT
+        )
+        self.ssh_timeout: int = int(ssh_timeout) if ssh_timeout else self.DEFAULT_SSH_TIMEOUT_SEC
+        self.use_sudo: bool = bool(use_sudo)
+        self.bdf_discovery: str = (bdf_discovery or "auto").strip().lower()
+
+    def _traffic_type_cli(self) -> Optional[str]:
+        """Render ``--traffic-type`` argument or ``None`` if all are enabled."""
+        if not self.traffic_types or set(self.traffic_types) == set(TRAFFIC_TYPES):
+            return None
+        afmctl_names = {
+            "ifoe_req": "request",
+            "ifoe_resp": "response",
+            "non_ifoe": "non-ifoe",
+        }
+        return ",".join(afmctl_names[t] for t in self.traffic_types)
+
+    def build_ping_command(self, bdf: str, dst_accelerator: int) -> str:
+        """Render the ``afmctl test ping`` command line for one invocation."""
+        parts: List[str] = []
+        if self.use_sudo:
+            parts.append("sudo")
+        parts.extend([self.afmctl_path, "test", "ping"])
+        parts.extend(["-b", bdf])
+        parts.extend(["-c", str(self.pings_per_port)])
+        port_spec = _format_ports_arg(self.ports)
+        if port_spec:
+            parts.extend(["-p", port_spec])
+        parts.extend(["--dst-accelerator", str(dst_accelerator)])
+        if self.per_ping_timeout:
+            parts.extend(["-t", str(self.per_ping_timeout)])
+        ttype = self._traffic_type_cli()
+        if ttype:
+            parts.extend(["--traffic-type", ttype])
+        return " ".join(shlex.quote(p) for p in parts)
+
+    def _discover_bdfs_per_node(self) -> Dict[str, List[str]]:
+        """Run ``afmctl show device`` on each reachable host and parse BDFs."""
+        cmd = self.afmctl_path + " show device"
+        if self.use_sudo:
+            cmd = "sudo " + cmd
+        cmd = f"{cmd} 2>&1 || true"
+        out_dict = self.phdl.exec(cmd, timeout=self.ssh_timeout, print_console=False)
+        per_node: Dict[str, List[str]] = {}
+        for node, output in out_dict.items():
+            devices = parse_afmctl_show_device(output or "")
+            per_node[node] = [d["bdf"] for d in devices if d.get("bdf")]
+        return per_node
+
+    def _evaluate_summary(self, parsed: Dict) -> Tuple[str, List[str]]:
+        """Decide PASS/FAIL for one parsed afmctl ping output.
+
+        Returns:
+            Tuple of (status_string, list_of_human_readable_errors).
+        """
+        summary = parsed.get("summary") or {}
+        errors: List[str] = []
+        status = "PASS"
+        for ttype in self.traffic_types:
+            if ttype not in summary:
+                errors.append(f"Missing {TRAFFIC_LABELS.get(ttype, ttype)} summary line in afmctl output")
+                status = "FAIL"
+                continue
+            entry = summary[ttype]
+            if entry.get("total", 0) == 0:
+                errors.append(f"{TRAFFIC_LABELS[ttype]}: zero pings reported")
+                status = "FAIL"
+                continue
+            loss = float(entry.get("loss_pct", 0.0))
+            if loss > self.loss_threshold_pct + 1e-9:
+                errors.append(
+                    f"{TRAFFIC_LABELS[ttype]}: {entry['fail']}/{entry['total']} failed "
+                    f"({loss:.2f}% loss > {self.loss_threshold_pct:.2f}% threshold)"
+                )
+                status = "FAIL"
+        for ttype in self.traffic_types:
+            for port, port_result in (parsed.get("ports") or {}).items():
+                rr = port_result.get(ttype)
+                if rr and rr.get("status") == "FAIL":
+                    errors.append(
+                        f"Port {port} {TRAFFIC_LABELS[ttype]}: "
+                        f"{rr['pass']}/{rr['total']} (FAIL)"
+                    )
+                    status = "FAIL"
+        return status, errors
+
+    def _resolve_bdfs_for_node(self, node: str, discovered: Dict[str, List[str]]) -> List[str]:
+        """Return the BDFs that should be exercised on a single node."""
+        if self.bdfs:
+            return list(self.bdfs)
+        if self.bdf_discovery == "auto":
+            return list(discovered.get(node, []))
+        return []
+
+    def run(self) -> Dict:
+        """Execute IFoE L2 connectivity check across all reachable nodes.
+
+        Returns:
+            ``{node: {status, errors, accelerators: {bdf: {dst_accelerator:
+            {command, raw_output, parsed, status, errors}}}, ...}}``.
+        """
+        self.log_info(
+            f"Running IFoE L2 connectivity check (afmctl={self.afmctl_path}, "
+            f"dst_accelerators={self.dst_accelerators}, ports={self.ports}, "
+            f"pings_per_port={self.pings_per_port}, "
+            f"traffic_types={list(self.traffic_types)}, "
+            f"loss_threshold_pct={self.loss_threshold_pct})"
+        )
+
+        discovered: Dict[str, List[str]] = {}
+        if not self.bdfs and self.bdf_discovery == "auto":
+            self.log_info("Auto-discovering accelerator BDFs via 'afmctl show device'")
+            discovered = self._discover_bdfs_per_node()
+
+        self.results = {}
+        for node in self.phdl.reachable_hosts:
+            self.results[node] = {
+                "status": "PASS",
+                "errors": [],
+                "accelerators": {},
+            }
+            node_bdfs = self._resolve_bdfs_for_node(node, discovered)
+            if not node_bdfs:
+                msg = (
+                    "No IFoE BDFs configured and auto-discovery returned no devices"
+                    if self.bdf_discovery == "auto"
+                    else "No IFoE BDFs configured (bdf_discovery=config)"
+                )
+                self.results[node]["status"] = "FAIL"
+                self.results[node]["errors"].append(msg)
+                continue
+            self.results[node]["bdfs_under_test"] = node_bdfs
+
+        for bdf in self._all_unique_bdfs(discovered):
+            for dst in self.dst_accelerators:
+                cmd = self.build_ping_command(bdf, dst)
+                self.log_info(f"Executing on cluster: {cmd}")
+                out_dict = self.phdl.exec(cmd, timeout=self.ssh_timeout, print_console=False)
+                for node, output in out_dict.items():
+                    if node not in self.results:
+                        continue
+                    accel_block = self.results[node]["accelerators"].setdefault(bdf, {})
+                    if bdf not in self.results[node].get("bdfs_under_test", []):
+                        accel_block[str(dst)] = {
+                            "command": cmd,
+                            "status": "SKIPPED",
+                            "errors": [f"BDF {bdf} not present on this node"],
+                            "raw_output": "",
+                            "parsed": {},
+                        }
+                        continue
+                    parsed = AfmctlPingParser.parse(output or "")
+                    status, errs = self._evaluate_summary(parsed)
+                    if parsed.get("parse_errors"):
+                        status = "FAIL"
+                        errs.extend(parsed["parse_errors"])
+                    accel_block[str(dst)] = {
+                        "command": cmd,
+                        "dst_accelerator": dst,
+                        "status": status,
+                        "errors": errs,
+                        "raw_output": output or "",
+                        "parsed": parsed,
+                    }
+                    if status == "FAIL":
+                        self.results[node]["status"] = "FAIL"
+                        for err in errs:
+                            self.results[node]["errors"].append(f"{bdf} -> accel {dst}: {err}")
+
+        return self.results
+
+    def _all_unique_bdfs(self, discovered: Dict[str, List[str]]) -> List[str]:
+        """Union of explicitly configured BDFs and per-node discovered BDFs."""
+        seen: List[str] = []
+        for b in self.bdfs:
+            if b not in seen:
+                seen.append(b)
+        if not self.bdfs and self.bdf_discovery == "auto":
+            for blist in discovered.values():
+                for b in blist:
+                    if b not in seen:
+                        seen.append(b)
+        return seen

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -308,9 +308,9 @@ class PreflightReportGenerator(PreflightCheck):
 
         node_results = ifoe_results.get('node_results') or {}
         total_nodes = len(node_results)
-        failed_nodes = list(ifoe_results.get('failed_nodes') or [
-            n for n, r in node_results.items() if r.get('status') == 'FAIL'
-        ])
+        failed_nodes = list(
+            ifoe_results.get('failed_nodes') or [n for n, r in node_results.items() if r.get('status') == 'FAIL']
+        )
         passing_nodes = total_nodes - len(failed_nodes)
         total_invocations = int(ifoe_results.get('total_invocations', 0))
         failed_invocations = int(ifoe_results.get('failed_invocations', 0))
@@ -318,8 +318,7 @@ class PreflightReportGenerator(PreflightCheck):
         summary_text = f"{passing_nodes}/{total_nodes} nodes passed IFoE L2 ping"
         if total_invocations:
             summary_text += (
-                f"; {total_invocations - failed_invocations}/{total_invocations} "
-                f"afmctl invocations succeeded"
+                f"; {total_invocations - failed_invocations}/{total_invocations} afmctl invocations succeeded"
             )
         return {
             'status': status,
@@ -880,10 +879,13 @@ class PreflightReportGenerator(PreflightCheck):
         """
 
         if not failed_nodes:
-            return header + """
+            return (
+                header
+                + """
             <p class="status-pass">All reachable nodes passed IFoE L2 ping.</p>
         </section>
         """
+            )
 
         rows = []
         for node in failed_nodes:
@@ -919,9 +921,7 @@ class PreflightReportGenerator(PreflightCheck):
                             if isinstance(port_result.get(k), dict) and port_result[k].get('status') == 'FAIL'
                         ]
                         if bad:
-                            parts = ", ".join(
-                                f"{lbl}={rr['pass']}/{rr['total']}" for lbl, rr in bad
-                            )
+                            parts = ", ".join(f"{lbl}={rr['pass']}/{rr['total']}" for lbl, rr in bad)
                             failed_ports.append(f"port {html.escape(str(port))} ({parts})")
 
                     detail_html = ""
@@ -958,9 +958,11 @@ class PreflightReportGenerator(PreflightCheck):
                 </tr>
                 """)
             if not (node_block.get('accelerators') or {}) and node_errors:
-                node_err_html = "<ul style='margin:6px 0;color:#721c24;'>" + "".join(
-                    f"<li>{html.escape(str(e))}</li>" for e in node_errors
-                ) + "</ul>"
+                node_err_html = (
+                    "<ul style='margin:6px 0;color:#721c24;'>"
+                    + "".join(f"<li>{html.escape(str(e))}</li>" for e in node_errors)
+                    + "</ul>"
+                )
                 rows.append(f"""
                 <tr>
                     <td><code>{html.escape(str(node))}</code></td>
@@ -969,7 +971,8 @@ class PreflightReportGenerator(PreflightCheck):
                 </tr>
                 """)
 
-        table = """
+        table = (
+            """
             <p class="error-summary">The following IFoE L2 ping invocations failed:</p>
             <table>
                 <thead>
@@ -982,11 +985,14 @@ class PreflightReportGenerator(PreflightCheck):
                     </tr>
                 </thead>
                 <tbody>
-        """ + "".join(rows) + """
+        """
+            + "".join(rows)
+            + """
                 </tbody>
             </table>
         </section>
         """
+        )
 
         return header + table
 

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -99,6 +99,7 @@ class PreflightReportGenerator(PreflightCheck):
         connectivity_results = self.results.get('rdma_connectivity', {})
         rocm_results = self.results.get('rocm_versions', {})
         interface_results = self.results.get('interface_names', {})
+        ifoe_l2_results = self.results.get('ifoe_l2_connectivity', {})
         reachability_results = self.results.get('node_reachability')
         ssh_connectivity_results = self.results.get('ssh_connectivity')
         summary = {
@@ -106,6 +107,7 @@ class PreflightReportGenerator(PreflightCheck):
             'checks': {
                 'ssh_reachability': self._summarize_reachability_results(reachability_results),
                 'gid_consistency': self._summarize_gid_results(gid_results),
+                'ifoe_l2_connectivity': self._summarize_ifoe_l2_results(ifoe_l2_results),
                 'rdma_connectivity': self._summarize_connectivity_results(connectivity_results),
                 'rocm_versions': self._summarize_rocm_results(rocm_results),
                 'interface_names': self._summarize_interface_results(interface_results),
@@ -125,6 +127,11 @@ class PreflightReportGenerator(PreflightCheck):
         if summary['checks']['gid_consistency']['status'] == 'FAIL':
             summary['recommendations'].append(
                 "Fix GID configuration on RDMA interfaces before running performance tests"
+            )
+
+        if summary['checks']['ifoe_l2_connectivity']['status'] == 'FAIL':
+            summary['recommendations'].append(
+                "Address IFoE L2 ping failures via afmctl on affected nodes before benchmarking"
             )
 
         if summary['checks']['rdma_connectivity']['status'] == 'FAIL':
@@ -282,6 +289,48 @@ class PreflightReportGenerator(PreflightCheck):
             'summary': f"{compliant_nodes}/{total_nodes} nodes have compliant interface names",
         }
 
+    def _summarize_ifoe_l2_results(self, ifoe_results):
+        """Summarize IFoE L2 connectivity (afmctl) check results."""
+        if not ifoe_results or ifoe_results.get('skipped'):
+            msg = (
+                ifoe_results.get('message')
+                if isinstance(ifoe_results, dict)
+                else 'IFoE L2 connectivity test not performed'
+            )
+            return {
+                'status': 'SKIPPED',
+                'total_nodes': 0,
+                'failed_nodes': [],
+                'total_invocations': 0,
+                'failed_invocations': 0,
+                'summary': msg or 'IFoE L2 connectivity test skipped',
+            }
+
+        node_results = ifoe_results.get('node_results') or {}
+        total_nodes = len(node_results)
+        failed_nodes = list(ifoe_results.get('failed_nodes') or [
+            n for n, r in node_results.items() if r.get('status') == 'FAIL'
+        ])
+        passing_nodes = total_nodes - len(failed_nodes)
+        total_invocations = int(ifoe_results.get('total_invocations', 0))
+        failed_invocations = int(ifoe_results.get('failed_invocations', 0))
+        status = 'PASS' if not failed_nodes else 'FAIL'
+        summary_text = f"{passing_nodes}/{total_nodes} nodes passed IFoE L2 ping"
+        if total_invocations:
+            summary_text += (
+                f"; {total_invocations - failed_invocations}/{total_invocations} "
+                f"afmctl invocations succeeded"
+            )
+        return {
+            'status': status,
+            'total_nodes': total_nodes,
+            'passing_nodes': passing_nodes,
+            'failed_nodes': failed_nodes,
+            'total_invocations': total_invocations,
+            'failed_invocations': failed_invocations,
+            'summary': summary_text,
+        }
+
     def _summarize_reachability_results(self, reachability_results):
         """Summarize SSH reachability check results."""
         if not reachability_results:
@@ -383,6 +432,7 @@ class PreflightReportGenerator(PreflightCheck):
 
             {self._generate_executive_summary_html(summary)}
             {self._generate_gid_consistency_html(results.get('gid_consistency', {}))}
+            {self._generate_ifoe_l2_html(results.get('ifoe_l2_connectivity', {}))}
             {self._generate_connectivity_html(results.get('rdma_connectivity', {}))}
             {self._generate_ssh_connectivity_html(results.get('ssh_connectivity', {}))}
             {self._generate_rocm_versions_html(results.get('rocm_versions', {}))}
@@ -795,6 +845,150 @@ class PreflightReportGenerator(PreflightCheck):
         </section>
         """
         return html
+
+    def _generate_ifoe_l2_html(self, ifoe_results):
+        """Generate IFoE L2 connectivity section - failure details and a per-node breakdown."""
+        if not ifoe_results:
+            return ""
+
+        if ifoe_results.get('skipped'):
+            msg = ifoe_results.get('message', 'IFoE L2 connectivity test skipped')
+            return f"""
+        <section>
+            <h2>IFoE L2 Connectivity (afmctl)</h2>
+            <p><em>{html.escape(msg)}</em></p>
+        </section>
+        """
+
+        node_results = ifoe_results.get('node_results') or {}
+        if not node_results:
+            return ""
+
+        failed_nodes = sorted(n for n, r in node_results.items() if r.get('status') == 'FAIL')
+        total_invocations = int(ifoe_results.get('total_invocations', 0))
+        failed_invocations = int(ifoe_results.get('failed_invocations', 0))
+        loss_threshold = ifoe_results.get('loss_threshold_pct', 0.0)
+        traffic_types = ifoe_results.get('traffic_types') or []
+
+        header = f"""
+        <section>
+            <h2>IFoE L2 Connectivity (afmctl)</h2>
+            <p>Tested via <code>afmctl test ping</code>.
+            Traffic types enforced: <code>{html.escape(", ".join(str(t) for t in traffic_types))}</code>;
+            loss threshold: <code>{html.escape(str(loss_threshold))}%</code>;
+            invocations: <code>{total_invocations - failed_invocations}/{total_invocations}</code> succeeded.</p>
+        """
+
+        if not failed_nodes:
+            return header + """
+            <p class="status-pass">All reachable nodes passed IFoE L2 ping.</p>
+        </section>
+        """
+
+        rows = []
+        for node in failed_nodes:
+            node_block = node_results[node]
+            node_errors = node_block.get('errors') or []
+            for bdf, invocations in (node_block.get('accelerators') or {}).items():
+                for dst, invocation in invocations.items():
+                    if invocation.get('status') != 'FAIL':
+                        continue
+                    parsed = invocation.get('parsed') or {}
+                    summary_lines = []
+                    for ttype, label in (
+                        ('ifoe_req', 'IFoE Request'),
+                        ('ifoe_resp', 'IFoE Response'),
+                        ('non_ifoe', 'Non-IFoE'),
+                    ):
+                        s = (parsed.get('summary') or {}).get(ttype)
+                        if not s:
+                            continue
+                        summary_lines.append(
+                            f"{html.escape(label)}: {s['pass']}/{s['total']} "
+                            f"PASS, {s['fail']}/{s['total']} fail ({s['loss_pct']:.2f}% loss)"
+                        )
+                    failed_ports = []
+                    for port, port_result in (parsed.get('ports') or {}).items():
+                        bad = [
+                            (label, port_result[k])
+                            for k, label in (
+                                ('ifoe_req', 'IFoE Req'),
+                                ('ifoe_resp', 'IFoE Rsp'),
+                                ('non_ifoe', 'Non-IFoE'),
+                            )
+                            if isinstance(port_result.get(k), dict) and port_result[k].get('status') == 'FAIL'
+                        ]
+                        if bad:
+                            parts = ", ".join(
+                                f"{lbl}={rr['pass']}/{rr['total']}" for lbl, rr in bad
+                            )
+                            failed_ports.append(f"port {html.escape(str(port))} ({parts})")
+
+                    detail_html = ""
+                    if summary_lines:
+                        detail_html += "<ul style='margin:6px 0;'>"
+                        for line in summary_lines:
+                            detail_html += f"<li>{line}</li>"
+                        detail_html += "</ul>"
+                    if failed_ports:
+                        detail_html += "<p><strong>Failed ports:</strong> " + "; ".join(failed_ports) + "</p>"
+                    invocation_errors = invocation.get('errors') or []
+                    if invocation_errors:
+                        detail_html += "<ul style='margin:6px 0;color:#721c24;'>"
+                        for err in invocation_errors[:20]:
+                            detail_html += f"<li>{html.escape(str(err))}</li>"
+                        detail_html += "</ul>"
+
+                    raw = invocation.get('raw_output') or ''
+                    if raw.strip():
+                        snippet = raw if len(raw) <= 4000 else raw[:4000] + "\n... (truncated) ..."
+                        detail_html += (
+                            "<details><summary>afmctl output</summary>"
+                            f"<pre style='white-space:pre-wrap;'>{html.escape(snippet)}</pre>"
+                            "</details>"
+                        )
+
+                    rows.append(f"""
+                <tr>
+                    <td><code>{html.escape(str(node))}</code></td>
+                    <td><code>{html.escape(str(bdf))}</code></td>
+                    <td>{html.escape(str(dst))}</td>
+                    <td><code>{html.escape(invocation.get('command', ''))}</code></td>
+                    <td>{detail_html}</td>
+                </tr>
+                """)
+            if not (node_block.get('accelerators') or {}) and node_errors:
+                node_err_html = "<ul style='margin:6px 0;color:#721c24;'>" + "".join(
+                    f"<li>{html.escape(str(e))}</li>" for e in node_errors
+                ) + "</ul>"
+                rows.append(f"""
+                <tr>
+                    <td><code>{html.escape(str(node))}</code></td>
+                    <td colspan='3'><em>No afmctl invocations completed</em></td>
+                    <td>{node_err_html}</td>
+                </tr>
+                """)
+
+        table = """
+            <p class="error-summary">The following IFoE L2 ping invocations failed:</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Node</th>
+                        <th>BDF</th>
+                        <th>--dst-accelerator</th>
+                        <th>Command</th>
+                        <th>Failure Details</th>
+                    </tr>
+                </thead>
+                <tbody>
+        """ + "".join(rows) + """
+                </tbody>
+            </table>
+        </section>
+        """
+
+        return header + table
 
     @staticmethod
     def _rdma_pair_row_fields(pair_key, pair_result):

--- a/cvs/lib/preflight/unittests/test_ifoe_l2_connectivity.py
+++ b/cvs/lib/preflight/unittests/test_ifoe_l2_connectivity.py
@@ -199,9 +199,7 @@ class TestIfoeL2ConnectivityCheck(unittest.TestCase):
         self.assertIn('--traffic-type request,non-ifoe', cmd)
 
     def test_traffic_type_aliases_normalized(self):
-        check = IfoeL2ConnectivityCheck(
-            MagicMock(), traffic_types=['REQUEST', 'response', 'non-ifoe']
-        )
+        check = IfoeL2ConnectivityCheck(MagicMock(), traffic_types=['REQUEST', 'response', 'non-ifoe'])
         self.assertEqual(set(check.traffic_types), {'ifoe_req', 'ifoe_resp', 'non_ifoe'})
 
     def test_run_passes_with_explicit_bdfs(self):

--- a/cvs/lib/preflight/unittests/test_ifoe_l2_connectivity.py
+++ b/cvs/lib/preflight/unittests/test_ifoe_l2_connectivity.py
@@ -1,0 +1,328 @@
+"""Unit tests for IFoE L2 connectivity preflight check (AIMVT-180)."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+
+from cvs.lib.preflight.ifoe_l2_connectivity import (
+    AfmctlPingParser,
+    IfoeL2ConnectivityCheck,
+    parse_afmctl_show_device,
+)
+
+
+PASSING_OUTPUT = """\
+0001:01:00.1                   : Ping test results (1 pings per port pair)
+Accel ID    Port#     IFoE Req        IFoE Rsp        Non-IFoE
+--------    -----     --------        ---------       --------
+0           0         1/1 PASS        1/1 PASS        1/1 PASS
+0           1         1/1 PASS        1/1 PASS        1/1 PASS
+
+Summary:
+  IFoE Request    : 2/2 PASS, 0/2 fail (0.00% loss)
+  IFoE Response   : 2/2 PASS, 0/2 fail (0.00% loss)
+  Non-IFoE        : 2/2 PASS, 0/2 fail (0.00% loss)
+"""
+
+
+FAILING_OUTPUT = """\
+0001:01:00.1                   : Ping test results (3 pings per port pair)
+Accel ID    Port#     IFoE Req        IFoE Rsp        Non-IFoE
+--------    -----     --------        ---------       --------
+0           0         3/3 PASS        3/3 PASS        3/3 PASS
+0           1         0/3 FAIL        3/3 PASS        1/3 FAIL
+0           2         3/3 PASS        2/3 FAIL        3/3 PASS
+
+Summary:
+  IFoE Request    : 6/9 PASS, 3/9 fail (33.33% loss)
+  IFoE Response   : 8/9 PASS, 1/9 fail (11.11% loss)
+  Non-IFoE        : 7/9 PASS, 2/9 fail (22.22% loss)
+"""
+
+
+PARTIAL_LOSS_OUTPUT = """\
+0001:01:00.1                   : Ping test results (10 pings per port pair)
+Accel ID    Port#     IFoE Req        IFoE Rsp        Non-IFoE
+--------    -----     --------        ---------       --------
+0           0         9/10 FAIL       10/10 PASS      10/10 PASS
+
+Summary:
+  IFoE Request    : 9/10 PASS, 1/10 fail (10.00% loss)
+  IFoE Response   : 10/10 PASS, 0/10 fail (0.00% loss)
+  Non-IFoE        : 10/10 PASS, 0/10 fail (0.00% loss)
+"""
+
+
+SHOW_DEVICE_OUTPUT = """\
+BDF                              : 0001:01:00.1
+Spec:
+  Accelerator id                 : 0
+  Local accelerators             : 0, 1
+  Capability:
+    No. of network ports         : 72
+"""
+
+
+class TestAfmctlPingParser(unittest.TestCase):
+    """Tests for the afmctl ping output parser."""
+
+    def test_passing_output_parsed(self):
+        parsed = AfmctlPingParser.parse(PASSING_OUTPUT)
+        self.assertEqual(parsed['bdf'], '0001:01:00.1')
+        self.assertEqual(parsed['pings_per_port'], 1)
+        self.assertEqual(set(parsed['ports'].keys()), {'0', '1'})
+        for port in ('0', '1'):
+            for ttype in ('ifoe_req', 'ifoe_resp', 'non_ifoe'):
+                self.assertEqual(parsed['ports'][port][ttype]['status'], 'PASS')
+                self.assertEqual(parsed['ports'][port][ttype]['pass'], 1)
+                self.assertEqual(parsed['ports'][port][ttype]['total'], 1)
+        for ttype in ('ifoe_req', 'ifoe_resp', 'non_ifoe'):
+            self.assertEqual(parsed['summary'][ttype]['status'], 'PASS')
+            self.assertEqual(parsed['summary'][ttype]['loss_pct'], 0.0)
+            self.assertEqual(parsed['summary'][ttype]['pass'], 2)
+            self.assertEqual(parsed['summary'][ttype]['fail'], 0)
+        self.assertFalse(parsed['parse_errors'])
+
+    def test_failing_output_parsed(self):
+        parsed = AfmctlPingParser.parse(FAILING_OUTPUT)
+        self.assertEqual(parsed['pings_per_port'], 3)
+        self.assertEqual(parsed['ports']['0']['ifoe_req']['status'], 'PASS')
+        self.assertEqual(parsed['ports']['1']['ifoe_req']['status'], 'FAIL')
+        self.assertEqual(parsed['ports']['1']['ifoe_req']['pass'], 0)
+        self.assertEqual(parsed['ports']['2']['ifoe_resp']['status'], 'FAIL')
+        self.assertAlmostEqual(parsed['summary']['ifoe_req']['loss_pct'], 33.33, places=2)
+        self.assertEqual(parsed['summary']['ifoe_req']['status'], 'FAIL')
+        self.assertEqual(parsed['summary']['ifoe_resp']['status'], 'FAIL')
+        self.assertEqual(parsed['summary']['non_ifoe']['status'], 'FAIL')
+
+    def test_empty_output(self):
+        parsed = AfmctlPingParser.parse('')
+        self.assertEqual(parsed['ports'], {})
+        self.assertEqual(parsed['summary'], {})
+        self.assertTrue(parsed['parse_errors'])
+
+    def test_garbage_output(self):
+        parsed = AfmctlPingParser.parse('command not found\nbash: afmctl: No such file\n')
+        self.assertEqual(parsed['ports'], {})
+        self.assertEqual(parsed['summary'], {})
+        self.assertTrue(parsed['parse_errors'])
+
+    def test_partial_loss_output(self):
+        parsed = AfmctlPingParser.parse(PARTIAL_LOSS_OUTPUT)
+        self.assertAlmostEqual(parsed['summary']['ifoe_req']['loss_pct'], 10.0)
+        self.assertEqual(parsed['summary']['ifoe_req']['fail'], 1)
+        self.assertEqual(parsed['summary']['ifoe_req']['status'], 'FAIL')
+        self.assertEqual(parsed['summary']['ifoe_resp']['status'], 'PASS')
+
+
+class TestParseAfmctlShowDevice(unittest.TestCase):
+    """Tests for parse_afmctl_show_device()."""
+
+    def test_single_device(self):
+        devices = parse_afmctl_show_device(SHOW_DEVICE_OUTPUT)
+        self.assertEqual(len(devices), 1)
+        d = devices[0]
+        self.assertEqual(d['bdf'], '0001:01:00.1')
+        self.assertEqual(d['accelerator_id'], 0)
+        self.assertEqual(d['local_accelerators'], [0, 1])
+        self.assertEqual(d['num_network_ports'], 72)
+
+    def test_multiple_devices(self):
+        two_devs = SHOW_DEVICE_OUTPUT + "\n" + SHOW_DEVICE_OUTPUT.replace('0001:01:00.1', '0002:01:00.1')
+        devices = parse_afmctl_show_device(two_devs)
+        self.assertEqual(len(devices), 2)
+        self.assertEqual({d['bdf'] for d in devices}, {'0001:01:00.1', '0002:01:00.1'})
+
+    def test_empty(self):
+        self.assertEqual(parse_afmctl_show_device(''), [])
+
+    def test_garbage(self):
+        self.assertEqual(parse_afmctl_show_device('bash: afmctl: command not found\n'), [])
+
+
+class TestIfoeL2ConnectivityCheck(unittest.TestCase):
+    """Tests for the IfoeL2ConnectivityCheck class."""
+
+    def _make_phdl(self, reachable_hosts, exec_responses):
+        """Build a MagicMock phdl that returns scripted exec() responses.
+
+        Args:
+            reachable_hosts: list of host names.
+            exec_responses: list of {host: output} dicts returned by successive
+                ``phdl.exec()`` calls.
+        """
+        phdl = MagicMock()
+        phdl.reachable_hosts = list(reachable_hosts)
+        phdl.exec = MagicMock(side_effect=exec_responses)
+        return phdl
+
+    def test_build_ping_command_defaults(self):
+        check = IfoeL2ConnectivityCheck(MagicMock())
+        cmd = check.build_ping_command('0001:01:00.1', 0)
+        self.assertIn('afmctl test ping', cmd)
+        self.assertIn('-b 0001:01:00.1', cmd)
+        self.assertIn('-c 1', cmd)
+        self.assertIn('--dst-accelerator 0', cmd)
+        self.assertNotIn('-p ', cmd)
+        self.assertNotIn('--traffic-type', cmd)
+
+    def test_build_ping_command_with_ports_and_timeout(self):
+        check = IfoeL2ConnectivityCheck(
+            MagicMock(),
+            afmctl_path='/usr/local/bin/afmctl',
+            ports=[0, 1, 2],
+            pings_per_port=5,
+            per_ping_timeout=10,
+            use_sudo=True,
+            traffic_types=['ifoe_req'],
+        )
+        cmd = check.build_ping_command('0001:01:00.1', 3)
+        self.assertTrue(cmd.startswith('sudo /usr/local/bin/afmctl test ping'))
+        self.assertIn('-b 0001:01:00.1', cmd)
+        self.assertIn('-c 5', cmd)
+        self.assertIn('-p 0,1,2', cmd)
+        self.assertIn('--dst-accelerator 3', cmd)
+        self.assertIn('-t 10', cmd)
+        self.assertIn('--traffic-type request', cmd)
+
+    def test_build_ping_command_ports_string(self):
+        check = IfoeL2ConnectivityCheck(MagicMock(), ports='0-7')
+        cmd = check.build_ping_command('0001:01:00.1', 1)
+        self.assertIn('-p 0-7', cmd)
+
+    def test_traffic_type_subset_two(self):
+        check = IfoeL2ConnectivityCheck(MagicMock(), traffic_types=['ifoe_req', 'non_ifoe'])
+        cmd = check.build_ping_command('0001:01:00.1', 0)
+        self.assertIn('--traffic-type request,non-ifoe', cmd)
+
+    def test_traffic_type_aliases_normalized(self):
+        check = IfoeL2ConnectivityCheck(
+            MagicMock(), traffic_types=['REQUEST', 'response', 'non-ifoe']
+        )
+        self.assertEqual(set(check.traffic_types), {'ifoe_req', 'ifoe_resp', 'non_ifoe'})
+
+    def test_run_passes_with_explicit_bdfs(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA', 'nodeB'],
+            exec_responses=[
+                {'nodeA': PASSING_OUTPUT, 'nodeB': PASSING_OUTPUT},
+            ],
+        )
+        check = IfoeL2ConnectivityCheck(
+            phdl,
+            bdfs=['0001:01:00.1'],
+            dst_accelerators=[0],
+            bdf_discovery='config',
+        )
+        results = check.run()
+        self.assertEqual(set(results.keys()), {'nodeA', 'nodeB'})
+        for node in ('nodeA', 'nodeB'):
+            self.assertEqual(results[node]['status'], 'PASS')
+            accel_block = results[node]['accelerators']['0001:01:00.1']
+            self.assertEqual(accel_block['0']['status'], 'PASS')
+            self.assertEqual(accel_block['0']['parsed']['summary']['ifoe_req']['loss_pct'], 0.0)
+        self.assertEqual(phdl.exec.call_count, 1)
+
+    def test_run_marks_failure_on_loss(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[{'nodeA': FAILING_OUTPUT}],
+        )
+        check = IfoeL2ConnectivityCheck(
+            phdl,
+            bdfs=['0001:01:00.1'],
+            bdf_discovery='config',
+        )
+        results = check.run()
+        self.assertEqual(results['nodeA']['status'], 'FAIL')
+        self.assertTrue(results['nodeA']['errors'])
+        self.assertIn('0001:01:00.1 -> accel 0', results['nodeA']['errors'][0])
+        invocation = results['nodeA']['accelerators']['0001:01:00.1']['0']
+        self.assertEqual(invocation['status'], 'FAIL')
+
+    def test_run_loss_threshold_allows_partial_loss(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[{'nodeA': PARTIAL_LOSS_OUTPUT}],
+        )
+        check = IfoeL2ConnectivityCheck(
+            phdl,
+            bdfs=['0001:01:00.1'],
+            bdf_discovery='config',
+            loss_threshold_pct=15.0,
+        )
+        results = check.run()
+        invocation = results['nodeA']['accelerators']['0001:01:00.1']['0']
+        self.assertEqual(invocation['status'], 'FAIL')
+        node_status = results['nodeA']['status']
+        self.assertEqual(node_status, 'FAIL')
+        self.assertTrue(
+            any('Port 0 IFoE Request' in err for err in invocation['errors']),
+            f"expected port-level error, got: {invocation['errors']}",
+        )
+
+    def test_run_traffic_type_subset_ignores_excluded(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[{'nodeA': FAILING_OUTPUT}],
+        )
+        check = IfoeL2ConnectivityCheck(
+            phdl,
+            bdfs=['0001:01:00.1'],
+            bdf_discovery='config',
+            traffic_types=['ifoe_resp'],
+        )
+        results = check.run()
+        invocation = results['nodeA']['accelerators']['0001:01:00.1']['0']
+        self.assertEqual(invocation['status'], 'FAIL')
+        for err in invocation['errors']:
+            self.assertNotIn('IFoE Request', err)
+            self.assertNotIn('Non-IFoE', err)
+
+    def test_run_skipped_node_when_bdf_missing(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA', 'nodeB'],
+            exec_responses=[
+                {'nodeA': SHOW_DEVICE_OUTPUT, 'nodeB': 'bash: afmctl: command not found\n'},
+                {'nodeA': PASSING_OUTPUT, 'nodeB': 'bash: afmctl: command not found\n'},
+            ],
+        )
+        check = IfoeL2ConnectivityCheck(
+            phdl,
+            dst_accelerators=[0],
+            bdf_discovery='auto',
+        )
+        results = check.run()
+        self.assertEqual(results['nodeA']['status'], 'PASS')
+        self.assertEqual(results['nodeB']['status'], 'FAIL')
+        self.assertTrue(
+            any('No IFoE BDFs configured' in e for e in results['nodeB']['errors']),
+            f"expected discovery failure message, got: {results['nodeB']['errors']}",
+        )
+
+    def test_run_multiple_dst_accelerators(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[
+                {'nodeA': PASSING_OUTPUT},
+                {'nodeA': PASSING_OUTPUT},
+            ],
+        )
+        check = IfoeL2ConnectivityCheck(
+            phdl,
+            bdfs=['0001:01:00.1'],
+            dst_accelerators=[0, 1],
+            bdf_discovery='config',
+        )
+        results = check.run()
+        self.assertEqual(results['nodeA']['status'], 'PASS')
+        accel_block = results['nodeA']['accelerators']['0001:01:00.1']
+        self.assertEqual(set(accel_block.keys()), {'0', '1'})
+        self.assertEqual(phdl.exec.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/tests/preflight/README.md
+++ b/cvs/tests/preflight/README.md
@@ -4,12 +4,13 @@ A comprehensive validation system for GPU clusters before running performance te
 
 ## Overview
 
-The preflight checks system validates essential cluster health and configuration consistency across all nodes. It performs four critical validations:
+The preflight checks system validates essential cluster health and configuration consistency across all nodes. It performs the following validations:
 
 1. **GID Consistency** - Ensures RDMA interfaces have valid Global Identifier entries
-2. **RDMA Connectivity** - Tests node-to-node RDMA communication using `rping`
+2. **RDMA Interface Presence** - Validates that expected RDMA interfaces are present and link-up
 3. **ROCm Version Consistency** - Verifies consistent ROCm versions across all nodes
-4. **RDMA Interface Presence** - Validates that expected RDMA interfaces are present
+4. **IFoE L2 Connectivity** - Validates L2 reachability of IFoE links via `afmctl test ping` *(AIMVT-180; opt-in)*
+5. **RDMA Connectivity** - Tests node-to-node RDMA communication using `ibv_rc_pingpong`
 
 ## Quick Start
 
@@ -84,10 +85,54 @@ Located at: `cvs/input/config_file/preflight/preflight_config.json`
 ### Key Parameters
 
 - **`connectivity_check.rdma.connectivity_mode`**: `"basic"`, `"full_mesh"`, or `"skip"`
+- **`connectivity_check.ifoe.connectivity_mode`**: `"run"` or `"skip"` (default)
 - **`node_check.expected_rocm_version`**: ROCm version expected across all nodes
 - **`node_check.rdma_interfaces`**: List of expected RDMA interface names
 - **`connectivity_check.rdma.ibv_test_timeout`**: Timeout in seconds for ibv_rc_pingpong tests
 - **`connectivity_check.rdma.ibv_test_port_range`**: Port range for parallel ibv_rc_pingpong tests
+
+## IFoE L2 Connectivity (AIMVT-180)
+
+Validates L2 reachability of IFoE links by invoking `afmctl test ping` on
+each reachable node and parsing the per-port pass/fail counts and the
+aggregate `Summary:` section from `afmctl`'s output.
+
+Each invocation issues:
+
+```
+<afmctl_path> test ping -b <bdf> -c <pings_per_port> [-p <ports>] \
+    --dst-accelerator <accel_id> [-t <per_ping_timeout>] [--traffic-type ...]
+```
+
+The check is **opt-in**: it defaults to `connectivity_mode: "skip"` so it
+will not run unless explicitly enabled. Enable it by setting
+`preflight.connectivity_check.ifoe.connectivity_mode` to `"run"` once the
+IFoE driver and `afmctl` are available on every node.
+
+When `bdfs` is empty and `bdf_discovery` is `"auto"` (default), preflight
+runs `afmctl show device` on every reachable node and uses the BDFs it
+reports. A node is marked **FAIL** if any enabled traffic type
+(`ifoe_req`, `ifoe_resp`, `non_ifoe`) exceeds `loss_threshold_pct` (default
+`0.0`), or if any per-port table entry reports `FAIL`.
+
+### Example IFoE config block
+
+```json
+"connectivity_check": {
+  "ifoe": {
+    "connectivity_mode": "run",
+    "afmctl_path": "/usr/local/bin/afmctl",
+    "use_sudo": true,
+    "bdf_discovery": "auto",
+    "dst_accelerators": [0, 1],
+    "ports": "all",
+    "pings_per_port": 5,
+    "traffic_types": ["ifoe_req", "ifoe_resp", "non_ifoe"],
+    "loss_threshold_pct": 0.0,
+    "ssh_timeout": 240
+  }
+}
+```
 
 ## Output and Reporting
 

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -490,9 +490,7 @@ def test_ifoe_l2_connectivity(phdl, config_dict):
         return
 
     if not phdl.reachable_hosts:
-        log.warning(
-            "IFoE L2 connectivity skipped: no reachable hosts remain after earlier preflight pruning"
-        )
+        log.warning("IFoE L2 connectivity skipped: no reachable hosts remain after earlier preflight pruning")
         preflight_results['ifoe_l2_connectivity'] = {
             'mode': mode_normalized,
             'skipped': True,
@@ -512,9 +510,7 @@ def test_ifoe_l2_connectivity(phdl, config_dict):
     traffic_types = get_nested_config(
         config_dict, 'connectivity_check.ifoe', 'traffic_types', ['ifoe_req', 'ifoe_resp', 'non_ifoe']
     )
-    loss_threshold_pct = get_nested_config(
-        config_dict, 'connectivity_check.ifoe', 'loss_threshold_pct', 0.0
-    )
+    loss_threshold_pct = get_nested_config(config_dict, 'connectivity_check.ifoe', 'loss_threshold_pct', 0.0)
     ssh_timeout = get_nested_config(config_dict, 'connectivity_check.ifoe', 'ssh_timeout', 180)
     use_sudo = _config_flag_enabled(
         get_nested_config(config_dict, 'connectivity_check.ifoe', 'use_sudo', False), default=False

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -12,6 +12,7 @@ import json
 from cvs.lib.preflight.gid_consistency import GidConsistencyCheck
 from cvs.lib.preflight.version_check import RocmVersionCheck
 from cvs.lib.preflight.interface_consistency import InterfaceConsistencyCheck
+from cvs.lib.preflight.ifoe_l2_connectivity import IfoeL2ConnectivityCheck
 
 # RdmaConnectivityCheck not used - using legacy function temporarily
 from cvs.lib.preflight.report import PreflightReportGenerator
@@ -454,6 +455,150 @@ def test_gid_consistency(phdl, config_dict):
     preflight_update_test_result()
 
 
+def test_ifoe_l2_connectivity(phdl, config_dict):
+    """
+    Test IFoE L2 connectivity using ``afmctl test ping`` (AIMVT-180).
+
+    Runs ``afmctl test ping`` on each reachable node for every configured
+    (BDF, dst-accelerator) pairing and validates the per-port pass/fail
+    counts and Summary loss percentages against the configured threshold.
+
+    Configuration lives under ``connectivity_check.ifoe`` in the preflight
+    config file. The check is opt-in: when ``connectivity_mode`` is
+    ``"skip"`` (or omitted) the test records a SKIPPED result and returns
+    without contacting nodes. Nodes that fail L2 ping are reported but are
+    **not** pruned from ``phdl`` — operators can decide whether to proceed
+    with downstream RDMA / RCCL testing.
+    """
+    global preflight_results
+
+    mode = get_nested_config(config_dict, 'connectivity_check.ifoe', 'connectivity_mode', 'skip')
+    if isinstance(mode, str):
+        mode_normalized = mode.strip().lower()
+    else:
+        mode_normalized = 'skip' if not mode else 'run'
+
+    if mode_normalized in ('skip', 'off', 'disabled', 'false', '0'):
+        log.info("IFoE L2 connectivity test skipped by configuration (mode=%s)", mode)
+        preflight_results['ifoe_l2_connectivity'] = {
+            'mode': mode_normalized,
+            'skipped': True,
+            'message': 'IFoE L2 connectivity test skipped by configuration',
+            'node_results': {},
+        }
+        preflight_update_test_result()
+        return
+
+    if not phdl.reachable_hosts:
+        log.warning(
+            "IFoE L2 connectivity skipped: no reachable hosts remain after earlier preflight pruning"
+        )
+        preflight_results['ifoe_l2_connectivity'] = {
+            'mode': mode_normalized,
+            'skipped': True,
+            'message': 'No reachable nodes available for IFoE L2 connectivity testing',
+            'node_results': {},
+        }
+        preflight_update_test_result()
+        return
+
+    afmctl_path = get_nested_config(config_dict, 'connectivity_check.ifoe', 'afmctl_path', 'afmctl')
+    bdfs = get_nested_config(config_dict, 'connectivity_check.ifoe', 'bdfs', [])
+    bdf_discovery = get_nested_config(config_dict, 'connectivity_check.ifoe', 'bdf_discovery', 'auto')
+    dst_accelerators = get_nested_config(config_dict, 'connectivity_check.ifoe', 'dst_accelerators', [0])
+    ports = get_nested_config(config_dict, 'connectivity_check.ifoe', 'ports', 'all')
+    pings_per_port = get_nested_config(config_dict, 'connectivity_check.ifoe', 'pings_per_port', 1)
+    per_ping_timeout = get_nested_config(config_dict, 'connectivity_check.ifoe', 'per_ping_timeout', None)
+    traffic_types = get_nested_config(
+        config_dict, 'connectivity_check.ifoe', 'traffic_types', ['ifoe_req', 'ifoe_resp', 'non_ifoe']
+    )
+    loss_threshold_pct = get_nested_config(
+        config_dict, 'connectivity_check.ifoe', 'loss_threshold_pct', 0.0
+    )
+    ssh_timeout = get_nested_config(config_dict, 'connectivity_check.ifoe', 'ssh_timeout', 180)
+    use_sudo = _config_flag_enabled(
+        get_nested_config(config_dict, 'connectivity_check.ifoe', 'use_sudo', False), default=False
+    )
+
+    log.info(
+        "Running IFoE L2 connectivity (afmctl=%s, bdf_discovery=%s, dst_accelerators=%s, "
+        "ports=%s, pings_per_port=%s, traffic_types=%s, loss_threshold_pct=%s) on %d host(s)",
+        afmctl_path,
+        bdf_discovery,
+        dst_accelerators,
+        ports,
+        pings_per_port,
+        traffic_types,
+        loss_threshold_pct,
+        len(phdl.reachable_hosts),
+    )
+
+    checker = IfoeL2ConnectivityCheck(
+        phdl,
+        afmctl_path=afmctl_path,
+        bdfs=bdfs if isinstance(bdfs, (list, tuple)) else [],
+        dst_accelerators=dst_accelerators,
+        ports=ports,
+        pings_per_port=pings_per_port,
+        per_ping_timeout=per_ping_timeout,
+        traffic_types=traffic_types,
+        loss_threshold_pct=loss_threshold_pct,
+        ssh_timeout=ssh_timeout,
+        use_sudo=use_sudo,
+        bdf_discovery=bdf_discovery,
+        config_dict=config_dict,
+    )
+
+    node_results = checker.run()
+
+    failed_nodes = [n for n, r in node_results.items() if r.get('status') == 'FAIL']
+    total_invocations = 0
+    failed_invocations = 0
+    for r in node_results.values():
+        for accel_block in (r.get('accelerators') or {}).values():
+            for invocation in accel_block.values():
+                if invocation.get('status') == 'SKIPPED':
+                    continue
+                total_invocations += 1
+                if invocation.get('status') == 'FAIL':
+                    failed_invocations += 1
+
+    summary_status = 'FAIL' if failed_nodes else 'PASS'
+    preflight_results['ifoe_l2_connectivity'] = {
+        'mode': mode_normalized,
+        'skipped': False,
+        'status': summary_status,
+        'node_results': node_results,
+        'total_nodes': len(node_results),
+        'failed_nodes': failed_nodes,
+        'total_invocations': total_invocations,
+        'failed_invocations': failed_invocations,
+        'loss_threshold_pct': loss_threshold_pct,
+        'traffic_types': list(traffic_types) if isinstance(traffic_types, (list, tuple)) else [traffic_types],
+    }
+
+    if failed_nodes:
+        log.warning(
+            "IFoE L2 connectivity FAIL on %d/%d node(s): %s",
+            len(failed_nodes),
+            len(node_results),
+            ", ".join(failed_nodes),
+        )
+        for node in failed_nodes:
+            for err in node_results[node].get('errors', []):
+                log.error("Node %s IFoE L2: %s", node, err)
+    else:
+        log.info(
+            "IFoE L2 connectivity PASS on %d/%d nodes (%d/%d invocations succeeded)",
+            len(node_results) - len(failed_nodes),
+            len(node_results),
+            total_invocations - failed_invocations,
+            total_invocations,
+        )
+
+    preflight_update_test_result()
+
+
 def test_rdma_connectivity(phdl, cluster_dict, config_dict):
     """
     Test RDMA connectivity between cluster nodes using ibv_rc_pingpong.
@@ -582,7 +727,13 @@ def test_generate_preflight_report(phdl, config_dict, request):
     log.info("Generating preflight check report")
 
     # Ensure we have results from all checks
-    required_checks = ['gid_consistency', 'rocm_versions', 'interface_names', 'rdma_connectivity']
+    required_checks = [
+        'gid_consistency',
+        'rocm_versions',
+        'interface_names',
+        'ifoe_l2_connectivity',
+        'rdma_connectivity',
+    ]
     missing_checks = [check for check in required_checks if check not in preflight_results]
 
     if missing_checks:


### PR DESCRIPTION
## Summary

Adds an **opt-in** preflight check that validates IFoE L2 reachability across the cluster by running `afmctl test ping` on every reachable node and parsing the per-port pass/fail table plus the aggregate `Summary:` block from afmctl's output. Disabled by default, so existing preflight runs on clusters that don't use IFoE are unaffected.

## Motivation

The existing preflight covers RDMA connectivity (GID consistency, RDMA interface presence, `ibv_rc_pingpong`) but doesn't exercise the IFoE-based fabric path. AIMVT-180 fills that gap with a fast L2-level gate before more expensive downstream tests.

## Technical Details

**New module — `cvs/lib/preflight/ifoe_l2_connectivity.py`**
- `IfoeL2ConnectivityCheck`: orchestrates one `afmctl test ping` invocation per `(bdf, dst_accelerator)` pairing on every reachable node via parallel SSH. No pairwise client/server coordination needed — `afmctl` drives the request/response state machine in the device.
- `AfmctlPingParser`: tolerant parser for the per-port table (one row per `(local_accel, port#)`, three traffic-type columns) and the aggregate `Summary:` block.
- `parse_afmctl_show_device`: parses `afmctl show device` for BDF auto-discovery.

**New pytest entry — `cvs/tests/preflight/preflight_checks.py`**
- `test_ifoe_l2_connectivity` is wired in between the interface-presence check and the existing RDMA connectivity check. Opt-in via `connectivity_check.ifoe.connectivity_mode` (`"run"` or `"skip"`; default `"skip"`).

**New config block — `cvs/input/config_file/preflight/preflight_config.json`**
- `connectivity_check.ifoe`: `afmctl_path`, `use_sudo`, `bdf_discovery` (`auto`/`config`), `bdfs`, `dst_accelerators`, `ports`, `pings_per_port`, `per_ping_timeout`, `traffic_types` (`ifoe_req`/`ifoe_resp`/`non_ifoe`), `loss_threshold_pct`, `ssh_timeout`. All keys have inline `_comment_*` docs.

**Reporting — `cvs/lib/preflight/report.py`**
- Adds the IFoE L2 result to the executive summary and emits a dedicated HTML section with a per-node breakdown of failing invocations, failed ports, parsed Summary lines, raw afmctl output (expandable), and the exact command that was run.

**PASS/FAIL logic**
- A node fails if any enabled traffic type's loss exceeds `loss_threshold_pct` (default `0.0`) **or** any per-port row reports `FAIL`.
- Skipped/unreachable nodes do not pollute the PASS/FAIL accounting.

**Documentation**
- `cvs/tests/preflight/README.md` and `cvs/input/config_file/preflight/README_preflight_config.md` updated with the new check, configuration reference, and example config block.

## Test Plan

- Unit tests: `python3 -m unittest cvs.lib.preflight.unittests.test_ifoe_l2_connectivity` → **20/20 pass**. Coverage:
  - Parser: passing / failing / partial-loss / empty / garbage afmctl output; multi-device `afmctl show device`.
  - Orchestrator: command rendering (defaults, sudo, port lists/strings, `-t` timeout, `--traffic-type` subsetting and aliases), passing/failing runs, loss-threshold leniency, auto-discovery fallback, multiple destination accelerators.
- Config validation: `preflight_config.json` parses cleanly with `python -m json.tool`.
- Backwards compatibility: default `connectivity_mode = "skip"` means no behavioral change for existing clusters; the new pytest entry records a SKIPPED result and returns immediately without contacting nodes.

## Out of Scope

- Real-traffic / load-store validation (this PR only covers the L2 ping prerequisite; existing tools like TransferBench / RCCL handle data-path validation).
- Triggering or driving the IFoE driver / `afmctl` install — operators are expected to install these and apply fabric config before flipping `connectivity_mode` to `"run"`.

Refs: [AIMVT-180](https://amd.atlassian.net/browse/AIMVT-180)

Made with [Cursor](https://cursor.com)