### PR TITLE
feat(dtni-v1): Step 4 — accuracy benchmarks (lm-eval MMLU + GSM8K)

### DIFF
--- a/cvs/frameworks/vllm_single/adapter.py
+++ b/cvs/frameworks/vllm_single/adapter.py
@@ -1,19 +1,19 @@
-"""VllmAdapter — single role, single host (in v1 smoke).
+"""VllmAdapter — single role, single host (in v1 smoke + accuracy).
 
 launch: pull image, mount models, start vllm serve, wait /health
-await: vllm runs forever; we let benchmark/parse drive the lifetime
-parse: in v1 smoke we just record TTFB via a single completion request
-
-Step 4 will add benchmark harness; for now the smoke proves end-to-end.
+await: vllm runs forever; parse phase drives the lifetime
+parse: smoke (single completion). If workload.benchmarks is non-empty, also
+       runs lm-eval against the live server and projects scores to scalars.
 """
 
 from __future__ import annotations
 
 import json
 import shlex
-import time
 
 from cvs.lib.base_adapter import BaseWorkloadAdapter
+from cvs.lib.benchmarks.harness_invokers import OUTPUT_DIR_IN_CONTAINER
+from cvs.lib.benchmarks.runner import run_benchmarks
 from cvs.lib.errors import WorkloadError
 from cvs.lib.substitution import substitute
 
@@ -26,12 +26,17 @@ class VllmAdapter(BaseWorkloadAdapter):
     def launch(self, ctx) -> None:
         wl = ctx.workload
         role_spec = wl["roles"]["server"]
-        # Resolve {model.path} etc inside command/env using ctx.scratch
         sub_ctx = ctx.scratch["sub_ctx"]
         command = substitute(role_spec["command"], sub_ctx)
         env = {k: substitute(v, sub_ctx) for k, v in role_spec.get("env", {}).items()}
         volumes = {substitute(k, sub_ctx): substitute(v, sub_ctx)
                    for k, v in role_spec.get("volumes", {}).items()}
+        # Bind-mount the run's host artifacts dir into the container so the
+        # benchmark harness (run via `docker exec`) can drop result JSONs
+        # that the parse phase reads back on the host. The in-container path
+        # is fixed so harness_invokers / runner can agree without ctx.
+        volumes[str(ctx.artifacts_dir)] = OUTPUT_DIR_IN_CONTAINER
+
         image_tag = wl["image"]["tag"]
         port = role_spec["port"]
 
@@ -59,11 +64,45 @@ class VllmAdapter(BaseWorkloadAdapter):
         )
 
     def parse(self, ctx) -> None:
-        """Smoke: issue one completion request, record TTFB + tokens/sec."""
+        """Smoke + (optionally) accuracy benchmarks.
+
+        Smoke is always done — one completion request through the server,
+        records latency / token count. When ``workload.benchmarks`` is
+        non-empty, also runs lm-eval-harness against the live server and
+        projects each benchmark's score into ``ctx.result.scalars``.
+        """
+
+        self._run_smoke(ctx)
+
+        benchmarks = list(ctx.workload.get("benchmarks") or [])
+        if not benchmarks:
+            return
+
+        role_spec = ctx.workload["roles"]["server"]
+        port = role_spec["port"]
+        server_handle = self._server_handle(ctx)
+
+        # The harness exec'd into the server container shares network=host,
+        # so localhost reaches the server. The output dir is the well-known
+        # in-container mount established at launch time.
+        scalars = run_benchmarks(
+            benchmarks=benchmarks,
+            server_handle=server_handle,
+            base_url=f"http://localhost:{port}",
+            model_id=ctx.workload["model"]["id"],
+            output_dir_in_container=OUTPUT_DIR_IN_CONTAINER,
+            output_dir_on_host=ctx.artifacts_dir,
+        )
+        ctx.result.scalars.update(scalars)
+
+    def _run_smoke(self, ctx) -> None:
         role_spec = ctx.workload["roles"]["server"]
         port = role_spec["port"]
         host = ctx.bindings["server"][0]
-        executor = ctx.executor.executor_for(host) if hasattr(ctx.executor, "executor_for") else ctx.executor
+        executor = (
+            ctx.executor.executor_for(host)
+            if hasattr(ctx.executor, "executor_for") else ctx.executor
+        )
 
         prompt = "Once upon a time"
         body = json.dumps({
@@ -88,7 +127,6 @@ class VllmAdapter(BaseWorkloadAdapter):
                     elapsed_s = float(line.split("=", 1)[1])
                 except ValueError:
                     pass
-        # Try to count completion tokens (rough — vllm response JSON)
         n_tokens = 0
         try:
             for line in out.splitlines():
@@ -108,3 +146,19 @@ class VllmAdapter(BaseWorkloadAdapter):
         ctx.result.scalars["smoke_completion_tokens"] = float(n_tokens)
         ctx.result.scalars["smoke_throughput_tok_s"] = tok_per_s
         ctx.logs["smoke_request_raw.txt"] = out
+
+    def _server_handle(self, ctx):
+        """Return the ContainerHandle for the server role on this host.
+
+        Match the full name to avoid collisions if a future role/hostname
+        happens to contain ``_server_`` as a substring.
+        """
+        host = ctx.bindings["server"][0]
+        expected = f"{self.framework}_server_{host}_{ctx.run_id}"
+        for handle in ctx.containers:
+            if handle.name == expected:
+                return handle
+        raise WorkloadError(
+            f"vllm parse: no server container handle named {expected!r} "
+            f"(have: {[h.name for h in ctx.containers]})"
+        )

--- a/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/config.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "deepseek-r1",
+    "remote": 0,
+    "precision": "fp8"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_ROCM_USE_AITER": "1",
+        "ROCM_AITER_MLA": "1"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.9 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.85},
+  "gsm8k": {"kind": "min", "value": 0.90}
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-70b-fp8",
+    "remote": 0,
+    "precision": "fp8"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.9 --trust-remote-code --served-model-name {model.id} --quantization fp8"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.78},
+  "gsm8k": {"kind": "min", "value": 0.80}
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-8b",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 1}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 4096 --gpu-memory-utilization 0.85 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 1,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.65},
+  "gsm8k": {"kind": "min", "value": 0.55}
+}

--- a/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.3-70b-instruct",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.9 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.80},
+  "gsm8k": {"kind": "min", "value": 0.85}
+}

--- a/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "qwen3-next-80b-a3b-instruct",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.85 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.75},
+  "gsm8k": {"kind": "min", "value": 0.80}
+}

--- a/cvs/lib/benchmarks/__init__.py
+++ b/cvs/lib/benchmarks/__init__.py
@@ -1,0 +1,14 @@
+"""Accuracy benchmark machinery for DTNI v1 (Step 4, accuracy-only).
+
+One harness in v1: ``lm-eval-harness`` (covers MMLU + GSM8K + the LightEval
+supplementary set the tracker references). Perf benchmarks, samplers, sweeps,
+and the multi-lifecycle driver are deferred to v2 — see
+``jobs/ec849125/tmp/cvs-dtni-v2-harness-plan.md``.
+"""
+
+from cvs.lib.benchmarks.registry import (  # noqa: F401
+    BENCHMARK_REGISTRY,
+    BenchmarkSpec,
+    list_benchmarks,
+    lookup,
+)

--- a/cvs/lib/benchmarks/harness_invokers.py
+++ b/cvs/lib/benchmarks/harness_invokers.py
@@ -1,0 +1,73 @@
+"""Build the in-container command for a benchmark harness.
+
+One invoker in v1: ``lm-eval-harness`` against an OpenAI-compatible endpoint.
+Pure (no I/O) so unit-testable.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Callable
+
+from cvs.lib.benchmarks.registry import BenchmarkSpec
+
+
+# Well-known in-container path where the adapter bind-mounts the run's host
+# artifacts_dir. The harness writes results under this; runner reads them
+# from the host via the same mount.
+OUTPUT_DIR_IN_CONTAINER: str = "/cvs_artifacts"
+
+
+@dataclass(frozen=True)
+class HarnessCtx:
+    """Inputs the harness needs to construct its command line.
+
+    - ``base_url``: where the server is reachable from inside the harness's
+      container. For v1 single-node, harness shares ``network=host`` with the
+      server, so ``http://localhost:<port>`` is correct.
+    - ``model_id``: vLLM's ``--served-model-name`` — what we POST as ``model``.
+    - ``output_dir``: in-container path where the harness drops its JSON
+      (bind-mounted to the host artifacts dir). Each benchmark writes into a
+      ``<output_dir>/<benchmark_id>/`` subdir to keep results isolated.
+    """
+
+    base_url: str
+    model_id: str
+    output_dir: str
+
+
+def _lm_eval(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
+    """Build the lm_eval command line.
+
+    ``--output_path`` is a DIRECTORY for lm-eval-harness >=0.4: it writes
+    ``results_<timestamp>.json`` inside it. We give each benchmark its own
+    subdir so the runner can find that file unambiguously.
+    """
+    task = spec.extra.get("task", spec.id)
+    out_path = f"{hctx.output_dir}/{spec.id}"
+    parts = [
+        "lm_eval",
+        "--model", "local-completions",
+        "--model_args",
+        f"base_url={hctx.base_url}/v1/completions,model={hctx.model_id},num_concurrent=8,max_retries=3",
+        "--tasks", task,
+        "--num_fewshot", str(spec.shots),
+        "--output_path", out_path,
+        "--log_samples",
+    ]
+    return " ".join(shlex.quote(p) for p in parts)
+
+
+HARNESS_INVOKERS: dict[str, Callable[[BenchmarkSpec, HarnessCtx], str]] = {
+    "lm-eval-harness": _lm_eval,
+}
+
+
+def build_command(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
+    if spec.harness not in HARNESS_INVOKERS:
+        raise KeyError(
+            f"benchmark {spec.id!r}: unknown harness {spec.harness!r}; "
+            f"known: {sorted(HARNESS_INVOKERS)}"
+        )
+    return HARNESS_INVOKERS[spec.harness](spec, hctx)

--- a/cvs/lib/benchmarks/registry.py
+++ b/cvs/lib/benchmarks/registry.py
@@ -1,0 +1,59 @@
+"""BENCHMARK_REGISTRY — accuracy-only in v1.
+
+Per ``cvs-dtni-v1-spec.md`` §"Step 4: Accuracy benchmarks": MMLU + GSM8K via
+``lm-eval-harness``. Other tracker accuracy benchmarks (MMLU-Pro, BBH,
+HellaSwag, etc.) and all perf benchmarks land in v2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchmarkSpec:
+    """One benchmark.
+
+    - ``id``: short slug used in workload.benchmarks.
+    - ``harness``: HARNESS_INVOKERS key — picks the invocation builder.
+    - ``dataset_id``: catalog dataset key the harness will fetch (or has cached).
+    - ``score_metric``: key in the harness output JSON we extract as the
+      pass/fail scalar. The threshold file references the spec id, not this.
+    - ``score_filter``: lm-eval filter slug to pair with score_metric (newer
+      lm-eval keys are ``"<metric>,<filter>"``). ``None`` falls back to the
+      bare metric key and then to ``,none``.
+    - ``shots``: in-context examples for few-shot eval (``--num_fewshot``).
+    - ``extra``: harness-specific kwargs (e.g. ``{"task": "mmlu"}``).
+    """
+
+    id: str
+    harness: str
+    dataset_id: str
+    score_metric: str
+    score_filter: str | None = None
+    shots: int = 0
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+_ACCURACY: tuple[BenchmarkSpec, ...] = (
+    BenchmarkSpec("mmlu",  "lm-eval-harness", "mmlu",  "acc",         score_filter="none",         shots=5, extra={"task": "mmlu"}),
+    # gsm8k under lm-eval >=0.4 uses a strict-match filter chain by default.
+    BenchmarkSpec("gsm8k", "lm-eval-harness", "gsm8k", "exact_match", score_filter="strict-match", shots=5, extra={"task": "gsm8k"}),
+)
+
+
+BENCHMARK_REGISTRY: dict[str, BenchmarkSpec] = {b.id: b for b in _ACCURACY}
+
+
+def lookup(benchmark_id: str) -> BenchmarkSpec:
+    if benchmark_id not in BENCHMARK_REGISTRY:
+        raise KeyError(
+            f"unknown benchmark id {benchmark_id!r}; "
+            f"known: {sorted(BENCHMARK_REGISTRY)}"
+        )
+    return BENCHMARK_REGISTRY[benchmark_id]
+
+
+def list_benchmarks() -> tuple[str, ...]:
+    return tuple(BENCHMARK_REGISTRY)

--- a/cvs/lib/benchmarks/runner.py
+++ b/cvs/lib/benchmarks/runner.py
@@ -1,0 +1,139 @@
+"""Run accuracy benchmarks against a healthy server, project scores to scalars.
+
+Called from the adapter's ``parse()`` once the server is up. For each
+benchmark, the harness runs inside the server container (which has the host
+artifacts_dir bind-mounted at ``OUTPUT_DIR_IN_CONTAINER`` by the adapter at
+launch time) and drops a ``results_<ts>.json`` file in a per-benchmark
+subdir. We glob the host side of that mount, project the configured metric
+to ``ctx.result.scalars`` under the benchmark id so ``threshold.json`` can
+name it directly:
+
+    scalars["mmlu"]  = 0.732   ← matches `"mmlu": {"kind": "min", "value": 0.7}`
+    scalars["gsm8k"] = 0.815
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from cvs.lib.benchmarks.harness_invokers import HarnessCtx, build_command
+from cvs.lib.benchmarks.registry import BenchmarkSpec, lookup
+from cvs.lib.errors import WorkloadError
+
+
+# Per-benchmark wall-clock ceiling. MMLU on a smaller model can take ~2h;
+# this gives headroom. Total parse-phase budget is N benchmarks * this.
+PER_BENCHMARK_TIMEOUT_S: int = 4 * 3600
+
+
+def run_benchmarks(
+    *,
+    benchmarks: list[str],
+    server_handle,
+    base_url: str,
+    model_id: str,
+    output_dir_in_container: str,
+    output_dir_on_host: Path,
+) -> dict[str, float]:
+    """Run each benchmark id, return flat scalars dict for ctx.result.scalars.
+
+    ``server_handle`` is the ContainerHandle whose runner.exec we use to
+    ``docker exec`` the harness inside the same container as the server (the
+    rocm/vllm image ships ``lm_eval``).
+    """
+
+    scalars: dict[str, float] = {}
+    for bid in benchmarks:
+        spec = lookup(bid)
+        hctx = HarnessCtx(
+            base_url=base_url,
+            model_id=model_id,
+            output_dir=output_dir_in_container,
+        )
+        harness_cmd = build_command(spec, hctx)
+        docker_cmd = (
+            f"docker exec {shlex.quote(server_handle.name)} "
+            f"bash -c {shlex.quote(harness_cmd)}"
+        )
+        try:
+            server_handle.runner.exec(docker_cmd, timeout=PER_BENCHMARK_TIMEOUT_S)
+        except Exception as exc:
+            raise WorkloadError(f"benchmark {bid!r} harness failed: {exc}") from exc
+
+        result_json = _find_lm_eval_result(output_dir_on_host / bid)
+        if result_json is None:
+            raise WorkloadError(
+                f"benchmark {bid!r}: harness ran but produced no results JSON under "
+                f"{output_dir_on_host / bid}"
+            )
+        try:
+            payload = json.loads(result_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise WorkloadError(
+                f"benchmark {bid!r}: harness output {result_json} is not valid JSON: {exc}"
+            ) from exc
+
+        scalars.update(_project_scalars(spec, payload))
+
+    return scalars
+
+
+def _find_lm_eval_result(subdir: Path) -> Path | None:
+    """Return the newest ``results*.json`` under ``subdir`` (recursive), or None.
+
+    lm-eval-harness writes ``<output_path>/results_<timestamp>.json`` (and
+    sometimes nests under a model-name dir). We pick the most recently
+    modified match to be robust to either layout.
+    """
+    if not subdir.exists():
+        return None
+    matches = sorted(
+        subdir.rglob("results*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _project_scalars(spec: BenchmarkSpec, payload: dict[str, Any]) -> dict[str, float]:
+    """Extract spec.score_metric from lm-eval JSON under the benchmark id key.
+
+    lm-eval writes ``{"results": {task: {metric: value, metric_stderr: ...}}}``.
+    Modern lm-eval suffixes the metric name with ``,<filter>`` (e.g.
+    ``acc,none`` or ``exact_match,strict-match``). We try, in order:
+      1) the spec's preferred filter (``score_filter``)
+      2) the bare metric key (legacy)
+      3) ``,none`` (default filter slug)
+    Also surfaces ``<id>_stderr`` for diagnostics using the same lookup order.
+    """
+
+    out: dict[str, float] = {}
+    results = payload.get("results") or {}
+    task = spec.extra.get("task", spec.id)
+    task_results = results.get(task, {})
+
+    score = _pick_metric(task_results, spec.score_metric, spec.score_filter)
+    if isinstance(score, (int, float)):
+        out[spec.id] = float(score)
+
+    stderr = _pick_metric(task_results, f"{spec.score_metric}_stderr", spec.score_filter)
+    if isinstance(stderr, (int, float)):
+        out[f"{spec.id}_stderr"] = float(stderr)
+
+    return out
+
+
+def _pick_metric(task_results: dict[str, Any], metric: str, preferred_filter: str | None) -> Any:
+    """Walk filter-suffix variants for ``metric`` in priority order."""
+    candidates: list[str] = []
+    if preferred_filter:
+        candidates.append(f"{metric},{preferred_filter}")
+    candidates.append(metric)
+    candidates.append(f"{metric},none")
+    for key in candidates:
+        if key in task_results:
+            return task_results[key]
+    return None

--- a/cvs/lib/config_loader.py
+++ b/cvs/lib/config_loader.py
@@ -181,8 +181,29 @@ def load_workload(
         sugg = catalog.suggest("dataset", wl.dataset.id)
         hint = f" did you mean {sugg!r}?" if sugg else ""
         raise CatalogError(f"{path}: unknown dataset.id {wl.dataset.id!r}.{hint}")
-    # benchmark check deferred to whoever imports BENCHMARK_REGISTRY
+    _validate_benchmarks(path, wl.benchmarks)
     return wl
+
+
+def _validate_benchmarks(path: Path, benchmarks: list[str]) -> None:
+    """Reject unknown benchmark ids at load with a did-you-mean hint.
+
+    Imported lazily to avoid a config_loader -> benchmarks import cycle if
+    a benchmark module ever needs config types.
+    """
+    if not benchmarks:
+        return
+    import difflib
+
+    from cvs.lib.benchmarks.registry import BENCHMARK_REGISTRY
+
+    known = sorted(BENCHMARK_REGISTRY)
+    for bid in benchmarks:
+        if bid in BENCHMARK_REGISTRY:
+            continue
+        sugg = difflib.get_close_matches(bid, known, n=1, cutoff=0.6)
+        hint = f" did you mean {sugg[0]!r}?" if sugg else f" known: {known}"
+        raise CatalogError(f"{path}: unknown benchmark id {bid!r}.{hint}")
 
 
 # ---------- thresholds ----------

--- a/cvs/tests_dtni/unittests/test_benchmark_registry.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_registry.py
@@ -1,0 +1,50 @@
+"""Unit tests for cvs.lib.benchmarks.registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from cvs.lib.benchmarks.registry import (
+    BENCHMARK_REGISTRY,
+    BenchmarkSpec,
+    list_benchmarks,
+    lookup,
+)
+
+
+def test_registry_contains_v1_accuracy_set():
+    assert set(BENCHMARK_REGISTRY) == {"mmlu", "gsm8k"}
+
+
+def test_specs_are_well_formed():
+    for bid, spec in BENCHMARK_REGISTRY.items():
+        assert isinstance(spec, BenchmarkSpec)
+        assert spec.id == bid
+        assert spec.harness == "lm-eval-harness"
+        assert spec.dataset_id
+        assert spec.score_metric
+        assert spec.shots >= 0
+        # frozen dataclass: extra is a dict but immutable spec
+        assert isinstance(spec.extra, dict)
+
+
+def test_lookup_returns_spec():
+    spec = lookup("mmlu")
+    assert spec.score_metric == "acc"
+    assert spec.shots == 5
+    assert spec.extra["task"] == "mmlu"
+
+
+def test_lookup_unknown_raises_with_known_list():
+    with pytest.raises(KeyError) as exc_info:
+        lookup("mmmlu")
+    msg = str(exc_info.value)
+    assert "mmmlu" in msg
+    assert "gsm8k" in msg
+    assert "mmlu" in msg
+
+
+def test_list_benchmarks_is_stable():
+    ids = list_benchmarks()
+    assert isinstance(ids, tuple)
+    assert set(ids) == set(BENCHMARK_REGISTRY)

--- a/cvs/tests_dtni/unittests/test_benchmark_runner.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_runner.py
@@ -1,0 +1,153 @@
+"""Unit tests for cvs.lib.benchmarks.runner — projector + orchestration."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from cvs.lib.benchmarks.registry import lookup
+from cvs.lib.benchmarks.runner import _project_scalars, run_benchmarks
+from cvs.lib.errors import WorkloadError
+
+
+# ---- projector ------------------------------------------------------------
+
+
+def test_project_scalars_reads_bare_metric_key():
+    payload = {"results": {"mmlu": {"acc": 0.732, "acc_stderr": 0.011}}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {"mmlu": 0.732, "mmlu_stderr": 0.011}
+
+
+def test_project_scalars_prefers_filter_suffixed_key_for_gsm8k():
+    # gsm8k spec uses score_filter="strict-match" — must beat ",none".
+    payload = {"results": {"gsm8k": {
+        "exact_match,strict-match": 0.812,
+        "exact_match_stderr,strict-match": 0.009,
+        "exact_match,none": 0.99,  # red herring — should NOT be picked
+    }}}
+    out = _project_scalars(lookup("gsm8k"), payload)
+    assert out == {"gsm8k": 0.812, "gsm8k_stderr": 0.009}
+
+
+def test_project_scalars_falls_back_to_comma_none():
+    # mmlu spec uses score_filter="none"; verify that lookup hits.
+    payload = {"results": {"mmlu": {"acc,none": 0.71}}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {"mmlu": 0.71}
+
+
+def test_project_scalars_missing_task_returns_empty():
+    payload = {"results": {}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {}
+
+
+def test_project_scalars_skips_non_numeric_metric():
+    payload = {"results": {"mmlu": {"acc": "n/a"}}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {}
+
+
+# ---- runner orchestration -------------------------------------------------
+
+
+@dataclass
+class _FakeRunner:
+    """Drops a per-benchmark results JSON into <out_dir>/<bid>/results.json."""
+    out_dir: Path
+    payloads: dict
+    last_cmd: str = ""
+
+    def exec(self, cmd: str, timeout: int = 0) -> str:
+        self.last_cmd = cmd
+        for bid, payload in self.payloads.items():
+            if f"/{bid} " in cmd or cmd.endswith(f"/{bid}"):
+                sub = self.out_dir / bid
+                sub.mkdir(parents=True, exist_ok=True)
+                (sub / "results_20260606.json").write_text(json.dumps(payload))
+                return ""
+        return ""
+
+
+@dataclass
+class _FakeHandle:
+    name: str
+    runner: _FakeRunner
+
+
+def test_run_benchmarks_emits_scalars_per_id(tmp_path: Path):
+    payloads = {
+        "mmlu":  {"results": {"mmlu":  {"acc,none": 0.71, "acc_stderr,none": 0.01}}},
+        "gsm8k": {"results": {"gsm8k": {"exact_match,strict-match": 0.82}}},
+    }
+    runner = _FakeRunner(out_dir=tmp_path, payloads=payloads)
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+
+    scalars = run_benchmarks(
+        benchmarks=["mmlu", "gsm8k"],
+        server_handle=handle,
+        base_url="http://localhost:8000",
+        model_id="llama-3.1-8b",
+        output_dir_in_container=str(tmp_path),
+        output_dir_on_host=tmp_path,
+    )
+
+    assert scalars["mmlu"] == 0.71
+    assert scalars["mmlu_stderr"] == 0.01
+    assert scalars["gsm8k"] == 0.82
+
+
+def test_run_benchmarks_unknown_id_raises_before_exec(tmp_path: Path):
+    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+    with pytest.raises(KeyError):
+        run_benchmarks(
+            benchmarks=["does-not-exist"],
+            server_handle=handle,
+            base_url="http://localhost:8000",
+            model_id="x",
+            output_dir_in_container=str(tmp_path),
+            output_dir_on_host=tmp_path,
+        )
+    assert runner.last_cmd == ""
+
+
+def test_run_benchmarks_missing_output_raises(tmp_path: Path):
+    # FakeRunner won't write anything because payloads is empty.
+    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+    with pytest.raises(WorkloadError) as exc_info:
+        run_benchmarks(
+            benchmarks=["mmlu"],
+            server_handle=handle,
+            base_url="http://localhost:8000",
+            model_id="x",
+            output_dir_in_container=str(tmp_path),
+            output_dir_on_host=tmp_path,
+        )
+    assert "no results JSON" in str(exc_info.value)
+
+
+def test_run_benchmarks_invalid_json_raises(tmp_path: Path):
+    # Pre-create the per-benchmark subdir with a malformed results file.
+    sub = tmp_path / "mmlu"
+    sub.mkdir()
+    (sub / "results_bad.json").write_text("{not json")
+
+    # Fake runner that does NOT overwrite the file.
+    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+    with pytest.raises(WorkloadError) as exc_info:
+        run_benchmarks(
+            benchmarks=["mmlu"],
+            server_handle=handle,
+            base_url="http://localhost:8000",
+            model_id="x",
+            output_dir_in_container=str(tmp_path),
+            output_dir_on_host=tmp_path,
+        )
+    assert "not valid JSON" in str(exc_info.value)

--- a/cvs/tests_dtni/unittests/test_config_loader_benchmarks.py
+++ b/cvs/tests_dtni/unittests/test_config_loader_benchmarks.py
@@ -1,0 +1,87 @@
+"""Unit tests for cvs.lib.config_loader benchmark validation.
+
+Scope is narrow on purpose: this file exists to lock in the v1 behavior that
+load_workload rejects unknown benchmark ids at load time with a did-you-mean
+hint, against BENCHMARK_REGISTRY.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cvs.lib.catalog import Catalog, ModelEntry
+from cvs.lib.config_loader import load_workload
+from cvs.lib.errors import CatalogError
+
+
+def _minimal_workload(benchmarks: list[str]) -> dict:
+    return {
+        "schema_version": 1,
+        "framework": "vllm_single",
+        "gpu_arch": "mi300x",
+        "paths": {
+            "shared_fs": "/tmp/x",
+            "models_dir": "/tmp/x/models",
+            "datasets_dir": "/tmp/x/datasets",
+            "artifacts_dir": "/tmp/x/artifacts",
+            "images_dir": "/tmp/x/images",
+        },
+        "model": {"id": "llama-3.1-8b", "remote": 0, "precision": "bf16"},
+        "benchmarks": benchmarks,
+        "image": {"tag": "rocm/vllm:latest", "remote": 1},
+        "topology": {"roles": {"server": {"count": 1, "gpus_per_node": 1}}},
+        "roles": {
+            "server": {
+                "port": 8000,
+                "health_path": "/health",
+                "command": "vllm serve x",
+            }
+        },
+    }
+
+
+def _catalog() -> Catalog:
+    return Catalog(
+        models={"llama-3.1-8b": ModelEntry(id="llama-3.1-8b", hf_repo="x/y")},
+        datasets={},
+        benchmarks=(),
+    )
+
+
+def _write(tmp_path: Path, wl: dict) -> Path:
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(wl))
+    return p
+
+
+def test_known_benchmarks_load_clean(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload(["mmlu", "gsm8k"]))
+    wl = load_workload(p, catalog=_catalog())
+    assert wl.benchmarks == ["mmlu", "gsm8k"]
+
+
+def test_empty_benchmarks_load_clean(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload([]))
+    wl = load_workload(p, catalog=_catalog())
+    assert wl.benchmarks == []
+
+
+def test_unknown_benchmark_raises_with_did_you_mean(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload(["mmmlu"]))
+    with pytest.raises(CatalogError) as exc_info:
+        load_workload(p, catalog=_catalog())
+    msg = str(exc_info.value)
+    assert "mmmlu" in msg
+    assert "mmlu" in msg  # did-you-mean suggestion
+
+
+def test_unknown_benchmark_no_close_match_lists_known(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload(["totally-unrelated"]))
+    with pytest.raises(CatalogError) as exc_info:
+        load_workload(p, catalog=_catalog())
+    msg = str(exc_info.value)
+    assert "totally-unrelated" in msg
+    assert "mmlu" in msg and "gsm8k" in msg

--- a/cvs/tests_dtni/unittests/test_harness_invokers.py
+++ b/cvs/tests_dtni/unittests/test_harness_invokers.py
@@ -1,0 +1,59 @@
+"""Unit tests for cvs.lib.benchmarks.harness_invokers."""
+
+from __future__ import annotations
+
+import pytest
+
+from cvs.lib.benchmarks.harness_invokers import (
+    HARNESS_INVOKERS,
+    OUTPUT_DIR_IN_CONTAINER,
+    HarnessCtx,
+    build_command,
+)
+from cvs.lib.benchmarks.registry import lookup
+
+
+def _hctx() -> HarnessCtx:
+    return HarnessCtx(
+        base_url="http://localhost:8000",
+        model_id="llama-3.1-8b",
+        output_dir="/output",
+    )
+
+
+def test_invoker_registry_has_lm_eval():
+    assert "lm-eval-harness" in HARNESS_INVOKERS
+
+
+def test_output_dir_in_container_is_absolute():
+    assert OUTPUT_DIR_IN_CONTAINER.startswith("/")
+
+
+def test_build_command_mmlu_includes_required_flags():
+    cmd = build_command(lookup("mmlu"), _hctx())
+    assert "lm_eval" in cmd
+    assert "--model local-completions" in cmd
+    assert "base_url=http://localhost:8000/v1/completions" in cmd
+    assert "model=llama-3.1-8b" in cmd
+    assert "--tasks mmlu" in cmd
+    assert "--num_fewshot 5" in cmd
+    # --output_path is a directory per lm-eval >=0.4 convention.
+    assert "--output_path /output/mmlu" in cmd
+    assert "/output/mmlu.json" not in cmd
+    assert "--log_samples" in cmd
+
+
+def test_build_command_gsm8k_uses_task_arg_from_extra():
+    cmd = build_command(lookup("gsm8k"), _hctx())
+    assert "--tasks gsm8k" in cmd
+    assert "--num_fewshot 5" in cmd
+    assert "--output_path /output/gsm8k" in cmd
+
+
+def test_build_command_unknown_harness_raises():
+    from cvs.lib.benchmarks.registry import BenchmarkSpec
+    spec = BenchmarkSpec("fake", "no-such-harness", "mmlu", "acc")
+    with pytest.raises(KeyError) as exc_info:
+        build_command(spec, _hctx())
+    assert "no-such-harness" in str(exc_info.value)
+    assert "lm-eval-harness" in str(exc_info.value)


### PR DESCRIPTION
## Scope (per cvs-dtni-v1-spec.md §"Step 4")

Accuracy-only. MMLU + GSM8K via `lm-eval-harness`, called from `VllmAdapter.parse()` after smoke and before verdict.

### New lib

- `cvs/lib/benchmarks/{__init__,registry,harness_invokers,runner}.py`
  - `BenchmarkSpec` + `BENCHMARK_REGISTRY = {mmlu, gsm8k}` only
  - `HARNESS_INVOKERS = {"lm-eval-harness": _lm_eval}` — pure command builder, unit-testable
  - `run_benchmarks()` per-id: build command → `docker exec` in the server container → locate `results*.json` under per-benchmark subdir → project the configured metric to `ctx.result.scalars` under the benchmark id
  - `_project_scalars` walks filter-suffix variants (`"<metric>,<filter>"`, bare, `,none`) for lm-eval ≥ 0.4 compatibility; `gsm8k` uses `score_filter="strict-match"`

### Adapter wiring

- `cvs/frameworks/vllm_single/adapter.py`
  - `launch()` bind-mounts `ctx.artifacts_dir → OUTPUT_DIR_IN_CONTAINER` so the harness's result JSONs reach the host
  - `parse()` runs smoke unconditionally; benchmarks run only when `workload.benchmarks` is non-empty
  - `_server_handle()` exact-name match (`framework_role_host_run_id`), not substring

### Config loader

- `_validate_benchmarks()` rejects unknown benchmark ids at load with a did-you-mean hint against `BENCHMARK_REGISTRY` (previously deferred TODO).

### New workload configs (5, one per catalog model)

- `llama_3_1_8b_bf16_single_1_accuracy`
- `llama_3_1_70b_fp8_single_8_accuracy`
- `llama_3_3_70b_bf16_single_8_accuracy`
- `deepseek_r1_fp8_single_8_accuracy`
- `qwen3_next_80b_bf16_single_8_accuracy`

Each sets `"benchmarks": ["mmlu", "gsm8k"]` and adds matching `min`-kind threshold entries alongside the existing smoke metrics.

## Tests

- `test_benchmark_registry.py` (5): registry shape + lookup
- `test_harness_invokers.py` (5): command invariants + that `--output_path` is a directory
- `test_benchmark_runner.py` (8): filter-suffix priority + end-to-end orchestration via a fake docker handle dropping results JSONs into per-benchmark subdirs
- `test_config_loader_benchmarks.py` (4): load-time validation + did-you-mean

All 64 unit tests pass (Python 3.8 + `eval_type_backport` shim).

## Deferred to v2 (`jobs/ec849125 v2 harness plan`)

- Perf benchmarks, samplers (`rocm_smi`, `prometheus`), sweep machinery, lifecycle dispatch refactor, log parsers, additional accuracy benchmarks (MMLU-Pro, BBH, HellaSwag, …)
- Generic `BaseWorkloadAdapter.handle_for(role, host)` (v1 has it inline in the single adapter)
- Parse-phase wall-clock budget (today's `PER_BENCHMARK_TIMEOUT_S` is per-benchmark only)
- Threading the in-container artifacts mount path through `HarnessCtx` instead of a module constant (matters for disagg)

## Live verification

**Deferred — nodes down.** End-to-end accuracy run against MI300X will follow once the cluster returns.

## Base

Targets `atnair/cvs-dtni-v1`, not `main`.
