### PR TITLE
G4 Cluster/binder: NodePaths + content-based first-fit binder

### DIFF
--- a/cvs/lib/cluster/__init__.py
+++ b/cvs/lib/cluster/__init__.py
@@ -1,0 +1,12 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from cvs.lib.cluster.binder import BindResult, bind
+from cvs.lib.cluster.pool import ClusterPool, Node, load_cluster_file
+from cvs.lib.cluster.topology import node_matches
+
+__all__ = ["BindResult", "ClusterPool", "Node", "bind", "load_cluster_file", "node_matches"]

--- a/cvs/lib/cluster/binder.py
+++ b/cvs/lib/cluster/binder.py
@@ -1,0 +1,75 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional, Set
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cvs.lib.cluster.pool import ClusterPool
+from cvs.lib.cluster.topology import node_matches
+from cvs.lib.config.base import Topology
+
+
+class BindResult(BaseModel):
+    """Outcome of binding a config's roles to a cluster pool for one cell.
+
+    Downstream (G5b executor) reads ``bindings`` (role -> hostnames) to pick
+    SSH targets when ``status == "bound"``. ``skipped`` cells carry a concrete
+    ``reason`` so small dev clusters get useful partial coverage instead of
+    hard failure.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["bound", "skipped"]
+    bindings: Dict[str, List[str]] = Field(default_factory=dict)
+    reason: Optional[str] = None
+
+
+def bind(topology: Topology, pool: ClusterPool) -> BindResult:
+    """Deterministic first-fit binder.
+
+    Determinism is content-based, not insertion-order-based: callers may
+    assemble the node dict in any order and the same pool contents must yield
+    the same BindResult.bindings (this is what makes v2.A reuse-manifests
+    sound). We achieve this by iterating candidate hostnames in lexicographic
+    order. Within that order each role greedily claims the first ``count``
+    nodes that (a) match the selector, (b) have at least ``gpus_per_node`` GPUs,
+    and (c) are not already claimed by an earlier role.
+    """
+    claimed: Set[str] = set()
+    bindings: Dict[str, List[str]] = {}
+    candidate_order = sorted(pool.nodes.keys())
+
+    for role_name, role in topology.roles.items():
+        chosen: List[str] = []
+        for hostname in candidate_order:
+            if len(chosen) >= role.count:
+                break
+            if hostname in claimed:
+                continue
+            node = pool.nodes[hostname]
+            if not node_matches(node, role.selector):
+                continue
+            if node.gpus < role.gpus_per_node:
+                continue
+            chosen.append(hostname)
+
+        if len(chosen) < role.count:
+            reason = (
+                f"insufficient_nodes for role {role_name!r} "
+                f"(need {role.count} matching selector={role.selector!r} "
+                f"with >= {role.gpus_per_node} gpus, have {len(chosen)})"
+            )
+            return BindResult(status="skipped", bindings={}, reason=reason)
+
+        claimed.update(chosen)
+        bindings[role_name] = chosen
+
+    return BindResult(status="bound", bindings=bindings)

--- a/cvs/lib/cluster/pool.py
+++ b/cvs/lib/cluster/pool.py
@@ -1,0 +1,73 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NodePaths(BaseModel):
+    """Site host-paths exposed by a node, addressable by A3 ContainerSpec.
+
+    The cluster file is where *site* knowledge lives (e.g. the local HF model
+    cache, dataset roots), not the per-framework config. ContainerSpec mounts
+    these by name. extra=forbid is load-bearing so a typo (``model-cache``)
+    fails at load instead of silently resolving to None at launch time. All
+    fields are typed Optional[str] -- G2's str-contract discipline applied at
+    the cluster layer.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_cache: Optional[str] = None
+    dataset_root: Optional[str] = None
+
+
+class Node(BaseModel):
+    """A single physical node in the cluster pool.
+
+    Hardware-only: no role assignment lives here. Roles are matched to nodes by
+    the binder at run time using ``labels``. extra=forbid is load-bearing so
+    typos in a cluster file fail fast at load_cluster_file rather than silently
+    dropping fields.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ip: str
+    user: str
+    ssh_key: str = "id_rsa"
+    gpus: int = Field(default=0, ge=0)
+    labels: List[str] = Field(default_factory=list)
+    paths: NodePaths = Field(default_factory=NodePaths)
+
+
+class ClusterPool(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # No ordering claim here: the binder is deterministic content-based
+    # (lexicographic hostname iteration), not insertion-order. Two cluster
+    # files with the same nodes in different key order yield identical
+    # BindResults -- this is what makes v2.A reuse-manifests sound.
+    nodes: Dict[str, Node]
+
+
+def load_cluster_file(path: Union[str, Path]) -> ClusterPool:
+    p = Path(path)
+    text = p.read_text()
+    if p.suffix in (".yaml", ".yml"):
+        raw = yaml.safe_load(text)
+    elif p.suffix == ".json":
+        raw = json.loads(text)
+    else:
+        raise ValueError(f"unsupported cluster file extension {p.suffix!r} (use .yaml or .json)")
+    return ClusterPool.model_validate(raw)

--- a/cvs/lib/cluster/pool.py
+++ b/cvs/lib/cluster/pool.py
@@ -32,6 +32,63 @@ class NodePaths(BaseModel):
     dataset_root: Optional[str] = None
 
 
+class NodeDevices(BaseModel):
+    """Site/hardware device tokens (e.g. /dev/infiniband/uverbs*) the
+    container needs ``--device`` passthrough for.
+
+    Device enumeration is site-dependent (a Thor2 cluster exposes
+    ``/dev/infiniband/uverbs{0..7}`` + ``/dev/infiniband/rdma_cm``; an AINIC
+    cluster looks different). Putting this on the cluster file rather than
+    per-workload means the same vLLM/megatron/sglang config moves between
+    clusters without an edit.
+
+    ``ib`` and ``gpu`` are typed lists of docker --device tokens. ``extra``
+    is the escape hatch for site-specific devices we haven't categorized.
+    G5b merges all three into ``ContainerSpec.devices`` at launch time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ib: List[str] = Field(default_factory=list)
+    gpu: List[str] = Field(default_factory=list)
+    extra: List[str] = Field(default_factory=list)
+
+
+class NodeNetwork(BaseModel):
+    """Site/fabric-determined NCCL/UCX/Gloo collective env.
+
+    These knobs depend on the fabric (mlx5_* vs bnxt_re* vs rdma*), the GID
+    table (RoCEv2 per site), the QoS class, and the host NIC names. They are
+    NOT workload-dependent and should not be carried in per-workload
+    ``container.env`` (which leaks site bleed across configs and breaks
+    cross-site reuse).
+
+    Six typed Optional[str] knobs covering the universal NCCL/UCX/Gloo
+    site-env surface every multi-node framework hits (megatron, sglang-
+    disagg, jax, pytorch-xdit). Site-only vars not in this list (NCCL_IB_TC,
+    NCCL_NET_GDR_LEVEL, OFI provider, etc.) ride in ``extra_env`` until a
+    second site asks for typing.
+
+    G5b merges ``{typed fields as NCCL_*/UCX_*/GLOO_* env, then extra_env}``
+    into ``ContainerSpec.env`` before applying the per-workload override --
+    workload env wins on conflict (so per-run debug knobs still work).
+
+    extra=forbid catches typos in the typed fields (``nccl_ib_gid_indx`` ->
+    load-time error). Typos inside ``extra_env`` cannot be caught; that is
+    the escape hatch's cost.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    nccl_socket_ifname: Optional[str] = None  # -> NCCL_SOCKET_IFNAME
+    nccl_ib_hca: Optional[str] = None  # -> NCCL_IB_HCA
+    nccl_ib_gid_index: Optional[str] = None  # -> NCCL_IB_GID_INDEX
+    nccl_ib_sl: Optional[str] = None  # -> NCCL_IB_SL
+    ucx_net_devices: Optional[str] = None  # -> UCX_NET_DEVICES
+    gloo_socket_ifname: Optional[str] = None  # -> GLOO_SOCKET_IFNAME
+    extra_env: Dict[str, str] = Field(default_factory=dict)
+
+
 class Node(BaseModel):
     """A single physical node in the cluster pool.
 
@@ -49,6 +106,8 @@ class Node(BaseModel):
     gpus: int = Field(default=0, ge=0)
     labels: List[str] = Field(default_factory=list)
     paths: NodePaths = Field(default_factory=NodePaths)
+    devices: NodeDevices = Field(default_factory=NodeDevices)
+    network: NodeNetwork = Field(default_factory=NodeNetwork)
 
 
 class ClusterPool(BaseModel):

--- a/cvs/lib/cluster/topology.py
+++ b/cvs/lib/cluster/topology.py
@@ -1,0 +1,34 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+
+from cvs.lib.cluster.pool import Node
+
+_SPLIT_RE = re.compile(r"[\s,]+")
+
+
+def _required_labels(selector: Optional[str]) -> List[str]:
+    if not selector:
+        return []
+    return [tok for tok in _SPLIT_RE.split(selector.strip()) if tok]
+
+
+def node_matches(node: Node, selector: Optional[str]) -> bool:
+    """Return True if ``node`` satisfies the role ``selector``.
+
+    Selector grammar (intentionally simple and deterministic): a
+    whitespace/comma-separated list of required labels, all of which must be
+    present in ``node.labels`` (logical AND). Empty/None matches any node.
+    """
+    required = _required_labels(selector)
+    if not required:
+        return True
+    return all(label in node.labels for label in required)

--- a/cvs/lib/cluster/unittests/__init__.py
+++ b/cvs/lib/cluster/unittests/__init__.py
@@ -1,0 +1,6 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""

--- a/cvs/lib/cluster/unittests/test_binder.py
+++ b/cvs/lib/cluster/unittests/test_binder.py
@@ -1,0 +1,102 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import random
+import unittest
+
+from cvs.lib.cluster import ClusterPool, bind
+from cvs.lib.config.base import Role, Topology
+
+
+def _pool_from_order(hostnames):
+    return ClusterPool.model_validate(
+        {
+            "nodes": {
+                h: {"ip": f"10.0.0.{i}", "user": "u", "gpus": 8, "labels": ["mi300"]} for i, h in enumerate(hostnames)
+            }
+        }
+    )
+
+
+class TestBinderDeterminism(unittest.TestCase):
+    """G4 surface: same pool contents -> same BindResult regardless of how the
+    caller assembled the node dict. Three shuffled orderings is the minimal
+    proof per addendum gate row (the spike-blob x100 paranoia is dropped per
+    addendum 6.1)."""
+
+    def test_deterministic_across_3_randomized_orderings(self):
+        base = ["n0", "n1", "n2", "n3"]
+        topo = Topology(roles={"server": Role(count=2, gpus_per_node=8, selector="mi300")})
+
+        rng = random.Random(0)
+        orderings = []
+        while len(orderings) < 3:
+            shuffled = base[:]
+            rng.shuffle(shuffled)
+            if shuffled not in orderings:
+                orderings.append(shuffled)
+
+        results = {repr(bind(topo, _pool_from_order(order)).bindings) for order in orderings}
+        self.assertEqual(len(results), 1, f"non-deterministic bindings across orderings: {results}")
+
+
+class TestBinderSkipWithReason(unittest.TestCase):
+    """G4 surface: an under-resourced cell is reported skipped with a concrete
+    insufficient_nodes reason (not a hard error -- small dev clusters get
+    partial coverage)."""
+
+    def test_under_resourced_skipped_with_insufficient_nodes_reason(self):
+        pool = ClusterPool.model_validate(
+            {"nodes": {f"n{i}": {"ip": f"10.0.0.{i}", "user": "u", "gpus": 8, "labels": ["mi300"]} for i in range(3)}}
+        )
+        topo = Topology(roles={"d": Role(count=8, gpus_per_node=8, selector="mi300")})
+        res = bind(topo, pool)
+        self.assertEqual(res.status, "skipped")
+        self.assertIsNotNone(res.reason)
+        self.assertIn("insufficient_nodes", res.reason)
+
+
+class TestBinderSelectorMismatchSkips(unittest.TestCase):
+    """G4 surface: a role whose selector matches no node yields skipped (the
+    binder-driven complement to test_topology.test_node_matches)."""
+
+    def test_selector_mismatch_skips(self):
+        pool = ClusterPool.model_validate(
+            {"nodes": {"n0": {"ip": "10.0.0.0", "user": "u", "gpus": 8, "labels": ["mi300"]}}}
+        )
+        topo = Topology(roles={"s": Role(count=1, gpus_per_node=8, selector="mi355x")})
+        res = bind(topo, pool)
+        self.assertEqual(res.status, "skipped")
+
+
+class TestBinderMultiRoleNoOverlap(unittest.TestCase):
+    """G4 surface: the binder's actual non-trivial logic is claim-tracking
+    across roles -- two roles bound from the same pool must not share a
+    hostname. This is the test that catches a regression in claimed.update()
+    or the ``if hostname in claimed: continue`` guard."""
+
+    def test_multi_role_no_overlap(self):
+        pool = ClusterPool.model_validate(
+            {"nodes": {f"n{i}": {"ip": f"10.0.0.{i}", "user": "u", "gpus": 8, "labels": ["mi300"]} for i in range(4)}}
+        )
+        topo = Topology(
+            roles={
+                "prefill": Role(count=2, gpus_per_node=8, selector="mi300"),
+                "decode": Role(count=2, gpus_per_node=8, selector="mi300"),
+            }
+        )
+        res = bind(topo, pool)
+        self.assertEqual(res.status, "bound")
+        prefill = set(res.bindings["prefill"])
+        decode = set(res.bindings["decode"])
+        self.assertEqual(len(prefill), 2)
+        self.assertEqual(len(decode), 2)
+        self.assertEqual(prefill & decode, set(), f"role overlap: {prefill & decode}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/cluster/unittests/test_pool.py
+++ b/cvs/lib/cluster/unittests/test_pool.py
@@ -13,13 +13,15 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from cvs.lib.cluster import load_cluster_file
-from cvs.lib.cluster.pool import NodePaths
+from cvs.lib.cluster.pool import NodeDevices, NodeNetwork, NodePaths
 
 
 class TestLoadClusterFileRejectsUnknownKeys(unittest.TestCase):
-    """G4 minimal surface: extra=forbid is wired at three nesting levels
-    (top-level ClusterPool, per-Node, and per-NodePaths) so an unknown key in
-    a real cluster file fails fast at load_cluster_file (no silent acceptance)."""
+    """G4 minimal surface: extra=forbid is wired at five nesting levels
+    (top-level ClusterPool, per-Node, NodePaths, NodeDevices, NodeNetwork)
+    so an unknown key in a real cluster file fails fast at load_cluster_file
+    (no silent acceptance). The NodeNetwork case is the key one -- a typo
+    like ``nccl_ib_gid_indx`` would otherwise silently never be exported."""
 
     def _write(self, payload: dict) -> Path:
         tmp = Path(tempfile.mkdtemp()) / "cluster.json"
@@ -50,6 +52,43 @@ class TestLoadClusterFileRejectsUnknownKeys(unittest.TestCase):
                         "gpus": 8,
                         "labels": ["mi300"],
                         "paths": {"model_cache": "/data/hf", "model-cache": "/typo"},
+                    }
+                }
+            }
+        )
+        with self.assertRaises(ValidationError):
+            load_cluster_file(path)
+
+    def test_unknown_node_devices_key_rejected(self):
+        path = self._write(
+            {
+                "nodes": {
+                    "n0": {
+                        "ip": "1",
+                        "user": "u",
+                        "gpus": 8,
+                        "labels": ["mi300"],
+                        "devices": {"ib": ["/dev/infiniband/uverbs0"], "bogus_dev_kind": ["/dev/foo"]},
+                    }
+                }
+            }
+        )
+        with self.assertRaises(ValidationError):
+            load_cluster_file(path)
+
+    def test_unknown_node_network_key_rejected(self):
+        # The headline case: a typo in a typed NCCL knob (here
+        # ``nccl_ib_gid_indx``) silently never reaches NCCL_IB_GID_INDEX
+        # without extra=forbid. Load-time rejection is the whole point.
+        path = self._write(
+            {
+                "nodes": {
+                    "n0": {
+                        "ip": "1",
+                        "user": "u",
+                        "gpus": 8,
+                        "labels": ["mi300"],
+                        "network": {"nccl_ib_gid_index": "3", "nccl_ib_gid_indx": "4"},
                     }
                 }
             }
@@ -89,6 +128,60 @@ class TestNodePathsDefaults(unittest.TestCase):
         pool = load_cluster_file(path)
         self.assertEqual(pool.nodes["n0"].paths.model_cache, "/data/hf-cache")
         self.assertEqual(pool.nodes["n0"].paths.dataset_root, "/data/datasets")
+
+
+class TestNodeDevicesAndNetworkRoundtrip(unittest.TestCase):
+    """G4 minimal surface: Node.devices / Node.network default empty so cluster
+    files predating these fields keep loading; populated values round-trip with
+    typed Optional[str] / List[str] / Dict[str, str] shapes intact. G5b is
+    responsible for merging these into ContainerSpec at launch time."""
+
+    def test_devices_and_network_default_empty(self):
+        path = Path(tempfile.mkdtemp()) / "cluster.json"
+        path.write_text(json.dumps({"nodes": {"n0": {"ip": "1", "user": "u", "gpus": 8, "labels": ["mi300"]}}}))
+        pool = load_cluster_file(path)
+        self.assertEqual(pool.nodes["n0"].devices, NodeDevices())
+        self.assertEqual(pool.nodes["n0"].network, NodeNetwork())
+        self.assertEqual(pool.nodes["n0"].devices.ib, [])
+        self.assertEqual(pool.nodes["n0"].network.extra_env, {})
+
+    def test_devices_and_network_populated_roundtrip(self):
+        path = Path(tempfile.mkdtemp()) / "cluster.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "nodes": {
+                        "n0": {
+                            "ip": "1",
+                            "user": "u",
+                            "gpus": 8,
+                            "labels": ["mi300", "thor2"],
+                            "devices": {
+                                "ib": [f"/dev/infiniband/uverbs{i}" for i in range(8)] + ["/dev/infiniband/rdma_cm"],
+                                "gpu": ["/dev/kfd", "/dev/dri/renderD128"],
+                                "extra": [],
+                            },
+                            "network": {
+                                "nccl_socket_ifname": "bond0",
+                                "nccl_ib_hca": "bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re6,bnxt_re7",
+                                "nccl_ib_gid_index": "3",
+                                "nccl_ib_sl": "3",
+                                "ucx_net_devices": "bnxt_re0:1,bnxt_re1:1",
+                                "gloo_socket_ifname": "bond0",
+                                "extra_env": {"NCCL_IB_TC": "106", "NCCL_NET_GDR_LEVEL": "PHB"},
+                            },
+                        }
+                    }
+                }
+            )
+        )
+        pool = load_cluster_file(path)
+        n = pool.nodes["n0"]
+        self.assertEqual(len(n.devices.ib), 9)
+        self.assertIn("/dev/kfd", n.devices.gpu)
+        self.assertEqual(n.network.nccl_socket_ifname, "bond0")
+        self.assertEqual(n.network.nccl_ib_gid_index, "3")
+        self.assertEqual(n.network.extra_env["NCCL_IB_TC"], "106")
 
 
 if __name__ == "__main__":

--- a/cvs/lib/cluster/unittests/test_pool.py
+++ b/cvs/lib/cluster/unittests/test_pool.py
@@ -1,0 +1,95 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from cvs.lib.cluster import load_cluster_file
+from cvs.lib.cluster.pool import NodePaths
+
+
+class TestLoadClusterFileRejectsUnknownKeys(unittest.TestCase):
+    """G4 minimal surface: extra=forbid is wired at three nesting levels
+    (top-level ClusterPool, per-Node, and per-NodePaths) so an unknown key in
+    a real cluster file fails fast at load_cluster_file (no silent acceptance)."""
+
+    def _write(self, payload: dict) -> Path:
+        tmp = Path(tempfile.mkdtemp()) / "cluster.json"
+        tmp.write_text(json.dumps(payload))
+        return tmp
+
+    def test_unknown_top_level_key_rejected(self):
+        path = self._write({"nodes": {}, "garbage_top": 1})
+        with self.assertRaises(ValidationError):
+            load_cluster_file(path)
+
+    def test_unknown_per_node_key_rejected(self):
+        path = self._write(
+            {"nodes": {"n0": {"ip": "1", "user": "u", "gpus": 8, "labels": ["mi300"], "bogus_field": True}}}
+        )
+        with self.assertRaises(ValidationError):
+            load_cluster_file(path)
+
+    def test_unknown_node_paths_key_rejected(self):
+        # NodePaths is the A3 host-path seam; a typo like ``model-cache`` must
+        # fail at load rather than silently resolving to None at launch time.
+        path = self._write(
+            {
+                "nodes": {
+                    "n0": {
+                        "ip": "1",
+                        "user": "u",
+                        "gpus": 8,
+                        "labels": ["mi300"],
+                        "paths": {"model_cache": "/data/hf", "model-cache": "/typo"},
+                    }
+                }
+            }
+        )
+        with self.assertRaises(ValidationError):
+            load_cluster_file(path)
+
+
+class TestNodePathsDefaults(unittest.TestCase):
+    """G4 minimal surface: Node.paths defaults to an empty NodePaths so existing
+    cluster files (no ``paths`` key) keep loading; populated paths round-trip."""
+
+    def test_node_without_paths_defaults_to_empty_node_paths(self):
+        path = Path(tempfile.mkdtemp()) / "cluster.json"
+        path.write_text(json.dumps({"nodes": {"n0": {"ip": "1", "user": "u", "gpus": 8, "labels": ["mi300"]}}}))
+        pool = load_cluster_file(path)
+        self.assertEqual(pool.nodes["n0"].paths, NodePaths())
+        self.assertIsNone(pool.nodes["n0"].paths.model_cache)
+
+    def test_node_paths_roundtrip(self):
+        path = Path(tempfile.mkdtemp()) / "cluster.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "nodes": {
+                        "n0": {
+                            "ip": "1",
+                            "user": "u",
+                            "gpus": 8,
+                            "labels": ["mi300"],
+                            "paths": {"model_cache": "/data/hf-cache", "dataset_root": "/data/datasets"},
+                        }
+                    }
+                }
+            )
+        )
+        pool = load_cluster_file(path)
+        self.assertEqual(pool.nodes["n0"].paths.model_cache, "/data/hf-cache")
+        self.assertEqual(pool.nodes["n0"].paths.dataset_root, "/data/datasets")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/cluster/unittests/test_topology.py
+++ b/cvs/lib/cluster/unittests/test_topology.py
@@ -1,0 +1,38 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+import unittest
+
+from cvs.lib.cluster import node_matches
+from cvs.lib.cluster.pool import Node
+
+
+def _node(labels):
+    return Node(ip="1", user="u", gpus=8, labels=labels)
+
+
+class TestNodeMatches(unittest.TestCase):
+    """G4 minimal surface: selector grammar is whitespace/comma-split required
+    labels (logical AND); empty/None matches any node."""
+
+    def test_empty_selector_matches_any(self):
+        self.assertTrue(node_matches(_node(["mi300"]), None))
+        self.assertTrue(node_matches(_node([]), ""))
+
+    def test_single_label_required(self):
+        self.assertTrue(node_matches(_node(["mi300", "ib"]), "mi300"))
+        self.assertFalse(node_matches(_node(["mi355x"]), "mi300"))
+
+    def test_multi_label_logical_and(self):
+        n = _node(["mi300", "ib", "site42"])
+        self.assertTrue(node_matches(n, "mi300 ib"))
+        self.assertTrue(node_matches(n, "mi300,ib"))
+        self.assertFalse(node_matches(n, "mi300 rocm7"))  # rocm7 absent -> no match
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Re-derives the DTNI cluster layer (`cvs/lib/cluster/{pool,topology,binder}.py`) from `dev/dtni`, with the tightenings called out in addendum §2 row G4 and §6.1 restructure note.

- **`NodePaths` typed model on `Node.paths`** (addendum §6.1 line 353): the A3 site host-path seam (`model_cache`, `dataset_root`). `Optional[str]`-typed, `extra=\"forbid\"` — a typo (`model-cache`) fails at load instead of silently resolving to `None` at vLLM launch time. Defaults to empty `NodePaths()` so existing cluster files keep loading.
- **`extra=\"forbid\"` at all three nesting levels** (`ClusterPool`, `Node`, `NodePaths`), each with a unit test.
- **Content-based determinism** in the binder (lexicographic hostname iteration), not insertion-order. Two cluster files with the same nodes in different key order yield identical `BindResult`s — what makes v2.A reuse-manifests sound. `ordered_hostnames()` retired as dead surface (no caller).
- **Multi-role no-overlap** test added — the binder's actual non-trivial logic (cross-role `claimed` set) was previously uncovered.
- **`node_matches` covered directly** by `test_topology.py` (selector grammar: empty/single/multi-label logical AND). The earlier `test_topology.py` was misnamed (exercised the binder); folded into `test_binder.py` and replaced with real `node_matches` tests.

Brief amended (`plans/dtni_rollout/g4-cluster.md`):
- `labels` stays `List[str]` (tag-set, logical-AND selector grammar) — the v1 oracle, v2 selector, and downstream consumers all use this; the earlier brief row reading `Dict[str, str]` would require a selector redesign with no consumer asking. Documented in the bake-in.
- Binder ordering story unified to \"content-based / lex\" (resolves the prior §2 row \"declaration order\" vs `binder.py` lex contradiction).

## Test plan

Offline gate (no GPU, reuses `.dtni_venv`):

\`\`\`
VENV=/data/atnair/repos/cvs_worktrees/cvs-dtni-spine/.dtni_venv/bin/python
cd /data/atnair/repos/cvs_worktrees/cvs-cluster
\$VENV -m unittest cvs.lib.cluster.unittests.test_pool \\
                  cvs.lib.cluster.unittests.test_topology \\
                  cvs.lib.cluster.unittests.test_binder   # 12 OK
/data/atnair/repos/cvs/.ruff_venv/bin/ruff check cvs/lib/cluster
/data/atnair/repos/cvs/.ruff_venv/bin/ruff format --check cvs/lib/cluster
\`\`\`

- [x] 12 unit tests green
- [x] ruff check + format --check clean
- [x] no security/redaction code (B7 honored)

Addendum §9 entry to be added on merge per the brief's \"Done\" step (and `dev/dtni` README G4 row ticked).