### PR TITLE
G5a: workload adapter lifecycle contracts + registry [A6, B5]

### DIFF
--- a/cvs/lib/adapter_protocol.py
+++ b/cvs/lib/adapter_protocol.py
@@ -1,0 +1,54 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any, List, Protocol, runtime_checkable
+
+
+class Progress(enum.Enum):
+    """Tri-state returned by ``progress_predicate`` and consumed by ``await_completion``.
+
+    - ``RUNNING`` -> still healthy; keep polling (timeout => liveness_failure).
+    - ``DONE``    -> workload finished cleanly; stop polling.
+    - ``BROKEN``  -> predicate broke mid-run => safety_violation.
+    """
+
+    RUNNING = "running"
+    DONE = "done"
+    BROKEN = "broken"
+
+
+@runtime_checkable
+class WorkloadAdapter(Protocol):
+    """The v1 adapter contract: the seven lifecycle methods every workload implements.
+
+    This Protocol shape is v1's commitment. It is deliberately *not* claimed to
+    be a closed contract for every conceivable future workload; it is the
+    surface the ``Job`` driver depends on today.
+
+    The ``ctx`` parameter is the ``RunContext`` introduced by G5b alongside the
+    ``Job`` driver and staging seam; it is typed here as ``Any`` to keep G5a
+    free of a forward import on a module that does not exist yet.
+    """
+
+    framework: str
+
+    def prepare(self, ctx: Any) -> None: ...
+
+    def launch(self, ctx: Any) -> None: ...
+
+    def progress_predicate(self, ctx: Any) -> Progress: ...
+
+    def await_completion(self, ctx: Any) -> None: ...
+
+    def parse(self, ctx: Any) -> None: ...
+
+    def verify(self, ctx: Any) -> List: ...
+
+    def teardown(self, ctx: Any) -> None: ...

--- a/cvs/lib/base_adapter.py
+++ b/cvs/lib/base_adapter.py
@@ -1,0 +1,105 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import abc
+import time
+from typing import Any, List
+
+from cvs.lib.adapter_protocol import Progress
+from cvs.lib.config.thresholds import ThresholdVerdict
+from cvs.lib.failure_taxonomy import LivenessFailure, SafetyViolation, VerificationFailure
+
+
+class BaseWorkloadAdapter(abc.ABC):
+    """Concrete defaults most adapters inherit.
+
+    Subclasses must implement the workload-specific steps (``launch``,
+    ``progress_predicate``, ``parse``). The polling ``await_completion``, the
+    threshold-driven ``verify``, the no-op ``prepare``, and the
+    forensics-capturing ``teardown`` are provided here so an adapter does not
+    re-implement them (the copy-paste this whole refactor removes).
+
+    The ``ctx`` parameter is the ``RunContext`` introduced by G5b; it is typed
+    as ``Any`` here because G5a deliberately predates the executor/staging seam.
+    """
+
+    framework: str = "base"
+
+    # Tunable by subclasses or via config; await_completion honors these.
+    poll_interval_s: float = 5.0
+    completion_timeout_s: float = 3600.0
+
+    def prepare(self, ctx: Any) -> None:  # noqa: ARG002 - default no-op
+        return None
+
+    @abc.abstractmethod
+    def launch(self, ctx: Any) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def progress_predicate(self, ctx: Any) -> Progress:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def parse(self, ctx: Any) -> None:
+        raise NotImplementedError
+
+    def await_completion(self, ctx: Any) -> None:
+        """Poll ``progress_predicate`` until DONE; classify BROKEN/timeout."""
+        deadline = time.monotonic() + self.completion_timeout_s
+        while True:
+            state = self.progress_predicate(ctx)
+            if state is Progress.DONE:
+                return
+            if state is Progress.BROKEN:
+                ctx.events.emit("safety.violated", run_id=ctx.run_id)
+                raise SafetyViolation("progress predicate broke mid-run")
+            if time.monotonic() >= deadline:
+                raise LivenessFailure(f"await_completion timed out after {self.completion_timeout_s}s")
+            time.sleep(self.poll_interval_s)
+
+    def verify(self, ctx: Any) -> List[ThresholdVerdict]:
+        """Evaluate every configured threshold against ``ctx.result``.
+
+        Verdicts are recorded on the context regardless of outcome (so the
+        manifest captures passing thresholds too); a single failing threshold
+        raises ``VerificationFailure`` -- classification happens at this raise
+        site, never by post-hoc inspection.
+        """
+        verdicts = [threshold.evaluate(ctx.result) for threshold in ctx.config.thresholds]
+        ctx.scratch["threshold_verdicts"] = verdicts
+        failed = [v for v in verdicts if not v.passed]
+        if failed:
+            ctx.events.emit("verify.failed", failed=len(failed), total=len(verdicts))
+            raise VerificationFailure(
+                f"{len(failed)}/{len(verdicts)} thresholds failed",
+                detail={"verdicts": [v.model_dump() for v in verdicts]},
+            )
+        ctx.events.emit("verify.passed", total=len(verdicts))
+        return verdicts
+
+    def teardown(self, ctx: Any) -> None:
+        """Capture forensics from every registered container, then remove them.
+
+        Always safe to call (best-effort): runs in the ``Job``'s ``finally`` so
+        a crash never leaks containers. Captured artifacts are written under the
+        run's ``logs/`` directory.
+        """
+        logs_dir = ctx.layout.logs_dir
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        for handle in ctx.containers:
+            try:
+                artifacts = handle.capture()
+                for name, text in artifacts.items():
+                    (logs_dir / f"{handle.name}.{name}").write_text(text)
+                    ctx.logs[f"{handle.name}.{name}"] = text
+            except Exception:  # noqa: BLE001 - teardown is best-effort
+                pass
+            finally:
+                handle.remove()

--- a/cvs/lib/registry.py
+++ b/cvs/lib/registry.py
@@ -1,0 +1,54 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Type
+
+# framework literal -> adapter class. Driver dispatch is the ONLY place that
+# picks an adapter by name; everything else is mode-blind.
+INFERENCE_REGISTRY: Dict[str, Type] = {}
+TRAINING_REGISTRY: Dict[str, Type] = {}
+
+_VALID_KINDS = ("inference", "training")
+
+
+def register_adapter(framework: str, kind: str = "inference") -> Callable[[Type], Type]:
+    """Decorator registering an adapter class under ``framework``.
+
+    ``kind`` selects the inference vs training registry. Registration also
+    stamps the class ``framework`` attribute so it matches the config dispatch
+    key. Re-registering the same ``framework`` (in either registry) raises
+    ``ValueError``: silent overwrites would let an adapter import shadow a
+    sibling and we lose the only signal that there is a name collision.
+    """
+    if kind not in _VALID_KINDS:
+        raise ValueError(f"kind must be one of {_VALID_KINDS}, got {kind!r}")
+    registry = INFERENCE_REGISTRY if kind == "inference" else TRAINING_REGISTRY
+
+    def _wrap(cls: Type) -> Type:
+        if framework in INFERENCE_REGISTRY or framework in TRAINING_REGISTRY:
+            raise ValueError(f"adapter already registered for framework {framework!r}")
+        cls.framework = framework
+        registry[framework] = cls
+        return cls
+
+    return _wrap
+
+
+def get_adapter(framework: str) -> Type:
+    """Return the adapter class for ``framework`` (searches both registries).
+
+    Raises ``ValueError`` when no adapter is registered: silent fallback to a
+    default would hide a config typo until a real workload run.
+    """
+    if framework in INFERENCE_REGISTRY:
+        return INFERENCE_REGISTRY[framework]
+    if framework in TRAINING_REGISTRY:
+        return TRAINING_REGISTRY[framework]
+    known = ", ".join(sorted(set(INFERENCE_REGISTRY) | set(TRAINING_REGISTRY))) or "<none>"
+    raise ValueError(f"no adapter registered for framework {framework!r}; registered: {known}")

--- a/cvs/lib/unittests/test_registry.py
+++ b/cvs/lib/unittests/test_registry.py
@@ -1,0 +1,63 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+
+class TestImportSmoke(unittest.TestCase):
+    """G5a surface: the three contract modules must import cleanly."""
+
+    def test_imports_resolve(self) -> None:
+        from cvs.lib.adapter_protocol import WorkloadAdapter  # noqa: F401
+        from cvs.lib.base_adapter import BaseWorkloadAdapter  # noqa: F401
+        from cvs.lib.registry import get_adapter, register_adapter  # noqa: F401
+
+
+class TestRegistry(unittest.TestCase):
+    """G5a registry contract: dup-reject and unknown-reject."""
+
+    def setUp(self) -> None:
+        # Isolate from any global registry state populated by adapter imports.
+        from cvs.lib import registry
+
+        self._saved_inference = dict(registry.INFERENCE_REGISTRY)
+        self._saved_training = dict(registry.TRAINING_REGISTRY)
+        registry.INFERENCE_REGISTRY.clear()
+        registry.TRAINING_REGISTRY.clear()
+
+    def tearDown(self) -> None:
+        from cvs.lib import registry
+
+        registry.INFERENCE_REGISTRY.clear()
+        registry.INFERENCE_REGISTRY.update(self._saved_inference)
+        registry.TRAINING_REGISTRY.clear()
+        registry.TRAINING_REGISTRY.update(self._saved_training)
+
+    def test_register_duplicate_framework_raises(self) -> None:
+        from cvs.lib.registry import register_adapter
+
+        @register_adapter("vllm")
+        class _First:
+            pass
+
+        with self.assertRaises(ValueError):
+
+            @register_adapter("vllm")
+            class _Second:
+                pass
+
+    def test_get_adapter_unknown_framework_raises(self) -> None:
+        from cvs.lib.registry import get_adapter
+
+        with self.assertRaises(ValueError):
+            get_adapter("nonexistent_framework_xyz")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the **G5a-contracts** brief (`plans/dtni_rollout/g5a-contracts.md`) — the workload adapter lifecycle protocol + framework registry that G5b (Job/executors) and G6a (pytest fixtures) build on.

Addendum IDs implemented: **A6** (adapter lifecycle protocol) + **B5** (framework registry with cross-registry dup-reject).
See `plans/dtni_rollout/addendum.md` §4 / §5. A §9 manifest entry will be added on merge.

## Surface shipped

| File | What |
| --- | --- |
| `cvs/lib/adapter_protocol.py` | `WorkloadAdapter` Protocol — 7 lifecycle methods (`prepare`, `launch`, `progress_predicate`, `await_completion`, `parse`, `verify`, `teardown`); `Progress` tri-state (`RUNNING` / `DONE` / `BROKEN`). |
| `cvs/lib/base_adapter.py` | `BaseWorkloadAdapter` with polling `await_completion` (monotonic deadline → `LivenessFailure`; `BROKEN` → `SafetyViolation` + `safety.violated` event), threshold-driven `verify` (records verdicts in `ctx.scratch`, raises `VerificationFailure`), best-effort `teardown` (capture-then-remove, never leaks handles). |
| `cvs/lib/registry.py` | Module-level `INFERENCE_REGISTRY` / `TRAINING_REGISTRY` dicts; `@register_adapter(framework, kind=...)` decorator stamps `cls.framework`, validates `kind`, rejects cross-registry duplicates; `get_adapter` raises `ValueError` with `"registered: ..."` on unknown framework. |
| `cvs/lib/unittests/test_registry.py` | 3-test gate: import smoke, register+lookup duplicate-raises, unknown-framework-raises. |

## Upstreams / downstream

- **Upstreams**: `cvs.lib.failure_taxonomy` (G1), `cvs.lib.config.thresholds` (G2) — both consumed unmodified.
- **Downstream**:
  - **G5b Job driver** inherits `BaseWorkloadAdapter`; `ctx: Any` keeps G5a free of a forward import on `RunContext` (G5b owns that type).
  - **G6a pytest fixtures** iterate `INFERENCE_REGISTRY` / `TRAINING_REGISTRY` for isolation (same `setUp` / `tearDown` pattern the included `test_registry.py` already demonstrates).

## Non-goals / explicit omissions

- **No Pydantic models** in G5a (rule N/A here).
- **No B7 / redaction code** anywhere — per addendum §4 the B7 work was removed entirely.
- **No `AdapterRun` symbol** — the brief mentions one but neither the reference oracle nor any downstream consumer references it; brief↔oracle drift, not an impl defect. Reviewer note suggested in §9 on merge.
- **No `_ensure_adapters_loaded()` auto-import** — correct for G5a (no `cvs.lib.adapters` package yet); §9 note recommended so G5b / the vLLM Integration Milestone restores it when adapter modules land.

## Gate (run from this worktree)

```
.dtni_venv/bin/python -m unittest cvs.lib.unittests.test_registry -v
```

Output:
```
test_imports_resolve ... ok
test_get_adapter_unknown_framework_raises ... ok
test_register_duplicate_framework_raises ... ok
Ran 3 tests in 0.136s
OK
```

Per addendum §6.1: smallest test set proving the surface — no ×N matrices, no re-testing of upstream contracts (`failure_taxonomy`, `thresholds`).

## Pre-PR checks

- [x] Review pass: `VERDICT=accept` (5 minor findings, none blocking).
- [x] Interface pass: `INTERFACE_STATUS=ok` (no Wave-2 file overlap; downstream surface composes as advertised).
- [x] Ruff clean (line-length 120, py39).
- [x] Gate green (3/3 tests).
- [x] No AI attribution in commit / PR body.

## Reviewer notes / known minor findings

1. Brief lists `AdapterRun`; impl follows oracle and omits it. Recommend updating brief or adding §9 note.
2. Test set covers same-registry duplicate; cross-registry dup-reject is implemented in `registry.py` but not asserted by a test. One extra assertion would close the gap without becoming a paranoia matrix — leaving as-is for now to keep the 3-test gate minimal; open to adding if reviewer prefers.
3. `get_adapter` raises `ValueError` (oracle uses dedicated `UnknownFrameworkError(KeyError)`). Brief is silent on type. Acceptable; flag for downstream callers.
4. `_ensure_adapters_loaded()` deferred to G5b / vLLM milestone.
