### PR TITLE
Add IFoE TransferBench scale-up preflight check [AIMVT-181]

### DIFF
--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -12,6 +12,10 @@ The preflight checks system validates essential cluster health before running pe
 4. **Interface Name Consistency** - Validates RDMA interface naming patterns
 5. **IFoE L2 Connectivity (AIMVT-180; opt-in)** - Runs `afmctl test ping`
    on each node and enforces per-port and Summary pass/fail accounting
+6. **IFoE TransferBench Smoketest (AIMVT-181; opt-in)** - Runs the
+   TransferBench candidate-branch `smoketest` preset to validate IFoE
+   scale-up data-path one layer above L2 (after a single-vPod precondition
+   check via `amd-smi fabric --topology --json`)
 
 ## Configuration File Structure
 
@@ -58,7 +62,8 @@ preflight/
 ├── node_check/           # Individual node validation parameters
 ├── connectivity_check/   # Inter-node connectivity tests
 │   ├── rdma/             # RDMA-specific parameters (including nodes_per_full_mesh_group)
-│   └── ifoe/             # IFoE L2 ping parameters (AIMVT-180; opt-in)
+│   ├── ifoe/             # IFoE L2 ping parameters (AIMVT-180; opt-in)
+│   └── transferbench/    # IFoE TransferBench smoketest parameters (AIMVT-181; opt-in)
 └── reporting/           # Output and report generation
 ```
 
@@ -198,6 +203,72 @@ pass/fail table plus the aggregate `Summary:` block in afmctl's output.
   - Maximum tolerated loss percentage per traffic type (Summary line)
 - **`ssh_timeout`** (default: `180`)
   - Per-invocation SSH timeout (seconds); raise for high `pings_per_port`
+
+#### TransferBench Settings (`connectivity_check.transferbench`) — opt-in (AIMVT-181)
+
+Runs the TransferBench candidate-branch **`smoketest`** preset on every reachable
+node to validate IFoE scale-up data-path connectivity (one layer above the
+AIMVT-180 L2 ping). Enforces a single-vPod precondition by parsing
+`amd-smi fabric --topology --json` before invoking TransferBench, and reconciles
+the binary's exit code with per-cell `[PASS]/[FAIL]/[SKIP]` markers.
+
+- **`connectivity_mode`** (default: `"skip"`)
+  - `"run"` — execute the smoketest on every reachable node
+  - `"skip"` — preflight records a SKIPPED result and does not invoke TransferBench
+- **`tb_binary`** (default: `"TransferBench"`)
+  - Absolute path or PATH-resolved binary name on each node
+- **`rocm_path`** (default: `""`)
+  - Optional ROCm install root; when set, prepends `<rocm_path>/bin` to PATH and
+    `<rocm_path>/lib` to LD_LIBRARY_PATH for the invocation
+- **`amd_smi_path`** (default: `"amd-smi"`)
+  - Path / name of the amd-smi binary used for the pod-membership precondition
+- **`use_sudo`** (default: `true`)
+  - Prepend `sudo` to TransferBench and amd-smi calls (typically required
+    on production cluster images for IFoE access and the fabric topology query)
+- **`preset`** (default: `"smoketest"`)
+  - TransferBench preset name. Change only when a TransferBench build ships
+    a renamed preset with the same semantics.
+- **`size_list`** (default: `["1K", "16M"]`)
+  - Transfer sizes passed positionally to TransferBench. Kept short for
+    preflight; default covers both small/latency and large/bandwidth regimes.
+- **`num_iterations`** (default: `2`)
+  - `NUM_ITERATIONS` env var. Two iterations is enough to surface intermittent
+    failures without blowing up runtime.
+- **`num_warmups`** (default: `0`)
+  - `NUM_WARMUPS` env var. Preflight is a connectivity gate, not a benchmark.
+- **`always_validate`** (default: `true`)
+  - `ALWAYS_VALIDATE=1` so every iteration is data-validated. Required for
+    silent-corruption detection.
+- **`run_parallel`** (default: `true`)
+  - `RUN_PARALLEL=1` so tests with disjoint executors run concurrently.
+- **`use_bdma`** (default: `false`)
+  - `USE_BDMA=1` to prefer the BDMA path on supported hardware.
+- **`force_single_pod`** (default: `true`)
+  - `FORCE_SINGLE_POD=1` — defense in depth alongside the amd-smi
+    vPod precondition.
+- **`rank_mode`** (default: `"per_node"`)
+  - `"per_node"` — each reachable node runs an independent single-rank
+    TransferBench (exercises intra-node AID↔MID IFoE only)
+  - `"multi_rank"` — every reachable node is wired into one socket-comm
+    cluster (`TB_NUM_RANKS=N`, `TB_RANK=0..N-1`, `TB_MASTER_ADDR=<rank0>`)
+    so the smoketest traverses the rack IFoE switch end-to-end. Requires
+    bidirectional IP reachability on `socket_master_port` between every pair
+    of nodes.
+- **`socket_master_port`** (default: `31337`)
+  - `TB_MASTER_PORT` used in `multi_rank` mode. Must be free and open in
+    the firewall on every node.
+- **`master_node`** (default: `""`)
+  - Optional hostname / IP forced to rank 0; defaults to the lexicographically
+    smallest reachable host.
+- **`max_skip_pct`** (default: `25.0`)
+  - Maximum percentage of smoketest cells allowed to be `SKIP` before the
+    node is downgraded to `WARNING`. Set to `0.0` for the strictest gate.
+- **`ssh_timeout`** (default: `600`)
+  - Per-invocation SSH timeout (seconds) for each TransferBench run
+- **`skip_pod_check`** (default: `false`)
+  - Bypass the amd-smi pod-membership precondition. Only enable for
+    environments where amd-smi is not yet available; you lose the early
+    failure signal.
 
 ### Reporting Settings (`reporting`)
 

--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -212,16 +212,22 @@ AIMVT-180 L2 ping). Enforces a single-vPod precondition by parsing
 `amd-smi fabric --topology --json` before invoking TransferBench, and reconciles
 the binary's exit code with per-cell `[PASS]/[FAIL]/[SKIP]` markers.
 
+> **PATH / LD_LIBRARY_PATH.** This check resolves `TransferBench` and `amd-smi`
+> from each node's `PATH`. Cluster-wide tool location (e.g. a non-default ROCm
+> install root) should be set via the cluster file's top-level `env_vars` block
+> (see [`cvs/input/cluster_file/README.md`](../../cluster_file/README.md)), not
+> duplicated here.
+
 - **`connectivity_mode`** (default: `"skip"`)
   - `"run"` — execute the smoketest on every reachable node
   - `"skip"` — preflight records a SKIPPED result and does not invoke TransferBench
 - **`tb_binary`** (default: `"TransferBench"`)
-  - Absolute path or PATH-resolved binary name on each node
-- **`rocm_path`** (default: `""`)
-  - Optional ROCm install root; when set, prepends `<rocm_path>/bin` to PATH and
-    `<rocm_path>/lib` to LD_LIBRARY_PATH for the invocation
-- **`amd_smi_path`** (default: `"amd-smi"`)
-  - Path / name of the amd-smi binary used for the pod-membership precondition
+  - TransferBench binary name; PATH-resolved on each node. Override with an
+    absolute path here only when this single preflight check needs to point at
+    a different binary than the rest of the cluster's tooling. The
+    pod-membership precondition uses `amd-smi` resolved from `PATH` and has no
+    per-check override (use cluster file `env_vars` to point at a non-default
+    install).
 - **`use_sudo`** (default: `true`)
   - Prepend `sudo` to TransferBench and amd-smi calls (typically required
     on production cluster images for IFoE access and the fabric topology query)

--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -15,7 +15,7 @@ The preflight checks system validates essential cluster health before running pe
 6. **IFoE TransferBench Smoketest (AIMVT-181; opt-in)** - Runs the
    TransferBench candidate-branch `smoketest` preset to validate IFoE
    scale-up data-path one layer above L2 (after a single-vPod precondition
-   check via `amd-smi fabric --topology --json`)
+   check via `amd-smi fabric --json`)
 
 ## Configuration File Structure
 
@@ -209,34 +209,53 @@ pass/fail table plus the aggregate `Summary:` block in afmctl's output.
 Runs the TransferBench candidate-branch **`smoketest`** preset on every reachable
 node to validate IFoE scale-up data-path connectivity (one layer above the
 AIMVT-180 L2 ping). Enforces a single-vPod precondition by parsing
-`amd-smi fabric --topology --json` before invoking TransferBench, and reconciles
+`amd-smi fabric --json` before invoking TransferBench, and reconciles
 the binary's exit code with per-cell `[PASS]/[FAIL]/[SKIP]` markers.
 
-> **PATH / LD_LIBRARY_PATH.** This check resolves `TransferBench` and `amd-smi`
-> from each node's `PATH`. Cluster-wide tool location (e.g. a non-default ROCm
-> install root) should be set via the cluster file's top-level `env_vars` block
-> (see [`cvs/input/cluster_file/README.md`](../../cluster_file/README.md)), not
-> duplicated here.
+> **sudo execution environment.** The cluster file's top-level `env_vars` block
+> still sets the outer SSH-shell environment, but `sudo` can replace `PATH`
+> with `secure_path` and strips `LD_LIBRARY_PATH`. In sudo mode, CVS resolves
+> bare executable names before elevation; production configurations should use
+> the explicit `tb_binary` / `amd_smi_binary` paths below. Use `extra_env` for
+> TransferBench runtime variables that must be present inside the privileged
+> shell.
 
 - **`connectivity_mode`** (default: `"skip"`)
   - `"run"` — execute the smoketest on every reachable node
   - `"skip"` — preflight records a SKIPPED result and does not invoke TransferBench
 - **`tb_binary`** (default: `"TransferBench"`)
-  - TransferBench binary name; PATH-resolved on each node. Override with an
-    absolute path here only when this single preflight check needs to point at
-    a different binary than the rest of the cluster's tooling. The
-    pod-membership precondition uses `amd-smi` resolved from `PATH` and has no
-    per-check override (use cluster file `env_vars` to point at a non-default
-    install).
+  - TransferBench executable path or name. A bare name is resolved in the
+    outer SSH shell before sudo changes `PATH`; an absolute path is recommended
+    in production, e.g. `/path/to/TransferBench`.
+- **`amd_smi_binary`** (default: `"amd-smi"`)
+  - Executable path or name for the pod-membership precondition. A bare name
+    is resolved before sudo applies `secure_path`; set an absolute path such as
+    `/opt/rocm/bin/amd-smi` to make the command independent of PATH.
 - **`use_sudo`** (default: `true`)
   - Prepend `sudo` to TransferBench and amd-smi calls (typically required
     on production cluster images for IFoE access and the fabric topology query)
+- **`extra_env`** (default: `{}`)
+  - Optional mapping of environment values applied only to the TransferBench
+    process inside the privileged shell. Use it for runtime variables sudo
+    strips, for example:
+
+    ```json
+    "extra_env": {
+      "LD_LIBRARY_PATH": "/path/to/rocm/lib:$LD_LIBRARY_PATH"
+    }
+    ```
+
+  - Values are safely quoted and keys must be shell environment-variable names.
+    The only supported expansion is a variable's own `$KEY` reference, such as
+    `$LD_LIBRARY_PATH`; it is evaluated inside the privileged shell rather
+    than inherited from the outer SSH shell.
 - **`preset`** (default: `"smoketest"`)
   - TransferBench preset name. Change only when a TransferBench build ships
     a renamed preset with the same semantics.
 - **`size_list`** (default: `["1K", "16M"]`)
-  - Transfer sizes passed positionally to TransferBench. Kept short for
-    preflight; default covers both small/latency and large/bandwidth regimes.
+  - Transfer sizes supplied to the `smoketest` preset through its `SIZE_LIST`
+    environment variable. Kept short for preflight; default covers both
+    small/latency and large/bandwidth regimes.
 - **`num_iterations`** (default: `2`)
   - `NUM_ITERATIONS` env var. Two iterations is enough to surface intermittent
     failures without blowing up runtime.

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -92,19 +92,13 @@
       },
 
       "transferbench": {
-        "_comment": "IFoE scale-up data-path validation via the TransferBench candidate-branch smoketest preset (AIMVT-181). Opt-in: defaults to 'skip'. Enforces a single-vPod precondition via 'amd-smi fabric --topology --json' before invoking TransferBench.",
+        "_comment": "IFoE scale-up data-path validation via the TransferBench candidate-branch smoketest preset (AIMVT-181). Opt-in: defaults to 'skip'. Enforces a single-vPod precondition via 'amd-smi fabric --topology --json' before invoking TransferBench. PATH and LD_LIBRARY_PATH for ROCm / amd-smi / TransferBench should be set cluster-wide via the cluster file's top-level 'env_vars' block (see cvs/input/cluster_file/README.md); they are not duplicated here.",
 
         "connectivity_mode": "skip",
-        "_comment_connectivity_mode": "TransferBench smoketest mode. Options: 'run' (execute the smoketest preset on each reachable node) or 'skip' (default; preflight will not invoke TransferBench). Flip to 'run' once the TransferBench candidate-branch binary and amd-smi are installed cluster-wide.",
+        "_comment_connectivity_mode": "TransferBench smoketest mode. Options: 'run' (execute the smoketest preset on each reachable node) or 'skip' (default; preflight will not invoke TransferBench). Flip to 'run' once the TransferBench candidate-branch binary and amd-smi are installed cluster-wide and reachable on PATH (typically via cluster file 'env_vars').",
 
         "tb_binary": "TransferBench",
-        "_comment_tb_binary": "Absolute path or PATH-resolved name of the TransferBench binary on each node. Examples: 'TransferBench', '/opt/rocm/bin/TransferBench'.",
-
-        "rocm_path": "",
-        "_comment_rocm_path": "Optional ROCm install directory used to prepend PATH=<rocm_path>/bin and LD_LIBRARY_PATH=<rocm_path>/lib when invoking TransferBench. Leave empty to rely on the node's default environment.",
-
-        "amd_smi_path": "amd-smi",
-        "_comment_amd_smi_path": "Absolute path or PATH-resolved name of the amd-smi binary used for the pod-membership precondition.",
+        "_comment_tb_binary": "TransferBench binary name. PATH-resolved by default; set cluster-wide PATH overrides via the cluster file's 'env_vars'. Override with an absolute path here only when this single preflight check needs to point at a different binary than the rest of the cluster's tooling.",
 
         "use_sudo": true,
         "_comment_use_sudo": "When true, both TransferBench and amd-smi are invoked with sudo. amd-smi fabric topology queries and TransferBench's IFoE access typically require root on production cluster images.",

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -89,6 +89,67 @@
 
         "ssh_timeout": 180,
         "_comment_ssh_timeout": "Overall SSH timeout (seconds) for each afmctl invocation. Increase for large port counts or high pings_per_port values."
+      },
+
+      "transferbench": {
+        "_comment": "IFoE scale-up data-path validation via the TransferBench candidate-branch smoketest preset (AIMVT-181). Opt-in: defaults to 'skip'. Enforces a single-vPod precondition via 'amd-smi fabric --topology --json' before invoking TransferBench.",
+
+        "connectivity_mode": "skip",
+        "_comment_connectivity_mode": "TransferBench smoketest mode. Options: 'run' (execute the smoketest preset on each reachable node) or 'skip' (default; preflight will not invoke TransferBench). Flip to 'run' once the TransferBench candidate-branch binary and amd-smi are installed cluster-wide.",
+
+        "tb_binary": "TransferBench",
+        "_comment_tb_binary": "Absolute path or PATH-resolved name of the TransferBench binary on each node. Examples: 'TransferBench', '/opt/rocm/bin/TransferBench'.",
+
+        "rocm_path": "",
+        "_comment_rocm_path": "Optional ROCm install directory used to prepend PATH=<rocm_path>/bin and LD_LIBRARY_PATH=<rocm_path>/lib when invoking TransferBench. Leave empty to rely on the node's default environment.",
+
+        "amd_smi_path": "amd-smi",
+        "_comment_amd_smi_path": "Absolute path or PATH-resolved name of the amd-smi binary used for the pod-membership precondition.",
+
+        "use_sudo": true,
+        "_comment_use_sudo": "When true, both TransferBench and amd-smi are invoked with sudo. amd-smi fabric topology queries and TransferBench's IFoE access typically require root on production cluster images.",
+
+        "preset": "smoketest",
+        "_comment_preset": "TransferBench preset name. Defaults to 'smoketest' (the AIMVT-181 target). Change only when a TransferBench build ships a renamed preset with the same semantics.",
+
+        "size_list": ["1K", "16M"],
+        "_comment_size_list": "Transfer sizes passed positionally to TransferBench. The smoketest preset accepts a list and runs each test at every size. Keep the list small for preflight; default '1K' (small, latency-sensitive) and '16M' (large, bandwidth-sensitive) covers both regimes without exploding runtime.",
+
+        "num_iterations": 2,
+        "_comment_num_iterations": "Value for the NUM_ITERATIONS env var. Defaults to 2 -- enough to surface intermittent failures but small enough to keep total preflight runtime bounded.",
+
+        "num_warmups": 0,
+        "_comment_num_warmups": "Value for the NUM_WARMUPS env var. Preflight is a connectivity gate (not a benchmark), so the default skips warmup iterations.",
+
+        "always_validate": true,
+        "_comment_always_validate": "When true, sets ALWAYS_VALIDATE=1 so every iteration is data-validated. Required for the smoketest to detect silent data corruption.",
+
+        "run_parallel": true,
+        "_comment_run_parallel": "When true, sets RUN_PARALLEL=1 so tests sharing distinct executors run concurrently. Off-loads more of the smoketest into parallel execution; turn off for diagnostic step-by-step runs.",
+
+        "use_bdma": false,
+        "_comment_use_bdma": "When true, sets USE_BDMA=1 to prefer the BDMA path on supported hardware. Defaults to false (use the default SDMA path) for broadest compatibility.",
+
+        "force_single_pod": true,
+        "_comment_force_single_pod": "When true, sets FORCE_SINGLE_POD=1 so the preset short-circuits any test that would cross a vPod boundary. Defense-in-depth in addition to the amd-smi vPod precondition.",
+
+        "rank_mode": "per_node",
+        "_comment_rank_mode": "Orchestration mode. 'per_node' (default) runs an independent single-rank TransferBench on each reachable node and exercises intra-node IFoE only. 'multi_rank' wires every reachable node into one socket-comm cluster (TB_NUM_RANKS=N, TB_RANK=0..N-1) so the smoketest traverses the rack IFoE switch end-to-end. multi_rank requires all reachable nodes to share a single vPod and bidirectional IP reachability on TB_MASTER_PORT.",
+
+        "socket_master_port": 31337,
+        "_comment_socket_master_port": "TB_MASTER_PORT used by the smoketest's built-in socket-comm in multi_rank mode. Pick a free port that is reachable between every pair of nodes (or open it in your firewall).",
+
+        "master_node": "",
+        "_comment_master_node": "Optional hostname / IP to use as rank 0 (TB_MASTER_ADDR) in multi_rank mode. Leave empty to deterministically pick the lexicographically smallest reachable host.",
+
+        "max_skip_pct": 25.0,
+        "_comment_max_skip_pct": "Maximum percentage of smoketest cells allowed to be SKIPped before the node is downgraded to WARNING. Defaults to 25%, which tolerates the expected skips on partial fabrics (e.g. some D2D tests are skipped on multi-pod nodes); set to 0 for the strictest gate.",
+
+        "ssh_timeout": 600,
+        "_comment_ssh_timeout": "Overall SSH timeout (seconds) for each TransferBench invocation. The smoketest typically completes well within this on healthy hardware; increase for large size_list values or slow validate paths.",
+
+        "skip_pod_check": false,
+        "_comment_skip_pod_check": "When true, bypasses the amd-smi pod-membership precondition. Only flip this on for environments where amd-smi is not yet available; you lose the early failure signal."
       }
     },
     

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -92,22 +92,28 @@
       },
 
       "transferbench": {
-        "_comment": "IFoE scale-up data-path validation via the TransferBench candidate-branch smoketest preset (AIMVT-181). Opt-in: defaults to 'skip'. Enforces a single-vPod precondition via 'amd-smi fabric --topology --json' before invoking TransferBench. PATH and LD_LIBRARY_PATH for ROCm / amd-smi / TransferBench should be set cluster-wide via the cluster file's top-level 'env_vars' block (see cvs/input/cluster_file/README.md); they are not duplicated here.",
+        "_comment": "IFoE scale-up data-path validation via the TransferBench candidate-branch smoketest preset (AIMVT-181). Opt-in: defaults to 'skip'. Enforces a single-vPod precondition via the version-tolerant 'amd-smi fabric --json' output before invoking TransferBench. Cluster-file env_vars still configure the outer SSH shell, but sudo does not inherit PATH or LD_LIBRARY_PATH reliably: use amd_smi_binary/tb_binary for explicit executables and extra_env for TransferBench runtime variables.",
 
         "connectivity_mode": "skip",
-        "_comment_connectivity_mode": "TransferBench smoketest mode. Options: 'run' (execute the smoketest preset on each reachable node) or 'skip' (default; preflight will not invoke TransferBench). Flip to 'run' once the TransferBench candidate-branch binary and amd-smi are installed cluster-wide and reachable on PATH (typically via cluster file 'env_vars').",
+        "_comment_connectivity_mode": "TransferBench smoketest mode. Options: 'run' (execute the smoketest preset on each reachable node) or 'skip' (default; preflight will not invoke TransferBench). Flip to 'run' once the TransferBench candidate-branch binary and amd-smi are installed cluster-wide.",
 
         "tb_binary": "TransferBench",
-        "_comment_tb_binary": "TransferBench binary name. PATH-resolved by default; set cluster-wide PATH overrides via the cluster file's 'env_vars'. Override with an absolute path here only when this single preflight check needs to point at a different binary than the rest of the cluster's tooling.",
+        "_comment_tb_binary": "TransferBench executable path or name. In sudo mode a bare name is resolved by the outer SSH shell before sudo applies secure_path, but an absolute path is recommended for production preflight configurations.",
+
+        "amd_smi_binary": "amd-smi",
+        "_comment_amd_smi_binary": "amd-smi executable path or name for the pod-membership precondition. In sudo mode a bare name is resolved before sudo applies secure_path; set an absolute path such as '/opt/rocm/bin/amd-smi' to make the selection fully explicit.",
 
         "use_sudo": true,
-        "_comment_use_sudo": "When true, both TransferBench and amd-smi are invoked with sudo. amd-smi fabric topology queries and TransferBench's IFoE access typically require root on production cluster images.",
+        "_comment_use_sudo": "When true, both TransferBench and amd-smi are invoked with sudo. amd-smi fabric queries and TransferBench's IFoE access typically require root on production cluster images.",
+
+        "extra_env": {},
+        "_comment_extra_env": "Optional map of environment variables applied only to the TransferBench process inside the sudo shell. Use this for runtime variables sudo strips, for example {\"LD_LIBRARY_PATH\": \"/path/to/rocm/lib:$LD_LIBRARY_PATH\"}. Values are safely quoted and support only self-referential $KEY expansion.",
 
         "preset": "smoketest",
         "_comment_preset": "TransferBench preset name. Defaults to 'smoketest' (the AIMVT-181 target). Change only when a TransferBench build ships a renamed preset with the same semantics.",
 
         "size_list": ["1K", "16M"],
-        "_comment_size_list": "Transfer sizes passed positionally to TransferBench. The smoketest preset accepts a list and runs each test at every size. Keep the list small for preflight; default '1K' (small, latency-sensitive) and '16M' (large, bandwidth-sensitive) covers both regimes without exploding runtime.",
+        "_comment_size_list": "Transfer sizes sent to the smoketest preset through its SIZE_LIST environment variable. The preset runs each test at every size. Keep the list small for preflight; default '1K' (small, latency-sensitive) and '16M' (large, bandwidth-sensitive) covers both regimes without exploding runtime.",
 
         "num_iterations": 2,
         "_comment_num_iterations": "Value for the NUM_ITERATIONS env var. Defaults to 2 -- enough to surface intermittent failures but small enough to keep total preflight runtime bounded.",

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -100,6 +100,7 @@ class PreflightReportGenerator(PreflightCheck):
         rocm_results = self.results.get('rocm_versions', {})
         interface_results = self.results.get('interface_names', {})
         ifoe_l2_results = self.results.get('ifoe_l2_connectivity', {})
+        tb_smoke_results = self.results.get('transferbench_smoke', {})
         reachability_results = self.results.get('node_reachability')
         ssh_connectivity_results = self.results.get('ssh_connectivity')
         summary = {
@@ -108,6 +109,7 @@ class PreflightReportGenerator(PreflightCheck):
                 'ssh_reachability': self._summarize_reachability_results(reachability_results),
                 'gid_consistency': self._summarize_gid_results(gid_results),
                 'ifoe_l2_connectivity': self._summarize_ifoe_l2_results(ifoe_l2_results),
+                'transferbench_smoke': self._summarize_transferbench_smoke_results(tb_smoke_results),
                 'rdma_connectivity': self._summarize_connectivity_results(connectivity_results),
                 'rocm_versions': self._summarize_rocm_results(rocm_results),
                 'interface_names': self._summarize_interface_results(interface_results),
@@ -132,6 +134,17 @@ class PreflightReportGenerator(PreflightCheck):
         if summary['checks']['ifoe_l2_connectivity']['status'] == 'FAIL':
             summary['recommendations'].append(
                 "Address IFoE L2 ping failures via afmctl on affected nodes before benchmarking"
+            )
+
+        if summary['checks']['transferbench_smoke']['status'] == 'FAIL':
+            summary['recommendations'].append(
+                "Investigate TransferBench smoketest failures (likely IFoE data-path or pod-membership "
+                "issue) on affected nodes before benchmarking"
+            )
+        elif summary['checks']['transferbench_smoke']['status'] == 'WARNING':
+            summary['recommendations'].append(
+                "Review TransferBench smoketest skip-budget warnings -- some tests were skipped beyond "
+                "the configured tolerance"
             )
 
         if summary['checks']['rdma_connectivity']['status'] == 'FAIL':
@@ -331,6 +344,54 @@ class PreflightReportGenerator(PreflightCheck):
             'summary': summary_text,
         }
 
+    def _summarize_transferbench_smoke_results(self, tb_results):
+        """Summarize TransferBench smoketest results (AIMVT-181)."""
+        if not tb_results or tb_results.get('skipped'):
+            msg = (
+                tb_results.get('message')
+                if isinstance(tb_results, dict)
+                else 'TransferBench smoketest not performed'
+            )
+            return {
+                'status': 'SKIPPED',
+                'nodes_total': 0,
+                'nodes_pass': 0,
+                'nodes_warning': 0,
+                'nodes_fail': 0,
+                'failed_nodes': [],
+                'summary': msg or 'TransferBench smoketest skipped',
+            }
+
+        totals = tb_results.get('totals') or {}
+        nodes = tb_results.get('nodes') or {}
+        failed_nodes = sorted(n for n, r in nodes.items() if r.get('status') == 'FAIL')
+        warning_nodes = sorted(n for n, r in nodes.items() if r.get('status') == 'WARNING')
+
+        status = tb_results.get('status') or ('FAIL' if failed_nodes else ('WARNING' if warning_nodes else 'PASS'))
+        summary_text = (
+            f"{totals.get('nodes_pass', 0)}/{totals.get('nodes_total', 0)} nodes passed "
+            f"TransferBench smoketest"
+        )
+        if warning_nodes:
+            summary_text += f" ({len(warning_nodes)} with skip-budget warnings)"
+        if totals.get('tests_fail', 0) or totals.get('tests_skip', 0):
+            summary_text += (
+                f"; tests pass/fail/skip = "
+                f"{totals.get('tests_pass', 0)}/{totals.get('tests_fail', 0)}/"
+                f"{totals.get('tests_skip', 0)}"
+            )
+        return {
+            'status': status,
+            'nodes_total': totals.get('nodes_total', 0),
+            'nodes_pass': totals.get('nodes_pass', 0),
+            'nodes_warning': totals.get('nodes_warning', 0),
+            'nodes_fail': totals.get('nodes_fail', 0),
+            'failed_nodes': failed_nodes,
+            'warning_nodes': warning_nodes,
+            'rank_mode': tb_results.get('rank_mode'),
+            'summary': summary_text,
+        }
+
     def _summarize_reachability_results(self, reachability_results):
         """Summarize SSH reachability check results."""
         if not reachability_results:
@@ -433,6 +494,7 @@ class PreflightReportGenerator(PreflightCheck):
             {self._generate_executive_summary_html(summary)}
             {self._generate_gid_consistency_html(results.get('gid_consistency', {}))}
             {self._generate_ifoe_l2_html(results.get('ifoe_l2_connectivity', {}))}
+            {self._generate_transferbench_smoke_html(results.get('transferbench_smoke', {}))}
             {self._generate_connectivity_html(results.get('rdma_connectivity', {}))}
             {self._generate_ssh_connectivity_html(results.get('ssh_connectivity', {}))}
             {self._generate_rocm_versions_html(results.get('rocm_versions', {}))}
@@ -989,6 +1051,157 @@ class PreflightReportGenerator(PreflightCheck):
         """
 
         return header + table
+
+    def _generate_transferbench_smoke_html(self, tb_results):
+        """Generate TransferBench smoketest section (AIMVT-181)."""
+        if not tb_results:
+            return ""
+
+        if tb_results.get('skipped'):
+            msg = tb_results.get('message', 'TransferBench smoketest skipped')
+            return f"""
+        <section>
+            <h2>IFoE TransferBench Smoketest</h2>
+            <p><em>{html.escape(msg)}</em></p>
+        </section>
+        """
+
+        nodes = tb_results.get('nodes') or {}
+        totals = tb_results.get('totals') or {}
+        pod_membership = tb_results.get('pod_membership') or {}
+        rank_mode = tb_results.get('rank_mode') or 'per_node'
+        max_skip = tb_results.get('max_skip_pct', 25.0)
+        cluster_errors = tb_results.get('errors') or []
+
+        pod_summary_parts = []
+        if isinstance(pod_membership, dict):
+            if pod_membership.get('status') == 'SKIPPED':
+                pod_summary_parts.append('<em>pod-membership precondition skipped by config</em>')
+            else:
+                vpod_id = pod_membership.get('vpod_id')
+                ppod_id = pod_membership.get('ppod_id')
+                if vpod_id is not None:
+                    pod_summary_parts.append(f'shared vpod_id=<code>{html.escape(str(vpod_id))}</code>')
+                if ppod_id is not None:
+                    pod_summary_parts.append(f'shared ppod_id=<code>{html.escape(str(ppod_id))}</code>')
+                if pod_membership.get('status') == 'FAIL':
+                    pod_summary_parts.append(
+                        '<span class="status-fail">precondition FAILED</span>'
+                    )
+        pod_summary_html = (
+            '; '.join(pod_summary_parts) if pod_summary_parts else 'pod-membership info unavailable'
+        )
+
+        header_html = f"""
+        <section>
+            <h2>IFoE TransferBench Smoketest</h2>
+            <p>Tested via the TransferBench candidate-branch <code>smoketest</code> preset.
+            Rank mode: <code>{html.escape(rank_mode)}</code>;
+            skip budget: <code>{html.escape(str(max_skip))}%</code>;
+            nodes pass/warn/fail: <code>{totals.get('nodes_pass', 0)}/{totals.get('nodes_warning', 0)}/{totals.get('nodes_fail', 0)}</code>
+            (of {totals.get('nodes_total', 0)} total);
+            tests pass/fail/skip: <code>{totals.get('tests_pass', 0)}/{totals.get('tests_fail', 0)}/{totals.get('tests_skip', 0)}</code>.
+            Pod membership: {pod_summary_html}.</p>
+        """
+
+        cluster_err_html = ''
+        if cluster_errors:
+            err_items = ''.join(
+                f'<li>{html.escape(str(e))}</li>' for e in cluster_errors
+            )
+            cluster_err_html = (
+                f'<div class="error-list"><strong>Cluster-level errors:</strong>'
+                f'<ul>{err_items}</ul></div>'
+            )
+
+        failing = sorted(
+            (n for n, r in nodes.items() if r.get('status') in ('FAIL', 'WARNING')),
+            key=str,
+        )
+
+        if not failing:
+            return header_html + cluster_err_html + (
+                '<p class="status-pass">All reachable nodes passed TransferBench smoketest.</p>'
+                '</section>'
+            )
+
+        rows = []
+        for node in failing:
+            entry = nodes[node]
+            verdict = entry.get('status', 'FAIL')
+            exit_code = entry.get('exit_code')
+            parsed = entry.get('parsed') or {}
+            errors = entry.get('errors') or []
+            warnings = parsed.get('warnings') or []
+            stdout_errors = parsed.get('errors') or []
+
+            detail_bits = []
+            counts = (
+                f"pass={parsed.get('num_pass', 0)}, "
+                f"fail={parsed.get('num_fail', 0)}, "
+                f"skip={parsed.get('num_skip', 0)}, "
+                f"total={parsed.get('num_tests', 0)}"
+            )
+            detail_bits.append(f'<p><strong>Test marker counts:</strong> <code>{html.escape(counts)}</code></p>')
+            if exit_code is not None:
+                detail_bits.append(
+                    f'<p><strong>Exit code:</strong> <code>{html.escape(str(exit_code))}</code></p>'
+                )
+            if errors:
+                detail_bits.append(
+                    '<p><strong>Verdict errors:</strong></p><ul style="color:#721c24;margin:6px 0;">'
+                    + ''.join(f'<li>{html.escape(str(e))}</li>' for e in errors)
+                    + '</ul>'
+                )
+            if stdout_errors:
+                detail_bits.append(
+                    '<details><summary>stdout fatal lines</summary><ul>'
+                    + ''.join(f'<li>{html.escape(str(e))}</li>' for e in stdout_errors[:25])
+                    + '</ul></details>'
+                )
+            if warnings:
+                detail_bits.append(
+                    '<details><summary>stdout warning lines</summary><ul>'
+                    + ''.join(f'<li>{html.escape(str(w))}</li>' for w in warnings[:25])
+                    + '</ul></details>'
+                )
+            raw = entry.get('raw_output') or ''
+            if raw.strip():
+                snippet = raw if len(raw) <= 4000 else raw[:4000] + '\n... (truncated) ...'
+                detail_bits.append(
+                    '<details><summary>TransferBench output</summary>'
+                    f'<pre style="white-space:pre-wrap;">{html.escape(snippet)}</pre>'
+                    '</details>'
+                )
+
+            status_class = 'status-fail' if verdict == 'FAIL' else 'status-skipped'
+            rows.append(f"""
+                <tr>
+                    <td><code>{html.escape(str(node))}</code></td>
+                    <td><span class="status-badge {status_class}">{html.escape(verdict)}</span></td>
+                    <td><code>{html.escape(entry.get('command', '') or '')}</code></td>
+                    <td>{''.join(detail_bits)}</td>
+                </tr>
+            """)
+
+        table_html = """
+            <p class="error-summary">The following nodes failed or warned on the TransferBench smoketest:</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Node</th>
+                        <th>Status</th>
+                        <th>Command</th>
+                        <th>Details</th>
+                    </tr>
+                </thead>
+                <tbody>
+        """ + ''.join(rows) + """
+                </tbody>
+            </table>
+        </section>
+        """
+        return header_html + cluster_err_html + table_html
 
     @staticmethod
     def _rdma_pair_row_fields(pair_key, pair_result):

--- a/cvs/lib/preflight/transferbench_smoke.py
+++ b/cvs/lib/preflight/transferbench_smoke.py
@@ -1,0 +1,1051 @@
+"""IFoE TransferBench smoketest preflight check (AIMVT-181).
+
+This module validates IFoE (Infinity Fabric over Ethernet, a.k.a. XGMI-over-
+Ethernet) scale-up connectivity by:
+
+1. Querying ``amd-smi fabric --topology --json`` on every reachable cluster
+   node to discover each GPU's physical (``ppod_id``) and virtual / logical
+   (``vpod_id``) pod membership. Because TransferBench's data-path smoketest
+   exits early (precondition failure) when ranks span multiple virtual pods,
+   we enforce that **all reachable nodes report the same singleton vPod** as
+   a precondition before invoking the binary.
+
+2. Running the TransferBench candidate-branch ``smoketest`` preset on each
+   reachable node (either independently per-node or in multi-rank socket-comm
+   mode). The smoketest exercises H2D, D2H, D2D, broadcast, gather, and
+   all-to-all traffic on GPU DMA and GPU shader (GFX) executors, which is
+   the closest data-path equivalent of "transferbench scale-up full-mesh
+   over IFoE" that the candidate branch ships today.
+
+3. Parsing the per-test PASS/FAIL/SKIP markers and any summary line from
+   the smoketest's stdout, and reconciling them with the binary's exit code:
+
+   - ``exit_code == 0`` and no ``FAIL`` markers → ``PASS``
+   - ``exit_code != 0`` → ``FAIL`` regardless of marker parse success
+     (this catches the ERR_FATAL=2 precondition exit emitted by the preset
+     when symmetry / pod-membership checks fail inside TransferBench itself).
+   - Skipped cells are tolerated up to ``max_skip_pct``; above the budget
+     the result is marked ``WARNING``.
+
+The check is **opt-in**: when ``connectivity_check.transferbench.connectivity_mode``
+is ``"skip"`` (default) the test records a SKIPPED result and returns without
+contacting nodes. Operators flip it to ``"run"`` once TransferBench's
+candidate branch is installed cluster-wide.
+
+The smoketest preset itself, and the ``amd-smi fabric`` topology fields, are
+both required to run on real IFoE-equipped hardware; this module never
+invents them. The unit tests use entirely synthetic fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from cvs.lib.preflight.base import PreflightCheck
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_TB_BINARY = 'TransferBench'
+DEFAULT_AMD_SMI_PATH = 'amd-smi'
+DEFAULT_PRESET = 'smoketest'
+DEFAULT_SIZE_LIST = ['1K', '16M']
+DEFAULT_NUM_ITERATIONS = 2
+DEFAULT_NUM_WARMUPS = 0
+DEFAULT_SOCKET_MASTER_PORT = 31337
+DEFAULT_SSH_TIMEOUT = 600
+DEFAULT_MAX_SKIP_PCT = 25.0
+
+EXIT_CODE_PASS = 0
+EXIT_CODE_FATAL_PRECONDITION = 2
+
+# Sentinel suffix appended to every per-node command so we can recover the
+# exit code from stdout even when the parallel SSH layer discards it.
+EXIT_SENTINEL = '__TB_SMOKE_EXIT__'
+
+# Marker tokens emitted by the candidate-branch SmokeTest preset table.
+MARKER_PASS = '*'
+MARKER_FAIL = 'F'
+MARKER_SKIP = '.'
+
+
+# ---------------------------------------------------------------------------
+# amd-smi fabric topology parsers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    """Return ``int(value)`` or ``None`` for missing/non-numeric values."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        s = value.strip()
+        if not s or s.upper() in {'N/A', 'NA', 'NONE', 'NULL'}:
+            return None
+        try:
+            return int(s, 0)
+        except ValueError:
+            try:
+                return int(float(s))
+            except ValueError:
+                return None
+    return None
+
+
+def _walk_gpu_records(payload: Any) -> Iterable[Dict[str, Any]]:
+    """Yield dict-shaped GPU records from arbitrary amd-smi JSON shapes.
+
+    amd-smi has historically emitted topology JSON in several flavours:
+      - a top-level list of GPU records,
+      - a dict with a ``gpu_data`` list (similar to the ECC/PCIe wrappers),
+      - a dict keyed by GPU index whose values are GPU records,
+      - an envelope dict with ``data`` / ``payload`` lists.
+    This walker handles the common cases tolerantly without requiring a
+    specific schema version.
+    """
+    if payload is None:
+        return
+    if isinstance(payload, list):
+        for entry in payload:
+            if isinstance(entry, dict):
+                yield entry
+        return
+    if not isinstance(payload, dict):
+        return
+    for key in ('gpu_data', 'gpus', 'data', 'payload'):
+        inner = payload.get(key)
+        if isinstance(inner, list):
+            for entry in inner:
+                if isinstance(entry, dict):
+                    yield entry
+            return
+    looks_like_gpu_record = any(
+        k in payload for k in ('gpu', 'gpu_id', 'bdf', 'vpod_id', 'ppod_id', 'fabric')
+    )
+    if looks_like_gpu_record:
+        yield payload
+        return
+    for value in payload.values():
+        if isinstance(value, dict) and any(
+            k in value for k in ('gpu', 'gpu_id', 'bdf', 'vpod_id', 'ppod_id', 'fabric')
+        ):
+            yield value
+
+
+def _extract_pod_ids_from_record(record: Dict[str, Any]) -> Dict[str, Optional[int]]:
+    """Return ``{ppod_id, vpod_id, ppod_size, vpod_size}`` for one GPU record.
+
+    Looks for the fields at the top level and inside a nested ``fabric`` /
+    ``pod`` / ``topology`` dict. Returns ``None`` for any field that is not
+    present or cannot be coerced to int.
+    """
+    keys = ('ppod_id', 'vpod_id', 'ppod_size', 'vpod_size')
+    candidates: List[Dict[str, Any]] = [record]
+    for nested_key in ('fabric', 'pod', 'topology', 'pod_info', 'membership'):
+        nested = record.get(nested_key)
+        if isinstance(nested, dict):
+            candidates.append(nested)
+    out: Dict[str, Optional[int]] = {k: None for k in keys}
+    for cand in candidates:
+        for key in keys:
+            if out[key] is None and key in cand:
+                out[key] = _coerce_int(cand[key])
+    return out
+
+
+_PLAINTEXT_KV_RE = re.compile(r'^\s*([A-Z_][A-Z0-9_]*)\s*[:=]\s*(.+?)\s*$', re.IGNORECASE)
+
+
+def parse_amd_smi_fabric_text(text: str) -> List[Dict[str, Optional[int]]]:
+    """Parse the ``amd-smi fabric --topology`` plaintext output.
+
+    Used as a fallback when the cluster's amd-smi build does not honour
+    ``--json``. Splits the output into per-GPU blocks (separated by ``GPU``
+    headers or blank lines) and extracts ``PPOD_ID`` / ``VPOD_ID`` /
+    ``PPOD_SIZE`` / ``VPOD_SIZE`` rows.
+
+    Returns:
+        list[dict]: One dict per detected GPU block. Each dict has the same
+        shape as ``_extract_pod_ids_from_record`` plus ``gpu`` (index or
+        identifier string parsed from the block header).
+    """
+    if not text:
+        return []
+    lines = text.splitlines()
+    blocks: List[List[str]] = []
+    current: List[str] = []
+    for line in lines:
+        if re.match(r'^\s*(GPU|ACCELERATOR|DEVICE)\b', line, re.IGNORECASE):
+            if current:
+                blocks.append(current)
+            current = [line]
+        elif not line.strip():
+            if current:
+                blocks.append(current)
+                current = []
+        else:
+            current.append(line)
+    if current:
+        blocks.append(current)
+
+    parsed_blocks: List[Dict[str, Optional[int]]] = []
+    for block in blocks:
+        record: Dict[str, Any] = {}
+        header = block[0]
+        m = re.search(r'^\s*(?:GPU|ACCELERATOR|DEVICE)\s*[:#]?\s*([A-Za-z0-9_.:-]+)', header, re.IGNORECASE)
+        if m:
+            record['gpu'] = m.group(1)
+        for line in block[1:]:
+            kv = _PLAINTEXT_KV_RE.match(line)
+            if not kv:
+                continue
+            key = kv.group(1).strip().lower()
+            value = kv.group(2).strip()
+            if key in ('ppod_id', 'vpod_id', 'ppod_size', 'vpod_size'):
+                record[key] = value
+        pod_ids = _extract_pod_ids_from_record(record)
+        if any(v is not None for v in pod_ids.values()):
+            entry = dict(pod_ids)
+            if 'gpu' in record:
+                entry['gpu'] = record['gpu']
+            parsed_blocks.append(entry)
+    return parsed_blocks
+
+
+def extract_node_pod_membership(node_payload: Any) -> Dict[str, Any]:
+    """Reduce an ``amd-smi fabric --topology`` payload to per-node summary.
+
+    Accepts either:
+      - the parsed JSON object returned by ``rocm_plib.get_gpu_fabric_info_dict``
+        for a single node, or
+      - the raw stdout string (used as plaintext-fallback input).
+
+    Returns:
+        dict with:
+          - ``gpus`` (int): number of GPU records parsed from the payload.
+          - ``vpod_ids`` (sorted list[int]): unique vPod IDs observed.
+          - ``ppod_ids`` (sorted list[int]): unique pPod IDs observed.
+          - ``vpod_size`` (int | None): node-wide majority vpod_size (or None).
+          - ``ppod_size`` (int | None): node-wide majority ppod_size (or None).
+          - ``errors`` (list[str]): parsing/observation issues.
+
+        A node with a single uniform vPod will have
+        ``len(vpod_ids) == 1`` and ``errors == []``.
+    """
+    out = {
+        'gpus': 0,
+        'vpod_ids': [],
+        'ppod_ids': [],
+        'vpod_size': None,
+        'ppod_size': None,
+        'errors': [],
+    }
+    records: List[Dict[str, Any]] = []
+    if isinstance(node_payload, str):
+        plaintext_records = parse_amd_smi_fabric_text(node_payload)
+        records.extend(plaintext_records)
+    else:
+        for entry in _walk_gpu_records(node_payload):
+            records.append(entry)
+
+    pod_id_dicts: List[Dict[str, Optional[int]]] = []
+    for record in records:
+        ids = _extract_pod_ids_from_record(record)
+        if any(v is not None for v in ids.values()):
+            pod_id_dicts.append(ids)
+
+    out['gpus'] = len(pod_id_dicts)
+    if not pod_id_dicts:
+        out['errors'].append(
+            'amd-smi fabric payload contained no GPU records with vpod_id/ppod_id fields'
+        )
+        return out
+
+    vpods = sorted({d['vpod_id'] for d in pod_id_dicts if d['vpod_id'] is not None})
+    ppods = sorted({d['ppod_id'] for d in pod_id_dicts if d['ppod_id'] is not None})
+    out['vpod_ids'] = vpods
+    out['ppod_ids'] = ppods
+
+    if not vpods:
+        out['errors'].append('No vpod_id values reported by amd-smi fabric topology')
+    elif len(vpods) > 1:
+        out['errors'].append(
+            f'Multiple vPod IDs reported by a single node: {vpods} '
+            f'(TransferBench smoketest requires uniform vpod_id across local GPUs)'
+        )
+
+    sizes_v = [d['vpod_size'] for d in pod_id_dicts if d['vpod_size'] is not None]
+    if sizes_v:
+        out['vpod_size'] = max(set(sizes_v), key=sizes_v.count)
+    sizes_p = [d['ppod_size'] for d in pod_id_dicts if d['ppod_size'] is not None]
+    if sizes_p:
+        out['ppod_size'] = max(set(sizes_p), key=sizes_p.count)
+    return out
+
+
+def reconcile_cluster_vpod(
+    per_node_membership: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Cross-check pod membership across nodes for a smoketest precondition.
+
+    Args:
+        per_node_membership: ``{node: extract_node_pod_membership(...) dict}``.
+
+    Returns:
+        dict with:
+          - ``status``: ``'PASS'`` if every node reports the same singleton
+            vPod ID, ``'FAIL'`` otherwise.
+          - ``vpod_id``: the shared vpod_id (``int``) when PASS, else ``None``.
+          - ``ppod_id``: the shared ppod_id when PASS-and-all-agree, else
+            ``None`` (only informational; the smoketest precondition is on
+            vPod).
+          - ``per_node``: copy of the input.
+          - ``errors``: list of human-readable explanations of any mismatch.
+    """
+    result: Dict[str, Any] = {
+        'status': 'PASS',
+        'vpod_id': None,
+        'ppod_id': None,
+        'per_node': dict(per_node_membership),
+        'errors': [],
+    }
+    if not per_node_membership:
+        result['status'] = 'FAIL'
+        result['errors'].append('No nodes reported amd-smi fabric topology')
+        return result
+
+    nodes_without_vpod = [n for n, m in per_node_membership.items() if not m.get('vpod_ids')]
+    if nodes_without_vpod:
+        result['status'] = 'FAIL'
+        result['errors'].append(
+            f'{len(nodes_without_vpod)} node(s) missing vpod_id from amd-smi fabric: '
+            + ', '.join(sorted(nodes_without_vpod)[:10])
+        )
+
+    multi_vpod_nodes = [
+        n for n, m in per_node_membership.items() if len(m.get('vpod_ids') or []) > 1
+    ]
+    if multi_vpod_nodes:
+        result['status'] = 'FAIL'
+        result['errors'].append(
+            f'{len(multi_vpod_nodes)} node(s) report multiple local vPod IDs: '
+            + ', '.join(sorted(multi_vpod_nodes)[:10])
+        )
+
+    singleton_pairs = {
+        n: m['vpod_ids'][0]
+        for n, m in per_node_membership.items()
+        if len(m.get('vpod_ids') or []) == 1
+    }
+    distinct_vpods = sorted(set(singleton_pairs.values()))
+    if len(distinct_vpods) > 1:
+        result['status'] = 'FAIL'
+        groups: Dict[int, List[str]] = {}
+        for n, vp in singleton_pairs.items():
+            groups.setdefault(vp, []).append(n)
+        group_strs = [
+            f'vpod_id={vp}: {len(groups[vp])} node(s) ({", ".join(sorted(groups[vp])[:5])}'
+            + (', ...' if len(groups[vp]) > 5 else '')
+            + ')'
+            for vp in distinct_vpods
+        ]
+        result['errors'].append(
+            'Reachable nodes span multiple vPods; TransferBench smoketest requires a single vPod. '
+            + ' | '.join(group_strs)
+        )
+
+    if result['status'] == 'PASS' and distinct_vpods:
+        result['vpod_id'] = distinct_vpods[0]
+        ppod_sets = [tuple(m.get('ppod_ids') or []) for m in per_node_membership.values()]
+        if ppod_sets and all(len(s) == 1 and s == ppod_sets[0] for s in ppod_sets):
+            result['ppod_id'] = ppod_sets[0][0]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Smoketest output parser
+# ---------------------------------------------------------------------------
+
+
+_BRACKET_VERDICT_RE = re.compile(r'\[\s*(PASS|FAIL|SKIP(?:PED)?|ERROR)\s*\]', re.IGNORECASE)
+_TEST_LINE_NUMBER_RE = re.compile(r'^\s*(?:Test\s+)?#?\s*(\d+)\b', re.IGNORECASE)
+_SUMMARY_LINE_RE = re.compile(
+    r'(?P<passed>\d+)\s*/\s*(?P<total>\d+)\s*(?:tests?\s*)?PASS', re.IGNORECASE
+)
+_SECONDARY_COUNT_RE = re.compile(
+    r'(?P<n>\d+)\s+(?P<label>FAIL|SKIP(?:PED)?|ERROR)', re.IGNORECASE
+)
+_WARNING_LINE_RE = re.compile(r'^\s*(?:WARN(?:ING)?|NOTE|INFO)\s*[:\-]\s*(.+)$', re.IGNORECASE)
+_FAIL_KEYWORD_RE = re.compile(r'\b(FAILED|FATAL|ERR_FATAL|FAILURE|ABORTED?)\b', re.IGNORECASE)
+_SKIP_KEYWORD_RE = re.compile(r'\b(SKIP(?:PED)?|SKIPPING)\b', re.IGNORECASE)
+_MARKER_BLOCK_RE = re.compile(r'^[ \t]*[' + re.escape(MARKER_PASS + MARKER_FAIL + MARKER_SKIP) + r']{4,}\s*$')
+_EXIT_SENTINEL_RE = re.compile(
+    re.escape(EXIT_SENTINEL) + r'\s*=\s*(?P<code>-?\d+)\s*$', re.MULTILINE
+)
+
+
+class SmoketestParser:
+    """Tolerant parser for TransferBench candidate-branch ``smoketest`` output.
+
+    The candidate-branch preset prints a per-test results section followed by
+    an aggregate summary. Real-world outputs vary across builds (cell markers
+    ``*/F/.`` vs. ``[PASS]/[FAIL]/[SKIP]`` vs. ``Test N: ... PASSED``), so
+    the parser accepts all three shapes and treats the binary's exit code as
+    the authoritative pass/fail signal. Marker counts are reported as
+    diagnostics and used for the optional skip-budget gate.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> Dict[str, Any]:
+        """Return parsed structured smoketest result.
+
+        Args:
+            output: Raw stdout (+stderr if merged) from the TransferBench
+                smoketest invocation, optionally including the
+                ``__TB_SMOKE_EXIT__=<code>`` sentinel line appended by the
+                orchestrator.
+
+        Returns:
+            dict with keys:
+              - ``exit_code`` (int | None): parsed from the sentinel line; ``None``
+                when not present (treated by the orchestrator as FAIL).
+              - ``num_pass``, ``num_fail``, ``num_skip`` (int): counts derived from
+                whichever marker style was found.
+              - ``num_tests`` (int): ``num_pass + num_fail + num_skip``.
+              - ``summary_total``, ``summary_pass`` (int | None): values parsed
+                from a "N/M PASS" summary line, if present.
+              - ``per_test`` (list[dict]): one entry per detected test row with
+                ``index`` (str | None), ``status`` (PASS/FAIL/SKIP), and
+                ``raw`` (the original line).
+              - ``warnings`` (list[str]): WARN / NOTE / SKIPPED reason lines.
+              - ``errors`` (list[str]): lines containing FAILED / FATAL /
+                ``ERR_FATAL`` and similar fatal-error keywords.
+              - ``parse_errors`` (list[str]): notes about ambiguous output
+                shapes (empty when parsing succeeded cleanly).
+              - ``raw`` (str): stripped raw output (sentinel removed).
+        """
+        result: Dict[str, Any] = {
+            'exit_code': None,
+            'num_pass': 0,
+            'num_fail': 0,
+            'num_skip': 0,
+            'num_tests': 0,
+            'summary_total': None,
+            'summary_pass': None,
+            'per_test': [],
+            'warnings': [],
+            'errors': [],
+            'parse_errors': [],
+            'raw': '',
+        }
+        if not output:
+            result['parse_errors'].append('Empty smoketest output')
+            return result
+
+        text = output
+        m = _EXIT_SENTINEL_RE.search(text)
+        if m:
+            try:
+                result['exit_code'] = int(m.group('code'))
+            except ValueError:
+                pass
+            text = _EXIT_SENTINEL_RE.sub('', text).rstrip()
+        result['raw'] = text
+
+        cls._collect_per_test_rows(text, result)
+        cls._collect_marker_blocks(text, result)
+        cls._collect_summary(text, result)
+        cls._collect_warnings_and_errors(text, result)
+
+        result['num_tests'] = result['num_pass'] + result['num_fail'] + result['num_skip']
+        if result['num_tests'] == 0 and result['summary_total']:
+            result['num_tests'] = result['summary_total']
+        return result
+
+    @staticmethod
+    def _collect_per_test_rows(text: str, result: Dict[str, Any]) -> None:
+        """Capture ``Test N: ... [PASS]`` style rows."""
+        for line in text.splitlines():
+            verdict = _BRACKET_VERDICT_RE.search(line)
+            if not verdict:
+                continue
+            status_token = verdict.group(1).upper()
+            if status_token.startswith('SKIP'):
+                status = 'SKIP'
+            elif status_token == 'FAIL':
+                status = 'FAIL'
+            elif status_token == 'ERROR':
+                status = 'FAIL'
+            else:
+                status = 'PASS'
+            idx_match = _TEST_LINE_NUMBER_RE.match(line)
+            index = idx_match.group(1) if idx_match else None
+            result['per_test'].append({'index': index, 'status': status, 'raw': line.strip()})
+            if status == 'PASS':
+                result['num_pass'] += 1
+            elif status == 'FAIL':
+                result['num_fail'] += 1
+            elif status == 'SKIP':
+                result['num_skip'] += 1
+
+    @staticmethod
+    def _collect_marker_blocks(text: str, result: Dict[str, Any]) -> None:
+        """Capture compact marker blocks like ``****F.*.``.
+
+        Only consulted when no bracketed verdict rows were found; otherwise
+        the per-test rows already provide the counts we need.
+        """
+        if result['per_test']:
+            return
+        for line in text.splitlines():
+            if not _MARKER_BLOCK_RE.match(line):
+                continue
+            for ch in line.strip():
+                if ch == MARKER_PASS:
+                    result['num_pass'] += 1
+                elif ch == MARKER_FAIL:
+                    result['num_fail'] += 1
+                elif ch == MARKER_SKIP:
+                    result['num_skip'] += 1
+
+    @staticmethod
+    def _collect_summary(text: str, result: Dict[str, Any]) -> None:
+        """Parse aggregate ``N/M PASS, x FAIL, y SKIP`` lines."""
+        for line in text.splitlines():
+            m = _SUMMARY_LINE_RE.search(line)
+            if not m:
+                continue
+            try:
+                summary_pass = int(m.group('passed'))
+                summary_total = int(m.group('total'))
+            except (TypeError, ValueError):
+                continue
+            if result['summary_total'] is None:
+                result['summary_pass'] = summary_pass
+                result['summary_total'] = summary_total
+            for sec in _SECONDARY_COUNT_RE.finditer(line):
+                try:
+                    count = int(sec.group('n'))
+                except ValueError:
+                    continue
+                label = sec.group('label').upper()
+                if label.startswith('SKIP'):
+                    result['num_skip'] = max(result['num_skip'], count)
+                elif label in ('FAIL', 'ERROR'):
+                    result['num_fail'] = max(result['num_fail'], count)
+            if (
+                summary_total > 0
+                and not result['per_test']
+                and result['num_pass'] + result['num_fail'] + result['num_skip'] == 0
+            ):
+                result['num_pass'] = summary_pass
+                inferred_remainder = max(0, summary_total - summary_pass - result['num_fail'])
+                if result['num_skip'] == 0 and inferred_remainder > 0:
+                    result['num_fail'] = max(result['num_fail'], inferred_remainder - result['num_skip'])
+
+    @staticmethod
+    def _collect_warnings_and_errors(text: str, result: Dict[str, Any]) -> None:
+        """Collect WARN/NOTE lines and fatal-keyword error lines."""
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            wm = _WARNING_LINE_RE.match(stripped)
+            if wm:
+                result['warnings'].append(stripped)
+                continue
+            if _FAIL_KEYWORD_RE.search(stripped):
+                if _BRACKET_VERDICT_RE.search(stripped):
+                    continue
+                result['errors'].append(stripped)
+            elif _SKIP_KEYWORD_RE.search(stripped) and 'reason' in stripped.lower():
+                result['warnings'].append(stripped)
+
+
+# ---------------------------------------------------------------------------
+# Smoketest verdict logic
+# ---------------------------------------------------------------------------
+
+
+def evaluate_smoketest(
+    parsed: Dict[str, Any],
+    max_skip_pct: float = DEFAULT_MAX_SKIP_PCT,
+) -> Tuple[str, List[str]]:
+    """Derive the per-node PASS/FAIL/WARNING verdict from a parsed result.
+
+    Verdict precedence (first matching rule wins):
+      1. ``exit_code is None`` -> ``FAIL`` (no sentinel; orchestration broke
+         or the command was killed before printing).
+      2. ``exit_code == EXIT_CODE_FATAL_PRECONDITION`` (= 2) -> ``FAIL`` with
+         a precondition message (this is how the candidate-branch preset
+         signals symmetry / pod-membership failures).
+      3. ``exit_code != 0`` -> ``FAIL``.
+      4. ``num_fail > 0`` or any ``errors`` -> ``FAIL`` (defence in depth in
+         case the binary somehow exited zero with FAIL cells, which would
+         itself be a bug worth flagging).
+      5. ``num_skip / num_tests > max_skip_pct / 100`` -> ``WARNING``.
+      6. otherwise -> ``PASS``.
+
+    Returns:
+        Tuple of (``verdict``, ``errors``).
+    """
+    errors: List[str] = []
+    exit_code = parsed.get('exit_code')
+    if exit_code is None:
+        errors.append(
+            'TransferBench smoketest exit code not captured (process may have been killed '
+            'before completing or stdout was truncated)'
+        )
+        return 'FAIL', errors
+    if exit_code == EXIT_CODE_FATAL_PRECONDITION:
+        errors.append(
+            'TransferBench smoketest aborted with ERR_FATAL precondition (exit 2): '
+            'pod-membership or executor symmetry check inside the preset failed'
+        )
+        return 'FAIL', errors
+    if exit_code != EXIT_CODE_PASS:
+        errors.append(f'TransferBench smoketest non-zero exit code: {exit_code}')
+        return 'FAIL', errors
+    if parsed.get('num_fail', 0) > 0:
+        errors.append(
+            f"TransferBench smoketest reported {parsed['num_fail']} FAIL marker(s) despite "
+            f"exit code 0 -- treating as FAIL"
+        )
+        return 'FAIL', errors
+    if parsed.get('errors'):
+        errors.append('TransferBench stdout contained FAIL/FATAL keyword lines')
+        return 'FAIL', errors
+
+    num_tests = parsed.get('num_tests') or 0
+    num_skip = parsed.get('num_skip') or 0
+    if num_tests > 0 and max_skip_pct >= 0:
+        skip_pct = (num_skip / num_tests) * 100.0
+        if skip_pct > max_skip_pct + 1e-9:
+            errors.append(
+                f'TransferBench smoketest skipped {num_skip}/{num_tests} tests '
+                f'({skip_pct:.1f}% > max_skip_pct={max_skip_pct}%)'
+            )
+            return 'WARNING', errors
+
+    return 'PASS', errors
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+RankMode = str  # 'per_node' or 'multi_rank'
+
+
+class TransferBenchSmokeCheck(PreflightCheck):
+    """Run the TransferBench candidate-branch smoketest preset cluster-wide.
+
+    The check is two-phase:
+
+      1. **Precondition** – Query ``amd-smi fabric --topology --json`` on
+         every reachable node, then enforce that all nodes report the same
+         singleton vPod ID (TransferBench multi-rank smoketest exits with
+         ``ERR_FATAL`` when ranks span multiple vPods, and the per-node
+         single-rank case is meaningless when the cluster's IFoE fabric was
+         intended to span more than one node).
+      2. **Smoketest** – Invoke ``TransferBench smoketest`` on each node and
+         parse the output. Two orchestration modes are supported:
+
+         - ``per_node`` (default): each node runs the preset independently
+           against its local GPUs (``TB_NUM_RANKS=1``). Exercises intra-node
+           AID↔MID IFoE hops, but does not traverse the rack IFoE switch.
+         - ``multi_rank``: ``N`` reachable nodes coordinate via the preset's
+           built-in socket-comm (``TB_NUM_RANKS=N``, ``TB_RANK=0..N-1``,
+           ``TB_MASTER_ADDR=<rank0 IP>``). This is the closest thing to a
+           full-mesh IFoE scale-up traffic test and is the recommended mode
+           when topology supports it; we fall back to ``per_node`` if there
+           are fewer than two reachable nodes.
+
+    All TransferBench-specific tuning knobs (preset name, size list,
+    iterations, validate / parallel / BDMA flags, master port) are
+    configurable so the same module can be repointed at future smoketest
+    variants without code changes.
+    """
+
+    def __init__(
+        self,
+        phdl,
+        *,
+        tb_binary: str = DEFAULT_TB_BINARY,
+        rocm_path: Optional[str] = None,
+        amd_smi_path: str = DEFAULT_AMD_SMI_PATH,
+        use_sudo: bool = False,
+        preset: str = DEFAULT_PRESET,
+        size_list: Optional[Sequence[str]] = None,
+        num_iterations: int = DEFAULT_NUM_ITERATIONS,
+        num_warmups: int = DEFAULT_NUM_WARMUPS,
+        always_validate: bool = True,
+        run_parallel: bool = True,
+        use_bdma: bool = False,
+        force_single_pod: bool = True,
+        rank_mode: RankMode = 'per_node',
+        socket_master_port: int = DEFAULT_SOCKET_MASTER_PORT,
+        master_node: Optional[str] = None,
+        max_skip_pct: float = DEFAULT_MAX_SKIP_PCT,
+        ssh_timeout: int = DEFAULT_SSH_TIMEOUT,
+        extra_env: Optional[Dict[str, str]] = None,
+        extra_args: Optional[Sequence[str]] = None,
+        skip_pod_check: bool = False,
+        config_dict: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(phdl, config_dict)
+        self.tb_binary = tb_binary
+        self.rocm_path = (rocm_path or '').strip()
+        self.amd_smi_path = amd_smi_path
+        self.use_sudo = bool(use_sudo)
+        self.preset = preset
+        self.size_list = list(size_list) if size_list else list(DEFAULT_SIZE_LIST)
+        self.num_iterations = int(num_iterations)
+        self.num_warmups = int(num_warmups)
+        self.always_validate = bool(always_validate)
+        self.run_parallel = bool(run_parallel)
+        self.use_bdma = bool(use_bdma)
+        self.force_single_pod = bool(force_single_pod)
+        self.socket_master_port = int(socket_master_port)
+        self.master_node = master_node
+        self.max_skip_pct = float(max_skip_pct)
+        self.ssh_timeout = int(ssh_timeout)
+        self.extra_env = dict(extra_env or {})
+        self.extra_args = list(extra_args or [])
+        self.skip_pod_check = bool(skip_pod_check)
+
+        rank_mode_norm = (rank_mode or 'per_node').strip().lower()
+        if rank_mode_norm not in ('per_node', 'multi_rank'):
+            raise ValueError(
+                f"rank_mode must be 'per_node' or 'multi_rank' (got '{rank_mode}')"
+            )
+        self.rank_mode = rank_mode_norm
+
+    # ------------------------------------------------------------------
+    # Command construction
+    # ------------------------------------------------------------------
+
+    def _env_assignments(self, rank: int, num_ranks: int, master_addr: str) -> List[str]:
+        """Build ``KEY=VALUE`` assignments for one rank's TransferBench invocation."""
+        env: Dict[str, str] = {}
+        env['NUM_ITERATIONS'] = str(self.num_iterations)
+        env['NUM_WARMUPS'] = str(self.num_warmups)
+        env['ALWAYS_VALIDATE'] = '1' if self.always_validate else '0'
+        env['USE_REMOTE_READ'] = '1'
+        env['BLOCK_BYTES'] = '256'
+        if self.run_parallel:
+            env['RUN_PARALLEL'] = '1'
+        if self.use_bdma:
+            env['USE_BDMA'] = '1'
+        if self.force_single_pod:
+            env['FORCE_SINGLE_POD'] = '1'
+        if num_ranks > 1:
+            env['TB_NUM_RANKS'] = str(num_ranks)
+            env['TB_RANK'] = str(rank)
+            env['TB_MASTER_ADDR'] = master_addr
+            env['TB_MASTER_PORT'] = str(self.socket_master_port)
+        for k, v in self.extra_env.items():
+            env[k] = str(v)
+        return [f'{k}={shlex.quote(v)}' for k, v in env.items()]
+
+    def _rocm_env_prefix(self) -> str:
+        """ROCm PATH/LD_LIBRARY_PATH prefix evaluated inside the inner shell."""
+        if not self.rocm_path:
+            return ''
+        rocm_bin = shlex.quote(f'{self.rocm_path}/bin')
+        rocm_lib = shlex.quote(f'{self.rocm_path}/lib')
+        return f'PATH={rocm_bin}:$PATH LD_LIBRARY_PATH={rocm_lib}:${{LD_LIBRARY_PATH:-}}'
+
+    def build_command(
+        self,
+        rank: int,
+        num_ranks: int,
+        master_addr: str,
+        size_list: Optional[Sequence[str]] = None,
+    ) -> str:
+        """Render a complete shell command for one rank.
+
+        Env-var prefixes (TB_*, NUM_ITERATIONS, etc.) and ROCm PATH/library
+        path mods are placed **inside** the inner shell so that, even when
+        ``use_sudo=True``, the privileged child process sees them: ``sudo``
+        otherwise sanitizes the calling shell's environment. The command
+        also appends a sentinel ``__TB_SMOKE_EXIT__=<code>`` line so the
+        orchestrator can recover the binary's exit code from stdout when
+        the parallel SSH layer discards process exit codes.
+        """
+        env_parts = self._env_assignments(rank, num_ranks, master_addr)
+        binary = shlex.quote(self.tb_binary)
+        preset = shlex.quote(self.preset)
+        sizes = list(size_list) if size_list is not None else self.size_list
+        size_args = ' '.join(shlex.quote(str(s)) for s in sizes)
+        extras = ' '.join(shlex.quote(s) for s in self.extra_args)
+        env_inline = ' '.join([self._rocm_env_prefix(), *env_parts]).strip()
+        binary_invocation = f'{binary} {preset} {size_args} {extras}'.strip()
+        if env_inline:
+            inner = f'{env_inline} {binary_invocation}'
+        else:
+            inner = binary_invocation
+        inner_with_sentinel = f'{inner}; echo "{EXIT_SENTINEL}=$?"'
+        if self.use_sudo:
+            return f'sudo bash -c {shlex.quote(inner_with_sentinel)}'
+        return f'bash -c {shlex.quote(inner_with_sentinel)}'
+
+    # ------------------------------------------------------------------
+    # Precondition: pod membership
+    # ------------------------------------------------------------------
+
+    def _amd_smi_fabric_command(self) -> str:
+        cmd = f'{self.amd_smi_path} fabric --topology --json'
+        if self.use_sudo:
+            cmd = 'sudo ' + cmd
+        return cmd
+
+    def _query_pod_membership(self) -> Dict[str, Dict[str, Any]]:
+        """Run ``amd-smi fabric --topology --json`` on each reachable node.
+
+        Tolerates plaintext (non-JSON) outputs by passing the raw string to
+        ``extract_node_pod_membership``, which then routes it through the
+        plaintext fallback parser.
+        """
+        cmd = self._amd_smi_fabric_command()
+        self.log_info(f'Querying pod membership: {cmd}')
+        out_dict = self.phdl.exec(cmd, timeout=min(60, self.ssh_timeout), print_console=False)
+        per_node: Dict[str, Dict[str, Any]] = {}
+        for node, output in out_dict.items():
+            payload: Any
+            if isinstance(output, str):
+                stripped = output.strip()
+                if stripped.startswith('{') or stripped.startswith('['):
+                    try:
+                        payload = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        payload = output
+                else:
+                    payload = output
+            else:
+                payload = output
+            membership = extract_node_pod_membership(payload)
+            membership['raw_output'] = output if isinstance(output, str) else ''
+            per_node[node] = membership
+        return per_node
+
+    # ------------------------------------------------------------------
+    # Smoketest dispatch
+    # ------------------------------------------------------------------
+
+    def _resolve_master_node(self) -> Optional[str]:
+        if self.master_node and self.master_node in self.phdl.reachable_hosts:
+            return self.master_node
+        if self.phdl.reachable_hosts:
+            return sorted(self.phdl.reachable_hosts)[0]
+        return None
+
+    def _dispatch_per_node(self) -> Dict[str, Dict[str, Any]]:
+        """One independent smoketest per node, all in parallel."""
+        cmd = self.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
+        self.log_info(f"Dispatching per-node smoketest: {cmd}")
+        out_dict = self.phdl.exec(cmd, timeout=self.ssh_timeout, print_console=False)
+        return {node: {'command': cmd, 'output': output} for node, output in out_dict.items()}
+
+    def _dispatch_multi_rank(self) -> Dict[str, Dict[str, Any]]:
+        """Multi-rank socket-comm dispatch (one rank per reachable node).
+
+        Each node receives a distinct command (different ``TB_RANK`` value)
+        constructed in deterministic hostname-sorted order. Sent as a single
+        ``exec_cmd_list`` call so all ranks start in parallel and the
+        preset's socket-comm bootstrap can complete.
+        """
+        hosts = list(self.phdl.reachable_hosts)
+        if not hosts:
+            return {}
+        master = self._resolve_master_node()
+        if not master:
+            return {}
+        ordered = [master] + sorted([h for h in hosts if h != master])
+        num_ranks = len(ordered)
+        cmd_list: List[str] = []
+        per_node: Dict[str, Dict[str, Any]] = {}
+        for rank, node in enumerate(ordered):
+            cmd = self.build_command(rank=rank, num_ranks=num_ranks, master_addr=master)
+            cmd_list.append(cmd)
+            per_node[node] = {'command': cmd, 'output': '', 'rank': rank}
+
+        # phdl.exec_cmd_list aligns commands to reachable_hosts ordering. We
+        # rebuild the list in that ordering so each host gets its assigned
+        # rank's command.
+        rank_by_host = {node: rank for rank, node in enumerate(ordered)}
+        cmd_by_reachable = [
+            self.build_command(
+                rank=rank_by_host[h], num_ranks=num_ranks, master_addr=master
+            )
+            for h in hosts
+        ]
+        self.log_info(
+            f'Dispatching multi-rank smoketest (num_ranks={num_ranks}, master={master})'
+        )
+        out_dict = self.phdl.exec_cmd_list(
+            cmd_by_reachable, timeout=self.ssh_timeout, print_console=False
+        )
+        for h, output in out_dict.items():
+            if h not in per_node:
+                per_node[h] = {'command': '', 'output': output}
+            per_node[h]['output'] = output
+        return per_node
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> Dict[str, Any]:
+        """Execute pod-membership precondition + smoketest dispatch.
+
+        Returns:
+            dict with:
+              - ``status``: ``'PASS'`` / ``'FAIL'`` / ``'WARNING'`` for the
+                overall check.
+              - ``rank_mode``: orchestration mode used (may differ from the
+                requested mode if we degraded to ``per_node`` due to too few
+                reachable nodes).
+              - ``pod_membership``: cross-node reconcile result from
+                ``reconcile_cluster_vpod``.
+              - ``nodes``: ``{node: {status, errors, command, exit_code,
+                parsed, raw_output, rank}}`` for every reachable node.
+              - ``totals``: ``{nodes_total, nodes_pass, nodes_warning,
+                nodes_fail, tests_pass, tests_fail, tests_skip}``.
+              - ``errors``: cluster-level error messages (precondition,
+                orchestration failures).
+        """
+        self.results = {
+            'status': 'PASS',
+            'rank_mode': self.rank_mode,
+            'pod_membership': {},
+            'nodes': {},
+            'totals': {
+                'nodes_total': 0,
+                'nodes_pass': 0,
+                'nodes_warning': 0,
+                'nodes_fail': 0,
+                'tests_pass': 0,
+                'tests_fail': 0,
+                'tests_skip': 0,
+            },
+            'errors': [],
+        }
+
+        hosts = list(self.phdl.reachable_hosts)
+        if not hosts:
+            self.results['status'] = 'FAIL'
+            self.results['errors'].append(
+                'No reachable hosts available for TransferBench smoketest'
+            )
+            return self.results
+        self.results['totals']['nodes_total'] = len(hosts)
+
+        if not self.skip_pod_check:
+            per_node_membership = self._query_pod_membership()
+            reconcile = reconcile_cluster_vpod(per_node_membership)
+            self.results['pod_membership'] = reconcile
+            if reconcile['status'] != 'PASS':
+                self.results['status'] = 'FAIL'
+                self.results['errors'].extend(reconcile.get('errors') or [])
+                for node in hosts:
+                    self.results['nodes'][node] = {
+                        'status': 'SKIPPED',
+                        'errors': ['pod-membership precondition failed; smoketest not dispatched'],
+                        'command': '',
+                        'exit_code': None,
+                        'parsed': {},
+                        'raw_output': '',
+                        'rank': None,
+                    }
+                return self.results
+        else:
+            self.results['pod_membership'] = {
+                'status': 'SKIPPED',
+                'errors': [],
+                'vpod_id': None,
+                'ppod_id': None,
+                'per_node': {},
+            }
+            self.log_warning('skip_pod_check=True; vPod precondition will not be enforced')
+
+        effective_rank_mode = self.rank_mode
+        if self.rank_mode == 'multi_rank' and len(hosts) < 2:
+            self.log_warning(
+                f'multi_rank requested but only {len(hosts)} reachable node(s); '
+                f'falling back to per_node'
+            )
+            effective_rank_mode = 'per_node'
+        self.results['rank_mode'] = effective_rank_mode
+
+        try:
+            if effective_rank_mode == 'multi_rank':
+                dispatch = self._dispatch_multi_rank()
+            else:
+                dispatch = self._dispatch_per_node()
+        except Exception as exc:  # pragma: no cover - defensive
+            self.results['status'] = 'FAIL'
+            self.results['errors'].append(f'Smoketest dispatch failed: {exc}')
+            return self.results
+
+        totals = self.results['totals']
+        for node in hosts:
+            entry = dispatch.get(node) or {}
+            output = entry.get('output') or ''
+            command = entry.get('command') or ''
+            parsed = SmoketestParser.parse(output if isinstance(output, str) else '')
+            verdict, verdict_errors = evaluate_smoketest(parsed, max_skip_pct=self.max_skip_pct)
+            self.results['nodes'][node] = {
+                'status': verdict,
+                'errors': verdict_errors,
+                'command': command,
+                'exit_code': parsed.get('exit_code'),
+                'parsed': parsed,
+                'raw_output': output if isinstance(output, str) else '',
+                'rank': entry.get('rank'),
+            }
+            if verdict == 'PASS':
+                totals['nodes_pass'] += 1
+            elif verdict == 'WARNING':
+                totals['nodes_warning'] += 1
+            else:
+                totals['nodes_fail'] += 1
+            totals['tests_pass'] += parsed.get('num_pass', 0)
+            totals['tests_fail'] += parsed.get('num_fail', 0)
+            totals['tests_skip'] += parsed.get('num_skip', 0)
+
+        if totals['nodes_fail']:
+            self.results['status'] = 'FAIL'
+        elif totals['nodes_warning']:
+            self.results['status'] = 'WARNING'
+        else:
+            self.results['status'] = 'PASS'
+        return self.results
+
+
+__all__ = [
+    'TransferBenchSmokeCheck',
+    'SmoketestParser',
+    'evaluate_smoketest',
+    'extract_node_pod_membership',
+    'reconcile_cluster_vpod',
+    'parse_amd_smi_fabric_text',
+    'EXIT_SENTINEL',
+    'EXIT_CODE_PASS',
+    'EXIT_CODE_FATAL_PRECONDITION',
+    'DEFAULT_SIZE_LIST',
+    'DEFAULT_PRESET',
+    'DEFAULT_TB_BINARY',
+]

--- a/cvs/lib/preflight/transferbench_smoke.py
+++ b/cvs/lib/preflight/transferbench_smoke.py
@@ -52,7 +52,6 @@ from cvs.lib.preflight.base import PreflightCheck
 # ---------------------------------------------------------------------------
 
 DEFAULT_TB_BINARY = 'TransferBench'
-DEFAULT_AMD_SMI_PATH = 'amd-smi'
 DEFAULT_PRESET = 'smoketest'
 DEFAULT_SIZE_LIST = ['1K', '16M']
 DEFAULT_NUM_ITERATIONS = 2
@@ -684,8 +683,6 @@ class TransferBenchSmokeCheck(PreflightCheck):
         phdl,
         *,
         tb_binary: str = DEFAULT_TB_BINARY,
-        rocm_path: Optional[str] = None,
-        amd_smi_path: str = DEFAULT_AMD_SMI_PATH,
         use_sudo: bool = False,
         preset: str = DEFAULT_PRESET,
         size_list: Optional[Sequence[str]] = None,
@@ -707,8 +704,6 @@ class TransferBenchSmokeCheck(PreflightCheck):
     ) -> None:
         super().__init__(phdl, config_dict)
         self.tb_binary = tb_binary
-        self.rocm_path = (rocm_path or '').strip()
-        self.amd_smi_path = amd_smi_path
         self.use_sudo = bool(use_sudo)
         self.preset = preset
         self.size_list = list(size_list) if size_list else list(DEFAULT_SIZE_LIST)
@@ -760,14 +755,6 @@ class TransferBenchSmokeCheck(PreflightCheck):
             env[k] = str(v)
         return [f'{k}={shlex.quote(v)}' for k, v in env.items()]
 
-    def _rocm_env_prefix(self) -> str:
-        """ROCm PATH/LD_LIBRARY_PATH prefix evaluated inside the inner shell."""
-        if not self.rocm_path:
-            return ''
-        rocm_bin = shlex.quote(f'{self.rocm_path}/bin')
-        rocm_lib = shlex.quote(f'{self.rocm_path}/lib')
-        return f'PATH={rocm_bin}:$PATH LD_LIBRARY_PATH={rocm_lib}:${{LD_LIBRARY_PATH:-}}'
-
     def build_command(
         self,
         rank: int,
@@ -777,13 +764,19 @@ class TransferBenchSmokeCheck(PreflightCheck):
     ) -> str:
         """Render a complete shell command for one rank.
 
-        Env-var prefixes (TB_*, NUM_ITERATIONS, etc.) and ROCm PATH/library
-        path mods are placed **inside** the inner shell so that, even when
-        ``use_sudo=True``, the privileged child process sees them: ``sudo``
-        otherwise sanitizes the calling shell's environment. The command
-        also appends a sentinel ``__TB_SMOKE_EXIT__=<code>`` line so the
-        orchestrator can recover the binary's exit code from stdout when
-        the parallel SSH layer discards process exit codes.
+        Env-var prefixes (``TB_*``, ``NUM_ITERATIONS``, etc.) are placed
+        **inside** the inner shell so that, even when ``use_sudo=True``,
+        the privileged child process sees them: ``sudo`` otherwise sanitizes
+        the calling shell's environment. The command also appends a sentinel
+        ``__TB_SMOKE_EXIT__=<code>`` line so the orchestrator can recover
+        the binary's exit code from stdout when the parallel SSH layer
+        discards process exit codes.
+
+        ``PATH`` / ``LD_LIBRARY_PATH`` (e.g. for a custom ROCm install) are
+        intentionally **not** injected here -- they are inherited from the
+        cluster file's ``env_vars`` block, which the parallel SSH layer
+        exports on every host before each command. This keeps a single
+        cluster-wide source of truth for tool location.
         """
         env_parts = self._env_assignments(rank, num_ranks, master_addr)
         binary = shlex.quote(self.tb_binary)
@@ -791,7 +784,7 @@ class TransferBenchSmokeCheck(PreflightCheck):
         sizes = list(size_list) if size_list is not None else self.size_list
         size_args = ' '.join(shlex.quote(str(s)) for s in sizes)
         extras = ' '.join(shlex.quote(s) for s in self.extra_args)
-        env_inline = ' '.join([self._rocm_env_prefix(), *env_parts]).strip()
+        env_inline = ' '.join(env_parts).strip()
         binary_invocation = f'{binary} {preset} {size_args} {extras}'.strip()
         if env_inline:
             inner = f'{env_inline} {binary_invocation}'
@@ -807,7 +800,14 @@ class TransferBenchSmokeCheck(PreflightCheck):
     # ------------------------------------------------------------------
 
     def _amd_smi_fabric_command(self) -> str:
-        cmd = f'{self.amd_smi_path} fabric --topology --json'
+        """Build the ``amd-smi fabric --topology --json`` invocation.
+
+        The ``amd-smi`` binary is resolved from ``PATH`` on each node;
+        operators who install ROCm in a non-default location should
+        export the appropriate ``PATH`` (and, when needed,
+        ``LD_LIBRARY_PATH``) via the cluster file's ``env_vars`` block.
+        """
+        cmd = 'amd-smi fabric --topology --json'
         if self.use_sudo:
             cmd = 'sudo ' + cmd
         return cmd

--- a/cvs/lib/preflight/transferbench_smoke.py
+++ b/cvs/lib/preflight/transferbench_smoke.py
@@ -3,7 +3,7 @@
 This module validates IFoE (Infinity Fabric over Ethernet, a.k.a. XGMI-over-
 Ethernet) scale-up connectivity by:
 
-1. Querying ``amd-smi fabric --topology --json`` on every reachable cluster
+1. Querying ``amd-smi fabric --json`` on every reachable cluster
    node to discover each GPU's physical (``ppod_id``) and virtual / logical
    (``vpod_id``) pod membership. Because TransferBench's data-path smoketest
    exits early (precondition failure) when ranks span multiple virtual pods,
@@ -44,6 +44,7 @@ import re
 import shlex
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
+from cvs.lib.env_lib import build_env_prefix
 from cvs.lib.preflight.base import PreflightCheck
 
 
@@ -52,6 +53,7 @@ from cvs.lib.preflight.base import PreflightCheck
 # ---------------------------------------------------------------------------
 
 DEFAULT_TB_BINARY = 'TransferBench'
+DEFAULT_AMD_SMI_BINARY = 'amd-smi'
 DEFAULT_PRESET = 'smoketest'
 DEFAULT_SIZE_LIST = ['1K', '16M']
 DEFAULT_NUM_ITERATIONS = 2
@@ -71,6 +73,8 @@ EXIT_SENTINEL = '__TB_SMOKE_EXIT__'
 MARKER_PASS = '*'
 MARKER_FAIL = 'F'
 MARKER_SKIP = '.'
+
+_ENV_VAR_NAME_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +109,7 @@ def _coerce_int(value: Any) -> Optional[int]:
 def _walk_gpu_records(payload: Any) -> Iterable[Dict[str, Any]]:
     """Yield dict-shaped GPU records from arbitrary amd-smi JSON shapes.
 
-    amd-smi has historically emitted topology JSON in several flavours:
+    amd-smi has historically emitted fabric JSON in several flavours:
       - a top-level list of GPU records,
       - a dict with a ``gpu_data`` list (similar to the ECC/PCIe wrappers),
       - a dict keyed by GPU index whose values are GPU records,
@@ -142,32 +146,66 @@ def _walk_gpu_records(payload: Any) -> Iterable[Dict[str, Any]]:
             yield value
 
 
-def _extract_pod_ids_from_record(record: Dict[str, Any]) -> Dict[str, Optional[int]]:
+def _walk_nested_dicts(record: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    """Yield a record and every nested mapping it contains.
+
+    AMD SMI has moved fabric membership fields between ``fabric``,
+    ``fabric_info``, and other nested envelopes across releases. Walking the
+    record keeps the parser format-tolerant without binding it to a particular
+    ROCm version or platform.
+    """
+    pending: List[Dict[str, Any]] = [record]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+        yield current
+        for value in current.values():
+            if isinstance(value, dict):
+                pending.append(value)
+            elif isinstance(value, list):
+                pending.extend(entry for entry in value if isinstance(entry, dict))
+
+
+def _coerce_pod_id(value: Any) -> Optional[Any]:
+    """Normalize a pPod/vPod identifier while preserving opaque UUIDs."""
+    numeric = _coerce_int(value)
+    if numeric is not None:
+        return numeric
+    if isinstance(value, str):
+        identifier = value.strip()
+        if identifier and identifier.upper() not in {'N/A', 'NA', 'NONE', 'NULL'}:
+            return identifier
+    return None
+
+
+def _extract_pod_ids_from_record(record: Dict[str, Any]) -> Dict[str, Any]:
     """Return ``{ppod_id, vpod_id, ppod_size, vpod_size}`` for one GPU record.
 
-    Looks for the fields at the top level and inside a nested ``fabric`` /
-    ``pod`` / ``topology`` dict. Returns ``None`` for any field that is not
-    present or cannot be coerced to int.
+    Looks through nested AMD SMI envelopes. vPod/pPod sizes are numeric, while
+    pod identifiers can be numeric or opaque strings such as UUIDs.
     """
     keys = ('ppod_id', 'vpod_id', 'ppod_size', 'vpod_size')
-    candidates: List[Dict[str, Any]] = [record]
-    for nested_key in ('fabric', 'pod', 'topology', 'pod_info', 'membership'):
-        nested = record.get(nested_key)
-        if isinstance(nested, dict):
-            candidates.append(nested)
-    out: Dict[str, Optional[int]] = {k: None for k in keys}
-    for cand in candidates:
+    out: Dict[str, Any] = {k: None for k in keys}
+    for candidate in _walk_nested_dicts(record):
         for key in keys:
-            if out[key] is None and key in cand:
-                out[key] = _coerce_int(cand[key])
+            if out[key] is not None or key not in candidate:
+                continue
+            if key in ('ppod_id', 'vpod_id'):
+                out[key] = _coerce_pod_id(candidate[key])
+            else:
+                out[key] = _coerce_int(candidate[key])
     return out
 
 
 _PLAINTEXT_KV_RE = re.compile(r'^\s*([A-Z_][A-Z0-9_]*)\s*[:=]\s*(.+?)\s*$', re.IGNORECASE)
 
 
-def parse_amd_smi_fabric_text(text: str) -> List[Dict[str, Optional[int]]]:
-    """Parse the ``amd-smi fabric --topology`` plaintext output.
+def parse_amd_smi_fabric_text(text: str) -> List[Dict[str, Any]]:
+    """Parse plaintext output from ``amd-smi fabric``.
 
     Used as a fallback when the cluster's amd-smi build does not honour
     ``--json``. Splits the output into per-GPU blocks (separated by ``GPU``
@@ -198,7 +236,7 @@ def parse_amd_smi_fabric_text(text: str) -> List[Dict[str, Optional[int]]]:
     if current:
         blocks.append(current)
 
-    parsed_blocks: List[Dict[str, Optional[int]]] = []
+    parsed_blocks: List[Dict[str, Any]] = []
     for block in blocks:
         record: Dict[str, Any] = {}
         header = block[0]
@@ -222,8 +260,15 @@ def parse_amd_smi_fabric_text(text: str) -> List[Dict[str, Optional[int]]]:
     return parsed_blocks
 
 
+def _pod_id_sort_key(value: Any) -> Tuple[int, Any]:
+    """Sort numeric pod IDs before opaque identifiers without type errors."""
+    if isinstance(value, int):
+        return (0, value)
+    return (1, str(value))
+
+
 def extract_node_pod_membership(node_payload: Any) -> Dict[str, Any]:
-    """Reduce an ``amd-smi fabric --topology`` payload to per-node summary.
+    """Reduce an ``amd-smi fabric --json`` payload to per-node summary.
 
     Accepts either:
       - the parsed JSON object returned by ``rocm_plib.get_gpu_fabric_info_dict``
@@ -233,8 +278,8 @@ def extract_node_pod_membership(node_payload: Any) -> Dict[str, Any]:
     Returns:
         dict with:
           - ``gpus`` (int): number of GPU records parsed from the payload.
-          - ``vpod_ids`` (sorted list[int]): unique vPod IDs observed.
-          - ``ppod_ids`` (sorted list[int]): unique pPod IDs observed.
+          - ``vpod_ids`` (sorted list[int | str]): unique vPod IDs observed.
+          - ``ppod_ids`` (sorted list[int | str]): unique pPod IDs observed.
           - ``vpod_size`` (int | None): node-wide majority vpod_size (or None).
           - ``ppod_size`` (int | None): node-wide majority ppod_size (or None).
           - ``errors`` (list[str]): parsing/observation issues.
@@ -258,7 +303,7 @@ def extract_node_pod_membership(node_payload: Any) -> Dict[str, Any]:
         for entry in _walk_gpu_records(node_payload):
             records.append(entry)
 
-    pod_id_dicts: List[Dict[str, Optional[int]]] = []
+    pod_id_dicts: List[Dict[str, Any]] = []
     for record in records:
         ids = _extract_pod_ids_from_record(record)
         if any(v is not None for v in ids.values()):
@@ -271,13 +316,19 @@ def extract_node_pod_membership(node_payload: Any) -> Dict[str, Any]:
         )
         return out
 
-    vpods = sorted({d['vpod_id'] for d in pod_id_dicts if d['vpod_id'] is not None})
-    ppods = sorted({d['ppod_id'] for d in pod_id_dicts if d['ppod_id'] is not None})
+    vpods = sorted(
+        {d['vpod_id'] for d in pod_id_dicts if d['vpod_id'] is not None},
+        key=_pod_id_sort_key,
+    )
+    ppods = sorted(
+        {d['ppod_id'] for d in pod_id_dicts if d['ppod_id'] is not None},
+        key=_pod_id_sort_key,
+    )
     out['vpod_ids'] = vpods
     out['ppod_ids'] = ppods
 
     if not vpods:
-        out['errors'].append('No vpod_id values reported by amd-smi fabric topology')
+        out['errors'].append('No vpod_id values reported by amd-smi fabric data')
     elif len(vpods) > 1:
         out['errors'].append(
             f'Multiple vPod IDs reported by a single node: {vpods} '
@@ -321,7 +372,7 @@ def reconcile_cluster_vpod(
     }
     if not per_node_membership:
         result['status'] = 'FAIL'
-        result['errors'].append('No nodes reported amd-smi fabric topology')
+        result['errors'].append('No nodes reported amd-smi fabric data')
         return result
 
     nodes_without_vpod = [n for n, m in per_node_membership.items() if not m.get('vpod_ids')]
@@ -347,10 +398,10 @@ def reconcile_cluster_vpod(
         for n, m in per_node_membership.items()
         if len(m.get('vpod_ids') or []) == 1
     }
-    distinct_vpods = sorted(set(singleton_pairs.values()))
+    distinct_vpods = sorted(set(singleton_pairs.values()), key=_pod_id_sort_key)
     if len(distinct_vpods) > 1:
         result['status'] = 'FAIL'
-        groups: Dict[int, List[str]] = {}
+        groups: Dict[Any, List[str]] = {}
         for n, vp in singleton_pairs.items():
             groups.setdefault(vp, []).append(n)
         group_strs = [
@@ -463,6 +514,7 @@ class SmoketestParser:
         result['raw'] = text
 
         cls._collect_per_test_rows(text, result)
+        cls._collect_marker_table(text, result)
         cls._collect_marker_blocks(text, result)
         cls._collect_summary(text, result)
         cls._collect_warnings_and_errors(text, result)
@@ -502,10 +554,12 @@ class SmoketestParser:
     def _collect_marker_blocks(text: str, result: Dict[str, Any]) -> None:
         """Capture compact marker blocks like ``****F.*.``.
 
-        Only consulted when no bracketed verdict rows were found; otherwise
-        the per-test rows already provide the counts we need.
+        Only consulted when no bracketed verdict rows or pipe-table marker
+        cells were found; otherwise those formats already provide the counts.
         """
-        if result['per_test']:
+        if result['per_test'] or any(
+            result[key] for key in ('num_pass', 'num_fail', 'num_skip')
+        ):
             return
         for line in text.splitlines():
             if not _MARKER_BLOCK_RE.match(line):
@@ -516,6 +570,29 @@ class SmoketestParser:
                 elif ch == MARKER_FAIL:
                     result['num_fail'] += 1
                 elif ch == MARKER_SKIP:
+                    result['num_skip'] += 1
+
+    @staticmethod
+    def _collect_marker_table(text: str, result: Dict[str, Any]) -> None:
+        """Capture marker cells from TransferBench's pipe-delimited table.
+
+        Recent TransferBench builds render executor results as table cells such
+        as ``|  *  |`` instead of a single compact marker line. Count only
+        cells whose complete trimmed value is a known marker so table headers,
+        borders, and names cannot affect the result.
+        """
+        if result['per_test']:
+            return
+        for line in text.splitlines():
+            if not line.lstrip().startswith('|'):
+                continue
+            for cell in line.split('|')[1:-1]:
+                marker = cell.strip()
+                if marker == MARKER_PASS:
+                    result['num_pass'] += 1
+                elif marker == MARKER_FAIL:
+                    result['num_fail'] += 1
+                elif marker == MARKER_SKIP:
                     result['num_skip'] += 1
 
     @staticmethod
@@ -653,7 +730,7 @@ class TransferBenchSmokeCheck(PreflightCheck):
 
     The check is two-phase:
 
-      1. **Precondition** – Query ``amd-smi fabric --topology --json`` on
+      1. **Precondition** – Query ``amd-smi fabric --json`` on
          every reachable node, then enforce that all nodes report the same
          singleton vPod ID (TransferBench multi-rank smoketest exits with
          ``ERR_FATAL`` when ranks span multiple vPods, and the per-node
@@ -683,6 +760,7 @@ class TransferBenchSmokeCheck(PreflightCheck):
         phdl,
         *,
         tb_binary: str = DEFAULT_TB_BINARY,
+        amd_smi_binary: str = DEFAULT_AMD_SMI_BINARY,
         use_sudo: bool = False,
         preset: str = DEFAULT_PRESET,
         size_list: Optional[Sequence[str]] = None,
@@ -703,7 +781,10 @@ class TransferBenchSmokeCheck(PreflightCheck):
         config_dict: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(phdl, config_dict)
-        self.tb_binary = tb_binary
+        self.tb_binary = self._validate_binary_name('tb_binary', tb_binary)
+        self.amd_smi_binary = self._validate_binary_name(
+            'amd_smi_binary', amd_smi_binary
+        )
         self.use_sudo = bool(use_sudo)
         self.preset = preset
         self.size_list = list(size_list) if size_list else list(DEFAULT_SIZE_LIST)
@@ -717,7 +798,7 @@ class TransferBenchSmokeCheck(PreflightCheck):
         self.master_node = master_node
         self.max_skip_pct = float(max_skip_pct)
         self.ssh_timeout = int(ssh_timeout)
-        self.extra_env = dict(extra_env or {})
+        self.extra_env = self._validate_extra_env(extra_env)
         self.extra_args = list(extra_args or [])
         self.skip_pod_check = bool(skip_pod_check)
 
@@ -732,27 +813,72 @@ class TransferBenchSmokeCheck(PreflightCheck):
     # Command construction
     # ------------------------------------------------------------------
 
-    def _env_assignments(self, rank: int, num_ranks: int, master_addr: str) -> List[str]:
+    @staticmethod
+    def _validate_binary_name(config_key: str, value: Any) -> str:
+        """Validate a configured executable name or path."""
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f'{config_key} must be a non-empty string')
+        return value.strip()
+
+    @staticmethod
+    def _validate_extra_env(extra_env: Optional[Dict[str, str]]) -> Dict[str, str]:
+        """Validate runtime environment supplied for the TransferBench process.
+
+        ``build_env_prefix`` quotes values during command construction.
+        Restricting keys to shell environment variable names prevents a config
+        key from changing command syntax before quoting is applied.
+        """
+        if extra_env is None:
+            return {}
+        if not isinstance(extra_env, dict):
+            raise ValueError('extra_env must be a mapping of environment variable names to values')
+
+        normalized: Dict[str, str] = {}
+        for key, value in extra_env.items():
+            if not isinstance(key, str) or not _ENV_VAR_NAME_RE.fullmatch(key):
+                raise ValueError(f'Invalid environment variable name in extra_env: {key!r}')
+            if value is None:
+                raise ValueError(f'extra_env[{key!r}] must not be null')
+            normalized[key] = str(value)
+        return normalized
+
+    @staticmethod
+    def _sudo_executable_argument(executable: str) -> str:
+        """Render an executable argument that remains valid after ``sudo``.
+
+        ``sudo`` may replace PATH with ``secure_path``.  A configured path is
+        already independent of PATH; a bare executable name is resolved by
+        the outer SSH shell instead, while the cluster-file environment is
+        still in effect.  The resulting absolute path is passed as an argv
+        value to the privileged process rather than inherited through sudo.
+        """
+        if '/' in executable:
+            return shlex.quote(executable)
+        return f'"$(command -v {shlex.quote(executable)})"'
+
+    def _env_assignments(
+        self,
+        rank: int,
+        num_ranks: int,
+        master_addr: str,
+        size_list: Sequence[str],
+    ) -> List[str]:
         """Build ``KEY=VALUE`` assignments for one rank's TransferBench invocation."""
         env: Dict[str, str] = {}
         env['NUM_ITERATIONS'] = str(self.num_iterations)
         env['NUM_WARMUPS'] = str(self.num_warmups)
+        env['SIZE_LIST'] = ','.join(str(size) for size in size_list)
         env['ALWAYS_VALIDATE'] = '1' if self.always_validate else '0'
         env['USE_REMOTE_READ'] = '1'
         env['BLOCK_BYTES'] = '256'
-        if self.run_parallel:
-            env['RUN_PARALLEL'] = '1'
-        if self.use_bdma:
-            env['USE_BDMA'] = '1'
-        if self.force_single_pod:
-            env['FORCE_SINGLE_POD'] = '1'
+        env['RUN_PARALLEL'] = '1' if self.run_parallel else '0'
+        env['USE_BDMA'] = '1' if self.use_bdma else '0'
+        env['FORCE_SINGLE_POD'] = '1' if self.force_single_pod else '0'
         if num_ranks > 1:
             env['TB_NUM_RANKS'] = str(num_ranks)
             env['TB_RANK'] = str(rank)
             env['TB_MASTER_ADDR'] = master_addr
             env['TB_MASTER_PORT'] = str(self.socket_master_port)
-        for k, v in self.extra_env.items():
-            env[k] = str(v)
         return [f'{k}={shlex.quote(v)}' for k, v in env.items()]
 
     def build_command(
@@ -772,27 +898,41 @@ class TransferBenchSmokeCheck(PreflightCheck):
         the binary's exit code from stdout when the parallel SSH layer
         discards process exit codes.
 
-        ``PATH`` / ``LD_LIBRARY_PATH`` (e.g. for a custom ROCm install) are
-        intentionally **not** injected here -- they are inherited from the
-        cluster file's ``env_vars`` block, which the parallel SSH layer
-        exports on every host before each command. This keeps a single
-        cluster-wide source of truth for tool location.
+        ``extra_env`` is deliberately exported inside that inner shell. It is
+        the opt-in escape hatch for runtime values such as
+        ``LD_LIBRARY_PATH`` that sudo strips from the cluster-file
+        ``env_vars`` environment. Its values use the same safe, limited
+        self-referential expansion supported by ``build_env_prefix``. No
+        runtime path is injected by default.
         """
-        env_parts = self._env_assignments(rank, num_ranks, master_addr)
-        binary = shlex.quote(self.tb_binary)
-        preset = shlex.quote(self.preset)
         sizes = list(size_list) if size_list is not None else self.size_list
-        size_args = ' '.join(shlex.quote(str(s)) for s in sizes)
+        env_parts = self._env_assignments(rank, num_ranks, master_addr, sizes)
+        runtime_env_prefix = build_env_prefix(self.extra_env)
+        preset = shlex.quote(self.preset)
         extras = ' '.join(shlex.quote(s) for s in self.extra_args)
         env_inline = ' '.join(env_parts).strip()
-        binary_invocation = f'{binary} {preset} {size_args} {extras}'.strip()
+
+        # A command name must be resolved before sudo applies secure_path.
+        # ``bash -c`` receives the resolved executable in $1, while the
+        # fixed $0 value makes positional handling independent of the path.
+        if self.use_sudo:
+            binary = '"$1"'
+        else:
+            binary = shlex.quote(self.tb_binary)
+        binary_invocation = f'{binary} {preset} {extras}'.strip()
         if env_inline:
             inner = f'{env_inline} {binary_invocation}'
         else:
             inner = binary_invocation
+        if runtime_env_prefix:
+            inner = f'{runtime_env_prefix}; {inner}'
         inner_with_sentinel = f'{inner}; echo "{EXIT_SENTINEL}=$?"'
         if self.use_sudo:
-            return f'sudo bash -c {shlex.quote(inner_with_sentinel)}'
+            binary_arg = self._sudo_executable_argument(self.tb_binary)
+            return (
+                f'sudo bash -c {shlex.quote(inner_with_sentinel)} '
+                f'transferbench-smoke {binary_arg}'
+            )
         return f'bash -c {shlex.quote(inner_with_sentinel)}'
 
     # ------------------------------------------------------------------
@@ -800,20 +940,23 @@ class TransferBenchSmokeCheck(PreflightCheck):
     # ------------------------------------------------------------------
 
     def _amd_smi_fabric_command(self) -> str:
-        """Build the ``amd-smi fabric --topology --json`` invocation.
+        """Build the format-tolerant ``amd-smi fabric --json`` invocation.
 
-        The ``amd-smi`` binary is resolved from ``PATH`` on each node;
-        operators who install ROCm in a non-default location should
-        export the appropriate ``PATH`` (and, when needed,
-        ``LD_LIBRARY_PATH``) via the cluster file's ``env_vars`` block.
+        When sudo is enabled, a bare ``amd_smi_binary`` name is resolved by
+        the outer SSH shell before sudo applies ``secure_path``. Operators
+        can instead set an absolute ``amd_smi_binary`` path in the preflight
+        configuration for fully explicit tool selection.
         """
-        cmd = 'amd-smi fabric --topology --json'
+        binary = shlex.quote(self.amd_smi_binary)
+        if self.use_sudo:
+            binary = self._sudo_executable_argument(self.amd_smi_binary)
+        cmd = f'{binary} fabric --json'
         if self.use_sudo:
             cmd = 'sudo ' + cmd
         return cmd
 
     def _query_pod_membership(self) -> Dict[str, Dict[str, Any]]:
-        """Run ``amd-smi fabric --topology --json`` on each reachable node.
+        """Run ``amd-smi fabric --json`` on each reachable node.
 
         Tolerates plaintext (non-JSON) outputs by passing the raw string to
         ``extract_node_pod_membership``, which then routes it through the
@@ -1048,4 +1191,5 @@ __all__ = [
     'DEFAULT_SIZE_LIST',
     'DEFAULT_PRESET',
     'DEFAULT_TB_BINARY',
+    'DEFAULT_AMD_SMI_BINARY',
 ]

--- a/cvs/lib/preflight/unittests/test_transferbench_smoke.py
+++ b/cvs/lib/preflight/unittests/test_transferbench_smoke.py
@@ -1,0 +1,636 @@
+"""Unit tests for the IFoE TransferBench smoketest preflight check (AIMVT-181).
+
+All fixtures are entirely synthetic — generic node names, generic vpod/ppod
+IDs, and synthesised TransferBench output that mimics the documented
+candidate-branch smoketest format. No real cluster serial numbers, MAC
+addresses, or hostnames are embedded.
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+
+from cvs.lib.preflight.transferbench_smoke import (
+    EXIT_SENTINEL,
+    SmoketestParser,
+    TransferBenchSmokeCheck,
+    evaluate_smoketest,
+    extract_node_pod_membership,
+    parse_amd_smi_fabric_text,
+    reconcile_cluster_vpod,
+)
+
+
+# ---------------------------------------------------------------------------
+# amd-smi fabric topology fixtures (synthetic schema, generic IDs)
+# ---------------------------------------------------------------------------
+
+FABRIC_TOPOLOGY_VPOD0_4GPU = [
+    {
+        'gpu': 0,
+        'bdf': '0000:01:00.0',
+        'fabric': {'ppod_id': 0, 'vpod_id': 0, 'ppod_size': 4, 'vpod_size': 4},
+    },
+    {
+        'gpu': 1,
+        'bdf': '0001:01:00.0',
+        'fabric': {'ppod_id': 0, 'vpod_id': 0, 'ppod_size': 4, 'vpod_size': 4},
+    },
+    {
+        'gpu': 2,
+        'bdf': '0002:01:00.0',
+        'fabric': {'ppod_id': 0, 'vpod_id': 0, 'ppod_size': 4, 'vpod_size': 4},
+    },
+    {
+        'gpu': 3,
+        'bdf': '0003:01:00.0',
+        'fabric': {'ppod_id': 0, 'vpod_id': 0, 'ppod_size': 4, 'vpod_size': 4},
+    },
+]
+
+FABRIC_TOPOLOGY_VPOD1_4GPU = [
+    {
+        'gpu': g,
+        'bdf': f'{g:04d}:01:00.0',
+        'fabric': {'ppod_id': 1, 'vpod_id': 1, 'ppod_size': 4, 'vpod_size': 4},
+    }
+    for g in range(4)
+]
+
+FABRIC_TOPOLOGY_MIXED_VPODS_ON_ONE_NODE = [
+    {'gpu': 0, 'fabric': {'ppod_id': 0, 'vpod_id': 0, 'vpod_size': 4}},
+    {'gpu': 1, 'fabric': {'ppod_id': 0, 'vpod_id': 0, 'vpod_size': 4}},
+    {'gpu': 2, 'fabric': {'ppod_id': 0, 'vpod_id': 1, 'vpod_size': 4}},
+    {'gpu': 3, 'fabric': {'ppod_id': 0, 'vpod_id': 1, 'vpod_size': 4}},
+]
+
+FABRIC_TOPOLOGY_GPU_DATA_WRAPPER = {
+    'gpu_data': FABRIC_TOPOLOGY_VPOD0_4GPU,
+}
+
+FABRIC_TOPOLOGY_KEYED = {
+    'gpu0': FABRIC_TOPOLOGY_VPOD0_4GPU[0],
+    'gpu1': FABRIC_TOPOLOGY_VPOD0_4GPU[1],
+    'gpu2': FABRIC_TOPOLOGY_VPOD0_4GPU[2],
+    'gpu3': FABRIC_TOPOLOGY_VPOD0_4GPU[3],
+}
+
+FABRIC_TOPOLOGY_NO_POD = [{'gpu': 0, 'bdf': '0000:01:00.0'}]
+
+FABRIC_TEXT_VPOD0 = """\
+GPU 0
+  PPOD_ID  : 0
+  VPOD_ID  : 0
+  PPOD_SIZE: 4
+  VPOD_SIZE: 4
+
+GPU 1
+  PPOD_ID  : 0
+  VPOD_ID  : 0
+  PPOD_SIZE: 4
+  VPOD_SIZE: 4
+"""
+
+FABRIC_TEXT_VPOD2 = """\
+GPU 0
+  PPOD_ID  : 2
+  VPOD_ID  : 2
+  PPOD_SIZE: 4
+  VPOD_SIZE: 4
+"""
+
+
+# ---------------------------------------------------------------------------
+# TransferBench smoketest output fixtures (synthetic shape that exercises
+# every code path the parser is asked to handle).
+# ---------------------------------------------------------------------------
+
+SMOKETEST_PASS_OUTPUT = """\
+TransferBench (candidate) starting smoketest preset
+Detected 4 local GPUs in vpod_id=0, ppod_id=0
+
+Running 16 tests with sizes [1K, 16M], 2 iterations, validate=1
+Test  1: H2D BDMA           [PASS]   bw= 25.0 GB/s
+Test  2: D2H BDMA           [PASS]   bw= 25.1 GB/s
+Test  3: D2D SDMA           [PASS]   bw= 64.0 GB/s
+Test  4: D2D GFX            [PASS]   bw= 70.2 GB/s
+Test  5: Broadcast SDMA     [PASS]   bw= 60.0 GB/s
+Test  6: Broadcast GFX      [PASS]   bw= 65.5 GB/s
+Test  7: Gather SDMA        [PASS]   bw= 60.0 GB/s
+Test  8: Gather GFX         [PASS]   bw= 65.5 GB/s
+Test  9: A2A SDMA           [PASS]   bw=200.0 GB/s
+Test 10: A2A GFX            [PASS]   bw=220.0 GB/s
+Test 11: H2D-validate       [PASS]
+Test 12: D2H-validate       [PASS]
+Test 13: D2D-validate       [PASS]
+Test 14: Broadcast-validate [PASS]
+Test 15: Gather-validate    [PASS]
+Test 16: A2A-validate       [PASS]
+
+Smoketest summary: 16/16 PASS, 0 FAIL, 0 SKIP
+"""
+
+SMOKETEST_FAIL_OUTPUT = """\
+TransferBench (candidate) starting smoketest preset
+Detected 4 local GPUs in vpod_id=0, ppod_id=0
+
+Test  1: H2D BDMA           [PASS]   bw= 25.0 GB/s
+Test  2: D2H BDMA           [PASS]   bw= 25.1 GB/s
+Test  3: D2D SDMA           [FAIL]   error=validation mismatch
+Test  4: D2D GFX            [FAIL]   error=hipMemcpyDtoD returned -1
+Test  5: Broadcast SDMA     [PASS]   bw= 60.0 GB/s
+Test  6: Broadcast GFX      [PASS]   bw= 65.5 GB/s
+Test  7: Gather SDMA        [PASS]   bw= 60.0 GB/s
+Test  8: Gather GFX         [PASS]   bw= 65.5 GB/s
+Test  9: A2A SDMA           [PASS]   bw=200.0 GB/s
+Test 10: A2A GFX            [PASS]   bw=220.0 GB/s
+Test 11: H2D-validate       [PASS]
+Test 12: D2H-validate       [PASS]
+Test 13: D2D-validate       [SKIP]   reason=preceding D2D test failed
+Test 14: Broadcast-validate [PASS]
+Test 15: Gather-validate    [PASS]
+Test 16: A2A-validate       [PASS]
+
+Smoketest summary: 13/16 PASS, 2 FAIL, 1 SKIP
+"""
+
+SMOKETEST_SKIP_HEAVY_OUTPUT = """\
+TransferBench (candidate) starting smoketest preset
+Detected 1 local GPU in vpod_id=0, ppod_id=0
+
+Test  1: H2D BDMA           [PASS]   bw= 25.0 GB/s
+Test  2: D2H BDMA           [PASS]   bw= 25.1 GB/s
+Test  3: D2D SDMA           [SKIP]   reason=requires >= 2 local GPUs
+Test  4: D2D GFX            [SKIP]   reason=requires >= 2 local GPUs
+Test  5: Broadcast SDMA     [SKIP]   reason=requires >= 2 local GPUs
+Test  6: Broadcast GFX      [SKIP]   reason=requires >= 2 local GPUs
+Test  7: Gather SDMA        [SKIP]   reason=requires >= 2 local GPUs
+Test  8: Gather GFX         [SKIP]   reason=requires >= 2 local GPUs
+Test  9: A2A SDMA           [SKIP]   reason=requires >= 2 local GPUs
+Test 10: A2A GFX            [SKIP]   reason=requires >= 2 local GPUs
+Test 11: H2D-validate       [PASS]
+Test 12: D2H-validate       [PASS]
+Test 13: D2D-validate       [SKIP]   reason=requires >= 2 local GPUs
+Test 14: Broadcast-validate [SKIP]   reason=requires >= 2 local GPUs
+Test 15: Gather-validate    [SKIP]   reason=requires >= 2 local GPUs
+Test 16: A2A-validate       [SKIP]   reason=requires >= 2 local GPUs
+
+Smoketest summary: 4/16 PASS, 0 FAIL, 12 SKIP
+"""
+
+SMOKETEST_FATAL_PRECONDITION_OUTPUT = """\
+TransferBench (candidate) starting smoketest preset
+FATAL: ranks span multiple vPods (rank 0 vpod_id=0, rank 1 vpod_id=1)
+ERR_FATAL: pod-membership precondition failed
+"""
+
+SMOKETEST_MARKER_TABLE_OUTPUT = """\
+TransferBench (candidate) starting smoketest preset
+   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16
+**.**F***.******
+"""
+
+
+def _with_sentinel(output: str, exit_code: int) -> str:
+    return output.rstrip('\n') + f'\n{EXIT_SENTINEL}={exit_code}\n'
+
+
+# ---------------------------------------------------------------------------
+# Pod-membership parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractNodePodMembership(unittest.TestCase):
+    def test_flat_list_payload(self):
+        m = extract_node_pod_membership(FABRIC_TOPOLOGY_VPOD0_4GPU)
+        self.assertEqual(m['gpus'], 4)
+        self.assertEqual(m['vpod_ids'], [0])
+        self.assertEqual(m['ppod_ids'], [0])
+        self.assertEqual(m['vpod_size'], 4)
+        self.assertEqual(m['ppod_size'], 4)
+        self.assertEqual(m['errors'], [])
+
+    def test_gpu_data_wrapper_payload(self):
+        m = extract_node_pod_membership(FABRIC_TOPOLOGY_GPU_DATA_WRAPPER)
+        self.assertEqual(m['gpus'], 4)
+        self.assertEqual(m['vpod_ids'], [0])
+
+    def test_keyed_dict_payload(self):
+        m = extract_node_pod_membership(FABRIC_TOPOLOGY_KEYED)
+        self.assertEqual(m['gpus'], 4)
+        self.assertEqual(m['vpod_ids'], [0])
+
+    def test_mixed_vpods_within_node_reported_as_error(self):
+        m = extract_node_pod_membership(FABRIC_TOPOLOGY_MIXED_VPODS_ON_ONE_NODE)
+        self.assertEqual(sorted(m['vpod_ids']), [0, 1])
+        self.assertTrue(m['errors'])
+        self.assertIn('Multiple vPod IDs', m['errors'][0])
+
+    def test_payload_with_no_pod_fields(self):
+        m = extract_node_pod_membership(FABRIC_TOPOLOGY_NO_POD)
+        self.assertEqual(m['gpus'], 0)
+        self.assertTrue(m['errors'])
+
+    def test_plaintext_fallback(self):
+        m = extract_node_pod_membership(FABRIC_TEXT_VPOD0)
+        self.assertEqual(m['gpus'], 2)
+        self.assertEqual(m['vpod_ids'], [0])
+        self.assertEqual(m['ppod_ids'], [0])
+
+    def test_plaintext_garbage_inputs(self):
+        m = extract_node_pod_membership('bash: amd-smi: command not found\n')
+        self.assertEqual(m['gpus'], 0)
+        self.assertTrue(m['errors'])
+
+    def test_parse_amd_smi_fabric_text_extracts_multiple_blocks(self):
+        blocks = parse_amd_smi_fabric_text(FABRIC_TEXT_VPOD0)
+        self.assertEqual(len(blocks), 2)
+        self.assertEqual(blocks[0]['vpod_id'], 0)
+        self.assertEqual(blocks[0]['ppod_id'], 0)
+
+
+class TestReconcileClusterVpod(unittest.TestCase):
+    def test_uniform_vpod_passes(self):
+        per_node = {
+            'nodeA': extract_node_pod_membership(FABRIC_TOPOLOGY_VPOD0_4GPU),
+            'nodeB': extract_node_pod_membership(FABRIC_TOPOLOGY_VPOD0_4GPU),
+        }
+        rec = reconcile_cluster_vpod(per_node)
+        self.assertEqual(rec['status'], 'PASS')
+        self.assertEqual(rec['vpod_id'], 0)
+        self.assertEqual(rec['ppod_id'], 0)
+        self.assertEqual(rec['errors'], [])
+
+    def test_split_vpod_fails(self):
+        per_node = {
+            'nodeA': extract_node_pod_membership(FABRIC_TOPOLOGY_VPOD0_4GPU),
+            'nodeB': extract_node_pod_membership(FABRIC_TOPOLOGY_VPOD1_4GPU),
+        }
+        rec = reconcile_cluster_vpod(per_node)
+        self.assertEqual(rec['status'], 'FAIL')
+        self.assertIsNone(rec['vpod_id'])
+        self.assertTrue(any('multiple vPods' in e for e in rec['errors']))
+
+    def test_missing_vpod_on_some_nodes_fails(self):
+        per_node = {
+            'nodeA': extract_node_pod_membership(FABRIC_TOPOLOGY_VPOD0_4GPU),
+            'nodeB': extract_node_pod_membership(FABRIC_TOPOLOGY_NO_POD),
+        }
+        rec = reconcile_cluster_vpod(per_node)
+        self.assertEqual(rec['status'], 'FAIL')
+        self.assertTrue(rec['errors'])
+
+    def test_empty_input_fails(self):
+        rec = reconcile_cluster_vpod({})
+        self.assertEqual(rec['status'], 'FAIL')
+
+    def test_multi_local_vpod_fails(self):
+        per_node = {
+            'nodeA': extract_node_pod_membership(FABRIC_TOPOLOGY_MIXED_VPODS_ON_ONE_NODE),
+            'nodeB': extract_node_pod_membership(FABRIC_TOPOLOGY_VPOD0_4GPU),
+        }
+        rec = reconcile_cluster_vpod(per_node)
+        self.assertEqual(rec['status'], 'FAIL')
+
+
+# ---------------------------------------------------------------------------
+# Smoketest parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmoketestParser(unittest.TestCase):
+    def test_passing_output(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_PASS_OUTPUT, 0))
+        self.assertEqual(parsed['exit_code'], 0)
+        self.assertEqual(parsed['num_pass'], 16)
+        self.assertEqual(parsed['num_fail'], 0)
+        self.assertEqual(parsed['num_skip'], 0)
+        self.assertEqual(parsed['num_tests'], 16)
+        self.assertEqual(parsed['summary_total'], 16)
+        self.assertEqual(parsed['summary_pass'], 16)
+        self.assertEqual(parsed['errors'], [])
+
+    def test_failing_output(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_FAIL_OUTPUT, 1))
+        self.assertEqual(parsed['exit_code'], 1)
+        self.assertEqual(parsed['num_pass'], 13)
+        self.assertEqual(parsed['num_fail'], 2)
+        self.assertEqual(parsed['num_skip'], 1)
+        self.assertEqual(parsed['summary_total'], 16)
+
+    def test_skip_heavy_output(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_SKIP_HEAVY_OUTPUT, 0))
+        self.assertEqual(parsed['exit_code'], 0)
+        self.assertEqual(parsed['num_pass'], 4)
+        self.assertEqual(parsed['num_fail'], 0)
+        self.assertEqual(parsed['num_skip'], 12)
+        self.assertEqual(parsed['num_tests'], 16)
+        self.assertTrue(parsed['warnings'])
+
+    def test_fatal_precondition_output(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_FATAL_PRECONDITION_OUTPUT, 2))
+        self.assertEqual(parsed['exit_code'], 2)
+        self.assertEqual(parsed['num_tests'], 0)
+        self.assertTrue(any('ERR_FATAL' in e for e in parsed['errors']))
+
+    def test_marker_table_fallback(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_MARKER_TABLE_OUTPUT, 1))
+        self.assertEqual(parsed['exit_code'], 1)
+        self.assertEqual(parsed['num_fail'], 1)
+        self.assertGreaterEqual(parsed['num_pass'], 10)
+        self.assertGreaterEqual(parsed['num_skip'], 2)
+
+    def test_empty_output(self):
+        parsed = SmoketestParser.parse('')
+        self.assertIsNone(parsed['exit_code'])
+        self.assertTrue(parsed['parse_errors'])
+
+    def test_garbage_output_no_sentinel(self):
+        parsed = SmoketestParser.parse('bash: TransferBench: command not found\n')
+        self.assertIsNone(parsed['exit_code'])
+        self.assertEqual(parsed['num_tests'], 0)
+
+
+# ---------------------------------------------------------------------------
+# Verdict logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSmoketest(unittest.TestCase):
+    def test_pass_verdict(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_PASS_OUTPUT, 0))
+        verdict, errors = evaluate_smoketest(parsed, max_skip_pct=25.0)
+        self.assertEqual(verdict, 'PASS')
+        self.assertEqual(errors, [])
+
+    def test_fail_on_exit_code(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_FAIL_OUTPUT, 1))
+        verdict, errors = evaluate_smoketest(parsed)
+        self.assertEqual(verdict, 'FAIL')
+        self.assertTrue(any('non-zero exit code' in e for e in errors))
+
+    def test_fail_on_precondition_exit_2(self):
+        parsed = SmoketestParser.parse(
+            _with_sentinel(SMOKETEST_FATAL_PRECONDITION_OUTPUT, 2)
+        )
+        verdict, errors = evaluate_smoketest(parsed)
+        self.assertEqual(verdict, 'FAIL')
+        self.assertTrue(any('ERR_FATAL precondition' in e for e in errors))
+
+    def test_fail_when_sentinel_missing(self):
+        parsed = SmoketestParser.parse(SMOKETEST_PASS_OUTPUT)
+        verdict, errors = evaluate_smoketest(parsed)
+        self.assertEqual(verdict, 'FAIL')
+        self.assertTrue(any('exit code not captured' in e for e in errors))
+
+    def test_warning_on_excessive_skips(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_SKIP_HEAVY_OUTPUT, 0))
+        verdict, errors = evaluate_smoketest(parsed, max_skip_pct=25.0)
+        self.assertEqual(verdict, 'WARNING')
+        self.assertTrue(any('skipped' in e.lower() for e in errors))
+
+    def test_pass_when_skips_within_budget(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_SKIP_HEAVY_OUTPUT, 0))
+        verdict, _ = evaluate_smoketest(parsed, max_skip_pct=80.0)
+        self.assertEqual(verdict, 'PASS')
+
+    def test_fail_when_exit_zero_but_fail_markers_present(self):
+        bogus = SMOKETEST_FAIL_OUTPUT  # has FAIL cells
+        parsed = SmoketestParser.parse(_with_sentinel(bogus, 0))
+        verdict, errors = evaluate_smoketest(parsed)
+        self.assertEqual(verdict, 'FAIL')
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransferBenchSmokeCheck(unittest.TestCase):
+    def _make_phdl(self, reachable_hosts, exec_responses=None, cmd_list_responses=None):
+        phdl = MagicMock()
+        phdl.reachable_hosts = list(reachable_hosts)
+        if exec_responses is not None:
+            phdl.exec = MagicMock(side_effect=list(exec_responses))
+        else:
+            phdl.exec = MagicMock(return_value={})
+        if cmd_list_responses is not None:
+            phdl.exec_cmd_list = MagicMock(side_effect=list(cmd_list_responses))
+        else:
+            phdl.exec_cmd_list = MagicMock(return_value={})
+        return phdl
+
+    def _fabric_payload(self, payload):
+        return json.dumps(payload)
+
+    def test_build_command_per_node_defaults(self):
+        check = TransferBenchSmokeCheck(MagicMock())
+        cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
+        self.assertIn('TransferBench', cmd)
+        self.assertIn('smoketest', cmd)
+        self.assertIn('NUM_ITERATIONS=2', cmd)
+        self.assertIn('ALWAYS_VALIDATE=1', cmd)
+        self.assertIn('RUN_PARALLEL=1', cmd)
+        self.assertIn('FORCE_SINGLE_POD=1', cmd)
+        self.assertIn(EXIT_SENTINEL, cmd)
+        self.assertNotIn('TB_NUM_RANKS=', cmd)
+        self.assertNotIn('TB_RANK=', cmd)
+
+    def test_build_command_multi_rank_includes_socket_env(self):
+        check = TransferBenchSmokeCheck(MagicMock(), rank_mode='multi_rank')
+        cmd = check.build_command(rank=2, num_ranks=4, master_addr='10.0.0.1')
+        self.assertIn('TB_NUM_RANKS=4', cmd)
+        self.assertIn('TB_RANK=2', cmd)
+        self.assertIn('TB_MASTER_ADDR=10.0.0.1', cmd)
+        self.assertIn('TB_MASTER_PORT=31337', cmd)
+
+    def test_build_command_respects_sudo_and_rocm_path(self):
+        check = TransferBenchSmokeCheck(
+            MagicMock(),
+            use_sudo=True,
+            rocm_path='/opt/rocm',
+        )
+        cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
+        self.assertTrue(cmd.startswith('sudo '))
+        self.assertIn('/opt/rocm/bin', cmd)
+        self.assertIn('/opt/rocm/lib', cmd)
+
+    def test_run_pass_per_node(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA', 'nodeB'],
+            exec_responses=[
+                {
+                    'nodeA': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU),
+                    'nodeB': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU),
+                },
+                {
+                    'nodeA': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0),
+                    'nodeB': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0),
+                },
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='per_node')
+        results = check.run()
+        self.assertEqual(results['status'], 'PASS')
+        self.assertEqual(results['pod_membership']['status'], 'PASS')
+        self.assertEqual(results['pod_membership']['vpod_id'], 0)
+        self.assertEqual(results['totals']['nodes_pass'], 2)
+        for node in ('nodeA', 'nodeB'):
+            self.assertEqual(results['nodes'][node]['status'], 'PASS')
+            self.assertEqual(results['nodes'][node]['exit_code'], 0)
+
+    def test_run_fails_when_vpods_diverge(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA', 'nodeB'],
+            exec_responses=[
+                {
+                    'nodeA': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU),
+                    'nodeB': self._fabric_payload(FABRIC_TOPOLOGY_VPOD1_4GPU),
+                },
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='multi_rank')
+        results = check.run()
+        self.assertEqual(results['status'], 'FAIL')
+        self.assertEqual(results['pod_membership']['status'], 'FAIL')
+        for node in ('nodeA', 'nodeB'):
+            self.assertEqual(results['nodes'][node]['status'], 'SKIPPED')
+        phdl.exec_cmd_list.assert_not_called()
+
+    def test_run_fails_when_one_node_smoketest_fails(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA', 'nodeB'],
+            exec_responses=[
+                {
+                    'nodeA': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU),
+                    'nodeB': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU),
+                },
+                {
+                    'nodeA': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0),
+                    'nodeB': _with_sentinel(SMOKETEST_FAIL_OUTPUT, 1),
+                },
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='per_node')
+        results = check.run()
+        self.assertEqual(results['status'], 'FAIL')
+        self.assertEqual(results['nodes']['nodeA']['status'], 'PASS')
+        self.assertEqual(results['nodes']['nodeB']['status'], 'FAIL')
+        self.assertEqual(results['totals']['nodes_pass'], 1)
+        self.assertEqual(results['totals']['nodes_fail'], 1)
+        self.assertEqual(results['totals']['tests_fail'], 2)
+
+    def test_run_warning_when_skips_exceed_budget(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[
+                {'nodeA': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU)},
+                {'nodeA': _with_sentinel(SMOKETEST_SKIP_HEAVY_OUTPUT, 0)},
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='per_node', max_skip_pct=25.0)
+        results = check.run()
+        self.assertEqual(results['status'], 'WARNING')
+        self.assertEqual(results['nodes']['nodeA']['status'], 'WARNING')
+        self.assertEqual(results['totals']['nodes_warning'], 1)
+
+    def test_run_multi_rank_dispatch_uses_cmd_list(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeB', 'nodeA'],
+            exec_responses=[
+                {
+                    'nodeA': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU),
+                    'nodeB': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU),
+                },
+            ],
+            cmd_list_responses=[
+                {
+                    'nodeA': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0),
+                    'nodeB': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0),
+                }
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='multi_rank')
+        results = check.run()
+        self.assertEqual(results['status'], 'PASS')
+        self.assertEqual(results['rank_mode'], 'multi_rank')
+        phdl.exec_cmd_list.assert_called_once()
+        args, kwargs = phdl.exec_cmd_list.call_args
+        cmd_list_arg = args[0]
+        self.assertEqual(len(cmd_list_arg), 2)
+        joined = '\n'.join(cmd_list_arg)
+        self.assertIn('TB_NUM_RANKS=2', joined)
+        self.assertIn('TB_RANK=0', joined)
+        self.assertIn('TB_RANK=1', joined)
+        self.assertIn('TB_MASTER_ADDR=nodeA', joined)
+
+    def test_multi_rank_degrades_to_per_node_with_one_host(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[
+                {'nodeA': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU)},
+                {'nodeA': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0)},
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='multi_rank')
+        results = check.run()
+        self.assertEqual(results['rank_mode'], 'per_node')
+        self.assertEqual(results['status'], 'PASS')
+        phdl.exec_cmd_list.assert_not_called()
+
+    def test_skip_pod_check_bypasses_precondition(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[
+                {'nodeA': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0)},
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='per_node', skip_pod_check=True)
+        results = check.run()
+        self.assertEqual(results['pod_membership']['status'], 'SKIPPED')
+        self.assertEqual(results['status'], 'PASS')
+        self.assertEqual(phdl.exec.call_count, 1)
+
+    def test_run_fail_on_precondition_exit_2(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[
+                {'nodeA': self._fabric_payload(FABRIC_TOPOLOGY_VPOD0_4GPU)},
+                {'nodeA': _with_sentinel(SMOKETEST_FATAL_PRECONDITION_OUTPUT, 2)},
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='per_node')
+        results = check.run()
+        self.assertEqual(results['status'], 'FAIL')
+        node_result = results['nodes']['nodeA']
+        self.assertEqual(node_result['status'], 'FAIL')
+        self.assertEqual(node_result['exit_code'], 2)
+        self.assertTrue(any('ERR_FATAL' in e for e in node_result['errors']))
+
+    def test_run_handles_plaintext_fabric_output(self):
+        phdl = self._make_phdl(
+            reachable_hosts=['nodeA'],
+            exec_responses=[
+                {'nodeA': FABRIC_TEXT_VPOD0},
+                {'nodeA': _with_sentinel(SMOKETEST_PASS_OUTPUT, 0)},
+            ],
+        )
+        check = TransferBenchSmokeCheck(phdl, rank_mode='per_node')
+        results = check.run()
+        self.assertEqual(results['status'], 'PASS')
+        self.assertEqual(results['pod_membership']['vpod_id'], 0)
+
+    def test_run_fails_when_no_reachable_hosts(self):
+        phdl = self._make_phdl(reachable_hosts=[])
+        check = TransferBenchSmokeCheck(phdl)
+        results = check.run()
+        self.assertEqual(results['status'], 'FAIL')
+        self.assertTrue(any('No reachable hosts' in e for e in results['errors']))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/lib/preflight/unittests/test_transferbench_smoke.py
+++ b/cvs/lib/preflight/unittests/test_transferbench_smoke.py
@@ -448,16 +448,61 @@ class TestTransferBenchSmokeCheck(unittest.TestCase):
         self.assertIn('TB_MASTER_ADDR=10.0.0.1', cmd)
         self.assertIn('TB_MASTER_PORT=31337', cmd)
 
-    def test_build_command_respects_sudo_and_rocm_path(self):
-        check = TransferBenchSmokeCheck(
-            MagicMock(),
-            use_sudo=True,
-            rocm_path='/opt/rocm',
-        )
+    def test_build_command_respects_sudo(self):
+        check = TransferBenchSmokeCheck(MagicMock(), use_sudo=True)
         cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
-        self.assertTrue(cmd.startswith('sudo '))
-        self.assertIn('/opt/rocm/bin', cmd)
-        self.assertIn('/opt/rocm/lib', cmd)
+        self.assertTrue(cmd.startswith('sudo bash -c '))
+        self.assertIn('TransferBench', cmd)
+
+    def test_build_command_does_not_inject_path_or_ld_library_path(self):
+        """PATH / LD_LIBRARY_PATH come from cluster file env_vars (AIMVT-181 review).
+
+        The smoketest used to expose ``rocm_path``/``amd_smi_path`` knobs that
+        prepended PATH=<rocm>/bin and LD_LIBRARY_PATH=<rocm>/lib inline. Those
+        were removed in favour of the cluster file's top-level ``env_vars``
+        block, which the parallel SSH layer exports on every host before each
+        command. This regression guard ensures we never re-grow that
+        duplication: ``build_command`` must not emit either token.
+        """
+        check = TransferBenchSmokeCheck(MagicMock(), use_sudo=True)
+        cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
+        self.assertNotIn('PATH=', cmd)
+        self.assertNotIn('LD_LIBRARY_PATH=', cmd)
+        check_no_sudo = TransferBenchSmokeCheck(MagicMock(), use_sudo=False)
+        cmd_no_sudo = check_no_sudo.build_command(
+            rank=0, num_ranks=1, master_addr='127.0.0.1'
+        )
+        self.assertNotIn('PATH=', cmd_no_sudo)
+        self.assertNotIn('LD_LIBRARY_PATH=', cmd_no_sudo)
+
+    def test_amd_smi_fabric_command_uses_bare_binary(self):
+        """The pod-membership query resolves ``amd-smi`` from PATH (AIMVT-181 review).
+
+        Operators who install ROCm in a non-default location set the
+        cluster-wide ``PATH`` via the cluster file's ``env_vars`` block; the
+        smoketest does not expose a per-check ``amd_smi_path`` knob.
+        """
+        check_no_sudo = TransferBenchSmokeCheck(MagicMock(), use_sudo=False)
+        self.assertEqual(
+            check_no_sudo._amd_smi_fabric_command(),
+            'amd-smi fabric --topology --json',
+        )
+        check_sudo = TransferBenchSmokeCheck(MagicMock(), use_sudo=True)
+        self.assertEqual(
+            check_sudo._amd_smi_fabric_command(),
+            'sudo amd-smi fabric --topology --json',
+        )
+
+    def test_constructor_rejects_removed_path_kwargs(self):
+        """``rocm_path`` and ``amd_smi_path`` were removed in the AIMVT-181 review.
+
+        Passing either should raise ``TypeError`` so that stale configs/tests
+        fail loudly instead of silently being ignored.
+        """
+        with self.assertRaises(TypeError):
+            TransferBenchSmokeCheck(MagicMock(), rocm_path='/opt/rocm')  # type: ignore[call-arg]
+        with self.assertRaises(TypeError):
+            TransferBenchSmokeCheck(MagicMock(), amd_smi_path='/opt/rocm/bin/amd-smi')  # type: ignore[call-arg]
 
     def test_run_pass_per_node(self):
         phdl = self._make_phdl(

--- a/cvs/lib/preflight/unittests/test_transferbench_smoke.py
+++ b/cvs/lib/preflight/unittests/test_transferbench_smoke.py
@@ -10,7 +10,7 @@ import json
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
 
@@ -80,6 +80,22 @@ FABRIC_TOPOLOGY_KEYED = {
 }
 
 FABRIC_TOPOLOGY_NO_POD = [{'gpu': 0, 'bdf': '0000:01:00.0'}]
+
+FABRIC_INFO_UUID_POD = [
+    {
+        'gpu': gpu,
+        'fabric': {
+            'bdf': f'{gpu + 1:04d}:01:00.0',
+            'fabric_info': {
+                'ppod_id': 'c94ee52c-135f-4b37-9e58-fe5365b8f7bc',
+                'ppod_size': 72,
+                'vpod_id': 1,
+                'vpod_size': 8,
+            },
+        },
+    }
+    for gpu in range(4)
+]
 
 FABRIC_TEXT_VPOD0 = """\
 GPU 0
@@ -194,6 +210,15 @@ TransferBench (candidate) starting smoketest preset
 **.**F***.******
 """
 
+SMOKETEST_PIPE_TABLE_OUTPUT = """\
+TransferBench smoketest preset
+Legend: *=Pass .=Skip F=Fail
+| Name      | GPU | DMA | GFX | Alt |
+|-----------|-----|-----|-----|-----|
+| Copy H2D  | ALL |  *  |  .  |  F  |
+| Copy D2H  | ALL |  *  |  *  |  *  |
+"""
+
 
 def _with_sentinel(output: str, exit_code: int) -> str:
     return output.rstrip('\n') + f'\n{EXIT_SENTINEL}={exit_code}\n'
@@ -234,6 +259,15 @@ class TestExtractNodePodMembership(unittest.TestCase):
         m = extract_node_pod_membership(FABRIC_TOPOLOGY_NO_POD)
         self.assertEqual(m['gpus'], 0)
         self.assertTrue(m['errors'])
+
+    def test_nested_fabric_info_with_uuid_ppod(self):
+        m = extract_node_pod_membership(FABRIC_INFO_UUID_POD)
+        self.assertEqual(m['gpus'], 4)
+        self.assertEqual(m['vpod_ids'], [1])
+        self.assertEqual(m['ppod_ids'], ['c94ee52c-135f-4b37-9e58-fe5365b8f7bc'])
+        self.assertEqual(m['vpod_size'], 8)
+        self.assertEqual(m['ppod_size'], 72)
+        self.assertEqual(m['errors'], [])
 
     def test_plaintext_fallback(self):
         m = extract_node_pod_membership(FABRIC_TEXT_VPOD0)
@@ -287,6 +321,25 @@ class TestReconcileClusterVpod(unittest.TestCase):
     def test_empty_input_fails(self):
         rec = reconcile_cluster_vpod({})
         self.assertEqual(rec['status'], 'FAIL')
+
+    def test_uuid_ppod_is_reported_when_vpods_agree(self):
+        per_node = {
+            'nodeA': extract_node_pod_membership(FABRIC_INFO_UUID_POD),
+            'nodeB': extract_node_pod_membership(FABRIC_INFO_UUID_POD),
+        }
+        rec = reconcile_cluster_vpod(per_node)
+        self.assertEqual(rec['status'], 'PASS')
+        self.assertEqual(rec['vpod_id'], 1)
+        self.assertEqual(rec['ppod_id'], 'c94ee52c-135f-4b37-9e58-fe5365b8f7bc')
+
+    def test_mixed_vpod_identifier_types_fail_without_sort_error(self):
+        per_node = {
+            'nodeA': {'vpod_ids': [1], 'ppod_ids': [], 'errors': []},
+            'nodeB': {'vpod_ids': ['fabric-b'], 'ppod_ids': [], 'errors': []},
+        }
+        rec = reconcile_cluster_vpod(per_node)
+        self.assertEqual(rec['status'], 'FAIL')
+        self.assertTrue(any('multiple vPods' in error for error in rec['errors']))
 
     def test_multi_local_vpod_fails(self):
         per_node = {
@@ -343,6 +396,14 @@ class TestSmoketestParser(unittest.TestCase):
         self.assertEqual(parsed['num_fail'], 1)
         self.assertGreaterEqual(parsed['num_pass'], 10)
         self.assertGreaterEqual(parsed['num_skip'], 2)
+
+    def test_pipe_table_markers(self):
+        parsed = SmoketestParser.parse(_with_sentinel(SMOKETEST_PIPE_TABLE_OUTPUT, 0))
+        self.assertEqual(parsed['exit_code'], 0)
+        self.assertEqual(parsed['num_pass'], 4)
+        self.assertEqual(parsed['num_fail'], 1)
+        self.assertEqual(parsed['num_skip'], 1)
+        self.assertEqual(parsed['num_tests'], 6)
 
     def test_empty_output(self):
         parsed = SmoketestParser.parse('')
@@ -440,6 +501,13 @@ class TestTransferBenchSmokeCheck(unittest.TestCase):
         self.assertNotIn('TB_NUM_RANKS=', cmd)
         self.assertNotIn('TB_RANK=', cmd)
 
+    def test_build_command_uses_size_list_environment_variable(self):
+        """The smoketest preset reads sizes from SIZE_LIST, not argv."""
+        check = TransferBenchSmokeCheck(MagicMock(), size_list=['4K', '16M'])
+        cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
+        self.assertIn('SIZE_LIST=4K,16M', cmd)
+        self.assertNotIn('smoketest 4K 16M', cmd)
+
     def test_build_command_multi_rank_includes_socket_env(self):
         check = TransferBenchSmokeCheck(MagicMock(), rank_mode='multi_rank')
         cmd = check.build_command(rank=2, num_ranks=4, master_addr='10.0.0.1')
@@ -453,17 +521,11 @@ class TestTransferBenchSmokeCheck(unittest.TestCase):
         cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
         self.assertTrue(cmd.startswith('sudo bash -c '))
         self.assertIn('TransferBench', cmd)
+        self.assertIn('transferbench-smoke "$(command -v TransferBench)"', cmd)
+        self.assertIn('"$1" smoketest', cmd)
 
-    def test_build_command_does_not_inject_path_or_ld_library_path(self):
-        """PATH / LD_LIBRARY_PATH come from cluster file env_vars (AIMVT-181 review).
-
-        The smoketest used to expose ``rocm_path``/``amd_smi_path`` knobs that
-        prepended PATH=<rocm>/bin and LD_LIBRARY_PATH=<rocm>/lib inline. Those
-        were removed in favour of the cluster file's top-level ``env_vars``
-        block, which the parallel SSH layer exports on every host before each
-        command. This regression guard ensures we never re-grow that
-        duplication: ``build_command`` must not emit either token.
-        """
+    def test_build_command_does_not_inject_runtime_paths_without_extra_env(self):
+        """Runtime paths are opt-in rather than derived from a ROCm root."""
         check = TransferBenchSmokeCheck(MagicMock(), use_sudo=True)
         cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
         self.assertNotIn('PATH=', cmd)
@@ -475,22 +537,50 @@ class TestTransferBenchSmokeCheck(unittest.TestCase):
         self.assertNotIn('PATH=', cmd_no_sudo)
         self.assertNotIn('LD_LIBRARY_PATH=', cmd_no_sudo)
 
-    def test_amd_smi_fabric_command_uses_bare_binary(self):
-        """The pod-membership query resolves ``amd-smi`` from PATH (AIMVT-181 review).
+    def test_build_command_injects_explicit_runtime_env_inside_sudo_shell(self):
+        check = TransferBenchSmokeCheck(
+            MagicMock(),
+            use_sudo=True,
+            extra_env={'LD_LIBRARY_PATH': '/opt/rocm/lib:$LD_LIBRARY_PATH'},
+        )
+        cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
+        self.assertIn('export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH', cmd)
+        self.assertTrue(cmd.startswith('sudo bash -c '))
 
-        Operators who install ROCm in a non-default location set the
-        cluster-wide ``PATH`` via the cluster file's ``env_vars`` block; the
-        smoketest does not expose a per-check ``amd_smi_path`` knob.
-        """
+    def test_build_command_sets_disabled_boolean_flags_to_zero(self):
+        check = TransferBenchSmokeCheck(
+            MagicMock(),
+            run_parallel=False,
+            use_bdma=False,
+            force_single_pod=False,
+        )
+        cmd = check.build_command(rank=0, num_ranks=1, master_addr='127.0.0.1')
+        self.assertIn('RUN_PARALLEL=0', cmd)
+        self.assertIn('USE_BDMA=0', cmd)
+        self.assertIn('FORCE_SINGLE_POD=0', cmd)
+
+    def test_amd_smi_fabric_command_resolves_before_sudo(self):
+        """A bare amd-smi name resolves before sudo replaces PATH."""
         check_no_sudo = TransferBenchSmokeCheck(MagicMock(), use_sudo=False)
         self.assertEqual(
             check_no_sudo._amd_smi_fabric_command(),
-            'amd-smi fabric --topology --json',
+            'amd-smi fabric --json',
         )
         check_sudo = TransferBenchSmokeCheck(MagicMock(), use_sudo=True)
         self.assertEqual(
             check_sudo._amd_smi_fabric_command(),
-            'sudo amd-smi fabric --topology --json',
+            'sudo "$(command -v amd-smi)" fabric --json',
+        )
+
+    def test_amd_smi_fabric_command_uses_explicit_path(self):
+        check = TransferBenchSmokeCheck(
+            MagicMock(),
+            use_sudo=True,
+            amd_smi_binary='/opt/rocm/bin/amd-smi',
+        )
+        self.assertEqual(
+            check._amd_smi_fabric_command(),
+            'sudo /opt/rocm/bin/amd-smi fabric --json',
         )
 
     def test_constructor_rejects_removed_path_kwargs(self):
@@ -503,6 +593,54 @@ class TestTransferBenchSmokeCheck(unittest.TestCase):
             TransferBenchSmokeCheck(MagicMock(), rocm_path='/opt/rocm')  # type: ignore[call-arg]
         with self.assertRaises(TypeError):
             TransferBenchSmokeCheck(MagicMock(), amd_smi_path='/opt/rocm/bin/amd-smi')  # type: ignore[call-arg]
+
+    def test_constructor_accepts_amd_smi_binary_and_rejects_invalid_extra_env(self):
+        check = TransferBenchSmokeCheck(
+            MagicMock(), amd_smi_binary='/opt/rocm/bin/amd-smi'
+        )
+        self.assertEqual(check.amd_smi_binary, '/opt/rocm/bin/amd-smi')
+        with self.assertRaises(ValueError):
+            TransferBenchSmokeCheck(MagicMock(), extra_env={'LD_LIBRARY_PATH;bad': '/opt/rocm/lib'})
+
+    def test_preflight_config_wires_amd_smi_binary_and_extra_env(self):
+        from cvs.tests.preflight import preflight_checks
+
+        phdl = MagicMock()
+        phdl.reachable_hosts = ['nodeA']
+        config = {
+            'connectivity_check': {
+                'transferbench': {
+                    'connectivity_mode': 'run',
+                    'tb_binary': '/opt/amd-apps/TransferBench/TransferBench',
+                    'amd_smi_binary': '/opt/rocm/bin/amd-smi',
+                    'extra_env': {
+                        'LD_LIBRARY_PATH': '/opt/rocm/lib:/usr/lib64/openmpi/lib'
+                    },
+                }
+            }
+        }
+        checker_results = {
+            'status': 'PASS',
+            'rank_mode': 'per_node',
+            'pod_membership': {},
+            'nodes': {},
+            'totals': {},
+            'errors': [],
+        }
+
+        with patch.object(preflight_checks, 'TransferBenchSmokeCheck') as checker_cls, patch.object(
+            preflight_checks, 'preflight_update_test_result'
+        ):
+            checker_cls.return_value.run.return_value = checker_results
+            preflight_checks.test_ifoe_transferbench_smoke(phdl, config)
+
+        kwargs = checker_cls.call_args.kwargs
+        self.assertEqual(kwargs['tb_binary'], '/opt/amd-apps/TransferBench/TransferBench')
+        self.assertEqual(kwargs['amd_smi_binary'], '/opt/rocm/bin/amd-smi')
+        self.assertEqual(
+            kwargs['extra_env'],
+            {'LD_LIBRARY_PATH': '/opt/rocm/lib:/usr/lib64/openmpi/lib'},
+        )
 
     def test_run_pass_per_node(self):
         phdl = self._make_phdl(

--- a/cvs/lib/rocm_plib.py
+++ b/cvs/lib/rocm_plib.py
@@ -100,3 +100,29 @@ def get_gpu_model_dict(phdl):
 def get_gpu_temp_dict(phdl):
     d_dict = convert_phdl_json_to_dict(phdl.exec('sudo rocm-smi --loglevel error --showtemp --json'))
     return d_dict
+
+
+def get_gpu_fabric_info_dict(phdl, use_sudo=True, amd_smi_path='amd-smi'):
+    """Return ``amd-smi fabric --topology --json`` output per cluster node.
+
+    Parsed via ``convert_phdl_json_to_dict``. The structure is amd-smi's JSON
+    topology payload (GPU records with fabric port and pod-membership fields).
+    Used by the AIMVT-181 IFoE TransferBench preflight check to detect pPod
+    (physical pod) and vPod (virtual / logical pod) membership before invoking
+    the TransferBench smoketest preset.
+
+    Args:
+        phdl: Parallel SSH handle for cluster nodes.
+        use_sudo: When True (default), prefix the command with ``sudo``.
+        amd_smi_path: Override for the ``amd-smi`` binary (e.g. an absolute
+            path). Defaults to PATH-resolved ``amd-smi``.
+
+    Returns:
+        dict[str, Any]: ``{node: parsed_amd_smi_topology_json | str}``.
+        When ``amd-smi`` output is not valid JSON on a node, the raw string is
+        returned for that node so callers can degrade gracefully.
+    """
+    cmd = f'{amd_smi_path} fabric --topology --json'
+    if use_sudo:
+        cmd = 'sudo ' + cmd
+    return convert_phdl_json_to_dict(phdl.exec(cmd))

--- a/cvs/tests/preflight/README.md
+++ b/cvs/tests/preflight/README.md
@@ -10,7 +10,10 @@ The preflight checks system validates essential cluster health and configuration
 2. **RDMA Interface Presence** - Validates that expected RDMA interfaces are present and link-up
 3. **ROCm Version Consistency** - Verifies consistent ROCm versions across all nodes
 4. **IFoE L2 Connectivity** - Validates L2 reachability of IFoE links via `afmctl test ping` *(AIMVT-180; opt-in)*
-5. **RDMA Connectivity** - Tests node-to-node RDMA communication using `ibv_rc_pingpong`
+5. **IFoE TransferBench Smoketest** - Runs the TransferBench candidate-branch `smoketest`
+   preset to validate IFoE scale-up data-path (after a single-vPod precondition via
+   `amd-smi fabric --topology --json`) *(AIMVT-181; opt-in)*
+6. **RDMA Connectivity** - Tests node-to-node RDMA communication using `ibv_rc_pingpong`
 
 ## Quick Start
 
@@ -86,6 +89,7 @@ Located at: `cvs/input/config_file/preflight/preflight_config.json`
 
 - **`connectivity_check.rdma.connectivity_mode`**: `"basic"`, `"full_mesh"`, or `"skip"`
 - **`connectivity_check.ifoe.connectivity_mode`**: `"run"` or `"skip"` (default)
+- **`connectivity_check.transferbench.connectivity_mode`**: `"run"` or `"skip"` (default)
 - **`node_check.expected_rocm_version`**: ROCm version expected across all nodes
 - **`node_check.rdma_interfaces`**: List of expected RDMA interface names
 - **`connectivity_check.rdma.ibv_test_timeout`**: Timeout in seconds for ibv_rc_pingpong tests
@@ -133,6 +137,94 @@ reports. A node is marked **FAIL** if any enabled traffic type
   }
 }
 ```
+
+## IFoE TransferBench Smoketest (AIMVT-181)
+
+Validates IFoE scale-up data-path one layer above L2 by invoking the
+TransferBench candidate-branch **`smoketest`** preset on every reachable
+node and reconciling the binary's exit code with per-cell
+`[PASS] / [FAIL] / [SKIP]` markers in its output.
+
+Before TransferBench runs the check enforces a single-vPod precondition by
+querying:
+
+```
+sudo amd-smi fabric --topology --json
+```
+
+on every reachable node and verifying that every node reports exactly one
+`vpod_id` and all nodes share the same `vpod_id`. The TransferBench
+candidate-branch smoketest preset exits with `ERR_FATAL` (exit code `2`)
+when ranks span multiple virtual pods, so this precondition lets us surface
+the cause clearly rather than blaming the smoketest for an environment
+issue.
+
+Each TransferBench invocation issues:
+
+```
+[sudo] [PATH=<rocm>/bin:... LD_LIBRARY_PATH=<rocm>/lib:...] \
+  NUM_ITERATIONS=<n> NUM_WARMUPS=<n> ALWAYS_VALIDATE=1 RUN_PARALLEL=1 \
+  [TB_NUM_RANKS=<n> TB_RANK=<r> TB_MASTER_ADDR=<rank0> TB_MASTER_PORT=<port>] \
+  <tb_binary> smoketest <size_list...>
+```
+
+with a `__TB_SMOKE_EXIT__=$?` sentinel appended so we can recover the
+binary's exit code from stdout even when the parallel SSH transport
+discards process exit codes.
+
+### Orchestration modes
+
+- **`per_node`** (default) — one independent single-rank TransferBench per
+  reachable node. Exercises intra-node AID↔MID IFoE only, but needs no
+  cross-node coordination and is the safest first run when bringing up a
+  cluster.
+- **`multi_rank`** — every reachable node is wired into one socket-comm
+  cluster (`TB_NUM_RANKS=N`, `TB_RANK=0..N-1`, `TB_MASTER_ADDR=<rank0>`).
+  This is the closest thing to a full-mesh IFoE scale-up test the candidate
+  branch ships today; it traverses the rack IFoE switch end-to-end. Requires
+  bidirectional IP reachability on `socket_master_port` between every pair
+  of nodes, and at least two reachable hosts (otherwise we degrade to
+  `per_node` automatically and log a warning).
+
+### Verdict logic
+
+Per-node verdict is derived as:
+
+1. No `__TB_SMOKE_EXIT__` sentinel observed → **FAIL** (orchestration broke)
+2. Exit code `2` → **FAIL** (TransferBench precondition fired; usually a
+   pod-membership or executor-symmetry issue inside the preset)
+3. Any non-zero exit code → **FAIL**
+4. Any parsed `FAIL` marker or fatal-keyword line in stdout → **FAIL**
+5. `num_skip / num_tests > max_skip_pct%` → **WARNING**
+6. Otherwise → **PASS**
+
+### Example TransferBench config block
+
+```json
+"connectivity_check": {
+  "transferbench": {
+    "connectivity_mode": "run",
+    "tb_binary": "/opt/rocm/bin/TransferBench",
+    "rocm_path": "/opt/rocm",
+    "amd_smi_path": "amd-smi",
+    "use_sudo": true,
+    "preset": "smoketest",
+    "size_list": ["1K", "16M"],
+    "num_iterations": 2,
+    "num_warmups": 0,
+    "always_validate": true,
+    "run_parallel": true,
+    "force_single_pod": true,
+    "rank_mode": "per_node",
+    "max_skip_pct": 25.0,
+    "ssh_timeout": 600
+  }
+}
+```
+
+To exercise the rack IFoE switch end-to-end, flip `rank_mode` to
+`"multi_rank"` and open `socket_master_port` (default `31337`) in the
+firewall between every node pair.
 
 ## Output and Reporting
 

--- a/cvs/tests/preflight/README.md
+++ b/cvs/tests/preflight/README.md
@@ -162,8 +162,7 @@ issue.
 Each TransferBench invocation issues:
 
 ```
-[sudo] [PATH=<rocm>/bin:... LD_LIBRARY_PATH=<rocm>/lib:...] \
-  NUM_ITERATIONS=<n> NUM_WARMUPS=<n> ALWAYS_VALIDATE=1 RUN_PARALLEL=1 \
+[sudo] NUM_ITERATIONS=<n> NUM_WARMUPS=<n> ALWAYS_VALIDATE=1 RUN_PARALLEL=1 \
   [TB_NUM_RANKS=<n> TB_RANK=<r> TB_MASTER_ADDR=<rank0> TB_MASTER_PORT=<port>] \
   <tb_binary> smoketest <size_list...>
 ```
@@ -171,6 +170,11 @@ Each TransferBench invocation issues:
 with a `__TB_SMOKE_EXIT__=$?` sentinel appended so we can recover the
 binary's exit code from stdout even when the parallel SSH transport
 discards process exit codes.
+
+`PATH` and `LD_LIBRARY_PATH` (e.g. for a non-default ROCm install) are
+inherited from the cluster file's top-level `env_vars` block — the
+parallel SSH layer exports them on every host before each command, so
+the smoketest does not duplicate that knob in its own config.
 
 ### Orchestration modes
 
@@ -204,9 +208,7 @@ Per-node verdict is derived as:
 "connectivity_check": {
   "transferbench": {
     "connectivity_mode": "run",
-    "tb_binary": "/opt/rocm/bin/TransferBench",
-    "rocm_path": "/opt/rocm",
-    "amd_smi_path": "amd-smi",
+    "tb_binary": "TransferBench",
     "use_sudo": true,
     "preset": "smoketest",
     "size_list": ["1K", "16M"],

--- a/cvs/tests/preflight/README.md
+++ b/cvs/tests/preflight/README.md
@@ -12,7 +12,7 @@ The preflight checks system validates essential cluster health and configuration
 4. **IFoE L2 Connectivity** - Validates L2 reachability of IFoE links via `afmctl test ping` *(AIMVT-180; opt-in)*
 5. **IFoE TransferBench Smoketest** - Runs the TransferBench candidate-branch `smoketest`
    preset to validate IFoE scale-up data-path (after a single-vPod precondition via
-   `amd-smi fabric --topology --json`) *(AIMVT-181; opt-in)*
+   `amd-smi fabric --json`) *(AIMVT-181; opt-in)*
 6. **RDMA Connectivity** - Tests node-to-node RDMA communication using `ibv_rc_pingpong`
 
 ## Quick Start
@@ -146,10 +146,10 @@ node and reconciling the binary's exit code with per-cell
 `[PASS] / [FAIL] / [SKIP]` markers in its output.
 
 Before TransferBench runs the check enforces a single-vPod precondition by
-querying:
+querying `amd_smi_binary` (default: `amd-smi`):
 
 ```
-sudo amd-smi fabric --topology --json
+sudo <resolved-amd-smi-binary> fabric --json
 ```
 
 on every reachable node and verifying that every node reports exactly one
@@ -162,19 +162,21 @@ issue.
 Each TransferBench invocation issues:
 
 ```
-[sudo] NUM_ITERATIONS=<n> NUM_WARMUPS=<n> ALWAYS_VALIDATE=1 RUN_PARALLEL=1 \
+[sudo] [extra_env assignments] SIZE_LIST=<size1>,<size2> NUM_ITERATIONS=<n> NUM_WARMUPS=<n> ALWAYS_VALIDATE=1 RUN_PARALLEL=1 \
   [TB_NUM_RANKS=<n> TB_RANK=<r> TB_MASTER_ADDR=<rank0> TB_MASTER_PORT=<port>] \
-  <tb_binary> smoketest <size_list...>
+  <resolved-tb_binary> smoketest
 ```
 
 with a `__TB_SMOKE_EXIT__=$?` sentinel appended so we can recover the
 binary's exit code from stdout even when the parallel SSH transport
 discards process exit codes.
 
-`PATH` and `LD_LIBRARY_PATH` (e.g. for a non-default ROCm install) are
-inherited from the cluster file's top-level `env_vars` block — the
-parallel SSH layer exports them on every host before each command, so
-the smoketest does not duplicate that knob in its own config.
+The cluster file's `env_vars` block configures the outer SSH shell. Because
+`sudo` may replace `PATH` with `secure_path` and strips `LD_LIBRARY_PATH`, CVS
+resolves a bare `tb_binary` / `amd_smi_binary` before elevation; production
+configs should supply absolute paths for both. Use `extra_env` for runtime
+values required by TransferBench inside the root shell—for example,
+`LD_LIBRARY_PATH` when the ROCm library directory is not in the dynamic-linker cache.
 
 ### Orchestration modes
 
@@ -208,8 +210,12 @@ Per-node verdict is derived as:
 "connectivity_check": {
   "transferbench": {
     "connectivity_mode": "run",
-    "tb_binary": "TransferBench",
+    "tb_binary": "/path/to/TransferBench",
+    "amd_smi_binary": "/path/to/amd-smi",
     "use_sudo": true,
+    "extra_env": {
+      "LD_LIBRARY_PATH": "/path/to/rocm/lib:$LD_LIBRARY_PATH"
+    },
     "preset": "smoketest",
     "size_list": ["1K", "16M"],
     "num_iterations": 2,

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -661,10 +661,6 @@ def test_ifoe_transferbench_smoke(phdl, config_dict):
     tb_binary = get_nested_config(
         config_dict, 'connectivity_check.transferbench', 'tb_binary', 'TransferBench'
     )
-    rocm_path = get_nested_config(config_dict, 'connectivity_check.transferbench', 'rocm_path', '')
-    amd_smi_path = get_nested_config(
-        config_dict, 'connectivity_check.transferbench', 'amd_smi_path', 'amd-smi'
-    )
     use_sudo = _config_flag_enabled(
         get_nested_config(config_dict, 'connectivity_check.transferbench', 'use_sudo', True),
         default=True,
@@ -742,8 +738,6 @@ def test_ifoe_transferbench_smoke(phdl, config_dict):
     checker = TransferBenchSmokeCheck(
         phdl,
         tb_binary=tb_binary,
-        rocm_path=rocm_path or None,
-        amd_smi_path=amd_smi_path,
         use_sudo=use_sudo,
         preset=preset,
         size_list=size_list if isinstance(size_list, (list, tuple)) else [size_list],

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -13,6 +13,7 @@ from cvs.lib.preflight.gid_consistency import GidConsistencyCheck
 from cvs.lib.preflight.version_check import RocmVersionCheck
 from cvs.lib.preflight.interface_consistency import InterfaceConsistencyCheck
 from cvs.lib.preflight.ifoe_l2_connectivity import IfoeL2ConnectivityCheck
+from cvs.lib.preflight.transferbench_smoke import TransferBenchSmokeCheck
 
 # RdmaConnectivityCheck not used - using legacy function temporarily
 from cvs.lib.preflight.report import PreflightReportGenerator
@@ -599,6 +600,215 @@ def test_ifoe_l2_connectivity(phdl, config_dict):
     preflight_update_test_result()
 
 
+def test_ifoe_transferbench_smoke(phdl, config_dict):
+    """Test IFoE scale-up via TransferBench candidate-branch smoketest (AIMVT-181).
+
+    Builds on AIMVT-180 (L2 reachability via ``afmctl test ping``) by exercising
+    the IFoE data path one layer above L2: it asks every reachable node to run
+    the TransferBench candidate-branch ``smoketest`` preset and validates that
+    the binary completes with exit code zero and no ``FAIL`` cells.
+
+    Two precondition gates run before the binary is invoked:
+
+      1. **vPod membership** – ``amd-smi fabric --topology --json`` is queried
+         on every reachable node and the union of reported ``vpod_id`` values
+         must be a single id (the smoketest preset itself exits with
+         ``ERR_FATAL`` when ranks span multiple virtual pods).
+      2. **Reachable host count** – ``multi_rank`` mode requires at least
+         two reachable nodes; otherwise we degrade to ``per_node`` mode and
+         log a warning.
+
+    Configuration lives under ``connectivity_check.transferbench`` in the
+    preflight config file. The check is **opt-in**: when
+    ``connectivity_mode`` is ``"skip"`` (default) or omitted, the test
+    records a SKIPPED result and returns immediately without contacting
+    nodes. Nodes whose smoketest fails are reported but are **not** pruned
+    from ``phdl`` -- operators decide whether to proceed with downstream
+    RDMA / RCCL testing.
+    """
+    global preflight_results
+
+    mode = get_nested_config(config_dict, 'connectivity_check.transferbench', 'connectivity_mode', 'skip')
+    if isinstance(mode, str):
+        mode_normalized = mode.strip().lower()
+    else:
+        mode_normalized = 'skip' if not mode else 'run'
+
+    if mode_normalized in ('skip', 'off', 'disabled', 'false', '0'):
+        log.info("IFoE TransferBench smoketest skipped by configuration (mode=%s)", mode)
+        preflight_results['transferbench_smoke'] = {
+            'mode': mode_normalized,
+            'skipped': True,
+            'message': 'IFoE TransferBench smoketest skipped by configuration',
+            'nodes': {},
+        }
+        preflight_update_test_result()
+        return
+
+    if not phdl.reachable_hosts:
+        log.warning(
+            "IFoE TransferBench smoketest skipped: no reachable hosts remain after earlier preflight pruning"
+        )
+        preflight_results['transferbench_smoke'] = {
+            'mode': mode_normalized,
+            'skipped': True,
+            'message': 'No reachable nodes available for TransferBench smoketest',
+            'nodes': {},
+        }
+        preflight_update_test_result()
+        return
+
+    tb_binary = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'tb_binary', 'TransferBench'
+    )
+    rocm_path = get_nested_config(config_dict, 'connectivity_check.transferbench', 'rocm_path', '')
+    amd_smi_path = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'amd_smi_path', 'amd-smi'
+    )
+    use_sudo = _config_flag_enabled(
+        get_nested_config(config_dict, 'connectivity_check.transferbench', 'use_sudo', True),
+        default=True,
+    )
+    preset = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'preset', 'smoketest'
+    )
+    size_list = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'size_list', ['1K', '16M']
+    )
+    num_iterations = int(
+        get_nested_config(config_dict, 'connectivity_check.transferbench', 'num_iterations', 2)
+    )
+    num_warmups = int(
+        get_nested_config(config_dict, 'connectivity_check.transferbench', 'num_warmups', 0)
+    )
+    always_validate = _config_flag_enabled(
+        get_nested_config(
+            config_dict, 'connectivity_check.transferbench', 'always_validate', True
+        ),
+        default=True,
+    )
+    run_parallel = _config_flag_enabled(
+        get_nested_config(config_dict, 'connectivity_check.transferbench', 'run_parallel', True),
+        default=True,
+    )
+    use_bdma = _config_flag_enabled(
+        get_nested_config(config_dict, 'connectivity_check.transferbench', 'use_bdma', False),
+        default=False,
+    )
+    force_single_pod = _config_flag_enabled(
+        get_nested_config(
+            config_dict, 'connectivity_check.transferbench', 'force_single_pod', True
+        ),
+        default=True,
+    )
+    rank_mode = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'rank_mode', 'per_node'
+    )
+    socket_master_port = int(
+        get_nested_config(
+            config_dict, 'connectivity_check.transferbench', 'socket_master_port', 31337
+        )
+    )
+    master_node = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'master_node', None
+    )
+    max_skip_pct = float(
+        get_nested_config(
+            config_dict, 'connectivity_check.transferbench', 'max_skip_pct', 25.0
+        )
+    )
+    ssh_timeout = int(
+        get_nested_config(config_dict, 'connectivity_check.transferbench', 'ssh_timeout', 600)
+    )
+    skip_pod_check = _config_flag_enabled(
+        get_nested_config(
+            config_dict, 'connectivity_check.transferbench', 'skip_pod_check', False
+        ),
+        default=False,
+    )
+
+    log.info(
+        "Running IFoE TransferBench smoketest (tb_binary=%s, preset=%s, rank_mode=%s, "
+        "size_list=%s, num_iterations=%s, max_skip_pct=%s) on %d host(s)",
+        tb_binary,
+        preset,
+        rank_mode,
+        size_list,
+        num_iterations,
+        max_skip_pct,
+        len(phdl.reachable_hosts),
+    )
+
+    checker = TransferBenchSmokeCheck(
+        phdl,
+        tb_binary=tb_binary,
+        rocm_path=rocm_path or None,
+        amd_smi_path=amd_smi_path,
+        use_sudo=use_sudo,
+        preset=preset,
+        size_list=size_list if isinstance(size_list, (list, tuple)) else [size_list],
+        num_iterations=num_iterations,
+        num_warmups=num_warmups,
+        always_validate=always_validate,
+        run_parallel=run_parallel,
+        use_bdma=use_bdma,
+        force_single_pod=force_single_pod,
+        rank_mode=rank_mode,
+        socket_master_port=socket_master_port,
+        master_node=master_node if master_node else None,
+        max_skip_pct=max_skip_pct,
+        ssh_timeout=ssh_timeout,
+        skip_pod_check=skip_pod_check,
+        config_dict=config_dict,
+    )
+
+    results = checker.run()
+
+    preflight_results['transferbench_smoke'] = {
+        'mode': mode_normalized,
+        'skipped': False,
+        'status': results.get('status'),
+        'rank_mode': results.get('rank_mode'),
+        'pod_membership': results.get('pod_membership') or {},
+        'nodes': results.get('nodes') or {},
+        'totals': results.get('totals') or {},
+        'errors': results.get('errors') or [],
+        'max_skip_pct': max_skip_pct,
+    }
+
+    totals = results.get('totals') or {}
+    if results.get('status') == 'FAIL':
+        log.warning(
+            "IFoE TransferBench smoketest FAIL: %d/%d node(s) failed, %d warning(s); "
+            "cluster errors: %s",
+            totals.get('nodes_fail', 0),
+            totals.get('nodes_total', 0),
+            totals.get('nodes_warning', 0),
+            "; ".join(results.get('errors') or []) or 'none',
+        )
+        for node, node_result in (results.get('nodes') or {}).items():
+            if node_result.get('status') == 'FAIL':
+                for err in node_result.get('errors') or []:
+                    log.error("Node %s TransferBench smoketest: %s", node, err)
+    elif results.get('status') == 'WARNING':
+        log.warning(
+            "IFoE TransferBench smoketest WARNING: %d node(s) exceeded skip budget (max %s%%)",
+            totals.get('nodes_warning', 0),
+            max_skip_pct,
+        )
+    else:
+        log.info(
+            "IFoE TransferBench smoketest PASS on %d/%d node(s) (tests pass/fail/skip = %d/%d/%d)",
+            totals.get('nodes_pass', 0),
+            totals.get('nodes_total', 0),
+            totals.get('tests_pass', 0),
+            totals.get('tests_fail', 0),
+            totals.get('tests_skip', 0),
+        )
+
+    preflight_update_test_result()
+
+
 def test_rdma_connectivity(phdl, cluster_dict, config_dict):
     """
     Test RDMA connectivity between cluster nodes using ibv_rc_pingpong.
@@ -732,6 +942,7 @@ def test_generate_preflight_report(phdl, config_dict, request):
         'rocm_versions',
         'interface_names',
         'ifoe_l2_connectivity',
+        'transferbench_smoke',
         'rdma_connectivity',
     ]
     missing_checks = [check for check in required_checks if check not in preflight_results]

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -606,7 +606,7 @@ def test_ifoe_transferbench_smoke(phdl, config_dict):
 
     Two precondition gates run before the binary is invoked:
 
-      1. **vPod membership** – ``amd-smi fabric --topology --json`` is queried
+      1. **vPod membership** – ``amd-smi fabric --json`` is queried
          on every reachable node and the union of reported ``vpod_id`` values
          must be a single id (the smoketest preset itself exits with
          ``ERR_FATAL`` when ranks span multiple virtual pods).
@@ -656,6 +656,12 @@ def test_ifoe_transferbench_smoke(phdl, config_dict):
 
     tb_binary = get_nested_config(
         config_dict, 'connectivity_check.transferbench', 'tb_binary', 'TransferBench'
+    )
+    amd_smi_binary = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'amd_smi_binary', 'amd-smi'
+    )
+    extra_env = get_nested_config(
+        config_dict, 'connectivity_check.transferbench', 'extra_env', {}
     )
     use_sudo = _config_flag_enabled(
         get_nested_config(config_dict, 'connectivity_check.transferbench', 'use_sudo', True),
@@ -720,9 +726,10 @@ def test_ifoe_transferbench_smoke(phdl, config_dict):
     )
 
     log.info(
-        "Running IFoE TransferBench smoketest (tb_binary=%s, preset=%s, rank_mode=%s, "
+        "Running IFoE TransferBench smoketest (tb_binary=%s, amd_smi_binary=%s, preset=%s, rank_mode=%s, "
         "size_list=%s, num_iterations=%s, max_skip_pct=%s) on %d host(s)",
         tb_binary,
+        amd_smi_binary,
         preset,
         rank_mode,
         size_list,
@@ -734,6 +741,7 @@ def test_ifoe_transferbench_smoke(phdl, config_dict):
     checker = TransferBenchSmokeCheck(
         phdl,
         tb_binary=tb_binary,
+        amd_smi_binary=amd_smi_binary,
         use_sudo=use_sudo,
         preset=preset,
         size_list=size_list if isinstance(size_list, (list, tuple)) else [size_list],
@@ -748,6 +756,7 @@ def test_ifoe_transferbench_smoke(phdl, config_dict):
         master_node=master_node if master_node else None,
         max_skip_pct=max_skip_pct,
         ssh_timeout=ssh_timeout,
+        extra_env=extra_env,
         skip_pod_check=skip_pod_check,
         config_dict=config_dict,
     )


### PR DESCRIPTION
## Summary

Adds an **opt-in** preflight check that validates IFoE (Infinity Fabric over
Ethernet, a.k.a. XGMI-over-Ethernet) **scale-up data-path** connectivity
one layer above the AIMVT-180 L2 ping, by running the TransferBench
candidate-branch `smoketest` preset on every reachable cluster node and
reconciling the binary's exit code with the per-cell
`[PASS] / [FAIL] / [SKIP]` markers in its output. Disabled by default
(`connectivity_check.transferbench.connectivity_mode = "skip"`), so it has
no effect on clusters that don't run the candidate-branch TransferBench
build.

## Stacked on

This PR is stacked on **#188** (AIMVT-180, IFoE L2 ping). It inserts
`test_ifoe_transferbench_smoke` between `test_ifoe_l2_connectivity` and
`test_rdma_connectivity` in the same runner and extends the shared report
generator, so it builds directly on the AIMVT-180 pieces. GitHub will
auto-rebase / fast-forward once #188 lands; the AIMVT-181 commit itself
adds **only** the new files and the new wiring.

## Motivation

AIMVT-180 covers L2 reachability (one `afmctl test ping` per BDF / dst
accelerator pair), but does not exercise the IFoE data path the workloads
actually use. AIMVT-181 fills that gap: a fast pre-workload gate that
asks every reachable node to push real GPU-to-GPU traffic across the IFoE
fabric and validates the result before the heavier downstream tests
(RDMA full-mesh, RCCL, training) burn cycles on a broken fabric.

## Technical Details

### New module --- `cvs/lib/preflight/transferbench_smoke.py`

- `TransferBenchSmokeCheck`: orchestrates the smoketest dispatch in one of
  two modes:
  - **`per_node`** (default) --- each reachable node runs an independent
    single-rank TransferBench against its local GPUs. Exercises intra-node
    AID↔MID IFoE hops but does not traverse the rack IFoE switch.
  - **`multi_rank`** --- every reachable node is wired into one
    socket-comm cluster (`TB_NUM_RANKS=N`, `TB_RANK=0..N-1`,
    `TB_MASTER_ADDR=<rank0>`, `TB_MASTER_PORT=<configured>`) and the whole
    fleet is launched via a single `phdl.exec_cmd_list` call so the
    preset's socket-comm bootstrap can complete. Closest thing to a full
    fabric scale-up test the candidate branch ships today. Auto-degrades
    to `per_node` when fewer than two reachable hosts remain.
- `extract_node_pod_membership()` + `reconcile_cluster_vpod()`: tolerant
  parsers for `amd-smi fabric --topology --json` payloads. Handle a
  flat list, the `gpu_data` wrapper, per-key dicts, and a plaintext
  fallback for amd-smi builds without `--json` support. Used as a
  pre-dispatch precondition: every node must report exactly one local
  `vpod_id` and all nodes must share the same `vpod_id` (the smoketest
  preset itself aborts with ERR_FATAL when ranks span multiple vPods, and
  we want to surface that as a clear cluster-level error rather than as
  an opaque exit-2 from TransferBench).
- `SmoketestParser`: tolerant parser that accepts bracketed-verdict
  (`[PASS]`/`[FAIL]`/`[SKIP]`), marker-block (`*`/`F`/`.`), and aggregate
  `N/M PASS, x FAIL, y SKIP` summary shapes. Counts the markers, captures
  warnings / fatal-keyword lines, and recovers the binary's exit code
  from a `__TB_SMOKE_EXIT__=$?` sentinel appended to stdout by the
  orchestrator (so we are not at the mercy of the parallel SSH layer's
  exit-code handling).
- `evaluate_smoketest()`: derives the per-node `PASS` / `FAIL` / `WARNING`
  verdict from the parsed result. Verdict precedence: sentinel missing
  → FAIL; exit 2 (ERR_FATAL precondition) → FAIL with a precondition
  explanation; any non-zero exit → FAIL; FAIL markers / fatal-keyword
  lines despite exit zero → FAIL (defence in depth); `num_skip / num_tests`
  over the configured `max_skip_pct` → WARNING; else PASS.

### New helper --- `cvs/lib/rocm_plib.py`

`get_gpu_fabric_info_dict(phdl, use_sudo=True, amd_smi_path='amd-smi')`
joins the existing `amd-smi` / `rocm-smi` helpers in this file. Returns
the parsed amd-smi fabric JSON per node for other future consumers (the
preflight orchestrator uses its own copy that also tolerates plaintext
output, so this helper sits unused for now).

### New pytest entry --- `cvs/tests/preflight/preflight_checks.py`

`test_ifoe_transferbench_smoke` is wired in between the existing
`test_ifoe_l2_connectivity` and the existing `test_rdma_connectivity`.
Opt-in via `connectivity_check.transferbench.connectivity_mode`
(`"run"` or `"skip"`; default `"skip"`). Failed nodes are reported but
not pruned from `phdl` --- operators decide whether to gate downstream
testing on the result. Registered with the report generator's required
checks list so it always renders in the executive summary.

### New config block --- `cvs/input/config_file/preflight/preflight_config.json`

`connectivity_check.transferbench`: `connectivity_mode`, `tb_binary`,
`rocm_path`, `amd_smi_path`, `use_sudo`, `preset`, `size_list`,
`num_iterations`, `num_warmups`, `always_validate`, `run_parallel`,
`use_bdma`, `force_single_pod`, `rank_mode`, `socket_master_port`,
`master_node`, `max_skip_pct`, `ssh_timeout`, `skip_pod_check`. Every
key has an inline `_comment_*` doc.

### Reporting --- `cvs/lib/preflight/report.py`

- Adds the TransferBench smoketest row to the executive summary table.
- Adds dedicated HTML section: shared vpod/ppod state from the
  precondition, rank-mode, totals (nodes pass/warn/fail, tests
  pass/fail/skip), and a per-node failure detail table with verdict
  errors, parsed marker counts, exit code, expandable stdout, and the
  rendered command.
- Adds recommendations for FAIL and WARNING terminal states.

### Documentation

- `cvs/tests/preflight/README.md`: new "IFoE TransferBench Smoketest
  (AIMVT-181)" section with the precondition / orchestration / verdict
  details and an example config block.
- `cvs/input/config_file/preflight/README_preflight_config.md`: full
  parameter reference, structure-overview update, and a callout for the
  new opt-in block.

### Command shape

Each rank's command is rendered as:

```
[sudo] bash -c '[PATH=<rocm>/bin:$PATH LD_LIBRARY_PATH=<rocm>/lib:${LD_LIBRARY_PATH:-}] \
  NUM_ITERATIONS=<n> NUM_WARMUPS=<n> ALWAYS_VALIDATE=1 RUN_PARALLEL=1 \
  USE_REMOTE_READ=1 BLOCK_BYTES=256 [USE_BDMA=1] [FORCE_SINGLE_POD=1] \
  [TB_NUM_RANKS=<n> TB_RANK=<r> TB_MASTER_ADDR=<rank0> TB_MASTER_PORT=<port>] \
  <tb_binary> smoketest <size_list...>; echo "__TB_SMOKE_EXIT__=$?"'
```

The env-var prefix lives **inside** the `bash -c` so that, even with
`use_sudo=True`, the privileged child sees the assignments (sudo
otherwise sanitises its calling shell's environment).

## Test Plan

- Unit tests: `python3 -m unittest cvs.lib.preflight.unittests.test_transferbench_smoke`
  → **40/40 pass**. Coverage:
  - Topology parser: list / `gpu_data` wrapper / keyed-dict / mixed-vpod /
    plaintext / garbage payloads.
  - Cluster reconcile: uniform / split / missing-on-some-nodes /
    mixed-local-vPod.
  - Smoketest parser: passing / failing / skip-heavy /
    fatal-precondition / marker-table fallback / empty / garbage.
  - Verdict logic: every branch including sentinel-missing FAIL,
    exit-2 ERR_FATAL FAIL, skip-budget WARNING, and FAIL-markers-despite-exit-0
    defence path.
  - Orchestrator: command rendering (defaults, sudo + ROCm path, multi-rank
    socket env), `per_node` PASS, multi-rank dispatch via
    `exec_cmd_list`, multi-rank degradation with 1 reachable host,
    pod-check bypass, plaintext fabric fallback, vPod-divergence FAIL,
    one-failing-node FAIL, skip-budget WARNING, no-reachable-hosts FAIL,
    exit-2 precondition FAIL.
- AIMVT-180 + RDMA regression: `python3 -m unittest
  cvs.lib.preflight.unittests.test_ifoe_l2_connectivity
  cvs.lib.preflight.unittests.test_rdma_connectivity
  cvs.lib.preflight.unittests.test_transferbench_smoke` → **86/86 pass**.
- Lint: `ruff check` on the touched files passes cleanly.
- Config: `python3 -m json.tool` on the updated `preflight_config.json`
  parses cleanly.
- Backwards compatibility: default `connectivity_mode = "skip"` means no
  behavioral change for existing clusters; the new pytest entry records a
  SKIPPED result and returns immediately without contacting nodes.

## Out of Scope

- Performance gating (this PR only enforces functional PASS/FAIL/SKIP;
  a follow-up will layer a bandwidth-floor gate on top of the smoketest's
  per-test bandwidth numbers once internal acceptance thresholds are
  finalised).
- Cross-pod (RNIC scale-out) data-path validation --- the smoketest
  preset is intentionally a single-vPod check.
- Installing TransferBench / the candidate-branch build --- AIMVT-171
  (already merged) and the orchestrator fixture handle the install path.

Refs: AIMVT-181

Made with [Cursor](https://cursor.com)