### PR TITLE
G6b Failure pattern scanner: seed catalog + ValueError-fail-closed loader

### DIFF
--- a/cvs/lib/failure_pattern_scanner.py
+++ b/cvs/lib/failure_pattern_scanner.py
@@ -1,0 +1,126 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Literal, Optional, Pattern as RePattern
+
+import yaml
+from pydantic import BaseModel, ConfigDict
+
+from cvs.lib.failure_taxonomy import FailureCategory
+
+DEFAULT_PATTERNS_FILE = Path(__file__).with_name("failure_patterns.yaml")
+
+# Closed source vocabulary -- only streams the spine actually captures. Adding
+# a third source is a deliberate edit here + a G6a wiring change, not a
+# silent YAML typo (e.g. "dmsg" would otherwise load fine and then never
+# match anything when G6a calls scan(text, source="dmesg")).
+SourceLiteral = Literal["dmesg", "framework_log"]
+# Closed severity vocabulary -- "fatal" flips the verdict in G6a's B4 wiring;
+# a typo ("FATAL", "fatel") would silently downgrade a fatal match.
+SeverityLiteral = Literal["fatal", "warn"]
+
+
+class FailurePattern(BaseModel):
+    """One row of ``failure_patterns.yaml``.
+
+    Loaded by :class:`FailurePatternScanner` at construction time. ``category``
+    must be a value from G1's :class:`FailureCategory` enum -- unknowns raise
+    at load (fail closed; see addendum G6b row #3). ``source`` and ``severity``
+    are typed Literals so vocabulary typos fail at load, not silently at scan.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    source: SourceLiteral
+    pattern: str
+    category: FailureCategory
+    severity: SeverityLiteral
+    hint: str
+
+
+class PatternHit(BaseModel):
+    """One ``(pattern, first matching line)`` hit produced by ``scan``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pattern_id: str
+    category: FailureCategory
+    source: SourceLiteral
+    line_no: int
+    line: str
+
+
+class FailurePatternScanner:
+    """Loads the seed catalog and matches it against captured log text.
+
+    Pure-function: ``scan`` takes a text blob plus the source label of the
+    stream it came from and returns one :class:`PatternHit` per pattern that
+    matched (first hit only -- one hit per pattern per stream is enough for the
+    verdict G6a wires up). ``source`` mismatches are silently skipped: G6a
+    multiplexes the same scanner over multiple streams and that is the normal
+    case, not an error (brief: source mismatch is *not* raised).
+    """
+
+    def __init__(self, patterns_file: Optional[Path] = None) -> None:
+        path = Path(patterns_file) if patterns_file else DEFAULT_PATTERNS_FILE
+        raw = yaml.safe_load(path.read_text()) or {}
+        entries = raw.get("patterns", []) or []
+        patterns: List[FailurePattern] = []
+        compiled: List[RePattern[str]] = []
+        seen_ids: set[str] = set()
+        for entry in entries:
+            # Pydantic validates extras + the FailureCategory enum + the
+            # source/severity Literals; unknown values raise ValidationError,
+            # which is a ValueError subclass -- matches the brief's
+            # ValueError contract.
+            pat = FailurePattern(**entry)
+            if pat.id in seen_ids:
+                raise ValueError(f"duplicate pattern id in catalog: {pat.id!r}")
+            seen_ids.add(pat.id)
+            # Re-raise re.error as ValueError so all three load-time failure
+            # modes (dup id, unknown category/source/severity, bad regex)
+            # share one exception type per the brief's fail-closed contract.
+            try:
+                compiled.append(re.compile(pat.pattern, re.IGNORECASE))
+            except re.error as exc:
+                raise ValueError(f"invalid regex for pattern {pat.id!r}: {exc}") from exc
+            patterns.append(pat)
+        self.patterns: List[FailurePattern] = patterns
+        self._compiled: List[RePattern[str]] = compiled
+
+    def scan(self, text: str, source: Optional[str] = None) -> List[PatternHit]:
+        """Return one hit per pattern whose regex first matches a line of ``text``.
+
+        If ``source`` is given, patterns declaring a different ``source`` are
+        skipped silently (multiplex case). One hit per pattern per call -- we
+        stop at the first matching line.
+        """
+        hits: List[PatternHit] = []
+        if not text:
+            return hits
+        lines = text.splitlines()
+        for pat, regex in zip(self.patterns, self._compiled):
+            if source is not None and pat.source != source:
+                continue
+            for idx, line in enumerate(lines, start=1):
+                if regex.search(line):
+                    hits.append(
+                        PatternHit(
+                            pattern_id=pat.id,
+                            category=pat.category,
+                            source=pat.source,
+                            line_no=idx,
+                            line=line.strip()[:500],
+                        )
+                    )
+                    break
+        return hits

--- a/cvs/lib/failure_patterns.yaml
+++ b/cvs/lib/failure_patterns.yaml
@@ -1,0 +1,30 @@
+# Seed catalog for the DTNI failure-pattern scanner. Adding a pattern is a
+# YAML edit -- no code change. Each row:
+#   id       : stable identifier (also the marker/event payload)
+#   source   : dmesg | framework_log  (which stream to scan; typed Literal)
+#   pattern  : Python regex, matched per line (case-insensitive)
+#   category : FailureCategory value from cvs.lib.failure_taxonomy
+#   severity : fatal | warn  (typed Literal; fatal flips the verdict)
+#   hint     : human-facing remediation pointer
+patterns:
+  - id: oom_killer
+    source: dmesg
+    pattern: "Out of memory: Killed process|invoked oom-killer"
+    category: failure_pattern_matched
+    severity: fatal
+    hint: "Host OOM killer fired; reduce batch/concurrency or check for a leak."
+  - id: hbm_ecc
+    source: dmesg
+    pattern: "uncorrectable|HBM.*ECC|GPU ECC error"
+    category: failure_pattern_matched
+    severity: fatal
+    hint: "Uncorrectable GPU memory error; quarantine the node."
+  - id: container_oom
+    source: dmesg
+    # Canonical cgroup-OOM dmesg lines contain "memory cgroup out of memory"
+    # OR an oom-kill: line with oom_memcg= (the memcg path). The earlier
+    # ".*container" alternative did not match real kernel output.
+    pattern: "memory cgroup out of memory|oom-kill:.*oom_memcg="
+    category: failure_pattern_matched
+    severity: fatal
+    hint: "Container hit its cgroup memory limit; raise --shm-size / limits."

--- a/cvs/lib/unittests/test_failure_pattern_scanner.py
+++ b/cvs/lib/unittests/test_failure_pattern_scanner.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from cvs.lib.failure_pattern_scanner import FailurePatternScanner
+from cvs.lib.failure_taxonomy import FailureCategory
+
+
+def _write_yaml(dir_path: Path, body: str) -> Path:
+    p = dir_path / "patterns.yaml"
+    p.write_text(body)
+    return p
+
+
+class TestFailurePatternScanner(unittest.TestCase):
+    def test_default_catalog_loads_and_every_pattern_has_valid_category(self):
+        """G6b row #1: ship the seed catalog; each entry binds to a FailureCategory."""
+        scanner = FailurePatternScanner()
+        self.assertGreater(len(scanner.patterns), 0, "default catalog must not be empty")
+        valid = {c for c in FailureCategory}
+        for pat in scanner.patterns:
+            self.assertIn(
+                pat.category,
+                valid,
+                f"pattern {pat.id!r} has category {pat.category!r} not in FailureCategory",
+            )
+
+    def test_duplicate_pattern_id_raises_value_error(self):
+        """G6b row #2: duplicate id at load time is a fail-closed ValueError."""
+        body = (
+            "patterns:\n"
+            "  - id: oom_killer\n"
+            "    source: dmesg\n"
+            "    pattern: \"Out of memory\"\n"
+            "    category: failure_pattern_matched\n"
+            "    severity: fatal\n"
+            "    hint: \"x\"\n"
+            "  - id: oom_killer\n"
+            "    source: dmesg\n"
+            "    pattern: \"invoked oom-killer\"\n"
+            "    category: failure_pattern_matched\n"
+            "    severity: fatal\n"
+            "    hint: \"y\"\n"
+        )
+        with TemporaryDirectory() as d:
+            path = _write_yaml(Path(d), body)
+            with self.assertRaises(ValueError):
+                FailurePatternScanner(patterns_file=path)
+
+    def test_unknown_category_in_yaml_raises_value_error(self):
+        """G6b row #3: unknown FailureCategory at load is a fail-closed ValueError."""
+        body = (
+            "patterns:\n"
+            "  - id: bogus\n"
+            "    source: dmesg\n"
+            "    pattern: \"whatever\"\n"
+            "    category: not_a_real_category\n"
+            "    severity: fatal\n"
+            "    hint: \"z\"\n"
+        )
+        with TemporaryDirectory() as d:
+            path = _write_yaml(Path(d), body)
+            with self.assertRaises(ValueError):
+                FailurePatternScanner(patterns_file=path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the DTNI failure-pattern scanner (W6 scanner half) per addendum §2 row G6b.

- **`FailurePatternScanner`** loads `failure_patterns.yaml` at construction, compiles each pattern's regex once, exposes a pure-function `scan(text, source=)` that returns one `PatternHit` per pattern per stream (first matching line). G6a wires this into the `workload_run` fixture and passes hits into `Job(scanner=...)` for B5.
- **Seed catalog: minimal.** Only the three patterns vLLM on MI300 trips — `oom_killer`, `hbm_ecc`, `container_oom`, all `source: dmesg`, all bound to `FailureCategory.failure_pattern_matched`. Catalog grows when the next adapter lands (addendum §6.1: barebones spine, don't over-author).
- **Uniform fail-closed at load.** All three failure modes (dup id, unknown category / `source` / `severity`, bad regex) raise `ValueError`. `source: Literal["dmesg", "framework_log"]` and `severity: Literal["fatal", "warn"]` document the vocabulary in code so a YAML typo (e.g. `dmsg`) fails immediately instead of silently never matching.
- **`container_oom` regex fix.** Previous `oom-kill:.*container` did not match canonical kernel cgroup-OOM dmesg lines (which contain `oom_memcg=/docker/<sha>`, not the literal word "container"). New pattern `memory cgroup out of memory|oom-kill:.*oom_memcg=` verified against a synthetic kernel-style line.

## Scoped down per the barebones-spine pass

Reviewer raised 12 findings; 4 addressed (commit + regex fix + Literal types + ValueError-wrap). Explicitly deferred:
- **Empty-catalog load-time guard** — one catalog file in tree, not user input. YAGNI.
- **`hbm_ecc` `uncorrectable` alternation tightening** — inherited verbatim from oracle; tune when first false positive surfaces, not preemptively.
- **`!!python/object` test** — `yaml.safe_load` rejects by construction; nothing to test.

## Test plan

\`\`\`
VENV=/data/atnair/repos/cvs_worktrees/cvs-dtni-spine/.dtni_venv/bin/python
cd /data/atnair/repos/cvs_worktrees/cvs-pattern-scanner
\$VENV -m unittest cvs.lib.unittests.test_failure_pattern_scanner   # 3 OK
/data/atnair/repos/cvs/.ruff_venv/bin/ruff check cvs/lib/failure_pattern_scanner.py
/data/atnair/repos/cvs/.ruff_venv/bin/ruff format --check cvs/lib/failure_pattern_scanner.py
\`\`\`

- [x] 3/3 tests green (catalog load + dup-id + unknown-category)
- [x] ruff check + format --check clean
- [x] `container_oom` matches a real-ish kernel cgroup-OOM line (sanity probe)
- [x] no security/redaction code (B7 honored)

Addendum §9 entry to be added on merge per the brief's \"Done\" step (and `dev/dtni` README G6b row ticked).