### PR TITLE
fix(config): fail closed on three inputs that slipped past load

### DIFF
--- a/cvs/lib/config/loader.py
+++ b/cvs/lib/config/loader.py
@@ -86,6 +86,12 @@ def _resolve_class(raw: dict) -> Type[BaseTestConfig]:
     framework = raw.get("framework")
     if framework is None:
         raise ConfigError("config is missing required 'framework' field")
+    # Guard the type before the registry lookup: an unhashable ``framework``
+    # (list/dict) would make ``CONFIG_REGISTRY.get(framework)`` raise a raw
+    # TypeError that escapes the ConfigError contract, and a non-str (int/bool)
+    # can never match a registered key anyway.
+    if not isinstance(framework, str):
+        raise ConfigError(f"'framework' must be a string, got {type(framework).__name__}")
     cls = CONFIG_REGISTRY.get(framework)
     if cls is None:
         known = ", ".join(sorted(CONFIG_REGISTRY)) or "<none>"

--- a/cvs/lib/config/migrate.py
+++ b/cvs/lib/config/migrate.py
@@ -39,6 +39,22 @@ def _csv_list(value) -> List[str]:
     return []
 
 
+def _result_float(metric: str, value) -> float:
+    """Coerce a v1 ``result_dict`` value to float, failing loud at conversion.
+
+    Unlike ``_int`` (which defaults), a non-numeric threshold target must NOT be
+    silently dropped -- that would drop the derived threshold and lose the
+    guarantee. Raise a clear ValueError naming the metric instead of letting the
+    bare ``float()`` error escape mid-derivation.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"result_dict metric {metric!r} has non-numeric value {value!r}; cannot derive a threshold from it"
+        ) from exc
+
+
 def _thresholds_from_result_dict(result_dict: Dict) -> List[Dict]:
     """Best-effort: floor throughput at the observed min, ceil latencies at max.
 
@@ -61,11 +77,11 @@ def _thresholds_from_result_dict(result_dict: Dict) -> List[Dict]:
         if not isinstance(entry, dict):
             continue
         if "total_throughput_per_sec" in entry:
-            throughputs.append(float(entry["total_throughput_per_sec"]))
+            throughputs.append(_result_float("total_throughput_per_sec", entry["total_throughput_per_sec"]))
         if "mean_ttft_ms" in entry:
-            ttfts.append(float(entry["mean_ttft_ms"]))
+            ttfts.append(_result_float("mean_ttft_ms", entry["mean_ttft_ms"]))
         if "mean_tpot_ms" in entry:
-            tpots.append(float(entry["mean_tpot_ms"]))
+            tpots.append(_result_float("mean_tpot_ms", entry["mean_tpot_ms"]))
     thresholds: List[Dict] = []
     if throughputs:
         thresholds.append(

--- a/cvs/lib/config/thresholds.py
+++ b/cvs/lib/config/thresholds.py
@@ -236,7 +236,10 @@ class MonotonicityThreshold(Threshold):
     metric: str
     direction: Literal["non_increasing", "non_decreasing"] = "non_increasing"
     window: float = Field(default=0.25, gt=0, le=1)
-    tolerance: float = 0.0
+    # Allowed reversal magnitude; must be non-negative. A negative tolerance makes
+    # ``worst <= tolerance`` unsatisfiable even for a perfectly monotonic series
+    # (worst is >= 0), so every run would fail with no error -- reject at load.
+    tolerance: float = Field(default=0.0, ge=0)
     role: Optional[str] = None
 
     def evaluate(self, view: ResultView) -> ThresholdVerdict:
@@ -273,7 +276,10 @@ class ConvergenceThreshold(Threshold):
     type: Literal["convergence"] = "convergence"
     metric: str
     target: float
-    epsilon: float
+    # Tolerance band around ``target``; must be non-negative. A negative epsilon
+    # makes ``abs(v - target) <= epsilon`` unsatisfiable, so the series can never
+    # converge regardless of the data -- a silent always-fail. Reject at load.
+    epsilon: float = Field(ge=0)
     # Same class of bug as PercentileThreshold.percentile: a by_step < 1 is
     # meaningless and would slice the series from the wrong end (``series[:0]``
     # -> vacuous, ``series[:-k]`` -> silently drops the tail).
@@ -302,7 +308,10 @@ class StabilityThreshold(Threshold):
 
     type: Literal["stability"] = "stability"
     metric: str
-    max_variance: float
+    # Variance is always >= 0, so a negative bound can never be satisfied and
+    # would fail every run with no error. Reject at load (0 means "require a
+    # perfectly constant series").
+    max_variance: float = Field(ge=0)
     source: Literal["samples", "trajectory"] = "samples"
     role: Optional[str] = None
 

--- a/cvs/lib/config/unittests/test_loader.py
+++ b/cvs/lib/config/unittests/test_loader.py
@@ -36,6 +36,15 @@ class TestConfigDispatch(unittest.TestCase):
         with self.assertRaises(ConfigError):
             parse_config({**make_base(), "framework": "vlm"})
 
+    def test_rejects_non_string_framework_as_configerror(self):
+        # A non-str framework must fail closed as ConfigError. An unhashable
+        # value (list/dict) previously leaked a raw TypeError from the registry
+        # dict.get(); int/bool can never match a registered key.
+        for bad in ([], {}, 1, True):
+            with self.subTest(framework=bad):
+                with self.assertRaises(ConfigError):
+                    parse_config({**make_base(), "framework": bad})
+
     def test_rejects_extra_key(self):
         for framework, base in iter_bases():
             with self.subTest(framework=framework):

--- a/cvs/lib/config/unittests/test_migrate.py
+++ b/cvs/lib/config/unittests/test_migrate.py
@@ -166,6 +166,25 @@ class TestMigrateFailsClosed(unittest.TestCase):
         with self.assertRaises(ValueError):
             migrate_vllm_megaconfig(mega, target_gpu="mi300")
 
+    def test_nonnumeric_result_value_fails_loud_with_context(self):
+        # A non-numeric result_dict target must abort migration with a clear,
+        # metric-named error -- not a bare float() ValueError mid-derivation, and
+        # never a silently-dropped threshold.
+        mega = {
+            "config": {"nnodes": "1"},
+            "benchmark_params": {
+                "bad": {
+                    "model": "z",
+                    "concurrency_levels": [1],
+                    "sequence_combinations": [{"isl": "1", "osl": "1"}],
+                    "server_script": "s.sh",
+                    "result_dict": {"c1": {"total_throughput_per_sec": "n/a"}},
+                },
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "total_throughput_per_sec"):
+            migrate_vllm_megaconfig(mega, target_gpu="mi300")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/lib/config/unittests/test_thresholds.py
+++ b/cvs/lib/config/unittests/test_thresholds.py
@@ -178,6 +178,35 @@ class TestNumericFieldBounds(unittest.TestCase):
                 ConvergenceThreshold(metric="loss", target=0.0, epsilon=0.1, by_step=bad)
         ConvergenceThreshold(metric="loss", target=0.0, epsilon=0.1, by_step=1)
 
+    def test_negative_bounds_rejected_at_load(self):
+        # A negative tolerance/epsilon/max_variance is never satisfiable (the
+        # measured quantity is >= 0), so it would silently fail every run rather
+        # than erroring. It must be rejected at construction, like percentile.
+        with self.assertRaises(ValidationError):
+            MonotonicityThreshold(metric="loss", tolerance=-0.1)
+        with self.assertRaises(ValidationError):
+            ConvergenceThreshold(metric="loss", target=0.0, epsilon=-0.1)
+        with self.assertRaises(ValidationError):
+            StabilityThreshold(metric="ttft_ms", max_variance=-1.0)
+
+    def test_zero_bounds_accepted(self):
+        # Zero is the meaningful strict edge (exact match / perfectly constant),
+        # so the lower bound is inclusive.
+        MonotonicityThreshold(metric="loss", tolerance=0.0)
+        ConvergenceThreshold(metric="loss", target=0.0, epsilon=0.0)
+        StabilityThreshold(metric="ttft_ms", max_variance=0.0)
+
+    def test_negative_bounds_rejected_via_config(self):
+        for framework, base in iter_bases():
+            for thr in (
+                {"type": "convergence", "metric": "loss", "target": 0.0, "epsilon": -0.1},
+                {"type": "stability", "metric": "ttft_ms", "max_variance": -1.0},
+                {"type": "monotonicity", "metric": "loss", "tolerance": -0.1},
+            ):
+                with self.subTest(framework=framework, threshold=thr["type"]):
+                    with self.assertRaises(ConfigError):
+                        parse_config({**base, "thresholds": [thr]})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

An adversarial review of the DTNI config-path unit tests (the suites restructured in #198) surfaced three inputs that were accepted at load and only misbehaved — or crashed — later. Each is fixed at the load boundary with a regression test that is red against the unfixed code.

- **`loader.py`** — a non-string `framework` (e.g. an unhashable `[]`/`{}`) leaked a raw `TypeError` out of `CONFIG_REGISTRY.get(...)` instead of the `ConfigError` contract. Now type-guarded before the registry lookup.
- **`thresholds.py`** — negative `tolerance` / `epsilon` / `max_variance` are unsatisfiable (the measured quantity is `>= 0`), so they silently failed *every* run with no error. Now bounded `ge=0` at load, matching the existing `percentile` / `by_step` discipline.
- **`migrate.py`** — a non-numeric `result_dict` value escaped as a bare `float()` `ValueError` mid-derivation. Now wrapped in a clear, metric-named error so a derived threshold is never silently dropped.

No behavior change for valid configs; these only tighten rejection of malformed input at the right layer.

## Test plan

- [x] `make test` — ruff format-check + lint clean, sdist build, `395` unittests OK, all CVS CLI tests pass.
- [x] New regression tests added: `test_rejects_non_string_framework_as_configerror` (loader); `test_negative_bounds_rejected_at_load` / `test_zero_bounds_accepted` / `test_negative_bounds_rejected_via_config` (thresholds); `test_nonnumeric_result_value_fails_loud_with_context` (migrate).
- [x] Mutation gate: reverting only the source fixes (keeping the new tests) turns all three red, confirming they fail for the real bug.