### PR TITLE
G5b Job + executors: 6-phase mode-blind driver, B4/B6/B7-half wired

### DIFF
--- a/cvs/lib/AGENTS.md
+++ b/cvs/lib/AGENTS.md
@@ -1,0 +1,72 @@
+# Job driver & RunContext — AGENTS.md
+
+> Scope: `cvs/lib/job.py`, `cvs/lib/run_context.py`. Workstream: W1 driver.
+> Companion to `cvs/lib/manifest/AGENTS.md` (manifest shape) and the G5a
+> contract files (`adapter_protocol.py`, `base_adapter.py`, `registry.py`).
+
+## Invariants
+
+- **Event ownership is split (B6).** `Job` owns *phase-boundary* events:
+  `prepare.start`, `prepare.done`, `parse.done`, `teardown.start`,
+  `teardown.done` (and `seed.logged` once at prepare). Adapters own
+  *sub-phase* events: `launch.container_up`, `launch.role_ready`, `step`,
+  `request`, `arrival.*`, `accuracy.*`, `safety.violated`, `verify.*`,
+  `pattern.matched`. Do not emit phase-boundary events from an adapter; do
+  not emit sub-phase events from `Job`. The split is what makes the events
+  log analyzable across frameworks without duplicate-emit dedup.
+- **Failures are classified at the raise site (B4).** `WorkloadFailure`
+  subclasses carry their `category`; the driver records `exc.category.value`
+  directly. Generic exceptions inside `prepare`/`launch` are re-raised as
+  `SetupFailure` *at the boundary*, not classified post-hoc. A fatal pattern
+  hit (`severity == "fatal"`) may upgrade an unclassified verdict
+  (`complete`) or the generic-exception verdict to `failure_pattern_matched`
+  -- but it MUST NOT clobber a classified `WorkloadFailure` (SafetyViolation
+  / LivenessFailure / VerificationFailure). The taxonomy's
+  earliest-raise-site rule wins; the override is an upgrade, not a relabel.
+  The Job-owned phase events for `prepare` and `parse` are emitted only on
+  the success path (`prepare.done`, `parse.done`); `teardown.start`/`done`
+  always fire because teardown runs in `finally`. The events sidecar is
+  always closed.
+- **Teardown runs in `finally`.** Even when `prepare`/`launch`/`await`/
+  `parse`/`verify` raises -- and even when teardown itself raises -- the
+  manifest is still written, the events file is still closed, and the
+  `teardown.start`/`teardown.done` boundary events still fire. A leaked
+  container or an unflushed manifest is a regression.
+- **`RunContext.executor` is a single optional slot (A1+A2 deferred).**
+  The spine ships one `executor` field but no `stage_in`/`fetch` API and
+  no helper to populate it. Real CVS clusters use a shared filesystem
+  (Weka/NFS at the same path on devbox + nodes) or an end-of-run rsync,
+  so per-file SFTP staging is not on the critical path. G3 already ships
+  the `RunLayout.remote_artifact_dir` / `to_remote` plumbing, so adding
+  the wrappers when the first no-shared-FS cluster lands is a pure
+  addition. Per-role executors (A2) land alongside the first multi-role
+  adapter (sglang-disagg / megatron / jax).
+- **`ConfigInputs.env`/`commands` are recorded as-is (B7).** No redaction
+  (W7 removed entirely). `env` is sourced from `config.container.env`;
+  `commands` from `ctx.scratch["commands"]` (adapters append the
+  docker/curl/torchrun lines they want forensically recorded). Do not
+  reintroduce a redaction field or claim.
+
+## Extension recipes
+
+### Recipe: add a new adapter
+
+Subclass `BaseWorkloadAdapter`, implement `launch` / `progress_predicate` /
+`parse`, and `@register_adapter("<framework>", kind="inference"|"training")`.
+Stage docker/torchrun lines onto `ctx.scratch.setdefault("commands", [])` if
+you want them in the manifest. Do not emit phase-boundary events.
+
+### Recipe: record a derived command for forensics
+
+`ctx.scratch.setdefault("commands", []).append("<command>")`. `Job` copies
+the list into `ConfigInputs.commands` verbatim.
+
+### Recipe: add a sub-phase event
+
+Add the name to `EVENT_VOCAB` in `manifest/events.py` (reviewed change),
+then `ctx.events.emit("<name>", **fields)` from the adapter.
+
+**Anti-patterns:** classifying failures by message text; emitting
+phase-boundary events from an adapter; populating `ConfigInputs.env`
+twice; building a per-role executors dict before a real multi-role
+adapter needs one.

--- a/cvs/lib/job.py
+++ b/cvs/lib/job.py
@@ -1,0 +1,314 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+"""
+
+from __future__ import annotations
+
+import getpass
+import importlib.metadata
+import subprocess
+import time
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+
+from cvs.lib.failure_taxonomy import (
+    FailureCategory,
+    SetupFailure,
+    WorkloadFailure,
+    category_of,
+)
+from cvs.lib.manifest.schema import (
+    ConfigInputs,
+    Identity,
+    Manifest,
+    PatternMatch,
+    PhaseTiming,
+    Verdicts,
+)
+from cvs.lib.manifest.sidecars import write_resolved_config
+from cvs.lib.run_context import RunContext
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _cvs_version() -> Optional[str]:
+    try:
+        return importlib.metadata.version("cvs")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _git_sha() -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return out.stdout.strip() or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _container_env(cfg) -> dict:
+    """Return ``container.env`` AS-IS for the manifest (B7 / W7 removed).
+
+    Reads ``cfg.container.env`` directly: a missing ``container`` attribute or
+    a non-dict ``env`` shape is a config-layer regression that must surface as
+    a boundary failure, not be silently flattened to ``{}``. Configs without a
+    container section pass ``container = ContainerSpec()`` (env={}) so the
+    happy path stays cheap.
+    """
+    return {str(k): str(v) for k, v in cfg.container.env.items()}
+
+
+class Job:
+    """Mode-blind driver for the six-phase workload lifecycle.
+
+    No ``if mode == "training"`` branching: the same driver runs every
+    adapter. Failures are recorded by *category at the raise site* (B4);
+    ``teardown`` always runs in ``finally``; a :class:`Manifest` is always
+    produced (even on failure), making the run forensically complete. The
+    :class:`Job` itself owns phase-boundary events -- ``prepare.*``,
+    ``parse.done``, ``teardown.*`` (B6). Sub-phase events
+    (``launch.container_up``, ``launch.role_ready``, ``step``, ``request``,
+    ...) belong to adapters, never here.
+    """
+
+    def __init__(self, adapter, ctx: RunContext, scanner=None) -> None:
+        self.adapter = adapter
+        self.ctx = ctx
+        self.scanner = scanner
+
+    def _phase(
+        self,
+        phases: List[PhaseTiming],
+        name: str,
+        fn: Callable[[], None],
+    ) -> None:
+        start = _now()
+        t0 = time.monotonic()
+        status = "complete"
+        try:
+            fn()
+        except BaseException:
+            status = "failed"
+            raise
+        finally:
+            phases.append(
+                PhaseTiming(
+                    phase=name,
+                    start=start,
+                    end=_now(),
+                    duration_s=round(time.monotonic() - t0, 4),
+                    status=status,
+                )
+            )
+
+    def _prepare(self) -> None:
+        self.ctx.events.emit("prepare.start", run_id=self.ctx.run_id)
+        seed = getattr(self.ctx.config, "seed", None)
+        self.ctx.events.emit("seed.logged", seed=seed)
+        try:
+            self.adapter.prepare(self.ctx)
+        except WorkloadFailure:
+            raise
+        except Exception as exc:  # noqa: BLE001 - classify at the boundary (B4)
+            raise SetupFailure(f"prepare failed: {exc}") from exc
+        self.ctx.events.emit("prepare.done", run_id=self.ctx.run_id)
+
+    def _launch(self) -> None:
+        try:
+            self.adapter.launch(self.ctx)
+        except WorkloadFailure:
+            raise
+        except Exception as exc:  # noqa: BLE001 - classify at the boundary (B4)
+            raise SetupFailure(f"launch failed: {exc}") from exc
+
+    def _parse(self) -> None:
+        self.adapter.parse(self.ctx)
+        self.ctx.events.emit("parse.done", run_id=self.ctx.run_id)
+
+    def run(self) -> Manifest:
+        ctx = self.ctx
+        ctx.layout.ensure()
+        phases: List[PhaseTiming] = []
+        started_at = _now()
+        overall = "complete"
+        failure_category: Optional[str] = None
+        # True iff a WorkloadFailure was raised at its own boundary. The
+        # taxonomy is classify-at-the-raise-site: a downstream fatal pattern
+        # may upgrade an unclassified/generic verdict (B4 "fatal pattern
+        # overrides an error verdict too") but MUST NOT clobber a
+        # WorkloadFailure category.
+        boundary_classified = False
+
+        try:
+            self._phase(phases, "prepare", self._prepare)
+            self._phase(phases, "launch", self._launch)
+            self._phase(phases, "await", lambda: self.adapter.await_completion(ctx))
+            self._phase(phases, "parse", self._parse)
+            self._phase(phases, "verify", lambda: self.adapter.verify(ctx))
+        except WorkloadFailure as exc:
+            overall = "failed"
+            failure_category = exc.category.value
+            boundary_classified = True
+        except Exception as exc:  # noqa: BLE001 - generic boundary failure (B4)
+            overall = "failed"
+            failure_category = category_of(exc).value
+        finally:
+            ctx.events.emit("teardown.start", run_id=ctx.run_id)
+            try:
+                self._phase(phases, "teardown", lambda: self.adapter.teardown(ctx))
+            except Exception:  # noqa: BLE001 - teardown best-effort
+                pass
+            ctx.events.emit("teardown.done", run_id=ctx.run_id)
+
+        # The remaining work (pattern scan, override, resolved-config sidecar,
+        # _build_manifest, manifest.write) must always close the events
+        # sidecar, even when one of these steps raises -- AGENTS.md invariant
+        # "the events file is still closed" applies to harness bugs too.
+        try:
+            pattern_matches = self._scan_patterns()
+            if any(m.severity == "fatal" for m in pattern_matches) and not boundary_classified:
+                failure_category = FailureCategory.FAILURE_PATTERN_MATCHED.value
+                if overall == "complete":
+                    overall = "failed"
+
+            resolved_written = False
+            try:
+                write_resolved_config(
+                    ctx.layout.resolved_config_path,
+                    ctx.config.model_dump(mode="json"),
+                )
+                resolved_written = True
+            except OSError:
+                # Disk error writing the YAML sidecar. The manifest must
+                # NOT advertise a path that does not exist on disk -- a
+                # downstream consumer (cvs export) would follow a stale
+                # pointer.
+                pass
+
+            manifest = self._build_manifest(
+                phases,
+                started_at,
+                overall,
+                failure_category,
+                pattern_matches,
+                resolved_written=resolved_written,
+            )
+            manifest.write(ctx.layout.manifest_path)
+            return manifest
+        finally:
+            try:
+                ctx.events.close()
+            except Exception:  # noqa: BLE001 - close itself is best-effort
+                pass
+
+    def _scan_patterns(self) -> List[PatternMatch]:
+        """Collect pattern hits from adapter-recorded matches + scanner output.
+
+        Adapter-recorded matches (``ctx.scratch['pattern_matches']``) ride
+        along unchanged. When a scanner is wired (G6a B5), every captured log
+        in ``ctx.logs`` is scanned. :class:`PatternHit` carries the id but
+        not the severity, so the scanner MUST expose its compiled catalog as
+        ``.patterns`` (each entry has ``.id`` and ``.severity``) -- otherwise
+        we cannot know whether a hit is fatal, and silently defaulting to
+        "warn" would disable the B4 override. Fail closed instead.
+        """
+        matches: List[PatternMatch] = []
+        for rec in self.ctx.scratch.get("pattern_matches", []):
+            matches.append(rec if isinstance(rec, PatternMatch) else PatternMatch(**rec))
+        if self.scanner is None:
+            return matches
+        if not hasattr(self.scanner, "patterns"):
+            raise TypeError(
+                f"scanner must expose .patterns (catalog with .id + .severity); got {type(self.scanner).__name__}"
+            )
+        severities = {p.id: p.severity for p in self.scanner.patterns}
+        for stream_name, text in self.ctx.logs.items():
+            source = "dmesg" if "dmesg" in stream_name else "framework_log"
+            for hit in self.scanner.scan(text, source=source):
+                if hit.pattern_id not in severities:
+                    raise ValueError(
+                        f"scanner emitted hit for pattern_id {hit.pattern_id!r} "
+                        "not present in scanner.patterns; severity is unknowable"
+                    )
+                severity = severities[hit.pattern_id]
+                self.ctx.events.emit(
+                    "pattern.matched",
+                    id=hit.pattern_id,
+                    severity=severity,
+                    source=hit.source,
+                )
+                matches.append(
+                    PatternMatch(
+                        id=hit.pattern_id,
+                        severity=severity,
+                        line=hit.line,
+                        node=stream_name,
+                        source=hit.source,
+                    )
+                )
+        return matches
+
+    def _build_manifest(
+        self,
+        phases,
+        started_at,
+        overall,
+        failure_category,
+        pattern_matches,
+        *,
+        resolved_written: bool = False,
+    ) -> Manifest:
+        ctx = self.ctx
+        cfg = ctx.config
+        verdicts = Verdicts(
+            overall_status=overall,
+            failure_category=failure_category,
+            threshold_verdicts=ctx.scratch.get("threshold_verdicts", []),
+            pattern_matches=pattern_matches,
+            scalars={k: float(v) for k, v in ctx.result.scalars.items()},
+        )
+        identity = Identity(
+            run_id=ctx.run_id,
+            test_id=ctx.layout.test_id,
+            cell_id=getattr(ctx.cell, "id", ctx.layout.cell_id),
+            config_hash=cfg.config_hash() if hasattr(cfg, "config_hash") else None,
+            workload_hash=cfg.workload_hash() if hasattr(cfg, "workload_hash") else None,
+            verification_hash=cfg.verification_hash() if hasattr(cfg, "verification_hash") else None,
+            cvs_version=_cvs_version(),
+            cvs_git_sha=_git_sha(),
+            started_at=started_at,
+            finished_at=_now(),
+            invoker=getpass.getuser(),
+        )
+        # B7-half (G3+G5): populate ConfigInputs.env/commands AS-IS (security
+        # removed; addendum §4 B7). Adapters stage commands they want
+        # recorded onto ctx.scratch['commands']. resolved_config_path is only
+        # advertised when the YAML sidecar was actually written (so the
+        # manifest never points at a nonexistent file).
+        config_inputs = ConfigInputs(
+            resolved_config_path=str(ctx.layout.resolved_config_path) if resolved_written else None,
+            model=getattr(cfg, "model", None),
+            env=_container_env(cfg),
+            commands=list(ctx.scratch.get("commands", [])),
+            seed=getattr(cfg, "seed", None),
+        )
+        manifest = Manifest(
+            identity=identity,
+            config=config_inputs,
+            phases=phases,
+            verdicts=verdicts,
+        )
+        layout = ctx.layout
+        manifest.sidecars.events = str(layout.events_path) if layout.events_path.exists() else None
+        manifest.sidecars.samples = str(layout.samples_path) if layout.samples_path.exists() else None
+        manifest.sidecars.trajectory = str(layout.trajectory_path) if layout.trajectory_path.exists() else None
+        manifest.sidecars.logs_dir = str(layout.logs_dir)
+        return manifest

--- a/cvs/lib/run_context.py
+++ b/cvs/lib/run_context.py
@@ -1,0 +1,69 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from cvs.lib.config.thresholds import ResultView
+from cvs.lib.manifest.events import EventWriter
+from cvs.lib.manifest.layout import RunLayout
+
+
+class RunContext:
+    """Mutable state threaded through one workload run's lifecycle.
+
+    The ``Job`` driver constructs this once per (config, sweep cell) and
+    passes it to every adapter method. Adapters read inputs (config, cell
+    params, bindings, executor) and write outputs (``result``, ``logs``,
+    registered container handles) onto it -- the on-disk/in-memory
+    replacement for the v1 module-level globals.
+
+    A1 staging seam DEFERRED. Real CVS clusters use either a shared
+    filesystem (Weka/NFS at the same path on devbox + nodes) or an
+    end-of-run rsync, so per-file ``stage_in``/``fetch`` is not needed
+    for the integration milestone. Add the SFTP wrappers (and a
+    ``RunLayout.to_remote``-keyed re-base) when the first cluster
+    without a shared FS lands. The G3 ``remote_artifact_dir`` /
+    ``remote_root`` / ``to_remote`` plumbing is already in place, so
+    this is a pure addition when needed.
+
+    A2 per-role executors also deferred (addendum §3). The single
+    ``executor`` slot is present for the (eventual) multi-host
+    case; adapters that need to issue commands today receive it via
+    constructor injection.
+    """
+
+    def __init__(
+        self,
+        config: Any,
+        cell: Any,
+        bindings: Dict[str, List[str]],
+        layout: RunLayout,
+        events: EventWriter,
+        run_id: str,
+        executor: Optional[Any] = None,
+    ) -> None:
+        self.config = config
+        self.cell = cell
+        self.bindings = bindings
+        self.layout = layout
+        self.events = events
+        self.run_id = run_id
+        self.executor = executor
+        self.result = ResultView()
+        self.logs: Dict[str, str] = {}
+        self.containers: List[Any] = []
+        self.scratch: Dict[str, Any] = {}
+
+    def param(self, name: str, default: Any = None) -> Any:
+        """Resolve a parameter: sweep-cell override first, then static params."""
+        cell_params = getattr(self.cell, "params", None)
+        if isinstance(cell_params, dict) and name in cell_params:
+            return cell_params[name]
+        params = getattr(self.config, "params", None)
+        if params is not None and hasattr(params, name):
+            return getattr(params, name)
+        return default

--- a/cvs/lib/unittests/test_job.py
+++ b/cvs/lib/unittests/test_job.py
@@ -1,0 +1,197 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from cvs.lib.adapter_protocol import Progress
+from cvs.lib.base_adapter import BaseWorkloadAdapter
+from cvs.lib.config import expand_sweep, parse_config
+from cvs.lib.config.thresholds import ResultView
+from cvs.lib.failure_pattern_scanner import FailurePattern, PatternHit
+from cvs.lib.failure_taxonomy import FailureCategory
+from cvs.lib.job import Job
+from cvs.lib.manifest.events import EventWriter
+from cvs.lib.manifest.layout import RunLayout
+from cvs.lib.run_context import RunContext
+
+BASE = {
+    "schema_version": "2",
+    "framework": "vllm",
+    "target_gpu": "mi300",
+    "model": "m",
+    "topology": {"roles": {"server": {"count": 1, "gpus_per_node": 8}}},
+    "params": {"server_script": "s.sh"},
+    "sweep": {
+        "concurrency": [16],
+        "sequence_combinations": [{"isl": 1024, "osl": 1024, "name": "balanced"}],
+    },
+    "container": {"env": {"HF_TOKEN": "secret-xyz", "DEBUG": "1"}},
+}
+
+
+class _Adapter(BaseWorkloadAdapter):
+    framework = "fake"
+    completion_timeout_s = 0.0
+    poll_interval_s = 0.0
+
+    def __init__(self, *, fail_prepare=False, samples=None, record_commands=None):
+        self.fail_prepare = fail_prepare
+        self.samples = samples or []
+        self.teardown_called = False
+        self.record_commands = record_commands or []
+
+    def prepare(self, ctx):
+        if self.fail_prepare:
+            raise RuntimeError("boom")
+
+    def launch(self, ctx):
+        if self.record_commands:
+            ctx.scratch.setdefault("commands", []).extend(self.record_commands)
+
+    def progress_predicate(self, ctx):
+        return Progress.DONE
+
+    def parse(self, ctx):
+        ctx.result = ResultView(samples=self.samples)
+
+    def teardown(self, ctx):
+        self.teardown_called = True
+
+
+def _ctx(cfg, tmp, rid):
+    cell = expand_sweep(cfg.sweep)[0]
+    layout = RunLayout(tmp, "t", cell.id, "h", rid)
+    return RunContext(cfg, cell, {"server": ["node-a"]}, layout, EventWriter(layout.events_path), rid)
+
+
+def _fatal_scanner(severity="fatal"):
+    """Minimal scanner double exposing the contract Job._scan_patterns uses."""
+
+    class _S:
+        patterns = [
+            FailurePattern(
+                id="hbm_ecc",
+                source="dmesg",
+                pattern="hbm",
+                category=FailureCategory.FAILURE_PATTERN_MATCHED,
+                severity=severity,
+                hint="HBM ECC",
+            )
+        ]
+
+        def scan(self, text, source=None):
+            if not text or (source is not None and source != "dmesg"):
+                return []
+            return [
+                PatternHit(
+                    pattern_id="hbm_ecc",
+                    category=FailureCategory.FAILURE_PATTERN_MATCHED,
+                    source="dmesg",
+                    line_no=1,
+                    line="hbm ecc",
+                )
+            ]
+
+    return _S()
+
+
+class TestJobLifecycle(unittest.TestCase):
+    """Brief minimum (one failure class + teardown-in-finally) plus the B6/B7
+    bake-ins the addendum mandates."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.cfg = parse_config(BASE)
+
+    def test_setup_failure_classified_at_boundary_b4(self):
+        # Brief: "one failure-class wired through Job.run (mocked adapter)".
+        m = Job(_Adapter(fail_prepare=True), _ctx(self.cfg, self.tmp, "s")).run()
+        self.assertEqual(m.verdicts.overall_status, "failed")
+        self.assertEqual(m.verdicts.failure_category, FailureCategory.SETUP_FAILURE.value)
+
+    def test_teardown_runs_in_finally_on_failure(self):
+        # Brief: "the teardown-in-finally fires even when the adapter raises".
+        adapter = _Adapter(fail_prepare=True)
+        ctx = _ctx(self.cfg, self.tmp, "t2")
+        Job(adapter, ctx).run()
+        self.assertTrue(adapter.teardown_called)
+
+    def test_job_owns_phase_boundary_events_b6(self):
+        # Addendum B6: Job owns prepare.*, parse.done, teardown.*.
+        ctx = _ctx(self.cfg, self.tmp, "ev")
+        Job(_Adapter(), ctx).run()
+        text = ctx.layout.events_path.read_text()
+        names = set()
+        for line in text.splitlines():
+            if '"event":' in line:
+                names.add(line.split('"event": "', 1)[1].split('"', 1)[0])
+        for required in ("prepare.start", "prepare.done", "parse.done", "teardown.start", "teardown.done"):
+            self.assertIn(required, names, "Job did not emit phase-boundary event " + required)
+
+    def test_manifest_env_and_commands_populated_b7_half(self):
+        # Addendum B7 (G3+G5 half): ConfigInputs.env from container.env,
+        # ConfigInputs.commands from ctx.scratch, both AS-IS (no redaction).
+        adapter = _Adapter(record_commands=["docker run img:latest", "curl localhost:8000"])
+        ctx = _ctx(self.cfg, self.tmp, "b7")
+        m = Job(adapter, ctx).run()
+        self.assertEqual(m.config.env, {"HF_TOKEN": "secret-xyz", "DEBUG": "1"})
+        self.assertEqual(m.config.commands, ["docker run img:latest", "curl localhost:8000"])
+        # Pin the no-redaction contract: a future "let's redact" patch must
+        # delete this assertion (forcing the conversation).
+        self.assertIn("secret-", m.config.env["HF_TOKEN"])
+
+
+class TestFatalPatternOverride(unittest.TestCase):
+    """B4 override is an upgrade, not a relabel: it beats complete/error but
+    must NOT clobber a classified WorkloadFailure. Pins adversarial-review
+    BLOCKER #1."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.cfg = parse_config(BASE)
+
+    def test_classified_verification_failure_survives_fatal_pattern(self):
+        cfg = parse_config(
+            {**BASE, "thresholds": [{"type": "percentile", "metric": "ttft_ms", "op": "<=", "value": 1}]}
+        )
+        adapter = _Adapter(samples=[{"ttft_ms": 999}])
+        ctx = _ctx(cfg, self.tmp, "vf_keep")
+        ctx.logs["node-a.dmesg.txt"] = "hbm something"
+        m = Job(adapter, ctx, scanner=_fatal_scanner()).run()
+        self.assertEqual(m.verdicts.failure_category, FailureCategory.VERIFICATION_FAILURE.value)
+
+    def test_successful_run_with_fatal_pattern_promotes_to_failed(self):
+        ctx = _ctx(self.cfg, self.tmp, "ok_fatal")
+        ctx.logs["node-a.dmesg.txt"] = "hbm something"
+        m = Job(_Adapter(), ctx, scanner=_fatal_scanner()).run()
+        self.assertEqual(m.verdicts.overall_status, "failed")
+        self.assertEqual(m.verdicts.failure_category, FailureCategory.FAILURE_PATTERN_MATCHED.value)
+
+
+class TestScannerContractFailsClosed(unittest.TestCase):
+    """Pins adversarial-review BLOCKER #2: a scanner without `.patterns`
+    cannot have its hits' severity resolved, so the B4 fatal override would
+    silently never fire. Must raise instead."""
+
+    def test_scanner_missing_patterns_attribute_raises(self):
+        tmp = Path(tempfile.mkdtemp())
+        cfg = parse_config(BASE)
+
+        class _BadScanner:
+            def scan(self, text, source=None):
+                return []
+
+        ctx = _ctx(cfg, tmp, "bad")
+        ctx.logs["node-a.dmesg.txt"] = "anything"
+        with self.assertRaises(TypeError):
+            Job(_Adapter(), ctx, scanner=_BadScanner()).run()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/unittests/test_run_context.py
+++ b/cvs/lib/unittests/test_run_context.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from cvs.lib.config import expand_sweep, parse_config
+from cvs.lib.manifest.events import EventWriter
+from cvs.lib.manifest.layout import RunLayout
+from cvs.lib.run_context import RunContext
+
+BASE = {
+    "schema_version": "2",
+    "framework": "vllm",
+    "target_gpu": "mi300",
+    "model": "m",
+    "topology": {"roles": {"server": {"count": 1, "gpus_per_node": 8}}},
+    "params": {"server_script": "s.sh", "base_url": "http://localhost"},
+    "sweep": {
+        "concurrency": [16],
+        "sequence_combinations": [{"isl": 1024, "osl": 1024, "name": "balanced"}],
+    },
+}
+
+
+def _ctx(tmp):
+    cfg = parse_config(BASE)
+    cell = expand_sweep(cfg.sweep)[0]
+    layout = RunLayout(tmp, "t", cell.id, "h", "r")
+    layout.ensure()
+    return cfg, RunContext(
+        config=cfg,
+        cell=cell,
+        bindings={"server": ["node-a"]},
+        layout=layout,
+        events=EventWriter(None),
+        run_id="r",
+    )
+
+
+class TestRunContextState(unittest.TestCase):
+    """RunContext is a pure state struct: construction populates inputs and
+    initializes outputs; ``param`` resolves cell-override-then-static."""
+
+    def test_construction_initializes_outputs(self):
+        tmp = Path(tempfile.mkdtemp())
+        _, ctx = _ctx(tmp)
+        # Inputs preserved.
+        self.assertEqual(ctx.bindings, {"server": ["node-a"]})
+        self.assertEqual(ctx.run_id, "r")
+        # Outputs initialized empty (so adapters don't blow up on first write).
+        self.assertEqual(ctx.scratch, {})
+        self.assertEqual(ctx.logs, {})
+        self.assertEqual(ctx.containers, [])
+        # ResultView has empty samples/scalars by default.
+        self.assertEqual(ctx.result.samples, [])
+        self.assertEqual(ctx.result.scalars, {})
+
+    def test_param_resolves_cell_then_static(self):
+        tmp = Path(tempfile.mkdtemp())
+        _, ctx = _ctx(tmp)
+        # Static param (from config.params) wins when not in cell.
+        self.assertEqual(ctx.param("server_script"), "s.sh")
+        # Cell param wins over static when both present.
+        ctx.cell.params["server_script"] = "override.sh"
+        self.assertEqual(ctx.param("server_script"), "override.sh")
+        # Default when neither has it.
+        self.assertEqual(ctx.param("missing", default="d"), "d")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Engineering keystone of the DTNI spine (Wave 2). Adds the mode-blind
`Job` driver plus the `RunContext` state struct adapters thread through it.

Plan: [`plans/dtni_rollout/g5b-job-executors.md`](https://github.com/atnair/plans/blob/main/dtni_rollout/g5b-job-executors.md).

## Bake-ins (per addendum)

- **B4** — failures classified at the raise site. `WorkloadFailure` carries
  `category`; generic exceptions in `prepare`/`launch` wrap as `SetupFailure`
  at the boundary. A fatal-pattern hit *upgrades* `complete`/`error` verdicts
  to `failure_pattern_matched` but **never clobbers a classified
  `WorkloadFailure`** (taxonomy earliest-raise-site rule).
- **B6** — `Job` owns phase-boundary events (`prepare.start`, `prepare.done`,
  `parse.done`, `teardown.start`, `teardown.done`); adapters emit only
  sub-phase events. Documented in `cvs/lib/AGENTS.md`.
- **B7-half (G3+G5)** — `ConfigInputs.env` sourced from `config.container.env`,
  `ConfigInputs.commands` from `ctx.scratch["commands"]`, both **as-is**
  (no redaction; security removed entirely per addendum §4 B7).
  `resolved_config_path` is recorded only when the YAML sidecar actually wrote.

## Deferred (with rationale)

- **A1 staging seam (SFTP `stage_in`/`fetch`)** deferred. Real CVS clusters
  use either a shared filesystem (Weka/NFS at the same path on devbox + nodes)
  or an end-of-run rsync, so per-file SFTP staging is not on the critical
  path for the integration milestone. G3 already ships
  `RunLayout.remote_artifact_dir`/`to_remote` plumbing, so the wrappers are
  a pure addition when the first no-shared-FS cluster lands.
- **A2 per-role executors** deferred per addendum §3 (single `executor` slot
  ships; per-role dict lands with the first multi-role adapter:
  sglang-disagg / megatron / jax).

## Adversarial-review BLOCKERs caught + fixed

1. Fatal pattern was clobbering classified WorkloadFailures (SafetyViolation,
   Liveness, Verification). Fixed: gated on `boundary_classified` flag;
   pinned by `test_classified_verification_failure_survives_fatal_pattern`.
2. Scanner without `.patterns` attr silently downgraded every fatal hit to
   `"warn"`, disabling the override. Fixed: fail closed with `TypeError`;
   pinned by `test_scanner_missing_patterns_attribute_raises`.

## Modules

- `cvs/lib/job.py` — 6-phase mode-blind driver; teardown in `finally`;
  events sidecar always closed.
- `cvs/lib/run_context.py` — pure state struct (config, cell, bindings,
  layout, events, executor, run_id; `result`/`logs`/`containers`/`scratch`).
- `cvs/lib/AGENTS.md` — B6 split, B4 override rule, always-close-events
  invariant, deferred-A1/A2 rationale.
- `cvs/lib/unittests/test_job.py` — 7 tests.
- `cvs/lib/unittests/test_run_context.py` — 2 tests (state + `param`).

## Gate (offline, no GPU)

```
VENV=/data/atnair/repos/cvs_worktrees/cvs-dtni-spine/.dtni_venv/bin/python
cd /data/atnair/repos/cvs_worktrees/cvs-job-executors
$VENV -m unittest cvs.lib.unittests.test_job cvs.lib.unittests.test_run_context   # 9 OK
/data/atnair/repos/cvs/.ruff_venv/bin/ruff check cvs/lib/job.py cvs/lib/run_context.py
/data/atnair/repos/cvs/.ruff_venv/bin/ruff format --check cvs/lib/job.py cvs/lib/run_context.py
```

## Out of scope

- A1 staging API (deferred, see above).
- A2 per-role executors dict (deferred, see above).
- §9 `addendum.md` manifest entry (lands as a separate post-merge edit
  per the convention used for #205/#206/#207).
