### PR TITLE
factory: scope from_configs placeholder resolution to cluster portion

### DIFF
--- a/cvs/core/orchestrators/factory.py
+++ b/cvs/core/orchestrators/factory.py
@@ -84,10 +84,13 @@ class OrchestratorConfig:
         Create config from multiple configuration sources.
 
         Merges cluster_config.json and <testsuite>_config.json configurations, with testsuite_config
-        taking precedence for overlapping keys. After merging, the {user-id} placeholder is
-        resolved recursively (via cvs.lib.utils_lib.resolve_cluster_config_placeholders) so SSH
-        credentials and any nested container fields carry real values when consumed by Pssh /
-        docker run. Unresolved <changeme> tokens trigger sys.exit(1) at this boundary.
+        taking precedence for overlapping keys. Before merging, the cluster_config is run through
+        cvs.lib.utils_lib.resolve_cluster_config_placeholders to substitute {user-id} and enforce
+        the <changeme> guard on cluster-portion fields (username, priv_key_file, container.*) --
+        unresolved <changeme> tokens in the cluster portion trigger sys.exit(1) at this boundary.
+        testsuite_config is then merged in verbatim; testsuite subsections (transferbench, rvs,
+        agfhc, ...) are resolved later by per-test fixtures (resolve_test_config_placeholders),
+        scoped to the subsection the test actually consumes.
 
         Args:
             cluster_config: Cluster configuration (dict or path to cluster_config.json)
@@ -114,19 +117,23 @@ class OrchestratorConfig:
             with open(testsuite_config) as f:
                 testsuite_config = json.load(f)
 
-        # Merge configurations
-        merged_config = cluster_config.copy()
-        if testsuite_config:
-            merged_config.update(testsuite_config)
-
-        # Resolve {user-id} recursively so SSH credentials (username, priv_key_file) and any
-        # nested container fields carry real values when consumed by Pssh / docker run. Applied
-        # AFTER the merge so testsuite overrides containing placeholders are also resolved.
+        # Resolve {user-id} on the CLUSTER PORTION ONLY, before merging. from_configs only
+        # consumes cluster-portion keys (orchestrator, node_dict, username, priv_key_file,
+        # password, head_node_dict, container). Testsuite subsections (transferbench, rvs,
+        # agfhc, ...) belong to per-test fixtures which do their own subsection-scoped
+        # resolution via resolve_test_config_placeholders. Resolving the merged dict here
+        # would walk testsuite subsections that use <changeme> as a legitimate auto-detect
+        # sentinel (e.g. transferbench.rocm_path), causing cross-subsection guard trips on
+        # tests that don't even use that subsection.
         from cvs.lib.utils_lib import (
             resolve_cluster_config_placeholders,
         )  # Lazy: avoids core->lib import at module load
 
-        merged_config = resolve_cluster_config_placeholders(merged_config)
+        cluster_config = resolve_cluster_config_placeholders(cluster_config)
+
+        merged_config = cluster_config.copy()
+        if testsuite_config:
+            merged_config.update(testsuite_config)
 
         # Extract only required keys for orchestrators
         required_config = {

--- a/cvs/core/orchestrators/unittests/test_factory.py
+++ b/cvs/core/orchestrators/unittests/test_factory.py
@@ -199,10 +199,15 @@ class TestOrchestratorConfig(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {"USER": "alice", "LOGNAME": "", "USERNAME": ""}, clear=False)
-    def test_from_configs_resolves_user_id_in_testsuite_override(self):
-        # Pins that resolution runs AFTER the cluster+testsuite merge. If a future
-        # refactor moves the resolver call before the merge, the testsuite override
-        # would leak {user-id} verbatim and this test would fail.
+    def test_from_configs_does_not_resolve_user_id_in_testsuite(self):
+        # Pins the new contract: from_configs runs placeholder resolution on
+        # cluster_config BEFORE the merge, so testsuite-side values pass through
+        # verbatim. Placeholder resolution for testsuite subsections is the per-
+        # test config_dict fixture's responsibility (resolve_test_config_placeholders),
+        # which is scoped to the subsection the test consumes. Resolving the merged
+        # dict at from_configs would walk testsuite subsections and trip the
+        # <changeme> guard on legit auto-detect sentinels (transferbench.rocm_path,
+        # rvs.path) belonging to tests that don't even use that subsection.
         cluster = {
             "node_dict": {"1.1.1.1": {}},
             "username": "literal_user",
@@ -210,12 +215,12 @@ class TestOrchestratorConfig(unittest.TestCase):
         }
         testsuite = {"username": "{user-id}"}
         cfg = OrchestratorConfig.from_configs(cluster, testsuite)
-        self.assertEqual(cfg.username, "alice")
+        self.assertEqual(cfg.username, "{user-id}")
 
     def test_from_configs_exits_on_unresolved_changeme(self):
-        # Pins that the resolver's <changeme> guard propagates through from_configs.
-        # Defends against a future change that disables the guard and silently leaks
-        # <changeme> into Pssh / docker run.
+        # Pins that the resolver's <changeme> guard propagates through from_configs
+        # for the cluster portion. Defends against a future change that disables
+        # the guard and silently leaks <changeme> into Pssh / docker run.
         cluster = {
             "node_dict": {"1.1.1.1": {}},
             "username": "<changeme>",
@@ -224,6 +229,26 @@ class TestOrchestratorConfig(unittest.TestCase):
         with self.assertRaises(SystemExit) as ctx:
             OrchestratorConfig.from_configs(cluster)
         self.assertEqual(ctx.exception.code, 1)
+
+    def test_from_configs_does_not_trip_changeme_in_testsuite(self):
+        # Regression test for the orch-fixture <changeme> regression: testsuite
+        # subsections (transferbench, rvs, ...) legitimately use <changeme> as a
+        # soft auto-detect sentinel for rocm_path / path. The per-test fixture
+        # (and detect_rocm_path) handles it. from_configs must NOT walk the
+        # testsuite subsections through the <changeme>-strict resolver -- the old
+        # behaviour caused cross-subsection guard trips (e.g. running rvs_cvs
+        # tripped on transferbench.rocm_path: <changeme>).
+        cluster = {
+            "node_dict": {"1.1.1.1": {}},
+            "username": "literal_user",
+            "priv_key_file": "/dev/null",
+        }
+        testsuite = {
+            "transferbench": {"rocm_path": "<changeme>"},
+            "rvs": {"path": "<changeme>/bin", "rocm_path": "<changeme>"},
+        }
+        cfg = OrchestratorConfig.from_configs(cluster, testsuite)
+        self.assertEqual(cfg.username, "literal_user")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Scope `OrchestratorConfig.from_configs` placeholder resolution to the **cluster portion only** (run before the merge), restoring the pre-#186 cross-subsection isolation that per-test `config_dict` fixtures depend on. Unblocks the `orch` fixture for `rvs_cvs`, `install_rvs`, `install_transferbench`, `transferbench_cvs`.

## Why

PR #186 (`d553238`, "factory: resolve {user-id} placeholders at OrchestratorConfig.from_configs boundary") moved placeholder resolution to run on the **merged** cluster + testsuite dict. The resolver enforces a strict `<changeme>` guard (`sys.exit(1)` on any `<changeme>` substring) -- correct for cluster-cred fields, wrong for testsuite subsections that legitimately use `<changeme>` as a soft auto-detect sentinel (e.g. `transferbench.rocm_path`, `rvs.rocm_path`, `rvs.path` -- consumed by `detect_rocm_path()` which treats `<changeme>` identically to `""` and falls back to probing `/opt/rocm/core-*` then `/opt/rocm`).

Symptom: every orch-fixture test exits at fixture setup with

```
ERROR: Unresolved placeholder found in cluster config!
  transferbench.rocm_path: <changeme>
```

even when the test in question (e.g. `rvs_cvs`) doesn't consume the `transferbench` subsection at all. Pre-#186 this never surfaced because the per-test `config_dict` fixture cherry-picked just its own subsection (`config_dict_t['rvs']`, `config_dict_t['transferbench']`, ...) before resolving -- `from_configs` never walked the testsuite subsections. #186's merge-and-walk lost that scoping.

`from_configs` only consumes 7 cluster-portion keys (`orchestrator`, `node_dict`, `username`, `priv_key_file`, `password`, `head_node_dict`, `container`), so resolving testsuite-side fields at this boundary was never necessary in the first place.

## What changed

### 1. `cvs/core/orchestrators/factory.py` -- resolve cluster portion before the merge

- `resolve_cluster_config_placeholders(cluster_config)` now runs on `cluster_config` **before** the merge, not on `merged_config` after it.
- `merged_config = cluster_config.copy(); merged_config.update(testsuite_config)` -- testsuite is merged in verbatim.
- Docstring rewritten to spell out the new contract: the `from_configs` boundary resolves only the cluster portion; testsuite subsections are resolved later by per-test fixtures (`resolve_test_config_placeholders`), scoped to the subsection the test actually consumes.
- Inline comment documents why a merged-dict walk is wrong (cross-subsection guard trips on legit auto-detect sentinels).

### 2. `cvs/core/orchestrators/unittests/test_factory.py` -- pin the new contract

- **Inverted** `test_from_configs_resolves_user_id_in_testsuite_override` -> `test_from_configs_does_not_resolve_user_id_in_testsuite`. The old test pinned the (now-incorrect) "resolve after merge" behavior; the new test asserts testsuite values pass through `from_configs` verbatim (`{user-id}` stays as `{user-id}`).
- **Added** `test_from_configs_does_not_trip_changeme_in_testsuite` -- direct regression test. Builds `testsuite = {"transferbench": {"rocm_path": "<changeme>"}, "rvs": {"path": "<changeme>/bin", "rocm_path": "<changeme>"}}` and asserts `from_configs` returns cleanly.
- **Unchanged** (guard preserved where it belongs): `test_from_configs_exits_on_unresolved_changeme` (cluster-portion `username: "<changeme>"` still `sys.exit(1)`s), `test_from_configs_resolves_user_id_in_username_and_priv_key`, `test_from_configs_resolves_user_id_throughout_container_block`, `test_from_configs_reads_from_file_path`.

Diff footprint (`git diff --stat`):

```
cvs/core/orchestrators/factory.py                | 33 ++++++++++-------
cvs/core/orchestrators/unittests/test_factory.py | 41 +++++++++++++++++-----
2 files changed, 53 insertions(+), 21 deletions(-)
```

## Test plan

- **Unit:** `python run_all_unittests.py` -> 327 passing, including the inverted + added factory tests. `test_from_configs_reads_from_file_path` continues to pass.
- **Lint/format:** `make fmt`, `make lint` clean (ruff + pylint 10.00/10).
- **Live:** `cvs run install_rvs` on Group D core42 node `h16u07` (10.245.135.115) inside the `aig-orch-sshd:1334-gfx94X` container (BMS pytorch ROCm 1334 gfx94X + openssh-server layer). Pre-fix: `sys.exit(1)` at orch fixture setup on `transferbench.rocm_path: <changeme>`. Post-fix: orch fixture passes and the test progresses to the per-test `config_dict` fixture (the next layer of `<changeme>` handling, see Out of scope).
- **Negative (guard preserved):** `OrchestratorConfig.from_configs(cluster={"username": "<changeme>", ...})` still `sys.exit(1)`s -- cluster-portion `<changeme>` guard is intact.

## Out of scope / Future additions

- **Per-test `config_dict` fixture in-subsection `<changeme>` trip.** Each of the 4 orch-fixture-ported tests calls `resolve_test_config_placeholders(config_dict_t['rvs'|'transferbench'], cluster_dict)` on its OWN subsection -- which itself ships `<changeme>` (added in `c30d7a3` / `f74a705`, Mar 2026) and routes through the same `_resolve_placeholders_in_dict` guard. This is a pre-existing latent bug, unrelated to the cross-subsection regression this PR fixes. Track separately. The proper fix is probably to teach `resolve_test_config_placeholders` (or its caller) that `<changeme>` for `rocm_path` / `path` is the documented auto-detect sentinel and should pass through.
- **Broader rework of the `<changeme>` guard inside `_resolve_placeholders_in_dict`** (opt-in vs. opt-out, Pydantic-layer enforcement, soft-vs-hard sentinel semantics) -- unchanged here. This PR fixes only the cross-subsection contamination introduced by the merge-and-walk in #186.
- **install_rvs.py / install_transferbench.py downstream test-quality issues** (false-PASS verification predicates, missing `cluster.env_vars` propagation, RVS source-build cmake compatibility) addressed in a separate follow-up branch (`atnair/install-verify-fixes`).
