### PR TITLE
feat(config): typed v2 workload config spine (schema, thresholds, sweep, vLLM, migration)

### DIFF
--- a/cvs/lib/config/__init__.py
+++ b/cvs/lib/config/__init__.py
@@ -1,0 +1,55 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from cvs.lib.config.base import BaseTestConfig, ContainerSpec, Role, Topology
+from cvs.lib.config.loader import (
+    CONFIG_REGISTRY,
+    ConfigError,
+    load_config_file,
+    parse_config,
+    register_config,
+    validate_config,
+)
+from cvs.lib.config.sweep import SweepCell, SweepParams, expand_sweep
+from cvs.lib.config.thresholds import (
+    ConvergenceThreshold,
+    GoodputThreshold,
+    MonotonicityThreshold,
+    PercentileThreshold,
+    RateThreshold,
+    ResultView,
+    StabilityThreshold,
+    Threshold,
+    ThresholdUnion,
+    ThresholdVerdict,
+)
+
+__all__ = [
+    "BaseTestConfig",
+    "ContainerSpec",
+    "Role",
+    "Topology",
+    "CONFIG_REGISTRY",
+    "ConfigError",
+    "register_config",
+    "parse_config",
+    "validate_config",
+    "load_config_file",
+    "SweepParams",
+    "SweepCell",
+    "expand_sweep",
+    "Threshold",
+    "ThresholdUnion",
+    "ThresholdVerdict",
+    "ResultView",
+    "PercentileThreshold",
+    "RateThreshold",
+    "GoodputThreshold",
+    "MonotonicityThreshold",
+    "ConvergenceThreshold",
+    "StabilityThreshold",
+]

--- a/cvs/lib/config/base.py
+++ b/cvs/lib/config/base.py
@@ -1,0 +1,202 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from cvs.lib.config.thresholds import ThresholdUnion
+
+
+def _coerce_token(value: object) -> str:
+    """Fail-closed str coercion for a ``ContainerSpec`` token.
+
+    A wrong-typed value -- ``None`` (an empty YAML mapping value), a ``bool``,
+    a ``float``, a nested list/dict -- must error at load instead of silently
+    becoming ``"None"`` / ``"True"`` / ``"8888.0"`` and emitting a malformed
+    ``docker run`` arg. Only ``str``/``int``/``Path`` stringify: ``bool`` is
+    rejected even though it subclasses ``int``, and ``float`` is rejected
+    because the only tokens here are ports, device IDs, paths and env values --
+    a ``float`` ``8888.0`` is a mistyped port (``-p 8888.0:...``), never intent.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"container spec value must be a string, not a bool: {value!r}")
+    if isinstance(value, (str, int, Path)):
+        return str(value)
+    raise ValueError(f"container spec value must be str/int/path, got {type(value).__name__}: {value!r}")
+
+
+class Role(BaseModel):
+    """A workload role's hardware requirement, satisfied by the binder (W5).
+
+    Roles live in the *config* (the workload), not the cluster file (the
+    hardware pool). ``selector`` is a label query against ``node.labels``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    count: int = Field(ge=0)
+    gpus_per_node: int = Field(default=0, ge=0)
+    selector: Optional[str] = None
+
+
+class Topology(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # A workload with zero roles has nothing for the binder to place; reject it
+    # at load rather than producing an unschedulable config.
+    roles: Dict[str, Role] = Field(min_length=1)
+
+
+class ContainerSpec(BaseModel):
+    """Container runtime surface (A3): how the workload image is launched.
+
+    The fields map 1:1 onto :class:`cvs.lib.runtime.ContainerHandle` kwargs.
+    Every value that reaches the handle is a ``str`` -- dict keys and values
+    included -- because ``ContainerHandle.build_run_command`` quotes each token
+    with ``shlex.quote``, which raises ``TypeError`` on a non-``str`` rather than
+    coercing. The spec therefore owns the conversion: an ``int`` port or a
+    ``pathlib.Path`` host-path is stringified here (the ``mode="before"``
+    validators below), so a wrong-typed value can never silently produce a
+    malformed ``docker run``.
+
+    Site-specific host paths (e.g. the model-weight cache feeding ``volumes``)
+    are resolved from the cluster file at bind time (G4/G5), not baked into
+    per-framework params.
+
+    ``env`` carries container environment, including credentials such as the HF
+    token on closed/internal clusters. It is deliberately *excluded* from
+    ``workload_hash`` (see :meth:`BaseTestConfig.workload_hash`) so workload
+    identity does not depend on the token value.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    volumes: Dict[str, str] = Field(default_factory=dict)
+    devices: List[str] = Field(default_factory=list)
+    ports: Dict[str, str] = Field(default_factory=dict)
+    env: Dict[str, str] = Field(default_factory=dict)
+    shm_size: Optional[str] = None
+    ipc: Optional[str] = None
+    network: Optional[str] = None
+
+    @field_validator("volumes", "ports", "env", mode="before")
+    @classmethod
+    def _stringify_mapping(cls, value):
+        if isinstance(value, dict):
+            return {_coerce_token(k): _coerce_token(v) for k, v in value.items()}
+        return value
+
+    @field_validator("devices", mode="before")
+    @classmethod
+    def _stringify_list(cls, value):
+        if isinstance(value, list):
+            return [_coerce_token(v) for v in value]
+        return value
+
+    def to_handle_kwargs(self) -> Dict[str, object]:
+        """Return the ``ContainerHandle`` kwargs this spec populates.
+
+        Only set keys are returned for the optional scalars, so handle defaults
+        apply when the spec leaves them unset.
+        """
+        kwargs: Dict[str, object] = {
+            "volumes": dict(self.volumes),
+            "devices": list(self.devices),
+            "ports": dict(self.ports),
+            "env": dict(self.env),
+        }
+        if self.shm_size is not None:
+            kwargs["shm_size"] = self.shm_size
+        if self.ipc is not None:
+            kwargs["ipc"] = self.ipc
+        if self.network is not None:
+            kwargs["network"] = self.network
+        return kwargs
+
+
+def _stable_hash(payload: object) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+class BaseTestConfig(BaseModel):
+    """Common, framework-agnostic config surface.
+
+    ``extra="forbid"`` is the load-time typo gate: a misspelled key fails
+    ``model_validate`` immediately instead of silently defaulting and surfacing
+    20 minutes into a workload run. Concrete framework configs add typed
+    ``params`` and ``sweep`` fields.
+
+    No secret/redaction layer (W7 removed): container environment, including
+    tokens, rides in ``container.env`` and is recorded as-is. The hashes below
+    are plain deterministic JSON serializations.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Subclasses narrow ``framework`` to a Literal used as the dispatch key.
+    WORKLOAD_KIND: ClassVar[str] = "unknown"
+
+    schema_version: str = "2"
+    framework: str
+    target_gpu: str
+    model: str
+    cluster_ref: Optional[str] = None
+    seed: int = 0
+    knobs: Dict[str, str] = Field(default_factory=dict)
+    container: ContainerSpec = Field(default_factory=ContainerSpec)
+    topology: Topology
+    thresholds: List[ThresholdUnion] = Field(default_factory=list)
+    benchmarks: List[str] = Field(default_factory=list)
+
+    @property
+    def workload_kind(self) -> str:
+        return self.WORKLOAD_KIND
+
+    def _dump(self) -> dict:
+        # Deterministic JSON-mode serialization used by the hashes below. No
+        # secret handling (security removed): ``container.env`` is dumped as-is.
+        return self.model_dump(mode="json")
+
+    def workload_hash(self) -> str:
+        """Hash of workload-defining inputs (framework, model, target_gpu, seed, knobs, params, topology).
+
+        ``seed`` is included: a different seed produces different numerical
+        results, so two otherwise-identical configs are *not* the same workload
+        for result-comparison/caching purposes and must hash differently.
+
+        Deliberately excludes ``container`` (volumes/devices/env) so workload
+        identity is stable across sites and independent of the token value.
+        """
+        dump = self._dump()
+        payload = {
+            "framework": dump.get("framework"),
+            "model": dump.get("model"),
+            "target_gpu": dump.get("target_gpu"),
+            "seed": dump.get("seed"),
+            "knobs": dump.get("knobs"),
+            "params": dump.get("params"),
+            "sweep": dump.get("sweep"),
+            "topology": dump.get("topology"),
+        }
+        return _stable_hash(payload)
+
+    def verification_hash(self) -> str:
+        """Hash of verification inputs (thresholds + opted-in benchmarks)."""
+        dump = self._dump()
+        payload = {"thresholds": dump.get("thresholds"), "benchmarks": dump.get("benchmarks")}
+        return _stable_hash(payload)
+
+    def config_hash(self) -> str:
+        """Hash of the full resolved config (the exact config, env included)."""
+        return _stable_hash(self._dump())

--- a/cvs/lib/config/frameworks/__init__.py
+++ b/cvs/lib/config/frameworks/__init__.py
@@ -1,0 +1,13 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+# Importing each framework module registers its config class in CONFIG_REGISTRY.
+# Add a new framework by creating cvs/lib/config/frameworks/<name>.py and
+# importing it here.
+from cvs.lib.config.frameworks import vllm  # noqa: F401
+
+__all__ = ["vllm"]

--- a/cvs/lib/config/frameworks/vllm.py
+++ b/cvs/lib/config/frameworks/vllm.py
@@ -1,0 +1,104 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from cvs.lib.config.inference import InferenceTestConfig
+from cvs.lib.config.loader import register_config
+from cvs.lib.config.sweep import SweepParams
+
+
+class SeqCombo(BaseModel):
+    """One input/output sequence-length pairing. ``name`` becomes a cell ID token."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    isl: int = Field(gt=0)
+    osl: int = Field(gt=0)
+    name: Optional[str] = None
+
+
+class VllmParams(BaseModel):
+    """Static (non-swept) vLLM parameters.
+
+    Framework-specific knobs that used to be hardcoded in the shared inference
+    base (the AITER env flags) belong in the top-level ``knobs`` of the config,
+    not here; ``params`` is the invariant per-run configuration.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    server_script: str
+    bench_serv_script: str = "benchmark_serving.py"
+    backend: str = "vllm"
+    dataset_name: str = "random"
+    num_prompts: int = Field(default=3200, gt=0)
+    max_model_length: int = Field(default=9216, gt=0)
+    request_rate: str = "inf"
+    tokenizer_mode: str = "auto"
+    percentile_metrics: List[str] = Field(default_factory=lambda: ["ttft", "tpot", "itl", "e2el"])
+    metric_percentiles: int = 99
+    base_url: str = "http://0.0.0.0"
+    port_no: int = 8888
+    burstiness: float = 1.0
+    random_range_ratio: float = 0.8
+    random_prefix_len: int = 0
+    container_image: Optional[str] = None
+
+
+class VllmSweepParams(SweepParams):
+    """vLLM sweep axes.
+
+    ``concurrency`` is an inference-only axis; a training config that tried to
+    set it would be rejected by its own ``SweepParams`` (extra="forbid").
+    """
+
+    concurrency: List[int] = Field(min_length=1)
+    sequence_combinations: List[SeqCombo] = Field(min_length=1)
+    tensor_parallelism: Optional[List[int]] = None
+
+    @field_validator("concurrency")
+    @classmethod
+    def _positive_concurrency(cls, values: List[int]) -> List[int]:
+        if any(v <= 0 for v in values):
+            raise ValueError("concurrency levels must be positive")
+        return values
+
+
+@register_config("vllm")
+class VllmConfig(InferenceTestConfig):
+    """A single (vLLM, model) workload config."""
+
+    framework: Literal["vllm"] = "vllm"
+    params: VllmParams
+    sweep: VllmSweepParams
+
+    @model_validator(mode="after")
+    def _tp_consistent_with_topology(self) -> "VllmConfig":
+        """Reject a TP sweep that the fixed topology cannot satisfy.
+
+        For single-node vLLM serving, tensor parallelism *is* the number of GPUs
+        the server occupies, i.e. a role's ``gpus_per_node``. Since the topology
+        is fixed at bind time, every swept ``tensor_parallelism`` value must
+        equal some role's ``gpus_per_node``; otherwise the cells would demand a
+        GPU count the binder never allocates -- a silent mismatch.
+        """
+        tps = self.sweep.tensor_parallelism
+        if tps:
+            gpus = {role.gpus_per_node for role in self.topology.roles.values()}
+            mismatched = sorted({t for t in tps if t not in gpus})
+            if mismatched:
+                raise ValueError(
+                    f"sweep.tensor_parallelism {mismatched} matches no role gpus_per_node "
+                    f"{sorted(gpus)}; topology is fixed, so TP cannot be swept independently "
+                    f"of GPU allocation"
+                )
+        return self

--- a/cvs/lib/config/inference.py
+++ b/cvs/lib/config/inference.py
@@ -1,0 +1,22 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from cvs.lib.config.base import BaseTestConfig
+
+
+class InferenceTestConfig(BaseTestConfig):
+    """Common base for inference-kind configs (vLLM, sglang, inferencemax, ...).
+
+    Sweep axes such as ``concurrency`` are valid here and rejected for training
+    configs (enforced by each framework's typed ``SweepParams``).
+    """
+
+    WORKLOAD_KIND: ClassVar[str] = "inference"

--- a/cvs/lib/config/loader.py
+++ b/cvs/lib/config/loader.py
@@ -1,0 +1,134 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import os
+import re
+from pathlib import Path
+from typing import Dict, Type
+
+import yaml
+from pydantic import ValidationError
+
+from cvs.lib.config.base import BaseTestConfig
+
+# framework literal -> concrete config class. Populated by @register_config when
+# each framework module under cvs/lib/config/frameworks/ is imported.
+CONFIG_REGISTRY: Dict[str, Type[BaseTestConfig]] = {}
+
+_ENV_REF_RE = re.compile(r"^\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}$")
+_SENTINEL = "<changeme>"
+
+
+class ConfigError(Exception):
+    """Raised when a config cannot be parsed, dispatched, or validated."""
+
+
+def register_config(framework: str):
+    """Decorator: register a concrete config class under its ``framework`` key."""
+
+    def _wrap(cls: Type[BaseTestConfig]) -> Type[BaseTestConfig]:
+        CONFIG_REGISTRY[framework] = cls
+        return cls
+
+    return _wrap
+
+
+def _ensure_frameworks_loaded() -> None:
+    # Lazy import so loader has no import-time dependency on the framework
+    # modules (which import this module for @register_config).
+    import cvs.lib.config.frameworks  # noqa: F401
+
+
+def _resolve_placeholders(obj):
+    """Resolve ``{user-id}`` and ``${env:VAR}`` in string leaves; reject sentinels.
+
+    B3: an ``${env:VAR}`` whose variable is *absent* from the environment fails
+    closed with a :class:`ConfigError` -- distinguishing an unset required value
+    from a deliberately-empty one (``export VAR=`` resolves to ``""`` and is
+    allowed). This stops a missing credential from silently becoming ``""`` and
+    surfacing far downstream.
+    """
+    if isinstance(obj, dict):
+        return {k: _resolve_placeholders(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_resolve_placeholders(v) for v in obj]
+    if isinstance(obj, str):
+        if _SENTINEL in obj:
+            raise ConfigError(f"unresolved '{_SENTINEL}' sentinel in config value: {obj!r}")
+        env_match = _ENV_REF_RE.match(obj)
+        if env_match:
+            var = env_match.group(1)
+            if var not in os.environ:
+                raise ConfigError(f"required env var '${{env:{var}}}' is not set")
+            return os.environ[var]
+        # An embedded or malformed ``${env:...}`` would otherwise slip through
+        # unresolved (and unchecked for unset), defeating the fail-closed intent.
+        if "${env:" in obj:
+            raise ConfigError(
+                f"malformed env reference {obj!r}: only a whole-value '${{env:VAR}}' is supported, not an embedded one"
+            )
+        return obj.replace("{user-id}", getpass.getuser())
+    return obj
+
+
+def _resolve_class(raw: dict) -> Type[BaseTestConfig]:
+    """Validate the config root and dispatch on ``framework`` to its class."""
+    if not isinstance(raw, dict):
+        raise ConfigError("config root must be a mapping")
+    framework = raw.get("framework")
+    if framework is None:
+        raise ConfigError("config is missing required 'framework' field")
+    cls = CONFIG_REGISTRY.get(framework)
+    if cls is None:
+        known = ", ".join(sorted(CONFIG_REGISTRY)) or "<none>"
+        raise ConfigError(f"unknown framework {framework!r}; registered frameworks: {known}")
+    return cls
+
+
+def validate_config(raw: dict) -> BaseTestConfig:
+    """Dispatch + schema-validate WITHOUT resolving ``${env:...}`` / ``{user-id}``.
+
+    The migration tool uses this to fail fast on a structurally invalid output
+    (e.g. an empty sweep axis) at *conversion* time, without requiring deferred
+    secrets such as ``${env:HF_TOKEN}`` to be present in the migrating shell --
+    that is the whole point of deferring them. ``parse_config`` is the runtime
+    path that also resolves placeholders.
+    """
+    _ensure_frameworks_loaded()
+    cls = _resolve_class(raw)
+    try:
+        return cls.model_validate(raw)
+    except ValidationError as exc:
+        raise ConfigError(f"invalid {raw.get('framework')} config: {exc}") from exc
+
+
+def parse_config(raw: dict) -> BaseTestConfig:
+    """Dispatch on ``framework``, resolve placeholders, and validate."""
+    _ensure_frameworks_loaded()
+    cls = _resolve_class(raw)
+    resolved = _resolve_placeholders(raw)
+    try:
+        return cls.model_validate(resolved)
+    except ValidationError as exc:
+        raise ConfigError(f"invalid {raw.get('framework')} config: {exc}") from exc
+
+
+def load_config_file(path) -> BaseTestConfig:
+    """Load a v2 YAML (or JSON) config file into its typed config object."""
+    p = Path(path)
+    text = p.read_text()
+    if p.suffix in (".yaml", ".yml"):
+        raw = yaml.safe_load(text)
+    elif p.suffix == ".json":
+        raw = json.loads(text)
+    else:
+        raise ConfigError(f"unsupported config extension {p.suffix!r} (use .yaml or .json)")
+    return parse_config(raw)

--- a/cvs/lib/config/migrate.py
+++ b/cvs/lib/config/migrate.py
@@ -1,0 +1,168 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+One-shot JSON (v1) -> v2 YAML config migration. Splits a vLLM mega-config (many
+models in one file) into one typed config per (framework, model), converts the
+stringified ``result_dict`` lookups into typed Threshold predicates, stamps
+``schema_version: "2"`` and forbids ``<changeme>`` sentinels.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+from cvs.lib.config.loader import ConfigError, validate_config
+
+_SENTINEL = "<changeme>"
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+
+
+def _int(value, default=None):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _csv_list(value) -> List[str]:
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    if isinstance(value, str):
+        return [tok.strip() for tok in value.split(",") if tok.strip()]
+    return []
+
+
+def _thresholds_from_result_dict(result_dict: Dict) -> List[Dict]:
+    """Best-effort: floor throughput at the observed min, ceil latencies at max.
+
+    The per-cell v1 ``result_dict`` is lossy to map onto v2's config-global
+    predicates; the migrated thresholds are a safe envelope and should be
+    reviewed/tightened against a fresh baseline run.
+
+    C5: the v1 metrics are *means* (``mean_ttft_ms`` / ``mean_tpot_ms``). They
+    are emitted as honest scalar (``rate``-type) predicates on the same
+    mean-named metric -- never relabeled as a P99 percentile, which would claim
+    a tail guarantee the data does not support.
+
+    Contract for the adapter (vertical, out of G2 scope): a ``rate`` threshold
+    reads ``ResultView.scalar(metric)``, so the vLLM ``parse`` step must surface
+    scalars literally named ``mean_ttft_ms`` / ``mean_tpot_ms`` or these
+    migrated thresholds evaluate to ``actual=None -> passed=False``.
+    """
+    throughputs, ttfts, tpots = [], [], []
+    for entry in (result_dict or {}).values():
+        if not isinstance(entry, dict):
+            continue
+        if "total_throughput_per_sec" in entry:
+            throughputs.append(float(entry["total_throughput_per_sec"]))
+        if "mean_ttft_ms" in entry:
+            ttfts.append(float(entry["mean_ttft_ms"]))
+        if "mean_tpot_ms" in entry:
+            tpots.append(float(entry["mean_tpot_ms"]))
+    thresholds: List[Dict] = []
+    if throughputs:
+        thresholds.append(
+            {"type": "rate", "metric": "total_throughput", "op": ">=", "value": min(throughputs), "unit": "tok/s"}
+        )
+    if ttfts:
+        thresholds.append({"type": "rate", "metric": "mean_ttft_ms", "op": "<=", "value": max(ttfts), "unit": "ms"})
+    if tpots:
+        thresholds.append({"type": "rate", "metric": "mean_tpot_ms", "op": "<=", "value": max(tpots), "unit": "ms"})
+    return thresholds
+
+
+def _assert_no_sentinel(obj) -> None:
+    if isinstance(obj, dict):
+        for value in obj.values():
+            _assert_no_sentinel(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            _assert_no_sentinel(value)
+    elif isinstance(obj, str) and _SENTINEL in obj:
+        raise ValueError(f"refusing to migrate config containing '{_SENTINEL}' sentinel")
+
+
+def migrate_vllm_megaconfig(raw: Dict, target_gpu: str) -> Dict[str, Dict]:
+    """Return ``{model_slug: v2_config_dict}`` for a vLLM v1 mega-config.
+
+    The HF token is emitted as a deferred ``${env:HF_TOKEN}`` reference under
+    ``container.env`` (no secret/redaction layer; security removed). It is
+    resolved by the loader at parse time and rides inline as ``-e HF_TOKEN=...``
+    on closed/internal clusters.
+    """
+    _assert_no_sentinel(raw)
+    top = raw.get("config", {})
+    bench_params = raw.get("benchmark_params", {})
+    nnodes = _int(top.get("nnodes"), 1) or 1
+
+    out: Dict[str, Dict] = {}
+    for model_key, entry in bench_params.items():
+        tp = _int(entry.get("tensor_parallelism"), 1) or 1
+        seqs = []
+        for combo in entry.get("sequence_combinations", []):
+            seqs.append(
+                {
+                    "isl": _int(combo.get("isl")),
+                    "osl": _int(combo.get("osl")),
+                    "name": combo.get("name", f"isl{combo.get('isl')}_osl{combo.get('osl')}"),
+                }
+            )
+        v2 = {
+            "schema_version": "2",
+            "framework": "vllm",
+            "target_gpu": target_gpu,
+            "model": entry.get("model", model_key),
+            "seed": _int(entry.get("seed"), 0) or 0,
+            "knobs": {"backend": entry.get("backend", "vllm")},
+            "container": {"env": {"HF_TOKEN": "${env:HF_TOKEN}"}},
+            "params": {
+                "server_script": entry.get("server_script", f"{model_key}.sh"),
+                "bench_serv_script": entry.get("bench_serv_script", "benchmark_serving.py"),
+                "backend": entry.get("backend", "vllm"),
+                "container_image": entry.get("container_image", top.get("container_image")),
+                "dataset_name": entry.get("dataset_name", "random"),
+                "num_prompts": _int(entry.get("num_prompts"), 3200) or 3200,
+                "max_model_length": _int(entry.get("max_model_length"), 9216) or 9216,
+                "request_rate": str(entry.get("request_rate", "inf")),
+                "tokenizer_mode": entry.get("tokenizer_mode", "auto"),
+                "percentile_metrics": _csv_list(entry.get("percentile_metrics")) or ["ttft", "tpot", "itl", "e2el"],
+                "metric_percentiles": _int(entry.get("metric_percentiles"), 99) or 99,
+                "port_no": _int(entry.get("port_no"), 8888) or 8888,
+            },
+            # TP is represented once, as the server role's gpus_per_node. It is
+            # deliberately NOT also emitted as a sweep axis: the topology is
+            # fixed at bind time, so a swept TP would silently diverge from the
+            # GPUs actually allocated (and a single-value axis only adds a
+            # redundant '-tensor_parallelism<n>' token to every cell ID).
+            "topology": {"roles": {"server": {"count": nnodes, "gpus_per_node": tp, "selector": target_gpu}}},
+            "sweep": {
+                "concurrency": list(entry.get("concurrency_levels", [16, 32, 64])),
+                "sequence_combinations": seqs,
+            },
+            "thresholds": _thresholds_from_result_dict(entry.get("result_dict", {})),
+            "benchmarks": ["throughput", "ttft_mean"],
+        }
+        slug = _slug(model_key)
+        if slug in out:
+            raise ValueError(
+                f"model key {model_key!r} slugifies to {slug!r}, which already maps to "
+                f"another model; rename one of the source model keys so no workload is "
+                f"silently dropped"
+            )
+        # Fail fast at conversion time on a structurally invalid output (e.g. an
+        # empty sequence_combinations / concurrency axis) instead of surfacing it
+        # only when the file is loaded for a run days later. Schema-only: deferred
+        # ${env:...} values are not resolved here.
+        try:
+            validate_config(v2)
+        except ConfigError as exc:
+            raise ValueError(f"migrated config for model {model_key!r} is invalid: {exc}") from exc
+        out[slug] = v2
+    return out

--- a/cvs/lib/config/sweep.py
+++ b/cvs/lib/config/sweep.py
@@ -1,0 +1,127 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, Dict, List, Tuple
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SweepCell(BaseModel):
+    """One expanded point of a sweep: a concrete set of params plus a stable ID.
+
+    The ``id`` lowers directly to a pytest parametrize ID, so ``pytest -k`` and
+    ``--collect-only`` line up with what the binder and manifests report.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    params: Dict[str, Any]
+
+
+class SweepParams(BaseModel):
+    """Base for per-framework sweep axes.
+
+    Subclasses declare typed axes. Sweep semantics (matching
+    ``pytest.mark.parametrize``):
+
+    - A **scalar list** (``concurrency: [16, 32, 64]``) is one cartesian axis.
+    - A **list of objects** (``sequence_combinations: [{isl, osl, name}]``) is a
+      *paired* axis: the fields inside each object co-vary as a single option;
+      an optional ``name`` becomes that option's ID token.
+    - Axes cross cartesian-style against each other.
+    - A bare scalar is a fixed param applied to every cell (not an axis).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    def expand(self) -> List[SweepCell]:
+        return expand_sweep(self)
+
+
+def _is_scalar(value: Any) -> bool:
+    return isinstance(value, (int, float, str, bool))
+
+
+def _axis_from_value(key: str, value: Any) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Return (options, tokens) for one sweep key.
+
+    Each option is a dict merged into a cell's params; the matching token is a
+    fragment of the cell ID.
+    """
+    options: List[Dict[str, Any]] = []
+    tokens: List[str] = []
+    if isinstance(value, list) and value and all(isinstance(v, dict) for v in value):
+        # Paired axis: each object is one bundled option.
+        for idx, obj in enumerate(value):
+            merged = {k: v for k, v in obj.items() if k != "name"}
+            options.append(merged)
+            # ``name`` may be absent OR present-but-None (pydantic dumps an
+            # unset Optional as null), so a plain ``.get(key, default)`` would
+            # yield the literal token "None". Fall back to a positional token.
+            name = obj.get("name")
+            tokens.append(str(name) if name not in (None, "") else f"{key}{idx}")
+    elif isinstance(value, list) and value:
+        # Scalar cartesian axis.
+        for scalar in value:
+            options.append({key: scalar})
+            tokens.append(f"{key}{scalar}")
+    return options, tokens
+
+
+def expand_sweep(sweep: Any) -> List[SweepCell]:
+    """Expand a sweep (a :class:`SweepParams` or plain dict) into cells."""
+    raw: Dict[str, Any]
+    if isinstance(sweep, SweepParams):
+        raw = sweep.model_dump(mode="json")
+    elif isinstance(sweep, dict):
+        raw = dict(sweep)
+    elif sweep is None:
+        raw = {}
+    else:
+        raise TypeError(f"cannot expand sweep of type {type(sweep)!r}")
+
+    fixed: Dict[str, Any] = {}
+    axes: List[Tuple[List[Dict[str, Any]], List[str]]] = []
+
+    # Sort keys for deterministic axis ordering -> deterministic cell IDs.
+    for key in sorted(raw.keys()):
+        value = raw[key]
+        if value is None:
+            continue
+        if _is_scalar(value):
+            fixed[key] = value
+            continue
+        options, tokens = _axis_from_value(key, value)
+        if options:
+            axes.append((options, tokens))
+
+    if not axes:
+        return [SweepCell(id="default", params=dict(fixed))]
+
+    option_lists = [opts for opts, _ in axes]
+    token_lists = [toks for _, toks in axes]
+
+    cells: List[SweepCell] = []
+    for combo_idx in itertools.product(*[range(len(opts)) for opts in option_lists]):
+        params: Dict[str, Any] = dict(fixed)
+        id_tokens: List[str] = []
+        for axis_pos, opt_idx in enumerate(combo_idx):
+            params.update(option_lists[axis_pos][opt_idx])
+            id_tokens.append(token_lists[axis_pos][opt_idx])
+        cells.append(SweepCell(id="-".join(id_tokens), params=params))
+    ids = [c.id for c in cells]
+    if len(set(ids)) != len(ids):
+        dupes = sorted({i for i in ids if ids.count(i) > 1})
+        raise ValueError(
+            f"sweep expansion produced duplicate cell IDs {dupes}; cell IDs must be "
+            f"unique (check for repeated scalar values or duplicate sequence names)"
+        )
+    return cells

--- a/cvs/lib/config/thresholds.py
+++ b/cvs/lib/config/thresholds.py
@@ -1,0 +1,345 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import operator
+import re
+from typing import Callable, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing_extensions import Annotated
+
+# Comparison operators. Every threshold carries an explicit ``op`` so the
+# comparison direction is *never* inferred from the metric name (the old
+# substring-"ms" heuristic flipped the comparison for any metric whose name
+# happened to contain those letters, e.g. ``latency_seconds``).
+_OPS: Dict[str, Callable[[float, float], bool]] = {
+    ">=": operator.ge,
+    "<=": operator.le,
+    ">": operator.gt,
+    "<": operator.lt,
+    "==": operator.eq,
+    "!=": operator.ne,
+}
+
+OpLiteral = Literal[">=", "<=", ">", "<", "==", "!="]
+
+_WHERE_RE = re.compile(r"^\s*(>=|<=|==|!=|>|<)\s*([-+]?\d*\.?\d+)\s*$")
+
+
+def _percentile(values: List[float], pct: float) -> Optional[float]:
+    """Linear-interpolation percentile (pct in [0, 100]). None if no data."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    frac = rank - low
+    return float(ordered[low] + (ordered[high] - ordered[low]) * frac)
+
+
+class ResultView:
+    """Read-only view over a workload's parsed results, consumed by thresholds.
+
+    Decouples threshold evaluation from how results are stored. An adapter's
+    ``parse`` step populates one of these from framework-native telemetry:
+
+    - ``scalars`` : derived single-value metrics (e.g. ``total_throughput``,
+      ``elapsed_s``).
+    - ``samples`` : long list of per-request/sample dicts (e.g. ttft_ms, tpot_ms).
+    - ``trajectory`` : long-format rows ``{step, metric, value, role, host}``.
+    """
+
+    def __init__(
+        self,
+        scalars: Optional[Dict[str, float]] = None,
+        samples: Optional[List[Dict[str, float]]] = None,
+        trajectory: Optional[List[Dict[str, object]]] = None,
+    ) -> None:
+        self.scalars = scalars or {}
+        self.samples = samples or []
+        self.trajectory = trajectory or []
+
+    def scalar(self, name: str) -> Optional[float]:
+        value = self.scalars.get(name)
+        return None if value is None else float(value)
+
+    def sample_values(self, metric: str) -> List[float]:
+        out = []
+        for row in self.samples:
+            if metric in row and row[metric] is not None:
+                out.append(float(row[metric]))
+        return out
+
+    def series(self, metric: str, role: Optional[str] = None) -> List[float]:
+        rows = [r for r in self.trajectory if r.get("metric") == metric]
+        if role is not None:
+            rows = [r for r in rows if r.get("role") == role]
+        rows = sorted(rows, key=lambda r: r.get("step", 0))
+        return [float(r["value"]) for r in rows if r.get("value") is not None]
+
+
+class ThresholdVerdict(BaseModel):
+    """Outcome of evaluating one threshold. Persisted verbatim into the manifest."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    threshold_type: str
+    metric: Optional[str] = None
+    op: Optional[str] = None
+    expected: Optional[float] = None
+    actual: Optional[float] = None
+    margin: Optional[float] = None
+    passed: bool
+    detail: Optional[str] = None
+
+
+class Threshold(BaseModel):
+    """Base for the typed threshold predicates."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def evaluate(self, view: ResultView) -> ThresholdVerdict:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class PercentileThreshold(Threshold):
+    """Percentile of a per-sample metric, e.g. P99 TTFT <= 50 ms."""
+
+    type: Literal["percentile"] = "percentile"
+    metric: str
+    # Bounded at load: an out-of-range percentile is an operator typo, not a
+    # runtime condition. Without this, ``percentile > 100`` indexes past the end
+    # of the sorted samples (IndexError mid-run) and ``percentile < 0`` silently
+    # returns a value below the data -- a bogus pass/fail with no error.
+    percentile: float = Field(default=99.0, ge=0, le=100)
+    op: OpLiteral
+    value: float
+    unit: Optional[str] = None
+
+    def evaluate(self, view: ResultView) -> ThresholdVerdict:
+        actual = _percentile(view.sample_values(self.metric), self.percentile)
+        passed = actual is not None and _OPS[self.op](actual, self.value)
+        return ThresholdVerdict(
+            threshold_type=self.type,
+            metric=self.metric,
+            op=self.op,
+            expected=self.value,
+            actual=actual,
+            margin=None if actual is None else actual - self.value,
+            passed=passed,
+            detail=None if actual is not None else f"no samples for metric '{self.metric}'",
+        )
+
+
+class RateThreshold(Threshold):
+    """Derived rate scalar, e.g. throughput >= 1200 tokens/sec."""
+
+    type: Literal["rate"] = "rate"
+    metric: str
+    op: OpLiteral
+    value: float
+    unit: Optional[str] = None
+
+    def evaluate(self, view: ResultView) -> ThresholdVerdict:
+        actual = view.scalar(self.metric)
+        passed = actual is not None and _OPS[self.op](actual, self.value)
+        return ThresholdVerdict(
+            threshold_type=self.type,
+            metric=self.metric,
+            op=self.op,
+            expected=self.value,
+            actual=actual,
+            margin=None if actual is None else actual - self.value,
+            passed=passed,
+            detail=None if actual is not None else f"no scalar '{self.metric}'",
+        )
+
+
+class GoodputThreshold(Threshold):
+    """MLPerf-shaped filtered rate: requests/sec meeting per-sample SLAs.
+
+    ``where`` maps a sample metric to a constraint string like ``"<=200"``.
+    Goodput = (# samples satisfying every constraint) / ``elapsed_s`` scalar.
+
+    B2: ``where`` is validated at load (the field validator below) so a
+    malformed constraint fails closed with a clear error instead of silently
+    filtering every sample out and reporting goodput 0.
+    """
+
+    type: Literal["goodput"] = "goodput"
+    op: OpLiteral
+    value: float
+    where: Dict[str, str] = Field(default_factory=dict)
+    elapsed_scalar: str = "elapsed_s"
+    unit: Optional[str] = None
+
+    @field_validator("where")
+    @classmethod
+    def _validate_where(cls, value: Dict[str, str]) -> Dict[str, str]:
+        for metric, constraint in value.items():
+            if not _WHERE_RE.match(constraint):
+                raise ValueError(
+                    f"malformed goodput constraint for metric '{metric}': {constraint!r} "
+                    f"(expected e.g. '<=200', '>= 1.5')"
+                )
+        return value
+
+    def _passes_filters(self, row: Dict[str, float]) -> bool:
+        for metric, constraint in self.where.items():
+            match = _WHERE_RE.match(constraint)
+            if not match:
+                return False
+            op_str, bound = match.group(1), float(match.group(2))
+            sample = row.get(metric)
+            if sample is None or not _OPS[op_str](float(sample), bound):
+                return False
+        return True
+
+    def evaluate(self, view: ResultView) -> ThresholdVerdict:
+        elapsed = view.scalar(self.elapsed_scalar)
+        good = sum(1 for row in view.samples if self._passes_filters(row))
+        actual = (good / elapsed) if elapsed else None
+        passed = actual is not None and _OPS[self.op](actual, self.value)
+        return ThresholdVerdict(
+            threshold_type=self.type,
+            metric="goodput",
+            op=self.op,
+            expected=self.value,
+            actual=actual,
+            margin=None if actual is None else actual - self.value,
+            passed=passed,
+            detail=None if actual is not None else f"missing '{self.elapsed_scalar}' scalar",
+        )
+
+
+class MonotonicityThreshold(Threshold):
+    """Trajectory monotonicity over a trailing window, e.g. loss non-increasing.
+
+    ``window`` is the trailing fraction (0, 1] of the series to inspect.
+    ``tolerance`` permits small reversals (noise) before declaring a violation.
+
+    B1: the not-enough-data guard is on the *windowed tail*, not the full
+    series. A small ``window`` can carve a length-1 tail out of a long series;
+    the pairwise loop would then never run and a vacuous pass would be reported.
+    """
+
+    type: Literal["monotonicity"] = "monotonicity"
+    metric: str
+    direction: Literal["non_increasing", "non_decreasing"] = "non_increasing"
+    window: float = Field(default=0.25, gt=0, le=1)
+    tolerance: float = 0.0
+    role: Optional[str] = None
+
+    def evaluate(self, view: ResultView) -> ThresholdVerdict:
+        series = view.series(self.metric, self.role)
+        tail = series[max(0, int(len(series) * (1.0 - self.window))) :]
+        if len(tail) < 2:
+            return ThresholdVerdict(
+                threshold_type=self.type,
+                metric=self.metric,
+                passed=False,
+                detail=f"not enough trajectory points in window for '{self.metric}'",
+            )
+        worst = 0.0
+        for prev, cur in zip(tail, tail[1:]):
+            delta = cur - prev
+            step_violation = delta if self.direction == "non_increasing" else -delta
+            worst = max(worst, step_violation)
+        passed = worst <= self.tolerance
+        return ThresholdVerdict(
+            threshold_type=self.type,
+            metric=self.metric,
+            op="<=",
+            expected=self.tolerance,
+            actual=worst,
+            margin=worst - self.tolerance,
+            passed=passed,
+            detail=f"direction={self.direction} window={self.window}",
+        )
+
+
+class ConvergenceThreshold(Threshold):
+    """Series reaches ``target`` +/- ``epsilon`` by ``by_step`` (if set)."""
+
+    type: Literal["convergence"] = "convergence"
+    metric: str
+    target: float
+    epsilon: float
+    # Same class of bug as PercentileThreshold.percentile: a by_step < 1 is
+    # meaningless and would slice the series from the wrong end (``series[:0]``
+    # -> vacuous, ``series[:-k]`` -> silently drops the tail).
+    by_step: Optional[int] = Field(default=None, ge=1)
+    role: Optional[str] = None
+
+    def evaluate(self, view: ResultView) -> ThresholdVerdict:
+        series = view.series(self.metric, self.role)
+        window = series if self.by_step is None else series[: self.by_step]
+        converged = any(abs(v - self.target) <= self.epsilon for v in window)
+        final = window[-1] if window else None
+        return ThresholdVerdict(
+            threshold_type=self.type,
+            metric=self.metric,
+            op="~=",
+            expected=self.target,
+            actual=final,
+            margin=None if final is None else final - self.target,
+            passed=converged,
+            detail=f"epsilon={self.epsilon} by_step={self.by_step}",
+        )
+
+
+class StabilityThreshold(Threshold):
+    """Rolling variance bound over a per-sample metric or trajectory series."""
+
+    type: Literal["stability"] = "stability"
+    metric: str
+    max_variance: float
+    source: Literal["samples", "trajectory"] = "samples"
+    role: Optional[str] = None
+
+    def evaluate(self, view: ResultView) -> ThresholdVerdict:
+        data = view.sample_values(self.metric) if self.source == "samples" else view.series(self.metric, self.role)
+        if len(data) < 2:
+            return ThresholdVerdict(
+                threshold_type=self.type,
+                metric=self.metric,
+                passed=False,
+                detail=f"not enough data for '{self.metric}'",
+            )
+        mean = sum(data) / len(data)
+        variance = sum((x - mean) ** 2 for x in data) / len(data)
+        passed = variance <= self.max_variance
+        return ThresholdVerdict(
+            threshold_type=self.type,
+            metric=self.metric,
+            op="<=",
+            expected=self.max_variance,
+            actual=variance,
+            margin=variance - self.max_variance,
+            passed=passed,
+            detail=f"source={self.source}",
+        )
+
+
+# Discriminated union: the ``type`` field selects the concrete predicate, and
+# extra="forbid" on each member turns a misspelled field into a load-time error.
+ThresholdUnion = Annotated[
+    Union[
+        PercentileThreshold,
+        RateThreshold,
+        GoodputThreshold,
+        MonotonicityThreshold,
+        ConvergenceThreshold,
+        StabilityThreshold,
+    ],
+    Field(discriminator="type"),
+]

--- a/cvs/lib/config/training.py
+++ b/cvs/lib/config/training.py
@@ -1,0 +1,24 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from cvs.lib.config.base import BaseTestConfig
+
+
+class TrainingTestConfig(BaseTestConfig):
+    """Common base for training-kind configs (megatron, jax, ...).
+
+    Provided in the spine so the discriminated-union machinery and markers are
+    exercised by the contract even though no real training adapter ships in v1.
+    Sweep axes such as ``parallelism_combos`` belong here and are rejected for
+    inference configs.
+    """
+
+    WORKLOAD_KIND: ClassVar[str] = "training"

--- a/cvs/lib/unittests/test_dtni_config.py
+++ b/cvs/lib/unittests/test_dtni_config.py
@@ -1,0 +1,335 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import os
+import unittest
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from cvs.lib.config import ContainerSpec, expand_sweep, parse_config
+from cvs.lib.config.loader import ConfigError
+from cvs.lib.config.thresholds import (
+    ConvergenceThreshold,
+    GoodputThreshold,
+    MonotonicityThreshold,
+    PercentileThreshold,
+    RateThreshold,
+    ResultView,
+    StabilityThreshold,
+)
+from cvs.lib.runtime.container_handle import ContainerHandle
+
+BASE = {
+    "schema_version": "2",
+    "framework": "vllm",
+    "target_gpu": "mi300",
+    "model": "meta-llama/Llama-3.1-70B",
+    "topology": {"roles": {"server": {"count": 1, "gpus_per_node": 8}}},
+    "container": {"env": {"HF_TOKEN": "hf_secret_abc"}},
+    "params": {"server_script": "s.sh"},
+    "sweep": {"concurrency": [16, 64], "sequence_combinations": [{"isl": 1024, "osl": 1024, "name": "balanced"}]},
+}
+
+
+class TestConfigValidation(unittest.TestCase):
+    def test_accepts_valid(self):
+        cfg = parse_config(BASE)
+        self.assertEqual(cfg.framework, "vllm")
+        self.assertEqual(cfg.workload_kind, "inference")
+
+    def test_rejects_unknown_framework(self):
+        with self.assertRaises(ConfigError):
+            parse_config({**BASE, "framework": "vlm"})
+
+    def test_rejects_extra_key(self):
+        with self.assertRaises(ConfigError):
+            parse_config({**BASE, "bogus": 1})
+
+    def test_workload_hash_excludes_container_env(self):
+        # Security removed: the token lives in container.env (plaintext). It
+        # must NOT be workload-defining, so workload_hash ignores `container`...
+        a = parse_config(BASE)
+        b = parse_config({**BASE, "container": {"env": {"HF_TOKEN": "different"}}})
+        self.assertEqual(a.workload_hash(), b.workload_hash())
+        # ...but it IS retained (config_hash distinguishes it), proving the env
+        # is not simply dropped everywhere; verification identity is unaffected.
+        self.assertNotEqual(a.config_hash(), b.config_hash())
+        self.assertEqual(a.verification_hash(), b.verification_hash())
+
+    def test_seed_is_workload_defining(self):
+        # A different seed yields different numerical results, so it must change
+        # workload identity (otherwise two runs collide in any hash-keyed cache).
+        a = parse_config(BASE)
+        b = parse_config({**BASE, "seed": 7})
+        self.assertNotEqual(a.workload_hash(), b.workload_hash())
+        self.assertNotEqual(a.config_hash(), b.config_hash())
+
+
+class TestSweepExpansion(unittest.TestCase):
+    def test_cartesian_times_paired(self):
+        cfg = parse_config(BASE)
+        cells = expand_sweep(cfg.sweep)
+        self.assertEqual(len(cells), 2)
+        ids = {c.id for c in cells}
+        self.assertEqual(ids, {"concurrency16-balanced", "concurrency64-balanced"})
+
+    def test_paired_bundle_fields_covary(self):
+        cfg = parse_config(
+            {
+                **BASE,
+                "sweep": {
+                    "concurrency": [16],
+                    "sequence_combinations": [
+                        {"isl": 1024, "osl": 1024, "name": "balanced"},
+                        {"isl": 8192, "osl": 1024, "name": "long_context"},
+                    ],
+                },
+            }
+        )
+        cells = {c.id: c.params for c in expand_sweep(cfg.sweep)}
+        self.assertEqual(cells["concurrency16-long_context"]["isl"], 8192)
+
+    def test_unnamed_combos_get_unique_positional_tokens(self):
+        cfg = parse_config(
+            {
+                **BASE,
+                "sweep": {
+                    "concurrency": [16],
+                    "sequence_combinations": [{"isl": 1, "osl": 1}, {"isl": 2, "osl": 2}],
+                },
+            }
+        )
+        ids = [c.id for c in expand_sweep(cfg.sweep)]
+        self.assertEqual(len(ids), len(set(ids)))
+        self.assertNotIn("concurrency16-None", ids)
+
+    def test_duplicate_cell_ids_raise(self):
+        with self.assertRaises(ValueError):
+            expand_sweep({"concurrency": [16, 16], "sequence_combinations": [{"isl": 1, "osl": 1, "name": "a"}]})
+
+
+class TestThresholds(unittest.TestCase):
+    def test_percentile_explicit_op(self):
+        view = ResultView(samples=[{"ttft_ms": x} for x in [10, 20, 30, 40, 200]])
+        ok = PercentileThreshold(metric="ttft_ms", percentile=50, op="<=", value=100).evaluate(view)
+        self.assertTrue(ok.passed)
+        bad = PercentileThreshold(metric="ttft_ms", percentile=99, op="<=", value=50).evaluate(view)
+        self.assertFalse(bad.passed)
+
+    def test_rate(self):
+        view = ResultView(scalars={"total_throughput": 1500})
+        self.assertTrue(RateThreshold(metric="total_throughput", op=">=", value=1200).evaluate(view).passed)
+
+    def test_goodput_filtered(self):
+        samples = [{"ttft_ms": 100, "tpot_ms": 10} for _ in range(8)] + [{"ttft_ms": 999, "tpot_ms": 99}]
+        view = ResultView(scalars={"elapsed_s": 1.0}, samples=samples)
+        verdict = GoodputThreshold(op=">=", value=8, where={"ttft_ms": "<=300", "tpot_ms": "<=40"}).evaluate(view)
+        self.assertEqual(verdict.actual, 8.0)
+        self.assertTrue(verdict.passed)
+
+    def test_convergence_full_vs_by_step(self):
+        traj = [{"step": i, "metric": "loss", "value": v} for i, v in enumerate([5.0, 1.0, 0.05])]
+        view = ResultView(trajectory=traj)
+        self.assertTrue(ConvergenceThreshold(metric="loss", target=0.0, epsilon=0.1).evaluate(view).passed)
+        # by_step=2 only inspects [5.0, 1.0] -> never within epsilon -> not converged.
+        early = ConvergenceThreshold(metric="loss", target=0.0, epsilon=0.1, by_step=2).evaluate(view)
+        self.assertFalse(early.passed)
+
+    def test_stability_variance_and_thin_data(self):
+        steady = ResultView(samples=[{"ttft_ms": 10.0} for _ in range(5)])
+        self.assertTrue(StabilityThreshold(metric="ttft_ms", max_variance=1.0).evaluate(steady).passed)
+        noisy = ResultView(samples=[{"ttft_ms": v} for v in [1.0, 100.0, 1.0, 100.0]])
+        self.assertFalse(StabilityThreshold(metric="ttft_ms", max_variance=1.0).evaluate(noisy).passed)
+        thin = StabilityThreshold(metric="ttft_ms", max_variance=1.0).evaluate(ResultView(samples=[{"ttft_ms": 10.0}]))
+        self.assertFalse(thin.passed)
+        self.assertIn("not enough", thin.detail)
+
+    def test_missing_data_verdicts(self):
+        empty = ResultView()
+        for verdict in (
+            RateThreshold(metric="total_throughput", op=">=", value=1).evaluate(empty),
+            PercentileThreshold(metric="ttft_ms", op="<=", value=1).evaluate(empty),
+            GoodputThreshold(op=">=", value=1, where={"ttft_ms": "<=1"}).evaluate(empty),
+        ):
+            self.assertFalse(verdict.passed)
+            self.assertIsNone(verdict.actual)
+
+
+THRESHOLD_TYPES = [
+    {"type": "rate", "metric": "total_throughput", "op": ">=", "value": 1000},
+    {"type": "percentile", "metric": "ttft_ms", "percentile": 99, "op": "<=", "value": 50},
+    {"type": "goodput", "op": ">=", "value": 8, "where": {"ttft_ms": "<=300"}},
+    {"type": "monotonicity", "metric": "loss", "direction": "non_increasing"},
+    {"type": "convergence", "metric": "loss", "target": 0.0, "epsilon": 0.1},
+    {"type": "stability", "metric": "ttft_ms", "max_variance": 5.0},
+]
+
+
+class TestThresholdUnionParsing(unittest.TestCase):
+    """The discriminated union is the core G2 parsing contract; exercise it via
+    parse_config (not just direct construction) so the discriminator and each
+    member's extra="forbid" are actually covered."""
+
+    def test_all_threshold_types_round_trip(self):
+        cfg = parse_config({**BASE, "thresholds": THRESHOLD_TYPES})
+        self.assertEqual(
+            [t.type for t in cfg.thresholds],
+            ["rate", "percentile", "goodput", "monotonicity", "convergence", "stability"],
+        )
+
+    def test_unknown_threshold_type_rejected(self):
+        with self.assertRaises(ConfigError):
+            parse_config({**BASE, "thresholds": [{"type": "bogus", "metric": "x"}]})
+
+    def test_misspelled_threshold_field_rejected(self):
+        bad = {"type": "rate", "metric": "x", "op": ">=", "value": 1, "bogus": 2}
+        with self.assertRaises(ConfigError):
+            parse_config({**BASE, "thresholds": [bad]})
+
+    def test_b2_malformed_where_rejected_via_config(self):
+        bad = {"type": "goodput", "op": ">=", "value": 1, "where": {"ttft_ms": "garbage"}}
+        with self.assertRaises(ConfigError):
+            parse_config({**BASE, "thresholds": [bad]})
+
+
+class TestThresholdBakeIns(unittest.TestCase):
+    def test_b1_monotonicity_guards_windowed_tail(self):
+        # series len 3, window 0.25 -> tail = last 1 point. Pre-fix this would
+        # vacuously pass (empty pairwise loop); post-fix it is not-enough-data.
+        traj = [{"step": i, "metric": "loss", "value": v} for i, v in enumerate([3.0, 2.0, 1.0])]
+        verdict = MonotonicityThreshold(metric="loss", window=0.25).evaluate(ResultView(trajectory=traj))
+        self.assertFalse(verdict.passed)
+        self.assertIn("not enough", verdict.detail)
+
+    def test_b1_monotonicity_still_evaluates_full_window(self):
+        traj = [{"step": i, "metric": "loss", "value": v} for i, v in enumerate([5.0, 4.0, 3.0, 2.0, 1.0])]
+        verdict = MonotonicityThreshold(metric="loss", window=1.0).evaluate(ResultView(trajectory=traj))
+        self.assertTrue(verdict.passed)
+
+    def test_b2_goodput_rejects_malformed_where_at_load(self):
+        with self.assertRaises(ValidationError):
+            GoodputThreshold(op=">=", value=8, where={"ttft_ms": "garbage"})
+
+    def test_b2_goodput_accepts_wellformed_where(self):
+        GoodputThreshold(op=">=", value=8, where={"ttft_ms": "<=300", "tpot_ms": ">= 1.5"})
+
+
+class TestLoaderEnv(unittest.TestCase):
+    def test_b3_unset_env_raises(self):
+        os.environ.pop("DTNI_TEST_MISSING", None)
+        self.addCleanup(os.environ.pop, "DTNI_TEST_MISSING", None)
+        cfg = {**BASE, "container": {"env": {"HF_TOKEN": "${env:DTNI_TEST_MISSING}"}}}
+        with self.assertRaises(ConfigError):
+            parse_config(cfg)
+
+    def test_b3_empty_env_allowed(self):
+        os.environ["DTNI_TEST_EMPTY"] = ""
+        self.addCleanup(os.environ.pop, "DTNI_TEST_EMPTY", None)
+        cfg = parse_config({**BASE, "container": {"env": {"HF_TOKEN": "${env:DTNI_TEST_EMPTY}"}}})
+        self.assertEqual(cfg.container.env["HF_TOKEN"], "")
+
+    def test_b3_embedded_env_ref_rejected(self):
+        os.environ["DTNI_TEST_SET"] = "x"
+        self.addCleanup(os.environ.pop, "DTNI_TEST_SET", None)
+        cfg = {**BASE, "params": {"server_script": "run ${env:DTNI_TEST_SET}.sh"}}
+        with self.assertRaises(ConfigError):
+            parse_config(cfg)
+
+
+class TestContainerSpecA3(unittest.TestCase):
+    def test_stringifies_non_str_values(self):
+        spec = ContainerSpec(ports={8888: 8888}, volumes={Path("/weights"): "/models"}, devices=[0, 1])
+        self.assertEqual(spec.ports, {"8888": "8888"})
+        self.assertEqual(spec.volumes, {"/weights": "/models"})
+        self.assertEqual(spec.devices, ["0", "1"])
+
+    def test_feeds_container_handle_without_typeerror(self):
+        # A3 contract: the spec owns str conversion, so ContainerHandle's
+        # shlex.quote (which raises TypeError on non-str) emits a clean command.
+        spec = ContainerSpec(ports={8888: 8888}, env={"HF_TOKEN": "tok"})
+        handle = ContainerHandle(image="img:tag", run_id="r1", runner=_FakeRunner(), **spec.to_handle_kwargs())
+        cmd = handle.build_run_command()
+        self.assertIn("8888:8888", cmd)
+        self.assertIn("HF_TOKEN=tok", cmd)
+
+    def test_rejects_non_token_values(self):
+        # Fail-closed: None/bool/list must error at load, never become
+        # "None"/"True"/"['x']" and emit a malformed docker arg.
+        for bad in ({"X": None}, {"X": True}, {"X": ["a"]}):
+            with self.assertRaises(ValidationError):
+                ContainerSpec(env=bad)
+        with self.assertRaises(ValidationError):
+            ContainerSpec(devices=[None])
+
+    def test_handle_fails_closed_on_raw_non_str(self):
+        # The other half of the contract: bypass the spec and feed the handle a
+        # non-str directly -> shlex.quote raises rather than emitting a bad arg.
+        handle = ContainerHandle(image="i", run_id="r", runner=_FakeRunner(), ports={8888: 8888})
+        with self.assertRaises(TypeError):
+            handle.build_run_command()
+
+
+class TestNumericFieldBounds(unittest.TestCase):
+    """Operator-authored numeric fields must be range-checked at load, not
+    indexed/sliced blindly at evaluate time (the percentile IndexError class)."""
+
+    def test_percentile_out_of_range_rejected_directly(self):
+        for bad in (150, -5, 100.1):
+            with self.assertRaises(ValidationError):
+                PercentileThreshold(metric="x", percentile=bad, op="<=", value=1)
+
+    def test_percentile_out_of_range_rejected_via_config(self):
+        for bad in (150, -5):
+            thr = {"type": "percentile", "metric": "x", "op": "<=", "value": 1, "percentile": bad}
+            with self.assertRaises(ConfigError):
+                parse_config({**BASE, "thresholds": [thr]})
+
+    def test_percentile_boundaries_accepted(self):
+        for ok in (0, 99, 100):
+            PercentileThreshold(metric="x", percentile=ok, op="<=", value=1)
+
+    def test_convergence_by_step_must_be_positive(self):
+        for bad in (0, -1):
+            with self.assertRaises(ValidationError):
+                ConvergenceThreshold(metric="loss", target=0.0, epsilon=0.1, by_step=bad)
+        ConvergenceThreshold(metric="loss", target=0.0, epsilon=0.1, by_step=1)
+
+
+class TestTopologyAndTpConsistency(unittest.TestCase):
+    def test_empty_roles_rejected(self):
+        with self.assertRaises(ConfigError):
+            parse_config({**BASE, "topology": {"roles": {}}})
+
+    def test_tp_matching_gpus_per_node_accepted(self):
+        # BASE server role has gpus_per_node=8.
+        cfg = parse_config({**BASE, "sweep": {**BASE["sweep"], "tensor_parallelism": [8]}})
+        self.assertEqual(cfg.sweep.tensor_parallelism, [8])
+
+    def test_tp_diverging_from_topology_rejected(self):
+        with self.assertRaises(ConfigError):
+            parse_config({**BASE, "sweep": {**BASE["sweep"], "tensor_parallelism": [4]}})
+
+
+class TestContainerSpecRejectsFloat(unittest.TestCase):
+    def test_float_token_rejected(self):
+        # A float port (8888.0) would stringify to a malformed "-p 8888.0:..".
+        with self.assertRaises(ValidationError):
+            ContainerSpec(ports={8888.0: 8888})
+        with self.assertRaises(ValidationError):
+            ContainerSpec(env={"RATIO": 0.8})
+        with self.assertRaises(ValidationError):
+            ContainerSpec(devices=[0.5])
+
+
+class _FakeRunner:
+    def exec(self, cmd, timeout=None):
+        return ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/unittests/test_dtni_migrate.py
+++ b/cvs/lib/unittests/test_dtni_migrate.py
@@ -1,0 +1,158 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import os
+import unittest
+
+from cvs.lib.config.loader import parse_config
+from cvs.lib.config.migrate import migrate_vllm_megaconfig
+
+MEGA = {
+    "config": {"nnodes": "1", "container_image": "img:tag"},
+    "benchmark_params": {
+        "gpt-oss-120b": {
+            "backend": "vllm",
+            "model": "openai/gpt-oss-120b",
+            "concurrency_levels": [16, 32],
+            "sequence_combinations": [{"isl": "1024", "osl": "1024", "name": "balanced"}],
+            "tensor_parallelism": "1",
+            "num_prompts": "3200",
+            "max_model_length": "9216",
+            "percentile_metrics": "ttft,tpot,itl,e2el",
+            "server_script": "gpt.sh",
+            "result_dict": {
+                "ISL=1024,OSL=1024,TP=1,CONC=16": {
+                    "total_throughput_per_sec": "4651",
+                    "mean_ttft_ms": "70",
+                    "mean_tpot_ms": "8",
+                }
+            },
+        },
+        "qwen3-80b": {
+            "backend": "vllm",
+            "model": "Qwen/Qwen3-Next-80B",
+            "concurrency_levels": [16],
+            "sequence_combinations": [{"isl": "8192", "osl": "1024", "name": "long_context"}],
+            "tensor_parallelism": "8",
+            "server_script": "qwen.sh",
+            "result_dict": {},
+        },
+    },
+}
+
+
+class TestMigrate(unittest.TestCase):
+    def setUp(self):
+        # Migrated configs reference ${env:HF_TOKEN}; B3 fails closed if unset,
+        # so provide it for the parse round-trip and restore afterwards.
+        self._prev_token = os.environ.get("HF_TOKEN")
+        os.environ["HF_TOKEN"] = "hf_test_token"
+
+    def tearDown(self):
+        if self._prev_token is None:
+            os.environ.pop("HF_TOKEN", None)
+        else:
+            os.environ["HF_TOKEN"] = self._prev_token
+
+    def test_splits_per_model_and_validates(self):
+        migrated = migrate_vllm_megaconfig(MEGA, target_gpu="mi355x")
+        self.assertEqual(set(migrated), {"gpt_oss_120b", "qwen3_80b"})
+        for v2 in migrated.values():
+            cfg = parse_config(v2)  # round-trips through the typed schema
+            self.assertEqual(cfg.framework, "vllm")
+            self.assertEqual(cfg.schema_version, "2")
+
+    def test_result_dict_becomes_honest_thresholds(self):
+        migrated = migrate_vllm_megaconfig(MEGA, target_gpu="mi355x")
+        thresholds = migrated["gpt_oss_120b"]["thresholds"]
+        by_metric = {t["metric"]: t for t in thresholds}
+        # Throughput floors at the observed min; latencies ceil at the max.
+        self.assertEqual((by_metric["total_throughput"]["op"], by_metric["total_throughput"]["value"]), (">=", 4651.0))
+        self.assertEqual((by_metric["mean_ttft_ms"]["op"], by_metric["mean_ttft_ms"]["value"]), ("<=", 70.0))
+        self.assertEqual(by_metric["mean_tpot_ms"]["op"], "<=")
+        # C5: a v1 mean is never relabeled as a P99 percentile.
+        self.assertFalse(any(t["type"] == "percentile" for t in thresholds))
+        self.assertFalse(any("percentile" in t for t in thresholds))
+
+    def test_empty_result_dict_yields_no_thresholds(self):
+        migrated = migrate_vllm_megaconfig(MEGA, target_gpu="mi355x")
+        self.assertEqual(migrated["qwen3_80b"]["thresholds"], [])
+
+    def test_emits_token_into_container_env_not_secrets(self):
+        migrated = migrate_vllm_megaconfig(MEGA, target_gpu="mi355x")
+        gpt = migrated["gpt_oss_120b"]
+        self.assertEqual(gpt["container"]["env"]["HF_TOKEN"], "${env:HF_TOKEN}")
+        self.assertNotIn("secrets", gpt)
+
+    def test_rejects_changeme_sentinel(self):
+        bad = {"config": {"hf_token_file": "<changeme>"}, "benchmark_params": {}}
+        with self.assertRaises(ValueError):
+            migrate_vllm_megaconfig(bad, target_gpu="mi300")
+
+    def test_topology_gpus_from_tp(self):
+        migrated = migrate_vllm_megaconfig(MEGA, target_gpu="mi355x")
+        self.assertEqual(migrated["qwen3_80b"]["topology"]["roles"]["server"]["gpus_per_node"], 8)
+
+    def test_tp_is_not_a_sweep_axis(self):
+        # TP lives once, in topology.gpus_per_node; it is not also a sweep axis
+        # (which would both diverge from the fixed topology and add a redundant
+        # cell-ID token).
+        migrated = migrate_vllm_megaconfig(MEGA, target_gpu="mi355x")
+        self.assertNotIn("tensor_parallelism", migrated["gpt_oss_120b"]["sweep"])
+
+
+class TestMigrateFailsClosed(unittest.TestCase):
+    """Migration must fail at conversion time on inputs that would otherwise
+    silently lose a workload or emit a config that only breaks when loaded.
+
+    These need no HF_TOKEN: migration self-validates schema-only, so the
+    deferred ``${env:HF_TOKEN}`` is never resolved here."""
+
+    def test_slug_collision_raises_not_drops(self):
+        # 'gpt-oss' and 'gpt_oss' both slugify to 'gpt_oss'; pre-fix the second
+        # silently overwrote the first.
+        mega = {
+            "config": {"nnodes": "1"},
+            "benchmark_params": {
+                "gpt-oss": {
+                    "model": "x",
+                    "concurrency_levels": [1],
+                    "sequence_combinations": [{"isl": "1", "osl": "1"}],
+                    "server_script": "s.sh",
+                    "result_dict": {},
+                },
+                "gpt_oss": {
+                    "model": "y",
+                    "concurrency_levels": [2],
+                    "sequence_combinations": [{"isl": "2", "osl": "2"}],
+                    "server_script": "s.sh",
+                    "result_dict": {},
+                },
+            },
+        }
+        with self.assertRaises(ValueError):
+            migrate_vllm_megaconfig(mega, target_gpu="mi300")
+
+    def test_empty_axis_rejected_at_migration_not_at_load(self):
+        mega = {
+            "config": {"nnodes": "1"},
+            "benchmark_params": {
+                "bad": {
+                    "model": "z",
+                    "concurrency_levels": [1],
+                    "sequence_combinations": [],
+                    "server_script": "s.sh",
+                    "result_dict": {},
+                },
+            },
+        }
+        with self.assertRaises(ValueError):
+            migrate_vllm_megaconfig(mega, target_gpu="mi300")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces the typed **v2 workload-config spine** under `cvs/lib/config/` (G2). No existing code consumes it yet — this is foundation for the DTNI refactor, landed in layered, independently reviewable commits.

- **Threshold engine** (`thresholds.py`): discriminated-union predicates (`rate`, `percentile`, `goodput`, `monotonicity`, `convergence`, `stability`) over a read-only `ResultView`. Every threshold carries an explicit `op` (comparison direction is never inferred from the metric name), and operator-authored numeric fields are range-bounded at load (`percentile` 0–100, `by_step` ≥ 1) so a typo fails validation instead of indexing out of range mid-run.
- **Base config** (`base.py`): `BaseTestConfig` / `ContainerSpec` with `extra="forbid"` as the load-time typo gate. `ContainerSpec` fail-closes on non-str tokens (rejects `bool`/`float`) so a wrong-typed value can't emit a malformed `docker` arg. `workload_hash` excludes `container.env` (token-independent, site-stable identity) but includes `seed`; `config_hash` covers the exact resolved config.
- **Sweep** (`sweep.py`): expands scalar (cartesian) and paired (co-varying) axes into `SweepCell`s with deterministic IDs that lower to pytest parametrize IDs; rejects duplicate cell IDs.
- **Loader/registry** (`loader.py`, `__init__.py`): `parse_config` dispatches on `framework`, resolves `{user-id}` / whole-value `${env:VAR}` (fails closed on unset/malformed), then validates. `validate_config` does the same without placeholder resolution for callers that must not require deferred secrets.
- **Framework layer** (`inference.py`, `training.py`, `frameworks/vllm.py`): workload-kind bases + the vLLM config/params/sweep, registered under `"vllm"`. A model validator rejects a `tensor_parallelism` sweep that no role's `gpus_per_node` can satisfy (keeps TP consistent with the fixed topology).
- **Migration** (`migrate.py`): one-shot v1 JSON mega-config → one typed v2 config per model; converts the lossy `result_dict` into honest scalar thresholds (a v1 *mean* is never relabeled as a P99); fails closed on `<changeme>` sentinels, slug collisions, and structurally invalid output.

## Test plan

- [x] `python -m unittest cvs.lib.unittests.test_dtni_config cvs.lib.unittests.test_dtni_migrate` — 47/47 pass (run in a venv with `pydantic>=2`).
- [x] `ruff check` + `ruff format --check` clean on all new files.
- [x] Tests exercise the contract through `parse_config` (not just direct construction) and include adversarial boundary/invalid/degenerate cases: out-of-range percentile, non-positive `by_step`, float/None/bool container tokens, empty topology, TP/topology divergence, slug collision, empty sweep axis.

## Notes / open items

- **Unconsumed spine:** the adapter-facing contracts (e.g. `ResultView.scalar("mean_ttft_ms")`, the migrated threshold metric names) are documented but **unenforced** until an adapter exists — that is the next PR's primary risk.
- **`seed` in `workload_hash`:** deliberate behavior choice (different seed = different workload identity). One line to revert if the team intends seed to be non-identifying.
- **Migration deferral:** the migration commit (`98dab38`) is self-contained. Its envelope thresholds can only be validated/tightened against a real baseline, so it may be preferable to land it alongside the first validation run rather than here. Drop with `git reset --soft HEAD~1` if deferring.