### PR TITLE
G1 Primitives: failure taxonomy + ContainerHandle [B8]

### DIFF
--- a/cvs/lib/failure_taxonomy.py
+++ b/cvs/lib/failure_taxonomy.py
@@ -1,0 +1,93 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Optional
+
+
+class FailureCategory(str, enum.Enum):
+    """The five disjoint failure categories, in priority order.
+
+    Failures are classified *at the boundary where they originate* (the raise
+    site), never by post-hoc inspection of a stack trace or by scanning console
+    output for the word "error". When more than one condition is present, the
+    earliest member in this declaration order wins.
+    """
+
+    SETUP_FAILURE = "setup_failure"
+    SAFETY_VIOLATION = "safety_violation"
+    FAILURE_PATTERN_MATCHED = "failure_pattern_matched"
+    LIVENESS_FAILURE = "liveness_failure"
+    VERIFICATION_FAILURE = "verification_failure"
+
+    @property
+    def priority(self) -> int:
+        return _PRIORITY[self]
+
+
+_PRIORITY = {cat: i for i, cat in enumerate(FailureCategory)}
+
+
+class WorkloadFailure(Exception):
+    """Base for all classified workload failures.
+
+    Each subclass binds a single :class:`FailureCategory`. The ``Job`` driver
+    catches ``WorkloadFailure`` and records ``exc.category`` directly; it never
+    guesses the category from the message.
+    """
+
+    category: FailureCategory = FailureCategory.SETUP_FAILURE
+
+    def __init__(self, message: str, *, detail: Optional[dict] = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.detail = detail or {}
+
+
+class SetupFailure(WorkloadFailure):
+    """``prepare`` or ``launch`` raised before the workload started running."""
+
+    category = FailureCategory.SETUP_FAILURE
+
+
+class SafetyViolation(WorkloadFailure):
+    """The progress predicate broke mid-run (server died, role crashed, ...)."""
+
+    category = FailureCategory.SAFETY_VIOLATION
+
+
+class FailurePatternMatched(WorkloadFailure):
+    """A pattern from ``failure_patterns.yaml`` hit a monitored log stream."""
+
+    category = FailureCategory.FAILURE_PATTERN_MATCHED
+
+
+class LivenessFailure(WorkloadFailure):
+    """``await_completion`` timed out without the progress predicate breaking."""
+
+    category = FailureCategory.LIVENESS_FAILURE
+
+
+class VerificationFailure(WorkloadFailure):
+    """At least one threshold evaluated to False at end-of-test."""
+
+    category = FailureCategory.VERIFICATION_FAILURE
+
+
+def category_of(exc: BaseException) -> FailureCategory:
+    """Map an exception to a category.
+
+    A :class:`WorkloadFailure` carries its category explicitly. Any other
+    exception escaping the lifecycle is treated as a setup failure (it occurred
+    outside a classified boundary, so it is, by definition, a harness/setup
+    problem rather than a workload verdict).
+    """
+    if isinstance(exc, WorkloadFailure):
+        return exc.category
+    return FailureCategory.SETUP_FAILURE

--- a/cvs/lib/runtime/__init__.py
+++ b/cvs/lib/runtime/__init__.py
@@ -1,0 +1,10 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from cvs.lib.runtime.container_handle import ContainerHandle
+
+__all__ = ["ContainerHandle"]

--- a/cvs/lib/runtime/container_handle.py
+++ b/cvs/lib/runtime/container_handle.py
@@ -1,0 +1,183 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import shlex
+import time
+from typing import Callable, Dict, List, Optional, Sequence
+
+# Teardown reclaims strictly by this label (label-scoped ``docker rm -f``), never
+# a global prune that could reap unrelated containers on a shared host.
+RUN_ID_LABEL = "cvs_run_id"
+
+
+class ContainerHandle:
+    """Context manager for a single workload container.
+
+    - Non-privileged by default: ``--privileged`` / ``seccomp=unconfined`` are
+      opt-in.
+    - Tagged ``cvs_run_id=<run_id>``; teardown removes by that label only, never
+      a global prune.
+    - On exit ``__exit__`` snapshots logs, ``dmesg`` and GPU state before
+      removal, even on the error path.
+    - ``command`` / ``extra_args`` are appended to the ``docker run`` line
+      unquoted, so an operator can pass arbitrary shell; never build them from
+      untrusted input.
+    - Spec fields (``name``, ``network``, ``ipc``, ``shm_size``, ``devices``,
+      ``volumes``, ``ports``, ``env``) must be ``str`` — dict keys *and* values.
+      Each token is quoted with ``shlex.quote``, which does not coerce, so a
+      non-``str`` (an ``int`` port, a ``pathlib.Path``) raises ``TypeError``
+      instead of silently emitting a wrong arg. The G2 ``ContainerSpec``
+      stringifies before passing.
+
+    The runtime is reached through an injected ``runner.exec(cmd) -> str | dict``
+    (duck-typed to :class:`cvs.lib.parallel.pssh.Pssh` or a local wrapper), so the
+    class is unit-testable with a fake.
+    """
+
+    def __init__(
+        self,
+        image: str,
+        run_id: str,
+        runner,
+        *,
+        name: Optional[str] = None,
+        devices: Optional[Sequence[str]] = None,
+        volumes: Optional[Dict[str, str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        shm_size: Optional[str] = None,
+        ports: Optional[Dict[str, str]] = None,
+        network: Optional[str] = None,
+        ipc: Optional[str] = None,
+        privileged: bool = False,
+        seccomp_unconfined: bool = False,
+        command: Optional[str] = None,
+        extra_args: Optional[Sequence[str]] = None,
+        readiness: Optional[Callable[["ContainerHandle"], bool]] = None,
+        readiness_timeout_s: float = 600.0,
+        readiness_interval_s: float = 5.0,
+    ) -> None:
+        self.image = image
+        self.run_id = run_id
+        self.runner = runner
+        self.name = name or f"cvs_{run_id}"
+        self.devices = list(devices or [])
+        self.volumes = dict(volumes or {})
+        self.env = dict(env or {})
+        self.shm_size = shm_size
+        self.ports = dict(ports or {})
+        self.network = network
+        self.ipc = ipc
+        self.privileged = privileged
+        self.seccomp_unconfined = seccomp_unconfined
+        self.command = command
+        self.extra_args = list(extra_args or [])
+        self.readiness = readiness
+        self.readiness_timeout_s = readiness_timeout_s
+        self.readiness_interval_s = readiness_interval_s
+        self.started = False
+
+    def build_run_command(self) -> str:
+        """Return the ``docker run -d`` command string. Pure / side-effect free."""
+        parts: List[str] = ["docker", "run", "-d"]
+        parts += ["--name", shlex.quote(self.name)]
+        parts += ["--label", f"{RUN_ID_LABEL}={shlex.quote(self.run_id)}"]
+        if self.privileged:
+            parts.append("--privileged")
+        if self.seccomp_unconfined:
+            parts += ["--security-opt", "seccomp=unconfined"]
+        if self.network:
+            parts += ["--network", shlex.quote(self.network)]
+        if self.ipc:
+            parts += ["--ipc", shlex.quote(self.ipc)]
+        if self.shm_size:
+            parts += ["--shm-size", shlex.quote(self.shm_size)]
+        for dev in self.devices:
+            parts += ["--device", shlex.quote(dev)]
+        for host_path, container_path in self.volumes.items():
+            parts += ["-v", f"{shlex.quote(host_path)}:{shlex.quote(container_path)}"]
+        for host_port, container_port in self.ports.items():
+            parts += ["-p", f"{shlex.quote(host_port)}:{shlex.quote(container_port)}"]
+        for key, value in self.env.items():
+            parts += ["-e", f"{shlex.quote(key)}={shlex.quote(value)}"]
+        # Appended unquoted on purpose; never pass untrusted input.
+        parts += list(self.extra_args)
+        parts.append(shlex.quote(self.image))
+        if self.command:
+            # Also raw / operator-authored: passed through verbatim, not quoted.
+            parts.append(self.command)
+        return " ".join(parts)
+
+    def _run(self, cmd: str, timeout: Optional[float] = None) -> str:
+        out = self.runner.exec(cmd, timeout=timeout) if timeout is not None else self.runner.exec(cmd)
+        # Pssh.exec returns a per-host dict; a local runner returns a plain
+        # string. Flatten either form to one string for callers.
+        if isinstance(out, dict):
+            return "\n".join(str(v) for v in out.values())
+        return str(out)
+
+    def __enter__(self) -> "ContainerHandle":
+        try:
+            self._run(self.build_run_command())
+            self.started = True
+            self._await_ready()
+        except BaseException:
+            # __exit__ does not run when __enter__ raises, so apply the same
+            # teardown contract here: forensics (if launched) then label-scoped
+            # removal, so a failed launch / readiness timeout never leaks a
+            # container. capture()/remove() are best-effort and re-raise nothing.
+            if self.started:
+                self.capture()
+            self.remove()
+            raise
+        return self
+
+    def _await_ready(self) -> None:
+        if self.readiness is None:
+            return
+        deadline = time.monotonic() + self.readiness_timeout_s
+        while time.monotonic() < deadline:
+            if self.readiness(self):
+                return
+            time.sleep(self.readiness_interval_s)
+        raise TimeoutError(f"container {self.name} not ready within {self.readiness_timeout_s}s")
+
+    def capture(self) -> Dict[str, str]:
+        """Snapshot logs + dmesg + GPU state. Best-effort; never raises."""
+        artifacts: Dict[str, str] = {}
+        probes = {
+            "container.log": f"docker logs {shlex.quote(self.name)} 2>&1 || true",
+            "dmesg.txt": "dmesg -T 2>&1 | tail -n 500 || true",
+            "gpu_state.txt": "(rocm-smi || amd-smi monitor || true) 2>&1",
+        }
+        for artifact_name, cmd in probes.items():
+            try:
+                artifacts[artifact_name] = self._run(cmd)
+            except Exception as exc:  # noqa: BLE001 - capture must never mask the real error
+                artifacts[artifact_name] = f"<capture failed: {exc}>"
+        return artifacts
+
+    def remove(self) -> None:
+        """Remove every container started under this run_id label."""
+        cmd = (
+            f"docker ps -aq --filter label={RUN_ID_LABEL}={shlex.quote(self.run_id)} "
+            f"| xargs --no-run-if-empty docker rm -f"
+        )
+        try:
+            self._run(cmd)
+        except Exception:  # noqa: BLE001 - teardown is best-effort
+            pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        try:
+            if self.started:
+                self.capture()
+        finally:
+            self.remove()
+        # Do not suppress exceptions raised inside the with-block.
+        return False

--- a/cvs/lib/unittests/test_dtni_failure_taxonomy.py
+++ b/cvs/lib/unittests/test_dtni_failure_taxonomy.py
@@ -1,0 +1,73 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import unittest
+
+from cvs.lib.failure_taxonomy import (
+    FailureCategory,
+    FailurePatternMatched,
+    LivenessFailure,
+    SafetyViolation,
+    SetupFailure,
+    VerificationFailure,
+    WorkloadFailure,
+    category_of,
+)
+
+
+class TestFailureTaxonomy(unittest.TestCase):
+    def test_five_disjoint_categories(self):
+        # The taxonomy is closed and the values are exactly these five: pinning
+        # the set catches a value typo, not just a count change.
+        self.assertEqual(
+            [c.value for c in FailureCategory],
+            [
+                "setup_failure",
+                "safety_violation",
+                "failure_pattern_matched",
+                "liveness_failure",
+                "verification_failure",
+            ],
+        )
+
+    def test_priority_order(self):
+        # Pin the exact category order and their priorities. This is what ranks
+        # severity when several conditions hold at once (lower wins), so a
+        # mid-list reorder must fail here rather than pass tautologically.
+        self.assertEqual(
+            [c.value for c in FailureCategory],
+            [
+                "setup_failure",
+                "safety_violation",
+                "failure_pattern_matched",
+                "liveness_failure",
+                "verification_failure",
+            ],
+        )
+        self.assertEqual([c.priority for c in FailureCategory], [0, 1, 2, 3, 4])
+
+    def test_exceptions_carry_category(self):
+        # Every subclass binds its category (so the driver records exc.category
+        # directly rather than guessing), and the base defaults to setup.
+        self.assertEqual(SetupFailure("x").category, FailureCategory.SETUP_FAILURE)
+        self.assertEqual(SafetyViolation("x").category, FailureCategory.SAFETY_VIOLATION)
+        self.assertEqual(FailurePatternMatched("x").category, FailureCategory.FAILURE_PATTERN_MATCHED)
+        self.assertEqual(LivenessFailure("x").category, FailureCategory.LIVENESS_FAILURE)
+        self.assertEqual(VerificationFailure("x").category, FailureCategory.VERIFICATION_FAILURE)
+        self.assertEqual(WorkloadFailure("x").category, FailureCategory.SETUP_FAILURE)
+
+    def test_category_of_unknown_is_setup(self):
+        # An exception raised outside a classified boundary (or a bare
+        # WorkloadFailure) is a setup/harness failure; a classified one keeps the
+        # category it declares.
+        self.assertEqual(category_of(ValueError("oops")), FailureCategory.SETUP_FAILURE)
+        self.assertEqual(category_of(WorkloadFailure("x")), FailureCategory.SETUP_FAILURE)
+        self.assertEqual(category_of(SafetyViolation("x")), FailureCategory.SAFETY_VIOLATION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/unittests/test_dtni_runtime.py
+++ b/cvs/lib/unittests/test_dtni_runtime.py
@@ -1,0 +1,118 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import unittest
+
+from cvs.lib.runtime.container_handle import ContainerHandle
+
+
+class TestContainerHandle(unittest.TestCase):
+    def test_non_privileged_default(self):
+        # The default-emitted run command carries no privilege escalation and is
+        # tagged with the run-id label that scoped teardown later filters on.
+        cmd = ContainerHandle("img:tag", "run1", runner=None).build_run_command()
+        self.assertNotIn("--privileged", cmd)
+        self.assertNotIn("seccomp=unconfined", cmd)
+        self.assertIn("cvs_run_id=run1", cmd)
+
+    def test_opt_in_privileged(self):
+        # Escalation flags are emitted only when the caller explicitly opts in.
+        cmd = ContainerHandle("img", "r", runner=None, privileged=True, seccomp_unconfined=True).build_run_command()
+        self.assertIn("--privileged", cmd)
+        self.assertIn("seccomp=unconfined", cmd)
+
+    def test_injection_chars_quoted_in_run_command(self):
+        # Every interpolated field is shell-quoted at the build boundary, so an
+        # injected `; rm -rf /` / `$(...)` stays inside one argument instead of
+        # running as a second command on the host. Cover several field kinds so a
+        # per-site quoting regression (not just the volume path) is caught.
+        cmd = ContainerHandle(
+            "img;rm -rf /",
+            "run1",
+            runner=None,
+            network="$(reboot)",
+            volumes={"/a b; rm -rf /": "/data"},
+            ports={"80; rm": "90 x"},
+            env={"K; rm": "v; rm -rf /"},
+        ).build_run_command()
+        self.assertIn("--network '$(reboot)'", cmd)
+        self.assertIn("-v '/a b; rm -rf /':/data", cmd)
+        self.assertIn("-p '80; rm':'90 x'", cmd)
+        self.assertIn("-e 'K; rm'='v; rm -rf /'", cmd)
+        self.assertIn("'img;rm -rf /'", cmd)
+
+
+class FakeRunner:
+    """Records every command it is handed and returns a canned result."""
+
+    def __init__(self, output=""):
+        self.cmds = []
+        self.output = output
+
+    def exec(self, cmd, timeout=None):
+        self.cmds.append(cmd)
+        return self.output
+
+
+class TestContainerHandleRuntime(unittest.TestCase):
+    def test_enter_exit_captures_then_removes(self):
+        # Happy path: launch, then on exit forensics are captured before the
+        # label-scoped removal (teardown order matters for diagnostics).
+        r = FakeRunner()
+        with ContainerHandle("img", "run1", r, readiness=lambda h: True):
+            pass
+        self.assertTrue(any("docker run -d" in c for c in r.cmds))
+        log_idx = next(i for i, c in enumerate(r.cmds) if "docker logs" in c)
+        rm_idx = next(i for i, c in enumerate(r.cmds) if "docker rm -f" in c)
+        self.assertLess(log_idx, rm_idx)
+
+    def test_exit_removes_and_does_not_suppress_body_exception(self):
+        # An exception in the with-body still triggers teardown and propagates
+        # (the context manager must not swallow it).
+        r = FakeRunner()
+        with self.assertRaises(ValueError):
+            with ContainerHandle("img", "run1", r, readiness=lambda h: True):
+                raise ValueError("boom")
+        self.assertTrue(any("docker rm -f" in c for c in r.cmds))
+
+    def test_enter_readiness_timeout_tears_down(self):
+        # Regression: __enter__ raising on a readiness timeout must still capture
+        # and remove the already-started container (else it leaks, since __exit__
+        # never runs when __enter__ raises).
+        r = FakeRunner()
+        h = ContainerHandle(
+            "img",
+            "run1",
+            r,
+            readiness=lambda h: False,
+            readiness_timeout_s=0.01,
+            readiness_interval_s=0.001,
+        )
+        with self.assertRaises(TimeoutError):
+            with h:
+                pass
+        self.assertTrue(any("docker run -d" in c for c in r.cmds))
+        self.assertTrue(any("docker logs" in c for c in r.cmds))
+        self.assertTrue(any("docker rm -f" in c for c in r.cmds))
+
+    def test_remove_is_label_scoped_not_prune(self):
+        # Teardown removes strictly by the run-id label and never prunes.
+        r = FakeRunner()
+        ContainerHandle("img", "run1", r).remove()
+        removed = [c for c in r.cmds if "docker rm -f" in c]
+        self.assertTrue(removed)
+        self.assertIn("--filter label=cvs_run_id=run1", removed[0])
+        self.assertNotIn("prune", removed[0])
+
+    def test_run_flattens_per_host_dict(self):
+        # A per-host dict result (Pssh) is flattened to one newline-joined string.
+        r = FakeRunner(output={"hostA": "out-a", "hostB": "out-b"})
+        self.assertEqual(ContainerHandle("img", "run1", r)._run("cmd"), "out-a\nout-b")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First group of the DTNI spine re-derivation (addendum §2 row **G1**) — the dependency-free leaves everything else imports:

- **`cvs/lib/failure_taxonomy.py`** — five disjoint, priority-ordered failure categories (setup / safety / failure-pattern / liveness / verification) + a `WorkloadFailure` base with one subclass per category + `category_of`. Failures are classified **at the raise site** (each subclass binds its category so the `Job` driver records `exc.category` directly), never by stack-trace inspection or console scraping; anything escaping outside a classified boundary maps to `setup_failure`.
- **`cvs/lib/runtime/container_handle.py`** — `ContainerHandle` context manager, reached through an injected `runner.exec` (duck-typed to `Pssh` or a local wrapper, so it is unit-testable with a fake):
  - non-privileged by default (`--privileged` / `seccomp=unconfined` are opt-in);
  - label-scoped teardown (`docker rm -f` filtered by `cvs_run_id`), never a global prune;
  - every interpolated spec field shell-quoted with `shlex.quote` at the build boundary; `command` / `extra_args` are the operator-authored **raw** trust boundary, passed through unquoted by design (**B8**);
  - `__enter__` applies the same teardown contract on its own failure path, so a failed launch / readiness timeout never leaks a container (`__exit__` does not run when `__enter__` raises).

**Security/redaction is intentionally not in this group** (removed entirely — addendum §4 B7 / §5 C4): no `lib/security/`, no `SecretValue`, no `redact_secrets`, no `--env-file`. Shell-injection quoting of command fields is unrelated and retained.

## Test plan

Offline, no GPU:

- `python -m unittest cvs.lib.unittests.test_dtni_runtime cvs.lib.unittests.test_dtni_failure_taxonomy` → **12 tests OK**
- `ruff check` + `ruff format --check` on the new files → clean
- `rg "docker system prune" cvs/lib/runtime` → no matches; `test_non_privileged_default` asserts the default-emitted command carries no `--privileged` / `seccomp=unconfined`; `test_injection_chars_quoted_in_run_command` covers per-field quoting

## Out of scope

G2+ (typed config / ContainerSpec, manifest, cluster/binder, lifecycle, surface, vertical) — separate groups per the addendum.