### PR TITLE
feat(dtni-v1): vllm perf benchmarks (vllm bench serve)

### DIFF
--- a/cvs/frameworks/vllm_single/adapter.py
+++ b/cvs/frameworks/vllm_single/adapter.py
@@ -90,6 +90,7 @@ class VllmAdapter(BaseWorkloadAdapter):
             server_handle=server_handle,
             base_url=f"http://localhost:{port}",
             model_id=ctx.workload["model"]["id"],
+            model_path=ctx.scratch["sub_ctx"]["model.path"],
             output_dir_in_container=OUTPUT_DIR_IN_CONTAINER,
             output_dir_on_host=ctx.artifacts_dir,
         )

--- a/cvs/frameworks/vllm_single/adapter.py
+++ b/cvs/frameworks/vllm_single/adapter.py
@@ -1,19 +1,19 @@
-"""VllmAdapter — single role, single host (in v1 smoke).
+"""VllmAdapter — single role, single host (in v1 smoke + accuracy).
 
 launch: pull image, mount models, start vllm serve, wait /health
-await: vllm runs forever; we let benchmark/parse drive the lifetime
-parse: in v1 smoke we just record TTFB via a single completion request
-
-Step 4 will add benchmark harness; for now the smoke proves end-to-end.
+await: vllm runs forever; parse phase drives the lifetime
+parse: smoke (single completion). If workload.benchmarks is non-empty, also
+       runs lm-eval against the live server and projects scores to scalars.
 """
 
 from __future__ import annotations
 
 import json
 import shlex
-import time
 
 from cvs.lib.base_adapter import BaseWorkloadAdapter
+from cvs.lib.benchmarks.harness_invokers import OUTPUT_DIR_IN_CONTAINER
+from cvs.lib.benchmarks.runner import run_benchmarks
 from cvs.lib.errors import WorkloadError
 from cvs.lib.substitution import substitute
 
@@ -26,12 +26,17 @@ class VllmAdapter(BaseWorkloadAdapter):
     def launch(self, ctx) -> None:
         wl = ctx.workload
         role_spec = wl["roles"]["server"]
-        # Resolve {model.path} etc inside command/env using ctx.scratch
         sub_ctx = ctx.scratch["sub_ctx"]
         command = substitute(role_spec["command"], sub_ctx)
         env = {k: substitute(v, sub_ctx) for k, v in role_spec.get("env", {}).items()}
         volumes = {substitute(k, sub_ctx): substitute(v, sub_ctx)
                    for k, v in role_spec.get("volumes", {}).items()}
+        # Bind-mount the run's host artifacts dir into the container so the
+        # benchmark harness (run via `docker exec`) can drop result JSONs
+        # that the parse phase reads back on the host. The in-container path
+        # is fixed so harness_invokers / runner can agree without ctx.
+        volumes[str(ctx.artifacts_dir)] = OUTPUT_DIR_IN_CONTAINER
+
         image_tag = wl["image"]["tag"]
         port = role_spec["port"]
 
@@ -59,11 +64,45 @@ class VllmAdapter(BaseWorkloadAdapter):
         )
 
     def parse(self, ctx) -> None:
-        """Smoke: issue one completion request, record TTFB + tokens/sec."""
+        """Smoke + (optionally) accuracy benchmarks.
+
+        Smoke is always done — one completion request through the server,
+        records latency / token count. When ``workload.benchmarks`` is
+        non-empty, also runs lm-eval-harness against the live server and
+        projects each benchmark's score into ``ctx.result.scalars``.
+        """
+
+        self._run_smoke(ctx)
+
+        benchmarks = list(ctx.workload.get("benchmarks") or [])
+        if not benchmarks:
+            return
+
+        role_spec = ctx.workload["roles"]["server"]
+        port = role_spec["port"]
+        server_handle = self._server_handle(ctx)
+
+        # The harness exec'd into the server container shares network=host,
+        # so localhost reaches the server. The output dir is the well-known
+        # in-container mount established at launch time.
+        scalars = run_benchmarks(
+            benchmarks=benchmarks,
+            server_handle=server_handle,
+            base_url=f"http://localhost:{port}",
+            model_id=ctx.workload["model"]["id"],
+            output_dir_in_container=OUTPUT_DIR_IN_CONTAINER,
+            output_dir_on_host=ctx.artifacts_dir,
+        )
+        ctx.result.scalars.update(scalars)
+
+    def _run_smoke(self, ctx) -> None:
         role_spec = ctx.workload["roles"]["server"]
         port = role_spec["port"]
         host = ctx.bindings["server"][0]
-        executor = ctx.executor.executor_for(host) if hasattr(ctx.executor, "executor_for") else ctx.executor
+        executor = (
+            ctx.executor.executor_for(host)
+            if hasattr(ctx.executor, "executor_for") else ctx.executor
+        )
 
         prompt = "Once upon a time"
         body = json.dumps({
@@ -88,7 +127,6 @@ class VllmAdapter(BaseWorkloadAdapter):
                     elapsed_s = float(line.split("=", 1)[1])
                 except ValueError:
                     pass
-        # Try to count completion tokens (rough — vllm response JSON)
         n_tokens = 0
         try:
             for line in out.splitlines():
@@ -108,3 +146,19 @@ class VllmAdapter(BaseWorkloadAdapter):
         ctx.result.scalars["smoke_completion_tokens"] = float(n_tokens)
         ctx.result.scalars["smoke_throughput_tok_s"] = tok_per_s
         ctx.logs["smoke_request_raw.txt"] = out
+
+    def _server_handle(self, ctx):
+        """Return the ContainerHandle for the server role on this host.
+
+        Match the full name to avoid collisions if a future role/hostname
+        happens to contain ``_server_`` as a substring.
+        """
+        host = ctx.bindings["server"][0]
+        expected = f"{self.framework}_server_{host}_{ctx.run_id}"
+        for handle in ctx.containers:
+            if handle.name == expected:
+                return handle
+        raise WorkloadError(
+            f"vllm parse: no server container handle named {expected!r} "
+            f"(have: {[h.name for h in ctx.containers]})"
+        )

--- a/cvs/frameworks/vllm_single/adapter.py
+++ b/cvs/frameworks/vllm_single/adapter.py
@@ -116,7 +116,7 @@ class VllmAdapter(BaseWorkloadAdapter):
             f"curl -s -X POST http://localhost:{port}/v1/completions "
             f"-H 'Content-Type: application/json' "
             f"-d {shlex.quote(body)}; "
-            f"t1=$(date +%s.%N); "
+            f"echo; t1=$(date +%s.%N); "
             f"echo \"ELAPSED=$(echo $t1 - $t0 | bc)\""
         )
         out = executor.exec(cmd, timeout=300)

--- a/cvs/input/configs/catalog/models.json
+++ b/cvs/input/configs/catalog/models.json
@@ -1,7 +1,20 @@
 {
-  "qwen3-next-80b-a3b-instruct": {"hf_repo": "Qwen/Qwen3-Next-80B-A3B-Instruct"},
-  "llama-3.1-8b": {"hf_repo": "meta-llama/Llama-3.1-8B-Instruct"},
-  "llama-3.1-70b-fp8": {"hf_repo": "meta-llama/Llama-3.1-70B-Instruct-FP8"},
-  "llama-3.3-70b-instruct": {"hf_repo": "meta-llama/Llama-3.3-70B-Instruct"},
-  "deepseek-r1": {"hf_repo": "deepseek-ai/DeepSeek-R1-0528"}
+  "qwen3-next-80b-a3b-instruct": {
+    "hf_repo": "Qwen/Qwen3-Next-80B-A3B-Instruct"
+  },
+  "llama-3.1-8b": {
+    "hf_repo": "meta-llama/Llama-3.1-8B-Instruct"
+  },
+  "llama-3.1-8b-nous": {
+    "hf_repo": "NousResearch/Meta-Llama-3.1-8B-Instruct"
+  },
+  "llama-3.1-70b-fp8": {
+    "hf_repo": "meta-llama/Llama-3.1-70B-Instruct-FP8"
+  },
+  "llama-3.3-70b-instruct": {
+    "hf_repo": "meta-llama/Llama-3.3-70B-Instruct"
+  },
+  "deepseek-r1": {
+    "hf_repo": "deepseek-ai/DeepSeek-R1-0528"
+  }
 }

--- a/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/config.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "deepseek-r1",
+    "remote": 0,
+    "precision": "fp8"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_ROCM_USE_AITER": "1",
+        "ROCM_AITER_MLA": "1"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.9 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.85},
+  "gsm8k": {"kind": "min", "value": 0.90}
+}

--- a/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_perf/config.json
+++ b/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_perf/config.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs": "/mnt/dtni/{user-id}/cvs",
+    "models_dir": "/mnt/dtni/{user-id}/models",
+    "datasets_dir": "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir": "{shared_fs}/images"
+  },
+  "model": {
+    "id": "deepseek-r1",
+    "remote": 0,
+    "precision": "fp8"
+  },
+  "benchmarks": [
+    "serve_synth_short",
+    "serve_synth_long"
+  ],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {
+        "count": 1,
+        "gpus_per_node": 8
+      }
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": [
+        "/dev/dri",
+        "/dev/kfd"
+      ],
+      "seccomp_unconfined": true,
+      "extra_args": [
+        "--group-add",
+        "video",
+        "--group-add",
+        "render"
+      ],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0",
+        "VLLM_ROCM_USE_AITER": "1",
+        "ROCM_AITER_MLA": "1"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 16384 --gpu-memory-utilization 0.90 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 128,
+    "output_len": 256,
+    "concurrency": 32
+  }
+}

--- a/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_perf/threshold.json
@@ -31,10 +31,6 @@
     "kind": "max_ms",
     "value": 5000
   },
-  "serve_synth_short.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 300000
-  },
   "serve_synth_long.completed": {
     "kind": "min",
     "value": 64
@@ -46,9 +42,5 @@
   "serve_synth_long.ttft_p95_ms": {
     "kind": "max_ms",
     "value": 600000
-  },
-  "serve_synth_long.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 1200000
   }
 }

--- a/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/deepseek_r1/deepseek_r1_fp8_single_8_perf/threshold.json
@@ -1,0 +1,54 @@
+{
+  "smoke_request_latency_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "smoke_completion_tokens": {
+    "kind": "min",
+    "value": 1
+  },
+  "serve_synth_short.completed": {
+    "kind": "min",
+    "value": 200
+  },
+  "serve_synth_short.request_throughput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.output_throughput": {
+    "kind": "min",
+    "value": 50.0
+  },
+  "serve_synth_short.request_goodput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 60000
+  },
+  "serve_synth_short.tpot_p95_ms": {
+    "kind": "max_ms",
+    "value": 5000
+  },
+  "serve_synth_short.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 300000
+  },
+  "serve_synth_long.completed": {
+    "kind": "min",
+    "value": 64
+  },
+  "serve_synth_long.output_throughput": {
+    "kind": "min",
+    "value": 25.0
+  },
+  "serve_synth_long.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "serve_synth_long.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 1200000
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-70b-fp8",
+    "remote": 0,
+    "precision": "fp8"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.9 --trust-remote-code --served-model-name {model.id} --quantization fp8"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.78},
+  "gsm8k": {"kind": "min", "value": 0.80}
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_perf/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_perf/config.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs": "/mnt/dtni/{user-id}/cvs",
+    "models_dir": "/mnt/dtni/{user-id}/models",
+    "datasets_dir": "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir": "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-70b-fp8",
+    "remote": 0,
+    "precision": "fp8"
+  },
+  "benchmarks": [
+    "serve_synth_short",
+    "serve_synth_long"
+  ],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {
+        "count": 1,
+        "gpus_per_node": 8
+      }
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": [
+        "/dev/dri",
+        "/dev/kfd"
+      ],
+      "seccomp_unconfined": true,
+      "extra_args": [
+        "--group-add",
+        "video",
+        "--group-add",
+        "render"
+      ],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.90 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 128,
+    "output_len": 256,
+    "concurrency": 32
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_perf/threshold.json
@@ -31,10 +31,6 @@
     "kind": "max_ms",
     "value": 5000
   },
-  "serve_synth_short.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 300000
-  },
   "serve_synth_long.completed": {
     "kind": "min",
     "value": 64
@@ -46,9 +42,5 @@
   "serve_synth_long.ttft_p95_ms": {
     "kind": "max_ms",
     "value": 600000
-  },
-  "serve_synth_long.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 1200000
   }
 }

--- a/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_70b_fp8/llama_3_1_70b_fp8_single_8_perf/threshold.json
@@ -1,0 +1,54 @@
+{
+  "smoke_request_latency_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "smoke_completion_tokens": {
+    "kind": "min",
+    "value": 1
+  },
+  "serve_synth_short.completed": {
+    "kind": "min",
+    "value": 200
+  },
+  "serve_synth_short.request_throughput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.output_throughput": {
+    "kind": "min",
+    "value": 50.0
+  },
+  "serve_synth_short.request_goodput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 60000
+  },
+  "serve_synth_short.tpot_p95_ms": {
+    "kind": "max_ms",
+    "value": 5000
+  },
+  "serve_synth_short.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 300000
+  },
+  "serve_synth_long.completed": {
+    "kind": "min",
+    "value": 64
+  },
+  "serve_synth_long.output_throughput": {
+    "kind": "min",
+    "value": 25.0
+  },
+  "serve_synth_long.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "serve_synth_long.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 1200000
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-8b",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 1}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 4096 --gpu-memory-utilization 0.85 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 1,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.65},
+  "gsm8k": {"kind": "min", "value": 0.55}
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_perf/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_perf/config.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs": "/mnt/dtni/{user-id}/cvs",
+    "models_dir": "/mnt/dtni/{user-id}/models",
+    "datasets_dir": "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir": "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-8b",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": [
+    "serve_synth_short",
+    "serve_synth_long"
+  ],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {
+        "count": 1,
+        "gpus_per_node": 1
+      }
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": [
+        "/dev/dri",
+        "/dev/kfd"
+      ],
+      "seccomp_unconfined": true,
+      "extra_args": [
+        "--group-add",
+        "video",
+        "--group-add",
+        "render"
+      ],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.90 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 1,
+    "input_len": 128,
+    "output_len": 256,
+    "concurrency": 32
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_perf/threshold.json
@@ -31,10 +31,6 @@
     "kind": "max_ms",
     "value": 5000
   },
-  "serve_synth_short.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 300000
-  },
   "serve_synth_long.completed": {
     "kind": "min",
     "value": 64
@@ -46,9 +42,5 @@
   "serve_synth_long.ttft_p95_ms": {
     "kind": "max_ms",
     "value": 600000
-  },
-  "serve_synth_long.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 1200000
   }
 }

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b/llama_3_1_8b_bf16_single_1_perf/threshold.json
@@ -1,0 +1,54 @@
+{
+  "smoke_request_latency_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "smoke_completion_tokens": {
+    "kind": "min",
+    "value": 1
+  },
+  "serve_synth_short.completed": {
+    "kind": "min",
+    "value": 200
+  },
+  "serve_synth_short.request_throughput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.output_throughput": {
+    "kind": "min",
+    "value": 50.0
+  },
+  "serve_synth_short.request_goodput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 60000
+  },
+  "serve_synth_short.tpot_p95_ms": {
+    "kind": "max_ms",
+    "value": 5000
+  },
+  "serve_synth_short.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 300000
+  },
+  "serve_synth_long.completed": {
+    "kind": "min",
+    "value": 64
+  },
+  "serve_synth_long.output_throughput": {
+    "kind": "min",
+    "value": 25.0
+  },
+  "serve_synth_long.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "serve_synth_long.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 1200000
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_accuracy/config.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs": "/mnt/dtni/{user-id}/cvs",
+    "models_dir": "/mnt/dtni/{user-id}/models",
+    "datasets_dir": "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir": "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-8b-nous",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": [
+    "mmlu",
+    "gsm8k"
+  ],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {
+        "count": 1,
+        "gpus_per_node": 1
+      }
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": [
+        "/dev/dri",
+        "/dev/kfd"
+      ],
+      "seccomp_unconfined": true,
+      "extra_args": [
+        "--group-add",
+        "video",
+        "--group-add",
+        "render"
+      ],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 4096 --gpu-memory-utilization 0.85 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 1,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_accuracy/threshold.json
@@ -1,0 +1,18 @@
+{
+  "smoke_request_latency_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "smoke_completion_tokens": {
+    "kind": "min",
+    "value": 1
+  },
+  "mmlu": {
+    "kind": "min",
+    "value": 0.65
+  },
+  "gsm8k": {
+    "kind": "min",
+    "value": 0.55
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_perf/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_perf/config.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs": "/mnt/dtni/{user-id}/cvs",
+    "models_dir": "/mnt/dtni/{user-id}/models",
+    "datasets_dir": "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir": "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.1-8b-nous",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": [
+    "serve_synth_short",
+    "serve_synth_long"
+  ],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {
+        "count": 1,
+        "gpus_per_node": 1
+      }
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": [
+        "/dev/dri",
+        "/dev/kfd"
+      ],
+      "seccomp_unconfined": true,
+      "extra_args": [
+        "--group-add",
+        "video",
+        "--group-add",
+        "render"
+      ],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.90 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 1,
+    "input_len": 128,
+    "output_len": 256,
+    "concurrency": 32
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_1_8b_nous/llama_3_1_8b_nous_bf16_single_1_perf/threshold.json
@@ -1,0 +1,46 @@
+{
+  "smoke_request_latency_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "smoke_completion_tokens": {
+    "kind": "min",
+    "value": 1
+  },
+  "serve_synth_short.completed": {
+    "kind": "min",
+    "value": 200
+  },
+  "serve_synth_short.request_throughput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.output_throughput": {
+    "kind": "min",
+    "value": 50.0
+  },
+  "serve_synth_short.request_goodput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 60000
+  },
+  "serve_synth_short.tpot_p95_ms": {
+    "kind": "max_ms",
+    "value": 5000
+  },
+  "serve_synth_long.completed": {
+    "kind": "min",
+    "value": 64
+  },
+  "serve_synth_long.output_throughput": {
+    "kind": "min",
+    "value": 25.0
+  },
+  "serve_synth_long.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.3-70b-instruct",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.9 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.80},
+  "gsm8k": {"kind": "min", "value": 0.85}
+}

--- a/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_perf/config.json
+++ b/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_perf/config.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs": "/mnt/dtni/{user-id}/cvs",
+    "models_dir": "/mnt/dtni/{user-id}/models",
+    "datasets_dir": "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir": "{shared_fs}/images"
+  },
+  "model": {
+    "id": "llama-3.3-70b-instruct",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": [
+    "serve_synth_short",
+    "serve_synth_long"
+  ],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {
+        "count": 1,
+        "gpus_per_node": 8
+      }
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": [
+        "/dev/dri",
+        "/dev/kfd"
+      ],
+      "seccomp_unconfined": true,
+      "extra_args": [
+        "--group-add",
+        "video",
+        "--group-add",
+        "render"
+      ],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.90 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 128,
+    "output_len": 256,
+    "concurrency": 32
+  }
+}

--- a/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_perf/threshold.json
@@ -31,10 +31,6 @@
     "kind": "max_ms",
     "value": 5000
   },
-  "serve_synth_short.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 300000
-  },
   "serve_synth_long.completed": {
     "kind": "min",
     "value": 64
@@ -46,9 +42,5 @@
   "serve_synth_long.ttft_p95_ms": {
     "kind": "max_ms",
     "value": 600000
-  },
-  "serve_synth_long.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 1200000
   }
 }

--- a/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/llama_3_3_70b/llama_3_3_70b_bf16_single_8_perf/threshold.json
@@ -1,0 +1,54 @@
+{
+  "smoke_request_latency_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "smoke_completion_tokens": {
+    "kind": "min",
+    "value": 1
+  },
+  "serve_synth_short.completed": {
+    "kind": "min",
+    "value": 200
+  },
+  "serve_synth_short.request_throughput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.output_throughput": {
+    "kind": "min",
+    "value": 50.0
+  },
+  "serve_synth_short.request_goodput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 60000
+  },
+  "serve_synth_short.tpot_p95_ms": {
+    "kind": "max_ms",
+    "value": 5000
+  },
+  "serve_synth_short.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 300000
+  },
+  "serve_synth_long.completed": {
+    "kind": "min",
+    "value": 64
+  },
+  "serve_synth_long.output_throughput": {
+    "kind": "min",
+    "value": 25.0
+  },
+  "serve_synth_long.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "serve_synth_long.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 1200000
+  }
+}

--- a/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/config.json
+++ b/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/config.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs":     "/mnt/dtni/{user-id}/cvs",
+    "models_dir":    "/mnt/dtni/{user-id}/models",
+    "datasets_dir":  "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir":    "{shared_fs}/images"
+  },
+  "model": {
+    "id": "qwen3-next-80b-a3b-instruct",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": ["mmlu", "gsm8k"],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {"count": 1, "gpus_per_node": 8}
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": ["/dev/dri", "/dev/kfd"],
+      "seccomp_unconfined": true,
+      "extra_args": ["--group-add", "video", "--group-add", "render"],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.85 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 16,
+    "output_len": 32,
+    "concurrency": 1
+  }
+}

--- a/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/threshold.json
+++ b/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_accuracy/threshold.json
@@ -1,0 +1,6 @@
+{
+  "smoke_request_latency_ms": {"kind": "max_ms", "value": 600000},
+  "smoke_completion_tokens":  {"kind": "min", "value": 1},
+  "mmlu":  {"kind": "min", "value": 0.75},
+  "gsm8k": {"kind": "min", "value": 0.80}
+}

--- a/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_perf/config.json
+++ b/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_perf/config.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "framework": "vllm_single",
+  "gpu_arch": "mi300x",
+  "paths": {
+    "shared_fs": "/mnt/dtni/{user-id}/cvs",
+    "models_dir": "/mnt/dtni/{user-id}/models",
+    "datasets_dir": "{shared_fs}/datasets",
+    "artifacts_dir": "{shared_fs}/artifacts",
+    "images_dir": "{shared_fs}/images"
+  },
+  "model": {
+    "id": "qwen3-next-80b-a3b-instruct",
+    "remote": 0,
+    "precision": "bf16"
+  },
+  "benchmarks": [
+    "serve_synth_short",
+    "serve_synth_long"
+  ],
+  "benchmark_datasets_remote": 1,
+  "image": {
+    "tag": "rocm/vllm:latest",
+    "remote": 1
+  },
+  "topology": {
+    "roles": {
+      "server": {
+        "count": 1,
+        "gpus_per_node": 8
+      }
+    }
+  },
+  "roles": {
+    "server": {
+      "shm_size": "64G",
+      "devices": [
+        "/dev/dri",
+        "/dev/kfd"
+      ],
+      "seccomp_unconfined": true,
+      "extra_args": [
+        "--group-add",
+        "video",
+        "--group-add",
+        "render"
+      ],
+      "volumes": {},
+      "env": {
+        "VLLM_USE_TRITON_FLASH_ATTN": "0"
+      },
+      "port": 8000,
+      "health_path": "/health",
+      "command": "vllm serve {model.path} --tensor-parallel-size {params.tensor_parallelism} --max-model-len 8192 --gpu-memory-utilization 0.90 --trust-remote-code --served-model-name {model.id}"
+    }
+  },
+  "params": {
+    "tensor_parallelism": 8,
+    "input_len": 128,
+    "output_len": 256,
+    "concurrency": 32
+  }
+}

--- a/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_perf/threshold.json
@@ -31,10 +31,6 @@
     "kind": "max_ms",
     "value": 5000
   },
-  "serve_synth_short.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 300000
-  },
   "serve_synth_long.completed": {
     "kind": "min",
     "value": 64
@@ -46,9 +42,5 @@
   "serve_synth_long.ttft_p95_ms": {
     "kind": "max_ms",
     "value": 600000
-  },
-  "serve_synth_long.e2el_p95_ms": {
-    "kind": "max_ms",
-    "value": 1200000
   }
 }

--- a/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_perf/threshold.json
+++ b/cvs/input/dtni/vllm_single/qwen3_next_80b/qwen3_next_80b_bf16_single_8_perf/threshold.json
@@ -1,0 +1,54 @@
+{
+  "smoke_request_latency_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "smoke_completion_tokens": {
+    "kind": "min",
+    "value": 1
+  },
+  "serve_synth_short.completed": {
+    "kind": "min",
+    "value": 200
+  },
+  "serve_synth_short.request_throughput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.output_throughput": {
+    "kind": "min",
+    "value": 50.0
+  },
+  "serve_synth_short.request_goodput": {
+    "kind": "min",
+    "value": 0.5
+  },
+  "serve_synth_short.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 60000
+  },
+  "serve_synth_short.tpot_p95_ms": {
+    "kind": "max_ms",
+    "value": 5000
+  },
+  "serve_synth_short.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 300000
+  },
+  "serve_synth_long.completed": {
+    "kind": "min",
+    "value": 64
+  },
+  "serve_synth_long.output_throughput": {
+    "kind": "min",
+    "value": 25.0
+  },
+  "serve_synth_long.ttft_p95_ms": {
+    "kind": "max_ms",
+    "value": 600000
+  },
+  "serve_synth_long.e2el_p95_ms": {
+    "kind": "max_ms",
+    "value": 1200000
+  }
+}

--- a/cvs/lib/benchmarks/__init__.py
+++ b/cvs/lib/benchmarks/__init__.py
@@ -1,0 +1,14 @@
+"""Accuracy benchmark machinery for DTNI v1 (Step 4, accuracy-only).
+
+One harness in v1: ``lm-eval-harness`` (covers MMLU + GSM8K + the LightEval
+supplementary set the tracker references). Perf benchmarks, samplers, sweeps,
+and the multi-lifecycle driver are deferred to v2 — see
+``jobs/ec849125/tmp/cvs-dtni-v2-harness-plan.md``.
+"""
+
+from cvs.lib.benchmarks.registry import (  # noqa: F401
+    BENCHMARK_REGISTRY,
+    BenchmarkSpec,
+    list_benchmarks,
+    lookup,
+)

--- a/cvs/lib/benchmarks/harness_invokers.py
+++ b/cvs/lib/benchmarks/harness_invokers.py
@@ -1,0 +1,73 @@
+"""Build the in-container command for a benchmark harness.
+
+One invoker in v1: ``lm-eval-harness`` against an OpenAI-compatible endpoint.
+Pure (no I/O) so unit-testable.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Callable
+
+from cvs.lib.benchmarks.registry import BenchmarkSpec
+
+
+# Well-known in-container path where the adapter bind-mounts the run's host
+# artifacts_dir. The harness writes results under this; runner reads them
+# from the host via the same mount.
+OUTPUT_DIR_IN_CONTAINER: str = "/cvs_artifacts"
+
+
+@dataclass(frozen=True)
+class HarnessCtx:
+    """Inputs the harness needs to construct its command line.
+
+    - ``base_url``: where the server is reachable from inside the harness's
+      container. For v1 single-node, harness shares ``network=host`` with the
+      server, so ``http://localhost:<port>`` is correct.
+    - ``model_id``: vLLM's ``--served-model-name`` — what we POST as ``model``.
+    - ``output_dir``: in-container path where the harness drops its JSON
+      (bind-mounted to the host artifacts dir). Each benchmark writes into a
+      ``<output_dir>/<benchmark_id>/`` subdir to keep results isolated.
+    """
+
+    base_url: str
+    model_id: str
+    output_dir: str
+
+
+def _lm_eval(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
+    """Build the lm_eval command line.
+
+    ``--output_path`` is a DIRECTORY for lm-eval-harness >=0.4: it writes
+    ``results_<timestamp>.json`` inside it. We give each benchmark its own
+    subdir so the runner can find that file unambiguously.
+    """
+    task = spec.extra.get("task", spec.id)
+    out_path = f"{hctx.output_dir}/{spec.id}"
+    parts = [
+        "lm_eval",
+        "--model", "local-completions",
+        "--model_args",
+        f"base_url={hctx.base_url}/v1/completions,model={hctx.model_id},num_concurrent=8,max_retries=3",
+        "--tasks", task,
+        "--num_fewshot", str(spec.shots),
+        "--output_path", out_path,
+        "--log_samples",
+    ]
+    return " ".join(shlex.quote(p) for p in parts)
+
+
+HARNESS_INVOKERS: dict[str, Callable[[BenchmarkSpec, HarnessCtx], str]] = {
+    "lm-eval-harness": _lm_eval,
+}
+
+
+def build_command(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
+    if spec.harness not in HARNESS_INVOKERS:
+        raise KeyError(
+            f"benchmark {spec.id!r}: unknown harness {spec.harness!r}; "
+            f"known: {sorted(HARNESS_INVOKERS)}"
+        )
+    return HARNESS_INVOKERS[spec.harness](spec, hctx)

--- a/cvs/lib/benchmarks/harness_invokers.py
+++ b/cvs/lib/benchmarks/harness_invokers.py
@@ -1,6 +1,10 @@
-"""Build the in-container command for a benchmark harness.
+"""Build the in-container command for each benchmark harness.
 
-One invoker in v1: ``lm-eval-harness`` against an OpenAI-compatible endpoint.
+Two invokers in v1:
+- ``lm-eval-harness``: accuracy (MMLU, GSM8K).
+- ``vllm-bench-serve``: the perf families from the DTNI Validation Tracker
+  (TTFT/TPOT/ITL/E2EL percentiles, throughput, goodput, ShareGPT trace).
+
 Pure (no I/O) so unit-testable.
 """
 
@@ -11,6 +15,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from cvs.lib.benchmarks.registry import BenchmarkSpec
+from cvs.lib.errors import ConfigError
 
 
 # Well-known in-container path where the adapter bind-mounts the run's host
@@ -24,12 +29,13 @@ class HarnessCtx:
     """Inputs the harness needs to construct its command line.
 
     - ``base_url``: where the server is reachable from inside the harness's
-      container. For v1 single-node, harness shares ``network=host`` with the
-      server, so ``http://localhost:<port>`` is correct.
-    - ``model_id``: vLLM's ``--served-model-name`` — what we POST as ``model``.
+      container. For v1 single-node, harness shares ``network=host`` with
+      the server, so ``http://localhost:<port>`` is correct.
+    - ``model_id``: vLLM's ``--served-model-name`` — what we POST as
+      ``model``.
     - ``output_dir``: in-container path where the harness drops its JSON
-      (bind-mounted to the host artifacts dir). Each benchmark writes into a
-      ``<output_dir>/<benchmark_id>/`` subdir to keep results isolated.
+      (bind-mounted to the host artifacts dir). Each benchmark writes into
+      a ``<output_dir>/<benchmark_id>/`` subdir to keep results isolated.
     """
 
     base_url: str
@@ -59,8 +65,87 @@ def _lm_eval(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
     return " ".join(shlex.quote(p) for p in parts)
 
 
+def _vllm_bench_serve(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
+    """Build the ``vllm bench serve`` command line.
+
+    Writes a single ``result.json`` under ``<output_dir>/<spec.id>/`` so the
+    runner can locate it deterministically. The required extras are:
+
+    - ``dataset_name``: ``random`` | ``sharegpt`` | etc.
+    - ``num_prompts``: int.
+    For ``random``: ``random_input_len``, ``random_output_len``.
+    For ``sharegpt``: ``dataset_path`` (in-container path to the JSON).
+
+    Optional extras:
+    - ``max_concurrency``, ``request_rate``, ``percentiles``,
+      ``goodput_slo`` (passed verbatim to ``--goodput`` — space-separated
+      ``KEY:VALUE_ms`` pairs).
+    """
+    e = spec.extra
+    if "dataset_name" not in e or "num_prompts" not in e:
+        raise ConfigError(
+            f"benchmark {spec.id!r}: vllm-bench-serve needs "
+            f"extra.dataset_name and extra.num_prompts"
+        )
+    out_dir = f"{hctx.output_dir}/{spec.id}"
+    parts: list[str] = [
+        "mkdir", "-p", out_dir, "&&",
+        "vllm", "bench", "serve",
+        "--backend", "vllm",
+        "--base-url", hctx.base_url,
+        "--model", hctx.model_id,
+        "--dataset-name", str(e["dataset_name"]),
+        "--num-prompts", str(int(e["num_prompts"])),
+        "--save-result",
+        "--result-dir", out_dir,
+        "--result-filename", "result.json",
+    ]
+
+    if e["dataset_name"] == "random":
+        if "random_input_len" not in e or "random_output_len" not in e:
+            raise ConfigError(
+                f"benchmark {spec.id!r}: dataset_name=random needs "
+                f"random_input_len and random_output_len in extra"
+            )
+        parts += [
+            "--random-input-len", str(int(e["random_input_len"])),
+            "--random-output-len", str(int(e["random_output_len"])),
+        ]
+    elif e["dataset_name"] == "sharegpt":
+        if "dataset_path" not in e:
+            raise ConfigError(
+                f"benchmark {spec.id!r}: dataset_name=sharegpt needs "
+                f"extra.dataset_path (in-container path to the JSON)"
+            )
+        parts += ["--dataset-path", str(e["dataset_path"])]
+
+    if "max_concurrency" in e:
+        parts += ["--max-concurrency", str(int(e["max_concurrency"]))]
+    if "request_rate" in e:
+        parts += ["--request-rate", str(e["request_rate"])]
+    if "percentiles" in e:
+        parts += ["--metric-percentiles", str(e["percentiles"])]
+    if "goodput_slo" in e:
+        # vllm splits goodput SLO strings on whitespace itself; pass each
+        # KEY:VALUE pair as a separate token after --goodput per its CLI.
+        slo_parts = str(e["goodput_slo"]).split()
+        if slo_parts:
+            parts += ["--goodput", *slo_parts]
+
+    # quote argv tokens, leave the shell operators (`&&`, `mkdir -p ...`)
+    # intact — the docker exec wrapper runs this under `bash -c`.
+    quoted: list[str] = []
+    for p in parts:
+        if p in ("&&",):
+            quoted.append(p)
+        else:
+            quoted.append(shlex.quote(p))
+    return " ".join(quoted)
+
+
 HARNESS_INVOKERS: dict[str, Callable[[BenchmarkSpec, HarnessCtx], str]] = {
     "lm-eval-harness": _lm_eval,
+    "vllm-bench-serve": _vllm_bench_serve,
 }
 
 

--- a/cvs/lib/benchmarks/harness_invokers.py
+++ b/cvs/lib/benchmarks/harness_invokers.py
@@ -57,6 +57,7 @@ def _lm_eval(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
     task = spec.extra.get("task", spec.id)
     out_path = f"{hctx.output_dir}/{spec.id}"
     parts = [
+        "pip", "install", "-q", "lm-eval[api]>=0.4.4", "&&",
         "lm_eval",
         "--model", "local-completions",
         "--model_args",
@@ -66,7 +67,13 @@ def _lm_eval(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
         "--output_path", out_path,
         "--log_samples",
     ]
-    return " ".join(shlex.quote(p) for p in parts)
+    quoted = []
+    for tok in parts:
+        if tok == "&&":
+            quoted.append(tok)
+        else:
+            quoted.append(shlex.quote(tok))
+    return " ".join(quoted)
 
 
 def _vllm_bench_serve(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:

--- a/cvs/lib/benchmarks/harness_invokers.py
+++ b/cvs/lib/benchmarks/harness_invokers.py
@@ -33,6 +33,9 @@ class HarnessCtx:
       the server, so ``http://localhost:<port>`` is correct.
     - ``model_id``: vLLM's ``--served-model-name`` — what we POST as
       ``model``.
+    - ``model_path``: in-container filesystem path to the model directory.
+      Used as the tokenizer source so the harness does not try to fetch
+      ``<model_id>`` from the HF hub (the id is just the API alias).
     - ``output_dir``: in-container path where the harness drops its JSON
       (bind-mounted to the host artifacts dir). Each benchmark writes into
       a ``<output_dir>/<benchmark_id>/`` subdir to keep results isolated.
@@ -40,6 +43,7 @@ class HarnessCtx:
 
     base_url: str
     model_id: str
+    model_path: str
     output_dir: str
 
 
@@ -56,7 +60,7 @@ def _lm_eval(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
         "lm_eval",
         "--model", "local-completions",
         "--model_args",
-        f"base_url={hctx.base_url}/v1/completions,model={hctx.model_id},num_concurrent=8,max_retries=3",
+        f"base_url={hctx.base_url}/v1/completions,model={hctx.model_id},tokenizer={hctx.model_path},tokenizer_backend=huggingface,num_concurrent=8,max_retries=3",
         "--tasks", task,
         "--num_fewshot", str(spec.shots),
         "--output_path", out_path,
@@ -94,6 +98,7 @@ def _vllm_bench_serve(spec: BenchmarkSpec, hctx: HarnessCtx) -> str:
         "--backend", "vllm",
         "--base-url", hctx.base_url,
         "--model", hctx.model_id,
+        "--tokenizer", hctx.model_path,
         "--dataset-name", str(e["dataset_name"]),
         "--num-prompts", str(int(e["num_prompts"])),
         "--save-result",

--- a/cvs/lib/benchmarks/projectors.py
+++ b/cvs/lib/benchmarks/projectors.py
@@ -1,0 +1,166 @@
+"""Per-harness JSON → scalar projection.
+
+A projector receives:
+- the BenchmarkSpec it ran
+- the parsed JSON payload from the harness
+
+and returns a flat ``{scalar_key: float}`` dict. The runner merges these into
+``ctx.result.scalars``, where ``threshold.json`` keys name them directly.
+
+Convention:
+- accuracy harnesses (lm-eval) project to the bare benchmark id, optionally
+  plus ``<id>_stderr``. Kept for back-compat with Step-4 thresholds.
+- perf harnesses (vllm-bench-serve) project to a dotted ``<id>.<field>``
+  namespace so multiple invocations of the same harness don't collide and
+  thresholds can name e.g. ``serve_synth_short.ttft_p95_ms``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from cvs.lib.benchmarks.registry import BenchmarkSpec
+
+
+# ---- lm-eval-harness ------------------------------------------------------
+
+
+def _is_real_number(v: Any) -> bool:
+    """True for int/float but NOT bool (bool is an int subclass in Python).
+
+    Without this, a payload field that happens to be True/False would be
+    coerced to 1.0/0.0 and treated as a real measurement by the threshold
+    engine.
+    """
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _project_lm_eval(spec: BenchmarkSpec, payload: dict[str, Any]) -> dict[str, float]:
+    """Extract spec.score_metric from lm-eval JSON under the benchmark id key.
+
+    lm-eval writes ``{"results": {task: {metric: value, metric_stderr: ...}}}``.
+    Modern lm-eval suffixes the metric name with ``,<filter>`` (e.g.
+    ``acc,none`` or ``exact_match,strict-match``). We try, in order:
+      1) the spec's preferred filter (``score_filter``)
+      2) the bare metric key (legacy)
+      3) ``,none`` (default filter slug)
+    Also surfaces ``<id>_stderr`` for diagnostics using the same lookup
+    order.
+    """
+    out: dict[str, float] = {}
+    results = payload.get("results") or {}
+    task = spec.extra.get("task", spec.id)
+    task_results = results.get(task, {})
+
+    if not spec.score_metric:
+        return out
+
+    score = _pick_metric(task_results, spec.score_metric, spec.score_filter)
+    if _is_real_number(score):
+        out[spec.id] = float(score)
+
+    stderr = _pick_metric(task_results, f"{spec.score_metric}_stderr", spec.score_filter)
+    if _is_real_number(stderr):
+        out[f"{spec.id}_stderr"] = float(stderr)
+
+    return out
+
+
+def _pick_metric(task_results: dict[str, Any], metric: str, preferred_filter: str | None) -> Any:
+    """Walk filter-suffix variants for ``metric`` in priority order."""
+    candidates: list[str] = []
+    if preferred_filter:
+        candidates.append(f"{metric},{preferred_filter}")
+    candidates.append(metric)
+    candidates.append(f"{metric},none")
+    for key in candidates:
+        if key in task_results:
+            return task_results[key]
+    return None
+
+
+# ---- vllm bench serve ----------------------------------------------------
+
+
+# Fields the vllm BenchmarkMetrics JSON exports as scalars (int/float).
+# Kept as a tuple so we don't silently absorb future JSON additions: if a
+# new field appears in vllm and we want it, list it here explicitly.
+_VLLM_SERVE_SCALAR_FIELDS: tuple[str, ...] = (
+    # Throughput / counters.
+    "completed",
+    "total_input",
+    "total_output",
+    "request_throughput",          # req/s (tracker row 41 component)
+    "request_goodput",             # req/s meeting SLO (tracker row 51)
+    "output_throughput",           # output tok/s (tracker row 41,42)
+    "total_token_throughput",      # (in + out) tok/s
+    # Latency means / medians / std.
+    "mean_ttft_ms",   "median_ttft_ms",  "std_ttft_ms",
+    "mean_tpot_ms",   "median_tpot_ms",  "std_tpot_ms",
+    "mean_itl_ms",    "median_itl_ms",   "std_itl_ms",
+    "mean_e2el_ms",   "median_e2el_ms",  "std_e2el_ms",
+)
+
+# Percentile arrays we explode into named scalars (P50/P90/P95/P99 typical).
+_VLLM_SERVE_PCTL_FIELDS: tuple[str, ...] = (
+    "percentiles_ttft_ms",
+    "percentiles_tpot_ms",
+    "percentiles_itl_ms",
+    "percentiles_e2el_ms",
+)
+
+
+def _project_vllm_bench_serve(spec: BenchmarkSpec, payload: dict[str, Any]) -> dict[str, float]:
+    """Project ``vllm bench serve --save-result`` JSON to scalars.
+
+    The JSON top-level is a single flat object (vllm.benchmarks.serve.
+    BenchmarkMetrics merged with --metadata). All exported scalars live
+    under ``<spec.id>.<field>``; percentile lists are unrolled to
+    ``<spec.id>.<metric>_p<NN>_ms``.
+    """
+    out: dict[str, float] = {}
+
+    for field in _VLLM_SERVE_SCALAR_FIELDS:
+        v = payload.get(field)
+        if _is_real_number(v):
+            out[f"{spec.id}.{field}"] = float(v)
+
+    for pkey in _VLLM_SERVE_PCTL_FIELDS:
+        # vllm writes percentiles as list[(percentile, value)].
+        raw = payload.get(pkey)
+        if not isinstance(raw, list):
+            continue
+        # Field naming: "percentiles_ttft_ms" -> metric "ttft"
+        # ("percentiles_" prefix and "_ms" suffix stripped).
+        metric = pkey[len("percentiles_"):-len("_ms")]
+        for entry in raw:
+            if not (isinstance(entry, (list, tuple)) and len(entry) == 2):
+                continue
+            pct, val = entry
+            if not _is_real_number(val):
+                continue
+            try:
+                pct_int = int(round(float(pct)))
+            except (TypeError, ValueError):
+                continue
+            out[f"{spec.id}.{metric}_p{pct_int:02d}_ms"] = float(val)
+
+    return out
+
+
+# ---- dispatch -------------------------------------------------------------
+
+
+PROJECTORS: dict[str, Callable[[BenchmarkSpec, dict[str, Any]], dict[str, float]]] = {
+    "lm-eval-harness": _project_lm_eval,
+    "vllm-bench-serve": _project_vllm_bench_serve,
+}
+
+
+def project(spec: BenchmarkSpec, payload: dict[str, Any]) -> dict[str, float]:
+    if spec.harness not in PROJECTORS:
+        raise KeyError(
+            f"benchmark {spec.id!r}: no projector for harness {spec.harness!r}; "
+            f"known: {sorted(PROJECTORS)}"
+        )
+    return PROJECTORS[spec.harness](spec, payload)

--- a/cvs/lib/benchmarks/projectors.py
+++ b/cvs/lib/benchmarks/projectors.py
@@ -102,6 +102,18 @@ _VLLM_SERVE_SCALAR_FIELDS: tuple[str, ...] = (
 )
 
 # Percentile arrays we explode into named scalars (P50/P90/P95/P99 typical).
+
+# Metric stems whose flat "p<NN>_<metric>_ms" keys we recognize from
+# current vllm bench serve output. Kept aligned with
+# _VLLM_SERVE_PCTL_FIELDS (the legacy nested form) so both shapes project
+# to the same scalar names.
+_VLLM_SERVE_PCTL_METRICS: tuple[str, ...] = ("ttft", "tpot", "itl", "e2el")
+
+
+def _vllm_pctl_re():
+    import re as _re
+    return _re.compile(r"^p(\d{1,3})_(ttft|tpot|itl|e2el)_ms$")
+
 _VLLM_SERVE_PCTL_FIELDS: tuple[str, ...] = (
     "percentiles_ttft_ms",
     "percentiles_tpot_ms",
@@ -126,12 +138,10 @@ def _project_vllm_bench_serve(spec: BenchmarkSpec, payload: dict[str, Any]) -> d
             out[f"{spec.id}.{field}"] = float(v)
 
     for pkey in _VLLM_SERVE_PCTL_FIELDS:
-        # vllm writes percentiles as list[(percentile, value)].
+        # Legacy shape: list[(percentile, value)].
         raw = payload.get(pkey)
         if not isinstance(raw, list):
             continue
-        # Field naming: "percentiles_ttft_ms" -> metric "ttft"
-        # ("percentiles_" prefix and "_ms" suffix stripped).
         metric = pkey[len("percentiles_"):-len("_ms")]
         for entry in raw:
             if not (isinstance(entry, (list, tuple)) and len(entry) == 2):
@@ -144,6 +154,19 @@ def _project_vllm_bench_serve(spec: BenchmarkSpec, payload: dict[str, Any]) -> d
             except (TypeError, ValueError):
                 continue
             out[f"{spec.id}.{metric}_p{pct_int:02d}_ms"] = float(val)
+
+    # Current vllm shape: flat keys "p<NN>_<metric>_ms" -> float.
+    # Normalize to the same "<spec.id>.<metric>_p<NN>_ms" namespace so
+    # threshold names stay stable across the two emission shapes.
+    _PCT_KEY_RE = _vllm_pctl_re()
+    for k, v in payload.items():
+        m = _PCT_KEY_RE.match(k)
+        if not m or not _is_real_number(v):
+            continue
+        pct_int, metric = int(m.group(1)), m.group(2)
+        if metric not in _VLLM_SERVE_PCTL_METRICS:
+            continue
+        out[f"{spec.id}.{metric}_p{pct_int:02d}_ms"] = float(v)
 
     return out
 

--- a/cvs/lib/benchmarks/registry.py
+++ b/cvs/lib/benchmarks/registry.py
@@ -1,0 +1,59 @@
+"""BENCHMARK_REGISTRY — accuracy-only in v1.
+
+Per ``cvs-dtni-v1-spec.md`` §"Step 4: Accuracy benchmarks": MMLU + GSM8K via
+``lm-eval-harness``. Other tracker accuracy benchmarks (MMLU-Pro, BBH,
+HellaSwag, etc.) and all perf benchmarks land in v2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchmarkSpec:
+    """One benchmark.
+
+    - ``id``: short slug used in workload.benchmarks.
+    - ``harness``: HARNESS_INVOKERS key — picks the invocation builder.
+    - ``dataset_id``: catalog dataset key the harness will fetch (or has cached).
+    - ``score_metric``: key in the harness output JSON we extract as the
+      pass/fail scalar. The threshold file references the spec id, not this.
+    - ``score_filter``: lm-eval filter slug to pair with score_metric (newer
+      lm-eval keys are ``"<metric>,<filter>"``). ``None`` falls back to the
+      bare metric key and then to ``,none``.
+    - ``shots``: in-context examples for few-shot eval (``--num_fewshot``).
+    - ``extra``: harness-specific kwargs (e.g. ``{"task": "mmlu"}``).
+    """
+
+    id: str
+    harness: str
+    dataset_id: str
+    score_metric: str
+    score_filter: str | None = None
+    shots: int = 0
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+_ACCURACY: tuple[BenchmarkSpec, ...] = (
+    BenchmarkSpec("mmlu",  "lm-eval-harness", "mmlu",  "acc",         score_filter="none",         shots=5, extra={"task": "mmlu"}),
+    # gsm8k under lm-eval >=0.4 uses a strict-match filter chain by default.
+    BenchmarkSpec("gsm8k", "lm-eval-harness", "gsm8k", "exact_match", score_filter="strict-match", shots=5, extra={"task": "gsm8k"}),
+)
+
+
+BENCHMARK_REGISTRY: dict[str, BenchmarkSpec] = {b.id: b for b in _ACCURACY}
+
+
+def lookup(benchmark_id: str) -> BenchmarkSpec:
+    if benchmark_id not in BENCHMARK_REGISTRY:
+        raise KeyError(
+            f"unknown benchmark id {benchmark_id!r}; "
+            f"known: {sorted(BENCHMARK_REGISTRY)}"
+        )
+    return BENCHMARK_REGISTRY[benchmark_id]
+
+
+def list_benchmarks() -> tuple[str, ...]:
+    return tuple(BENCHMARK_REGISTRY)

--- a/cvs/lib/benchmarks/registry.py
+++ b/cvs/lib/benchmarks/registry.py
@@ -1,8 +1,17 @@
-"""BENCHMARK_REGISTRY — accuracy-only in v1.
+"""BENCHMARK_REGISTRY — accuracy + perf in v1.
 
-Per ``cvs-dtni-v1-spec.md`` §"Step 4: Accuracy benchmarks": MMLU + GSM8K via
-``lm-eval-harness``. Other tracker accuracy benchmarks (MMLU-Pro, BBH,
-HellaSwag, etc.) and all perf benchmarks land in v2.
+Per ``cvs-dtni-v1-spec.md`` and the DTNI Validation Tracker §"PERFORMANCE
+BENCHMARK METRICS" / §"ACCURACY BENCHMARK METRICS":
+
+- accuracy: MMLU + GSM8K via ``lm-eval-harness``
+- perf: vLLM serving metrics via ``vllm-bench-serve`` (TTFT/TPOT/ITL/E2EL
+  percentiles, throughputs, goodput). One harness run yields the whole
+  multi-scalar family at once.
+
+Other tracker rows (sampler-derived: VRAM, KV cache %, mem-BW%, MFU; sweep-
+derived: latency-vs-load curve, scale efficiency, max-concurrent-at-SLA;
+sidecar-derived: model load time) land in v2 — see
+``jobs/ec849125/tmp/cvs-dtni-v2-harness-plan.md``.
 """
 
 from __future__ import annotations
@@ -13,24 +22,29 @@ from typing import Any
 
 @dataclass(frozen=True)
 class BenchmarkSpec:
-    """One benchmark.
+    """One benchmark invocation.
 
-    - ``id``: short slug used in workload.benchmarks.
-    - ``harness``: HARNESS_INVOKERS key — picks the invocation builder.
-    - ``dataset_id``: catalog dataset key the harness will fetch (or has cached).
-    - ``score_metric``: key in the harness output JSON we extract as the
-      pass/fail scalar. The threshold file references the spec id, not this.
-    - ``score_filter``: lm-eval filter slug to pair with score_metric (newer
-      lm-eval keys are ``"<metric>,<filter>"``). ``None`` falls back to the
-      bare metric key and then to ``,none``.
-    - ``shots``: in-context examples for few-shot eval (``--num_fewshot``).
-    - ``extra``: harness-specific kwargs (e.g. ``{"task": "mmlu"}``).
+    - ``id``: short slug used in workload.benchmarks AND as the threshold
+      scalar prefix (lm-eval) or full key (perf). For perf benchmarks,
+      scalars land at ``<id>.<field>`` (e.g. ``serve_synth.ttft_p95_ms``)
+      so multiple invocations of the same harness don't collide.
+    - ``harness``: HARNESS_INVOKERS / PROJECTORS key — picks the invocation
+      builder AND the JSON → scalar projector.
+    - ``dataset_id``: catalog dataset key the harness will fetch (or has
+      cached). ``""`` for synthetic-traffic harnesses.
+    - ``score_metric`` / ``score_filter`` / ``shots``: lm-eval-specific
+      (None / 0 for non-lm-eval harnesses).
+    - ``extra``: harness-specific kwargs. For ``vllm-bench-serve``: keys
+      include ``num_prompts``, ``random_input_len``, ``random_output_len``,
+      ``max_concurrency``, ``request_rate``, ``dataset_name``,
+      ``dataset_path``, ``percentiles``, ``goodput_slo`` (string passed
+      through to ``--goodput``).
     """
 
     id: str
     harness: str
-    dataset_id: str
-    score_metric: str
+    dataset_id: str = ""
+    score_metric: str | None = None
     score_filter: str | None = None
     shots: int = 0
     extra: dict[str, Any] = field(default_factory=dict)
@@ -42,8 +56,51 @@ _ACCURACY: tuple[BenchmarkSpec, ...] = (
     BenchmarkSpec("gsm8k", "lm-eval-harness", "gsm8k", "exact_match", score_filter="strict-match", shots=5, extra={"task": "gsm8k"}),
 )
 
+# vLLM-serve perf benchmarks. Each invocation produces the full BenchmarkMetrics
+# family from `vllm bench serve --save-result`. Workloads pick whichever shapes
+# they want; the threshold file names the specific scalars (e.g.
+# `serve_short.ttft_p95_ms`) it cares about.
+_PERF: tuple[BenchmarkSpec, ...] = (
+    # Synthetic random-token traffic, short context (tracker rows 33,34,35,
+    # 36,37,39,41,42,43,51 — TTFT/TPOT/prefill/normalized/decode-tail/e2e/
+    # global-throughput/decode-throughput/per-gpu/goodput).
+    BenchmarkSpec(
+        id="serve_synth_short",
+        harness="vllm-bench-serve",
+        extra={
+            "dataset_name": "random",
+            "num_prompts": 200,
+            "random_input_len": 128,
+            "random_output_len": 256,
+            "max_concurrency": 32,
+            "request_rate": "inf",  # offline burst
+            "percentiles": "50,90,95,99",
+            # SLOs target tracker row 51 (goodput) and 39 (P95/P99 e2e).
+            "goodput_slo": "ttft:2000 tpot:200",
+        },
+    ),
+    # Long-prefill stress (tracker row 23 + perf rows 35,36 — prefill latency,
+    # nTTFT). Smaller batch keeps the run bounded.
+    BenchmarkSpec(
+        id="serve_synth_long",
+        harness="vllm-bench-serve",
+        extra={
+            "dataset_name": "random",
+            "num_prompts": 64,
+            "random_input_len": 2048,
+            "random_output_len": 256,
+            "max_concurrency": 8,
+            "request_rate": "inf",
+            "percentiles": "50,90,95,99",
+        },
+    ),
+    # ShareGPT realistic load (tracker row 22) is intentionally NOT in v1:
+    # it needs a per-workload dataset_path the schema can't yet thread.
+    # Lands in v2 once the workload schema gets per-benchmark `extras`.
+)
 
-BENCHMARK_REGISTRY: dict[str, BenchmarkSpec] = {b.id: b for b in _ACCURACY}
+
+BENCHMARK_REGISTRY: dict[str, BenchmarkSpec] = {b.id: b for b in _ACCURACY + _PERF}
 
 
 def lookup(benchmark_id: str) -> BenchmarkSpec:

--- a/cvs/lib/benchmarks/runner.py
+++ b/cvs/lib/benchmarks/runner.py
@@ -1,15 +1,15 @@
-"""Run accuracy benchmarks against a healthy server, project scores to scalars.
+"""Run benchmarks against a healthy server, project scores to scalars.
 
 Called from the adapter's ``parse()`` once the server is up. For each
 benchmark, the harness runs inside the server container (which has the host
 artifacts_dir bind-mounted at ``OUTPUT_DIR_IN_CONTAINER`` by the adapter at
-launch time) and drops a ``results_<ts>.json`` file in a per-benchmark
-subdir. We glob the host side of that mount, project the configured metric
-to ``ctx.result.scalars`` under the benchmark id so ``threshold.json`` can
-name it directly:
+launch time) and drops its result JSON in a per-benchmark subdir. The
+runner finds it, calls the per-harness projector, and merges the resulting
+scalars into ``ctx.result.scalars`` so ``threshold.json`` can name them
+directly. Examples:
 
-    scalars["mmlu"]  = 0.732   ← matches `"mmlu": {"kind": "min", "value": 0.7}`
-    scalars["gsm8k"] = 0.815
+    scalars["mmlu"]                              = 0.732  # lm-eval
+    scalars["serve_synth_short.ttft_p95_ms"]     = 84.1   # vllm-bench-serve
 """
 
 from __future__ import annotations
@@ -17,16 +17,24 @@ from __future__ import annotations
 import json
 import shlex
 from pathlib import Path
-from typing import Any
 
 from cvs.lib.benchmarks.harness_invokers import HarnessCtx, build_command
-from cvs.lib.benchmarks.registry import BenchmarkSpec, lookup
+from cvs.lib.benchmarks.projectors import project
+from cvs.lib.benchmarks.registry import lookup
 from cvs.lib.errors import WorkloadError
 
 
 # Per-benchmark wall-clock ceiling. MMLU on a smaller model can take ~2h;
 # this gives headroom. Total parse-phase budget is N benchmarks * this.
 PER_BENCHMARK_TIMEOUT_S: int = 4 * 3600
+
+# Result-file glob per harness. lm-eval writes ``results_<ts>.json`` (and
+# sometimes nests under a model dir); vllm bench serve writes the exact
+# ``result.json`` we asked for via --result-filename.
+_RESULT_GLOBS: dict[str, str] = {
+    "lm-eval-harness":  "results*.json",
+    "vllm-bench-serve": "result.json",
+}
 
 
 def run_benchmarks(
@@ -41,10 +49,9 @@ def run_benchmarks(
     """Run each benchmark id, return flat scalars dict for ctx.result.scalars.
 
     ``server_handle`` is the ContainerHandle whose runner.exec we use to
-    ``docker exec`` the harness inside the same container as the server (the
-    rocm/vllm image ships ``lm_eval``).
+    ``docker exec`` the harness inside the same container as the server
+    (the rocm/vllm image ships both ``lm_eval`` and ``vllm bench serve``).
     """
-
     scalars: dict[str, float] = {}
     for bid in benchmarks:
         spec = lookup(bid)
@@ -63,77 +70,33 @@ def run_benchmarks(
         except Exception as exc:
             raise WorkloadError(f"benchmark {bid!r} harness failed: {exc}") from exc
 
-        result_json = _find_lm_eval_result(output_dir_on_host / bid)
+        glob_pat = _RESULT_GLOBS.get(spec.harness, "*.json")
+        result_json = _find_result(output_dir_on_host / bid, glob_pat)
         if result_json is None:
             raise WorkloadError(
-                f"benchmark {bid!r}: harness ran but produced no results JSON under "
-                f"{output_dir_on_host / bid}"
+                f"benchmark {bid!r}: harness ran but produced no result JSON "
+                f"({glob_pat}) under {output_dir_on_host / bid}"
             )
         try:
             payload = json.loads(result_json.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             raise WorkloadError(
-                f"benchmark {bid!r}: harness output {result_json} is not valid JSON: {exc}"
+                f"benchmark {bid!r}: harness output {result_json} is not "
+                f"valid JSON: {exc}"
             ) from exc
 
-        scalars.update(_project_scalars(spec, payload))
+        scalars.update(project(spec, payload))
 
     return scalars
 
 
-def _find_lm_eval_result(subdir: Path) -> Path | None:
-    """Return the newest ``results*.json`` under ``subdir`` (recursive), or None.
-
-    lm-eval-harness writes ``<output_path>/results_<timestamp>.json`` (and
-    sometimes nests under a model-name dir). We pick the most recently
-    modified match to be robust to either layout.
-    """
+def _find_result(subdir: Path, glob_pat: str) -> Path | None:
+    """Return the newest matching JSON under ``subdir`` (recursive), or None."""
     if not subdir.exists():
         return None
     matches = sorted(
-        subdir.rglob("results*.json"),
+        subdir.rglob(glob_pat),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
     return matches[0] if matches else None
-
-
-def _project_scalars(spec: BenchmarkSpec, payload: dict[str, Any]) -> dict[str, float]:
-    """Extract spec.score_metric from lm-eval JSON under the benchmark id key.
-
-    lm-eval writes ``{"results": {task: {metric: value, metric_stderr: ...}}}``.
-    Modern lm-eval suffixes the metric name with ``,<filter>`` (e.g.
-    ``acc,none`` or ``exact_match,strict-match``). We try, in order:
-      1) the spec's preferred filter (``score_filter``)
-      2) the bare metric key (legacy)
-      3) ``,none`` (default filter slug)
-    Also surfaces ``<id>_stderr`` for diagnostics using the same lookup order.
-    """
-
-    out: dict[str, float] = {}
-    results = payload.get("results") or {}
-    task = spec.extra.get("task", spec.id)
-    task_results = results.get(task, {})
-
-    score = _pick_metric(task_results, spec.score_metric, spec.score_filter)
-    if isinstance(score, (int, float)):
-        out[spec.id] = float(score)
-
-    stderr = _pick_metric(task_results, f"{spec.score_metric}_stderr", spec.score_filter)
-    if isinstance(stderr, (int, float)):
-        out[f"{spec.id}_stderr"] = float(stderr)
-
-    return out
-
-
-def _pick_metric(task_results: dict[str, Any], metric: str, preferred_filter: str | None) -> Any:
-    """Walk filter-suffix variants for ``metric`` in priority order."""
-    candidates: list[str] = []
-    if preferred_filter:
-        candidates.append(f"{metric},{preferred_filter}")
-    candidates.append(metric)
-    candidates.append(f"{metric},none")
-    for key in candidates:
-        if key in task_results:
-            return task_results[key]
-    return None

--- a/cvs/lib/benchmarks/runner.py
+++ b/cvs/lib/benchmarks/runner.py
@@ -43,6 +43,7 @@ def run_benchmarks(
     server_handle,
     base_url: str,
     model_id: str,
+    model_path: str,
     output_dir_in_container: str,
     output_dir_on_host: Path,
 ) -> dict[str, float]:
@@ -58,6 +59,7 @@ def run_benchmarks(
         hctx = HarnessCtx(
             base_url=base_url,
             model_id=model_id,
+            model_path=model_path,
             output_dir=output_dir_in_container,
         )
         harness_cmd = build_command(spec, hctx)

--- a/cvs/lib/benchmarks/runner.py
+++ b/cvs/lib/benchmarks/runner.py
@@ -1,0 +1,139 @@
+"""Run accuracy benchmarks against a healthy server, project scores to scalars.
+
+Called from the adapter's ``parse()`` once the server is up. For each
+benchmark, the harness runs inside the server container (which has the host
+artifacts_dir bind-mounted at ``OUTPUT_DIR_IN_CONTAINER`` by the adapter at
+launch time) and drops a ``results_<ts>.json`` file in a per-benchmark
+subdir. We glob the host side of that mount, project the configured metric
+to ``ctx.result.scalars`` under the benchmark id so ``threshold.json`` can
+name it directly:
+
+    scalars["mmlu"]  = 0.732   ← matches `"mmlu": {"kind": "min", "value": 0.7}`
+    scalars["gsm8k"] = 0.815
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from cvs.lib.benchmarks.harness_invokers import HarnessCtx, build_command
+from cvs.lib.benchmarks.registry import BenchmarkSpec, lookup
+from cvs.lib.errors import WorkloadError
+
+
+# Per-benchmark wall-clock ceiling. MMLU on a smaller model can take ~2h;
+# this gives headroom. Total parse-phase budget is N benchmarks * this.
+PER_BENCHMARK_TIMEOUT_S: int = 4 * 3600
+
+
+def run_benchmarks(
+    *,
+    benchmarks: list[str],
+    server_handle,
+    base_url: str,
+    model_id: str,
+    output_dir_in_container: str,
+    output_dir_on_host: Path,
+) -> dict[str, float]:
+    """Run each benchmark id, return flat scalars dict for ctx.result.scalars.
+
+    ``server_handle`` is the ContainerHandle whose runner.exec we use to
+    ``docker exec`` the harness inside the same container as the server (the
+    rocm/vllm image ships ``lm_eval``).
+    """
+
+    scalars: dict[str, float] = {}
+    for bid in benchmarks:
+        spec = lookup(bid)
+        hctx = HarnessCtx(
+            base_url=base_url,
+            model_id=model_id,
+            output_dir=output_dir_in_container,
+        )
+        harness_cmd = build_command(spec, hctx)
+        docker_cmd = (
+            f"docker exec {shlex.quote(server_handle.name)} "
+            f"bash -c {shlex.quote(harness_cmd)}"
+        )
+        try:
+            server_handle.runner.exec(docker_cmd, timeout=PER_BENCHMARK_TIMEOUT_S)
+        except Exception as exc:
+            raise WorkloadError(f"benchmark {bid!r} harness failed: {exc}") from exc
+
+        result_json = _find_lm_eval_result(output_dir_on_host / bid)
+        if result_json is None:
+            raise WorkloadError(
+                f"benchmark {bid!r}: harness ran but produced no results JSON under "
+                f"{output_dir_on_host / bid}"
+            )
+        try:
+            payload = json.loads(result_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise WorkloadError(
+                f"benchmark {bid!r}: harness output {result_json} is not valid JSON: {exc}"
+            ) from exc
+
+        scalars.update(_project_scalars(spec, payload))
+
+    return scalars
+
+
+def _find_lm_eval_result(subdir: Path) -> Path | None:
+    """Return the newest ``results*.json`` under ``subdir`` (recursive), or None.
+
+    lm-eval-harness writes ``<output_path>/results_<timestamp>.json`` (and
+    sometimes nests under a model-name dir). We pick the most recently
+    modified match to be robust to either layout.
+    """
+    if not subdir.exists():
+        return None
+    matches = sorted(
+        subdir.rglob("results*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0] if matches else None
+
+
+def _project_scalars(spec: BenchmarkSpec, payload: dict[str, Any]) -> dict[str, float]:
+    """Extract spec.score_metric from lm-eval JSON under the benchmark id key.
+
+    lm-eval writes ``{"results": {task: {metric: value, metric_stderr: ...}}}``.
+    Modern lm-eval suffixes the metric name with ``,<filter>`` (e.g.
+    ``acc,none`` or ``exact_match,strict-match``). We try, in order:
+      1) the spec's preferred filter (``score_filter``)
+      2) the bare metric key (legacy)
+      3) ``,none`` (default filter slug)
+    Also surfaces ``<id>_stderr`` for diagnostics using the same lookup order.
+    """
+
+    out: dict[str, float] = {}
+    results = payload.get("results") or {}
+    task = spec.extra.get("task", spec.id)
+    task_results = results.get(task, {})
+
+    score = _pick_metric(task_results, spec.score_metric, spec.score_filter)
+    if isinstance(score, (int, float)):
+        out[spec.id] = float(score)
+
+    stderr = _pick_metric(task_results, f"{spec.score_metric}_stderr", spec.score_filter)
+    if isinstance(stderr, (int, float)):
+        out[f"{spec.id}_stderr"] = float(stderr)
+
+    return out
+
+
+def _pick_metric(task_results: dict[str, Any], metric: str, preferred_filter: str | None) -> Any:
+    """Walk filter-suffix variants for ``metric`` in priority order."""
+    candidates: list[str] = []
+    if preferred_filter:
+        candidates.append(f"{metric},{preferred_filter}")
+    candidates.append(metric)
+    candidates.append(f"{metric},none")
+    for key in candidates:
+        if key in task_results:
+            return task_results[key]
+    return None

--- a/cvs/lib/benchmarks/runner.py
+++ b/cvs/lib/benchmarks/runner.py
@@ -73,17 +73,26 @@ def run_benchmarks(
             raise WorkloadError(f"benchmark {bid!r} harness failed: {exc}") from exc
 
         glob_pat = _RESULT_GLOBS.get(spec.harness, "*.json")
-        result_json = _find_result(output_dir_on_host / bid, glob_pat)
-        if result_json is None:
+        host_dir = output_dir_on_host / bid
+        # Read via the same remote executor that ran the harness -- the
+        # artifacts directory is on the host where the container ran, not
+        # necessarily on the runner's local filesystem.
+        find_cmd = (
+            f"find {shlex.quote(str(host_dir))} -type f -name {shlex.quote(glob_pat)} "
+            f"-printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | awk '{{print $2}}'"
+        )
+        latest = server_handle.runner.exec(find_cmd, timeout=30).strip()
+        if not latest:
             raise WorkloadError(
                 f"benchmark {bid!r}: harness ran but produced no result JSON "
-                f"({glob_pat}) under {output_dir_on_host / bid}"
+                f"({glob_pat}) under {host_dir}"
             )
+        raw = server_handle.runner.exec(f"cat {shlex.quote(latest)}", timeout=30)
         try:
-            payload = json.loads(result_json.read_text(encoding="utf-8"))
+            payload = json.loads(raw)
         except json.JSONDecodeError as exc:
             raise WorkloadError(
-                f"benchmark {bid!r}: harness output {result_json} is not "
+                f"benchmark {bid!r}: harness output {latest} is not "
                 f"valid JSON: {exc}"
             ) from exc
 

--- a/cvs/lib/config_loader.py
+++ b/cvs/lib/config_loader.py
@@ -181,8 +181,29 @@ def load_workload(
         sugg = catalog.suggest("dataset", wl.dataset.id)
         hint = f" did you mean {sugg!r}?" if sugg else ""
         raise CatalogError(f"{path}: unknown dataset.id {wl.dataset.id!r}.{hint}")
-    # benchmark check deferred to whoever imports BENCHMARK_REGISTRY
+    _validate_benchmarks(path, wl.benchmarks)
     return wl
+
+
+def _validate_benchmarks(path: Path, benchmarks: list[str]) -> None:
+    """Reject unknown benchmark ids at load with a did-you-mean hint.
+
+    Imported lazily to avoid a config_loader -> benchmarks import cycle if
+    a benchmark module ever needs config types.
+    """
+    if not benchmarks:
+        return
+    import difflib
+
+    from cvs.lib.benchmarks.registry import BENCHMARK_REGISTRY
+
+    known = sorted(BENCHMARK_REGISTRY)
+    for bid in benchmarks:
+        if bid in BENCHMARK_REGISTRY:
+            continue
+        sugg = difflib.get_close_matches(bid, known, n=1, cutoff=0.6)
+        hint = f" did you mean {sugg[0]!r}?" if sugg else f" known: {known}"
+        raise CatalogError(f"{path}: unknown benchmark id {bid!r}.{hint}")
 
 
 # ---------- thresholds ----------

--- a/cvs/tests_dtni/unittests/test_benchmark_registry.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_registry.py
@@ -12,19 +12,20 @@ from cvs.lib.benchmarks.registry import (
 )
 
 
-def test_registry_contains_v1_accuracy_set():
-    assert set(BENCHMARK_REGISTRY) == {"mmlu", "gsm8k"}
+def test_registry_contains_accuracy_and_perf_sets():
+    keys = set(BENCHMARK_REGISTRY)
+    # accuracy
+    assert {"mmlu", "gsm8k"} <= keys
+    # perf (vllm-bench-serve harness)
+    assert {"serve_synth_short", "serve_synth_long"} <= keys
 
 
 def test_specs_are_well_formed():
     for bid, spec in BENCHMARK_REGISTRY.items():
         assert isinstance(spec, BenchmarkSpec)
         assert spec.id == bid
-        assert spec.harness == "lm-eval-harness"
-        assert spec.dataset_id
-        assert spec.score_metric
+        assert spec.harness in {"lm-eval-harness", "vllm-bench-serve"}
         assert spec.shots >= 0
-        # frozen dataclass: extra is a dict but immutable spec
         assert isinstance(spec.extra, dict)
 
 
@@ -33,6 +34,14 @@ def test_lookup_returns_spec():
     assert spec.score_metric == "acc"
     assert spec.shots == 5
     assert spec.extra["task"] == "mmlu"
+
+
+def test_perf_spec_has_no_score_metric():
+    # Perf benchmarks don't use the lm-eval scoring fields.
+    spec = lookup("serve_synth_short")
+    assert spec.score_metric is None
+    assert spec.extra["dataset_name"] == "random"
+    assert spec.extra["num_prompts"] == 200
 
 
 def test_lookup_unknown_raises_with_known_list():

--- a/cvs/tests_dtni/unittests/test_benchmark_registry.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_registry.py
@@ -1,0 +1,50 @@
+"""Unit tests for cvs.lib.benchmarks.registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from cvs.lib.benchmarks.registry import (
+    BENCHMARK_REGISTRY,
+    BenchmarkSpec,
+    list_benchmarks,
+    lookup,
+)
+
+
+def test_registry_contains_v1_accuracy_set():
+    assert set(BENCHMARK_REGISTRY) == {"mmlu", "gsm8k"}
+
+
+def test_specs_are_well_formed():
+    for bid, spec in BENCHMARK_REGISTRY.items():
+        assert isinstance(spec, BenchmarkSpec)
+        assert spec.id == bid
+        assert spec.harness == "lm-eval-harness"
+        assert spec.dataset_id
+        assert spec.score_metric
+        assert spec.shots >= 0
+        # frozen dataclass: extra is a dict but immutable spec
+        assert isinstance(spec.extra, dict)
+
+
+def test_lookup_returns_spec():
+    spec = lookup("mmlu")
+    assert spec.score_metric == "acc"
+    assert spec.shots == 5
+    assert spec.extra["task"] == "mmlu"
+
+
+def test_lookup_unknown_raises_with_known_list():
+    with pytest.raises(KeyError) as exc_info:
+        lookup("mmmlu")
+    msg = str(exc_info.value)
+    assert "mmmlu" in msg
+    assert "gsm8k" in msg
+    assert "mmlu" in msg
+
+
+def test_list_benchmarks_is_stable():
+    ids = list_benchmarks()
+    assert isinstance(ids, tuple)
+    assert set(ids) == set(BENCHMARK_REGISTRY)

--- a/cvs/tests_dtni/unittests/test_benchmark_runner.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_runner.py
@@ -63,6 +63,7 @@ def test_run_benchmarks_lm_eval_then_vllm_serve_in_one_pass(tmp_path: Path):
         server_handle=handle,
         base_url="http://localhost:8000",
         model_id="llama-3.1-8b",
+        model_path="/models/foo",
         output_dir_in_container=str(tmp_path),
         output_dir_on_host=tmp_path,
     )
@@ -85,6 +86,7 @@ def test_run_benchmarks_unknown_id_raises_before_exec(tmp_path: Path):
             server_handle=handle,
             base_url="http://localhost:8000",
             model_id="x",
+            model_path="/models/foo",
             output_dir_in_container=str(tmp_path),
             output_dir_on_host=tmp_path,
         )
@@ -100,6 +102,7 @@ def test_run_benchmarks_missing_output_raises(tmp_path: Path):
             server_handle=handle,
             base_url="http://localhost:8000",
             model_id="x",
+            model_path="/models/foo",
             output_dir_in_container=str(tmp_path),
             output_dir_on_host=tmp_path,
         )
@@ -120,6 +123,7 @@ def test_run_benchmarks_invalid_json_raises(tmp_path: Path):
             server_handle=handle,
             base_url="http://localhost:8000",
             model_id="x",
+            model_path="/models/foo",
             output_dir_in_container=str(tmp_path),
             output_dir_on_host=tmp_path,
         )

--- a/cvs/tests_dtni/unittests/test_benchmark_runner.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_runner.py
@@ -7,6 +7,7 @@ file only exercises the runner's docker-exec / file-discovery loop.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -25,10 +26,32 @@ class _FakeRunner:
     last_cmd: str = ""
 
     def exec(self, cmd: str, timeout: int = 0) -> str:
+        # The runner now issues three command shapes per benchmark:
+        # 1) docker exec ... (the harness) -- drop the JSON payload on local
+        #    disk to simulate the bind-mount.
+        # 2) find <bid_dir> ... | sort -nr | head -1 | awk '{print $2}'
+        #    -- return the newest matching file path under <out_dir>/<bid>/.
+        # 3) cat <path> -- return the file contents.
         self.last_cmd = cmd
+        if cmd.startswith("cat "):
+            path = cmd[len("cat "):].strip().strip("'")
+            return Path(path).read_text(encoding="utf-8")
+        if cmd.startswith("find "):
+            # Path is the 2nd token; may be shlex-quoted or bare.
+            import shlex as _sh
+            try:
+                tokens = _sh.split(cmd)
+            except ValueError:
+                return ""
+            sub = Path(tokens[1]) if len(tokens) > 1 else None
+            if sub is None or not sub.is_dir():
+                return ""
+            candidates = sorted(sub.rglob("*.json"),
+                                key=lambda p: p.stat().st_mtime,
+                                reverse=True)
+            return f"{candidates[0]}\n" if candidates else ""
+        # Default: treat as the docker exec / harness invocation.
         for bid, payload in self.payloads.items():
-            # Match either lm-eval's "/<bid>" (--output_path is the dir) or
-            # vllm bench serve's "--result-dir .../<bid>" prefix path.
             if f"/{bid}" in cmd:
                 sub = self.out_dir / bid
                 sub.mkdir(parents=True, exist_ok=True)

--- a/cvs/tests_dtni/unittests/test_benchmark_runner.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_runner.py
@@ -1,4 +1,8 @@
-"""Unit tests for cvs.lib.benchmarks.runner — projector + orchestration."""
+"""Unit tests for cvs.lib.benchmarks.runner orchestration.
+
+Projector behavior is covered separately in test_projectors.py — this
+file only exercises the runner's docker-exec / file-discovery loop.
+"""
 
 from __future__ import annotations
 
@@ -8,67 +12,27 @@ from pathlib import Path
 
 import pytest
 
-from cvs.lib.benchmarks.registry import lookup
-from cvs.lib.benchmarks.runner import _project_scalars, run_benchmarks
+from cvs.lib.benchmarks.runner import run_benchmarks
 from cvs.lib.errors import WorkloadError
-
-
-# ---- projector ------------------------------------------------------------
-
-
-def test_project_scalars_reads_bare_metric_key():
-    payload = {"results": {"mmlu": {"acc": 0.732, "acc_stderr": 0.011}}}
-    out = _project_scalars(lookup("mmlu"), payload)
-    assert out == {"mmlu": 0.732, "mmlu_stderr": 0.011}
-
-
-def test_project_scalars_prefers_filter_suffixed_key_for_gsm8k():
-    # gsm8k spec uses score_filter="strict-match" — must beat ",none".
-    payload = {"results": {"gsm8k": {
-        "exact_match,strict-match": 0.812,
-        "exact_match_stderr,strict-match": 0.009,
-        "exact_match,none": 0.99,  # red herring — should NOT be picked
-    }}}
-    out = _project_scalars(lookup("gsm8k"), payload)
-    assert out == {"gsm8k": 0.812, "gsm8k_stderr": 0.009}
-
-
-def test_project_scalars_falls_back_to_comma_none():
-    # mmlu spec uses score_filter="none"; verify that lookup hits.
-    payload = {"results": {"mmlu": {"acc,none": 0.71}}}
-    out = _project_scalars(lookup("mmlu"), payload)
-    assert out == {"mmlu": 0.71}
-
-
-def test_project_scalars_missing_task_returns_empty():
-    payload = {"results": {}}
-    out = _project_scalars(lookup("mmlu"), payload)
-    assert out == {}
-
-
-def test_project_scalars_skips_non_numeric_metric():
-    payload = {"results": {"mmlu": {"acc": "n/a"}}}
-    out = _project_scalars(lookup("mmlu"), payload)
-    assert out == {}
-
-
-# ---- runner orchestration -------------------------------------------------
 
 
 @dataclass
 class _FakeRunner:
-    """Drops a per-benchmark results JSON into <out_dir>/<bid>/results.json."""
+    """Drops per-benchmark result JSONs into <out_dir>/<bid>/."""
     out_dir: Path
     payloads: dict
+    file_name: dict  # bid -> filename
     last_cmd: str = ""
 
     def exec(self, cmd: str, timeout: int = 0) -> str:
         self.last_cmd = cmd
         for bid, payload in self.payloads.items():
-            if f"/{bid} " in cmd or cmd.endswith(f"/{bid}"):
+            # Match either lm-eval's "/<bid>" (--output_path is the dir) or
+            # vllm bench serve's "--result-dir .../<bid>" prefix path.
+            if f"/{bid}" in cmd:
                 sub = self.out_dir / bid
                 sub.mkdir(parents=True, exist_ok=True)
-                (sub / "results_20260606.json").write_text(json.dumps(payload))
+                (sub / self.file_name[bid]).write_text(json.dumps(payload))
                 return ""
         return ""
 
@@ -79,16 +43,23 @@ class _FakeHandle:
     runner: _FakeRunner
 
 
-def test_run_benchmarks_emits_scalars_per_id(tmp_path: Path):
+def test_run_benchmarks_lm_eval_then_vllm_serve_in_one_pass(tmp_path: Path):
+    # Mix accuracy + perf in one call — exercises both file globs.
     payloads = {
         "mmlu":  {"results": {"mmlu":  {"acc,none": 0.71, "acc_stderr,none": 0.01}}},
-        "gsm8k": {"results": {"gsm8k": {"exact_match,strict-match": 0.82}}},
+        "serve_synth_short": {
+            "completed": 200,
+            "request_throughput": 12.5,
+            "output_throughput": 4321.0,
+            "percentiles_ttft_ms": [[95, 84.2]],
+        },
     }
-    runner = _FakeRunner(out_dir=tmp_path, payloads=payloads)
+    file_name = {"mmlu": "results_20260606.json", "serve_synth_short": "result.json"}
+    runner = _FakeRunner(out_dir=tmp_path, payloads=payloads, file_name=file_name)
     handle = _FakeHandle(name="cvs_smoke", runner=runner)
 
     scalars = run_benchmarks(
-        benchmarks=["mmlu", "gsm8k"],
+        benchmarks=["mmlu", "serve_synth_short"],
         server_handle=handle,
         base_url="http://localhost:8000",
         model_id="llama-3.1-8b",
@@ -96,13 +67,17 @@ def test_run_benchmarks_emits_scalars_per_id(tmp_path: Path):
         output_dir_on_host=tmp_path,
     )
 
+    # lm-eval projects to bare id (back-compat with Step-4 thresholds).
     assert scalars["mmlu"] == 0.71
     assert scalars["mmlu_stderr"] == 0.01
-    assert scalars["gsm8k"] == 0.82
+    # vllm serve projects to dotted namespace under the bench id.
+    assert scalars["serve_synth_short.completed"] == 200.0
+    assert scalars["serve_synth_short.output_throughput"] == 4321.0
+    assert scalars["serve_synth_short.ttft_p95_ms"] == 84.2
 
 
 def test_run_benchmarks_unknown_id_raises_before_exec(tmp_path: Path):
-    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    runner = _FakeRunner(out_dir=tmp_path, payloads={}, file_name={})
     handle = _FakeHandle(name="cvs_smoke", runner=runner)
     with pytest.raises(KeyError):
         run_benchmarks(
@@ -117,8 +92,7 @@ def test_run_benchmarks_unknown_id_raises_before_exec(tmp_path: Path):
 
 
 def test_run_benchmarks_missing_output_raises(tmp_path: Path):
-    # FakeRunner won't write anything because payloads is empty.
-    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    runner = _FakeRunner(out_dir=tmp_path, payloads={}, file_name={})
     handle = _FakeHandle(name="cvs_smoke", runner=runner)
     with pytest.raises(WorkloadError) as exc_info:
         run_benchmarks(
@@ -129,21 +103,20 @@ def test_run_benchmarks_missing_output_raises(tmp_path: Path):
             output_dir_in_container=str(tmp_path),
             output_dir_on_host=tmp_path,
         )
-    assert "no results JSON" in str(exc_info.value)
+    assert "no result JSON" in str(exc_info.value)
 
 
 def test_run_benchmarks_invalid_json_raises(tmp_path: Path):
-    # Pre-create the per-benchmark subdir with a malformed results file.
-    sub = tmp_path / "mmlu"
+    # Pre-create the per-benchmark subdir with a malformed result file
+    # named to match the vllm-serve glob.
+    sub = tmp_path / "serve_synth_short"
     sub.mkdir()
-    (sub / "results_bad.json").write_text("{not json")
-
-    # Fake runner that does NOT overwrite the file.
-    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    (sub / "result.json").write_text("{not json")
+    runner = _FakeRunner(out_dir=tmp_path, payloads={}, file_name={})
     handle = _FakeHandle(name="cvs_smoke", runner=runner)
     with pytest.raises(WorkloadError) as exc_info:
         run_benchmarks(
-            benchmarks=["mmlu"],
+            benchmarks=["serve_synth_short"],
             server_handle=handle,
             base_url="http://localhost:8000",
             model_id="x",

--- a/cvs/tests_dtni/unittests/test_benchmark_runner.py
+++ b/cvs/tests_dtni/unittests/test_benchmark_runner.py
@@ -1,0 +1,153 @@
+"""Unit tests for cvs.lib.benchmarks.runner — projector + orchestration."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from cvs.lib.benchmarks.registry import lookup
+from cvs.lib.benchmarks.runner import _project_scalars, run_benchmarks
+from cvs.lib.errors import WorkloadError
+
+
+# ---- projector ------------------------------------------------------------
+
+
+def test_project_scalars_reads_bare_metric_key():
+    payload = {"results": {"mmlu": {"acc": 0.732, "acc_stderr": 0.011}}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {"mmlu": 0.732, "mmlu_stderr": 0.011}
+
+
+def test_project_scalars_prefers_filter_suffixed_key_for_gsm8k():
+    # gsm8k spec uses score_filter="strict-match" — must beat ",none".
+    payload = {"results": {"gsm8k": {
+        "exact_match,strict-match": 0.812,
+        "exact_match_stderr,strict-match": 0.009,
+        "exact_match,none": 0.99,  # red herring — should NOT be picked
+    }}}
+    out = _project_scalars(lookup("gsm8k"), payload)
+    assert out == {"gsm8k": 0.812, "gsm8k_stderr": 0.009}
+
+
+def test_project_scalars_falls_back_to_comma_none():
+    # mmlu spec uses score_filter="none"; verify that lookup hits.
+    payload = {"results": {"mmlu": {"acc,none": 0.71}}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {"mmlu": 0.71}
+
+
+def test_project_scalars_missing_task_returns_empty():
+    payload = {"results": {}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {}
+
+
+def test_project_scalars_skips_non_numeric_metric():
+    payload = {"results": {"mmlu": {"acc": "n/a"}}}
+    out = _project_scalars(lookup("mmlu"), payload)
+    assert out == {}
+
+
+# ---- runner orchestration -------------------------------------------------
+
+
+@dataclass
+class _FakeRunner:
+    """Drops a per-benchmark results JSON into <out_dir>/<bid>/results.json."""
+    out_dir: Path
+    payloads: dict
+    last_cmd: str = ""
+
+    def exec(self, cmd: str, timeout: int = 0) -> str:
+        self.last_cmd = cmd
+        for bid, payload in self.payloads.items():
+            if f"/{bid} " in cmd or cmd.endswith(f"/{bid}"):
+                sub = self.out_dir / bid
+                sub.mkdir(parents=True, exist_ok=True)
+                (sub / "results_20260606.json").write_text(json.dumps(payload))
+                return ""
+        return ""
+
+
+@dataclass
+class _FakeHandle:
+    name: str
+    runner: _FakeRunner
+
+
+def test_run_benchmarks_emits_scalars_per_id(tmp_path: Path):
+    payloads = {
+        "mmlu":  {"results": {"mmlu":  {"acc,none": 0.71, "acc_stderr,none": 0.01}}},
+        "gsm8k": {"results": {"gsm8k": {"exact_match,strict-match": 0.82}}},
+    }
+    runner = _FakeRunner(out_dir=tmp_path, payloads=payloads)
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+
+    scalars = run_benchmarks(
+        benchmarks=["mmlu", "gsm8k"],
+        server_handle=handle,
+        base_url="http://localhost:8000",
+        model_id="llama-3.1-8b",
+        output_dir_in_container=str(tmp_path),
+        output_dir_on_host=tmp_path,
+    )
+
+    assert scalars["mmlu"] == 0.71
+    assert scalars["mmlu_stderr"] == 0.01
+    assert scalars["gsm8k"] == 0.82
+
+
+def test_run_benchmarks_unknown_id_raises_before_exec(tmp_path: Path):
+    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+    with pytest.raises(KeyError):
+        run_benchmarks(
+            benchmarks=["does-not-exist"],
+            server_handle=handle,
+            base_url="http://localhost:8000",
+            model_id="x",
+            output_dir_in_container=str(tmp_path),
+            output_dir_on_host=tmp_path,
+        )
+    assert runner.last_cmd == ""
+
+
+def test_run_benchmarks_missing_output_raises(tmp_path: Path):
+    # FakeRunner won't write anything because payloads is empty.
+    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+    with pytest.raises(WorkloadError) as exc_info:
+        run_benchmarks(
+            benchmarks=["mmlu"],
+            server_handle=handle,
+            base_url="http://localhost:8000",
+            model_id="x",
+            output_dir_in_container=str(tmp_path),
+            output_dir_on_host=tmp_path,
+        )
+    assert "no results JSON" in str(exc_info.value)
+
+
+def test_run_benchmarks_invalid_json_raises(tmp_path: Path):
+    # Pre-create the per-benchmark subdir with a malformed results file.
+    sub = tmp_path / "mmlu"
+    sub.mkdir()
+    (sub / "results_bad.json").write_text("{not json")
+
+    # Fake runner that does NOT overwrite the file.
+    runner = _FakeRunner(out_dir=tmp_path, payloads={})
+    handle = _FakeHandle(name="cvs_smoke", runner=runner)
+    with pytest.raises(WorkloadError) as exc_info:
+        run_benchmarks(
+            benchmarks=["mmlu"],
+            server_handle=handle,
+            base_url="http://localhost:8000",
+            model_id="x",
+            output_dir_in_container=str(tmp_path),
+            output_dir_on_host=tmp_path,
+        )
+    assert "not valid JSON" in str(exc_info.value)

--- a/cvs/tests_dtni/unittests/test_config_loader_benchmarks.py
+++ b/cvs/tests_dtni/unittests/test_config_loader_benchmarks.py
@@ -1,0 +1,87 @@
+"""Unit tests for cvs.lib.config_loader benchmark validation.
+
+Scope is narrow on purpose: this file exists to lock in the v1 behavior that
+load_workload rejects unknown benchmark ids at load time with a did-you-mean
+hint, against BENCHMARK_REGISTRY.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cvs.lib.catalog import Catalog, ModelEntry
+from cvs.lib.config_loader import load_workload
+from cvs.lib.errors import CatalogError
+
+
+def _minimal_workload(benchmarks: list[str]) -> dict:
+    return {
+        "schema_version": 1,
+        "framework": "vllm_single",
+        "gpu_arch": "mi300x",
+        "paths": {
+            "shared_fs": "/tmp/x",
+            "models_dir": "/tmp/x/models",
+            "datasets_dir": "/tmp/x/datasets",
+            "artifacts_dir": "/tmp/x/artifacts",
+            "images_dir": "/tmp/x/images",
+        },
+        "model": {"id": "llama-3.1-8b", "remote": 0, "precision": "bf16"},
+        "benchmarks": benchmarks,
+        "image": {"tag": "rocm/vllm:latest", "remote": 1},
+        "topology": {"roles": {"server": {"count": 1, "gpus_per_node": 1}}},
+        "roles": {
+            "server": {
+                "port": 8000,
+                "health_path": "/health",
+                "command": "vllm serve x",
+            }
+        },
+    }
+
+
+def _catalog() -> Catalog:
+    return Catalog(
+        models={"llama-3.1-8b": ModelEntry(id="llama-3.1-8b", hf_repo="x/y")},
+        datasets={},
+        benchmarks=(),
+    )
+
+
+def _write(tmp_path: Path, wl: dict) -> Path:
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(wl))
+    return p
+
+
+def test_known_benchmarks_load_clean(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload(["mmlu", "gsm8k"]))
+    wl = load_workload(p, catalog=_catalog())
+    assert wl.benchmarks == ["mmlu", "gsm8k"]
+
+
+def test_empty_benchmarks_load_clean(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload([]))
+    wl = load_workload(p, catalog=_catalog())
+    assert wl.benchmarks == []
+
+
+def test_unknown_benchmark_raises_with_did_you_mean(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload(["mmmlu"]))
+    with pytest.raises(CatalogError) as exc_info:
+        load_workload(p, catalog=_catalog())
+    msg = str(exc_info.value)
+    assert "mmmlu" in msg
+    assert "mmlu" in msg  # did-you-mean suggestion
+
+
+def test_unknown_benchmark_no_close_match_lists_known(tmp_path: Path):
+    p = _write(tmp_path, _minimal_workload(["totally-unrelated"]))
+    with pytest.raises(CatalogError) as exc_info:
+        load_workload(p, catalog=_catalog())
+    msg = str(exc_info.value)
+    assert "totally-unrelated" in msg
+    assert "mmlu" in msg and "gsm8k" in msg

--- a/cvs/tests_dtni/unittests/test_harness_invokers.py
+++ b/cvs/tests_dtni/unittests/test_harness_invokers.py
@@ -18,6 +18,7 @@ def _hctx() -> HarnessCtx:
     return HarnessCtx(
         base_url="http://localhost:8000",
         model_id="llama-3.1-8b",
+        model_path="/models/llama-3.1-8b",
         output_dir="/output",
     )
 
@@ -43,6 +44,10 @@ def test_lm_eval_command_includes_required_flags():
     assert "--model local-completions" in cmd
     assert "base_url=http://localhost:8000/v1/completions" in cmd
     assert "model=llama-3.1-8b" in cmd
+    # tokenizer must be the on-disk path so HF does not try to fetch
+    # the served-model-name as a repo id.
+    assert "tokenizer=/models/llama-3.1-8b" in cmd
+    assert "tokenizer_backend=huggingface" in cmd
     assert "--tasks mmlu" in cmd
     assert "--num_fewshot 5" in cmd
     assert "--output_path /output/mmlu" in cmd
@@ -72,6 +77,7 @@ def test_serve_random_includes_required_flags():
     assert "--backend vllm" in cmd
     assert "--base-url http://localhost:8000" in cmd
     assert "--model llama-3.1-8b" in cmd
+    assert "--tokenizer /models/llama-3.1-8b" in cmd
     assert "--dataset-name random" in cmd
     assert "--num-prompts 200" in cmd
     assert "--random-input-len 128" in cmd

--- a/cvs/tests_dtni/unittests/test_harness_invokers.py
+++ b/cvs/tests_dtni/unittests/test_harness_invokers.py
@@ -1,0 +1,59 @@
+"""Unit tests for cvs.lib.benchmarks.harness_invokers."""
+
+from __future__ import annotations
+
+import pytest
+
+from cvs.lib.benchmarks.harness_invokers import (
+    HARNESS_INVOKERS,
+    OUTPUT_DIR_IN_CONTAINER,
+    HarnessCtx,
+    build_command,
+)
+from cvs.lib.benchmarks.registry import lookup
+
+
+def _hctx() -> HarnessCtx:
+    return HarnessCtx(
+        base_url="http://localhost:8000",
+        model_id="llama-3.1-8b",
+        output_dir="/output",
+    )
+
+
+def test_invoker_registry_has_lm_eval():
+    assert "lm-eval-harness" in HARNESS_INVOKERS
+
+
+def test_output_dir_in_container_is_absolute():
+    assert OUTPUT_DIR_IN_CONTAINER.startswith("/")
+
+
+def test_build_command_mmlu_includes_required_flags():
+    cmd = build_command(lookup("mmlu"), _hctx())
+    assert "lm_eval" in cmd
+    assert "--model local-completions" in cmd
+    assert "base_url=http://localhost:8000/v1/completions" in cmd
+    assert "model=llama-3.1-8b" in cmd
+    assert "--tasks mmlu" in cmd
+    assert "--num_fewshot 5" in cmd
+    # --output_path is a directory per lm-eval >=0.4 convention.
+    assert "--output_path /output/mmlu" in cmd
+    assert "/output/mmlu.json" not in cmd
+    assert "--log_samples" in cmd
+
+
+def test_build_command_gsm8k_uses_task_arg_from_extra():
+    cmd = build_command(lookup("gsm8k"), _hctx())
+    assert "--tasks gsm8k" in cmd
+    assert "--num_fewshot 5" in cmd
+    assert "--output_path /output/gsm8k" in cmd
+
+
+def test_build_command_unknown_harness_raises():
+    from cvs.lib.benchmarks.registry import BenchmarkSpec
+    spec = BenchmarkSpec("fake", "no-such-harness", "mmlu", "acc")
+    with pytest.raises(KeyError) as exc_info:
+        build_command(spec, _hctx())
+    assert "no-such-harness" in str(exc_info.value)
+    assert "lm-eval-harness" in str(exc_info.value)

--- a/cvs/tests_dtni/unittests/test_harness_invokers.py
+++ b/cvs/tests_dtni/unittests/test_harness_invokers.py
@@ -10,7 +10,8 @@ from cvs.lib.benchmarks.harness_invokers import (
     HarnessCtx,
     build_command,
 )
-from cvs.lib.benchmarks.registry import lookup
+from cvs.lib.benchmarks.registry import BenchmarkSpec, lookup
+from cvs.lib.errors import ConfigError
 
 
 def _hctx() -> HarnessCtx:
@@ -21,15 +22,22 @@ def _hctx() -> HarnessCtx:
     )
 
 
-def test_invoker_registry_has_lm_eval():
+# ---- registry-level -------------------------------------------------------
+
+
+def test_invoker_registry_has_both_harnesses():
     assert "lm-eval-harness" in HARNESS_INVOKERS
+    assert "vllm-bench-serve" in HARNESS_INVOKERS
 
 
 def test_output_dir_in_container_is_absolute():
     assert OUTPUT_DIR_IN_CONTAINER.startswith("/")
 
 
-def test_build_command_mmlu_includes_required_flags():
+# ---- lm-eval --------------------------------------------------------------
+
+
+def test_lm_eval_command_includes_required_flags():
     cmd = build_command(lookup("mmlu"), _hctx())
     assert "lm_eval" in cmd
     assert "--model local-completions" in cmd
@@ -37,23 +45,106 @@ def test_build_command_mmlu_includes_required_flags():
     assert "model=llama-3.1-8b" in cmd
     assert "--tasks mmlu" in cmd
     assert "--num_fewshot 5" in cmd
-    # --output_path is a directory per lm-eval >=0.4 convention.
     assert "--output_path /output/mmlu" in cmd
     assert "/output/mmlu.json" not in cmd
     assert "--log_samples" in cmd
 
 
-def test_build_command_gsm8k_uses_task_arg_from_extra():
+def test_lm_eval_gsm8k_uses_task_arg_from_extra():
     cmd = build_command(lookup("gsm8k"), _hctx())
     assert "--tasks gsm8k" in cmd
-    assert "--num_fewshot 5" in cmd
     assert "--output_path /output/gsm8k" in cmd
 
 
-def test_build_command_unknown_harness_raises():
-    from cvs.lib.benchmarks.registry import BenchmarkSpec
-    spec = BenchmarkSpec("fake", "no-such-harness", "mmlu", "acc")
+def test_unknown_harness_raises():
+    spec = BenchmarkSpec("fake", "no-such-harness")
     with pytest.raises(KeyError) as exc_info:
         build_command(spec, _hctx())
     assert "no-such-harness" in str(exc_info.value)
-    assert "lm-eval-harness" in str(exc_info.value)
+
+
+# ---- vllm-bench-serve -----------------------------------------------------
+
+
+def test_serve_random_includes_required_flags():
+    cmd = build_command(lookup("serve_synth_short"), _hctx())
+    assert "vllm bench serve" in cmd
+    assert "--backend vllm" in cmd
+    assert "--base-url http://localhost:8000" in cmd
+    assert "--model llama-3.1-8b" in cmd
+    assert "--dataset-name random" in cmd
+    assert "--num-prompts 200" in cmd
+    assert "--random-input-len 128" in cmd
+    assert "--random-output-len 256" in cmd
+    assert "--max-concurrency 32" in cmd
+    assert "--request-rate inf" in cmd
+    assert "--metric-percentiles 50,90,95,99" in cmd
+    # Goodput SLOs are split into separate tokens after --goodput.
+    assert "--goodput ttft:2000 tpot:200" in cmd
+    # Result lands at <output_dir>/<id>/result.json — runner globs it.
+    assert "--save-result" in cmd
+    assert "--result-dir /output/serve_synth_short" in cmd
+    assert "--result-filename result.json" in cmd
+    # The mkdir -p prefix is left as a shell operator (not shlex-quoted away).
+    assert cmd.startswith("mkdir -p /output/serve_synth_short && vllm bench serve")
+
+
+def test_serve_random_requires_random_lengths():
+    spec = BenchmarkSpec(
+        id="bad_random",
+        harness="vllm-bench-serve",
+        extra={"dataset_name": "random", "num_prompts": 10},
+    )
+    with pytest.raises(ConfigError) as exc_info:
+        build_command(spec, _hctx())
+    assert "random_input_len" in str(exc_info.value)
+
+
+def test_serve_sharegpt_requires_dataset_path():
+    spec = BenchmarkSpec(
+        id="bad_sharegpt",
+        harness="vllm-bench-serve",
+        extra={"dataset_name": "sharegpt", "num_prompts": 10},
+    )
+    with pytest.raises(ConfigError) as exc_info:
+        build_command(spec, _hctx())
+    assert "dataset_path" in str(exc_info.value)
+
+
+def test_serve_missing_required_extras_raise():
+    spec = BenchmarkSpec(id="empty", harness="vllm-bench-serve", extra={})
+    with pytest.raises(ConfigError):
+        build_command(spec, _hctx())
+
+
+def test_serve_optional_flags_only_when_present():
+    spec = BenchmarkSpec(
+        id="bare",
+        harness="vllm-bench-serve",
+        extra={
+            "dataset_name": "random",
+            "num_prompts": 10,
+            "random_input_len": 64,
+            "random_output_len": 64,
+        },
+    )
+    cmd = build_command(spec, _hctx())
+    assert "--max-concurrency" not in cmd
+    assert "--request-rate" not in cmd
+    assert "--metric-percentiles" not in cmd
+    assert "--goodput" not in cmd
+
+
+def test_serve_sharegpt_path_threaded_through():
+    spec = BenchmarkSpec(
+        id="sharegpt_local",
+        harness="vllm-bench-serve",
+        extra={
+            "dataset_name": "sharegpt",
+            "num_prompts": 50,
+            "dataset_path": "/data/sharegpt.json",
+        },
+    )
+    cmd = build_command(spec, _hctx())
+    assert "--dataset-name sharegpt" in cmd
+    assert "--dataset-path /data/sharegpt.json" in cmd

--- a/cvs/tests_dtni/unittests/test_projectors.py
+++ b/cvs/tests_dtni/unittests/test_projectors.py
@@ -1,0 +1,147 @@
+"""Unit tests for cvs.lib.benchmarks.projectors."""
+
+from __future__ import annotations
+
+import pytest
+
+from cvs.lib.benchmarks.projectors import _project_lm_eval, _project_vllm_bench_serve, project
+from cvs.lib.benchmarks.registry import BenchmarkSpec, lookup
+
+
+# ---- lm-eval --------------------------------------------------------------
+
+
+def test_lm_eval_bare_metric_key():
+    payload = {"results": {"mmlu": {"acc": 0.732, "acc_stderr": 0.011}}}
+    out = _project_lm_eval(lookup("mmlu"), payload)
+    assert out == {"mmlu": 0.732, "mmlu_stderr": 0.011}
+
+
+def test_lm_eval_prefers_filter_suffix_for_gsm8k():
+    payload = {"results": {"gsm8k": {
+        "exact_match,strict-match": 0.812,
+        "exact_match_stderr,strict-match": 0.009,
+        "exact_match,none": 0.99,  # red herring
+    }}}
+    out = _project_lm_eval(lookup("gsm8k"), payload)
+    assert out == {"gsm8k": 0.812, "gsm8k_stderr": 0.009}
+
+
+def test_lm_eval_missing_task_returns_empty():
+    out = _project_lm_eval(lookup("mmlu"), {"results": {}})
+    assert out == {}
+
+
+def test_lm_eval_skips_non_numeric_metric():
+    payload = {"results": {"mmlu": {"acc": "n/a"}}}
+    out = _project_lm_eval(lookup("mmlu"), payload)
+    assert out == {}
+
+
+# ---- vllm-bench-serve -----------------------------------------------------
+
+
+def _serve_spec(id: str = "serve_x") -> BenchmarkSpec:
+    return BenchmarkSpec(
+        id=id,
+        harness="vllm-bench-serve",
+        extra={"dataset_name": "random", "num_prompts": 10,
+               "random_input_len": 64, "random_output_len": 64},
+    )
+
+
+def test_vllm_serve_scalars_namespaced_by_benchmark_id():
+    payload = {
+        "completed": 200,
+        "request_throughput": 12.5,
+        "request_goodput": 11.8,
+        "output_throughput": 4321.0,
+        "total_token_throughput": 6543.2,
+        "mean_ttft_ms": 71.5,
+        "median_ttft_ms": 73.8,
+        "std_ttft_ms": 2.1,
+        "mean_tpot_ms": 7.91,
+    }
+    out = _project_vllm_bench_serve(_serve_spec("svc"), payload)
+    assert out["svc.completed"] == 200.0
+    assert out["svc.request_throughput"] == 12.5
+    assert out["svc.request_goodput"] == 11.8
+    assert out["svc.output_throughput"] == 4321.0
+    assert out["svc.total_token_throughput"] == 6543.2
+    assert out["svc.mean_ttft_ms"] == 71.5
+    assert out["svc.median_ttft_ms"] == 73.8
+    assert out["svc.std_ttft_ms"] == 2.1
+    assert out["svc.mean_tpot_ms"] == 7.91
+    # spec.id prefix means two invocations don't collide.
+    assert all(k.startswith("svc.") for k in out)
+
+
+def test_vllm_serve_percentile_lists_unrolled_to_named_scalars():
+    payload = {
+        "percentiles_ttft_ms": [[50, 73.8], [95, 84.2], [99, 91.0]],
+        "percentiles_tpot_ms": [[50, 7.96], [99, 8.03]],
+        "percentiles_itl_ms":  [[95, 9.5]],
+        "percentiles_e2el_ms": [[50, 2100.0], [95, 2400.0]],
+    }
+    out = _project_vllm_bench_serve(_serve_spec("svc"), payload)
+    assert out["svc.ttft_p50_ms"] == 73.8
+    assert out["svc.ttft_p95_ms"] == 84.2
+    assert out["svc.ttft_p99_ms"] == 91.0
+    assert out["svc.tpot_p50_ms"] == 7.96
+    assert out["svc.tpot_p99_ms"] == 8.03
+    assert out["svc.itl_p95_ms"] == 9.5
+    assert out["svc.e2el_p50_ms"] == 2100.0
+    assert out["svc.e2el_p95_ms"] == 2400.0
+
+
+def test_vllm_serve_skips_non_numeric_and_malformed_pctls():
+    payload = {
+        "completed": "abc",                       # non-numeric → dropped
+        "percentiles_ttft_ms": [
+            [50, "not-a-number"],                  # bad value
+            ["bogus", 100],                        # bad percentile
+            [95, 84.2],                            # good
+            "not-a-tuple",                         # bad entry
+        ],
+        "percentiles_tpot_ms": "not-a-list",      # bad container
+    }
+    out = _project_vllm_bench_serve(_serve_spec("svc"), payload)
+    assert "svc.completed" not in out
+    assert out == {"svc.ttft_p95_ms": 84.2}
+
+
+def test_vllm_serve_empty_payload_returns_empty_dict():
+    assert _project_vllm_bench_serve(_serve_spec(), {}) == {}
+
+
+def test_vllm_serve_bool_field_is_not_coerced_to_scalar():
+    # bool is a subclass of int in Python — `isinstance(True, int)` is True.
+    # Without an explicit bool guard the threshold engine would see 1.0/0.0
+    # as a real measurement.
+    payload = {
+        "completed": True,
+        "percentiles_ttft_ms": [[95, False]],
+    }
+    out = _project_vllm_bench_serve(_serve_spec("svc"), payload)
+    assert out == {}
+
+
+def test_lm_eval_bool_field_is_not_coerced_to_scalar():
+    payload = {"results": {"mmlu": {"acc": True}}}
+    out = _project_lm_eval(lookup("mmlu"), payload)
+    assert out == {}
+
+
+# ---- dispatch -------------------------------------------------------------
+
+
+def test_dispatch_routes_by_harness():
+    payload = {"results": {"mmlu": {"acc": 0.7}}}
+    out = project(lookup("mmlu"), payload)
+    assert out == {"mmlu": 0.7}
+
+
+def test_dispatch_unknown_harness_raises():
+    spec = BenchmarkSpec("fake", "no-such")
+    with pytest.raises(KeyError):
+        project(spec, {})

--- a/cvs/tests_dtni/unittests/test_projectors.py
+++ b/cvs/tests_dtni/unittests/test_projectors.py
@@ -132,6 +132,27 @@ def test_lm_eval_bool_field_is_not_coerced_to_scalar():
     assert out == {}
 
 
+def test_vllm_serve_flat_pNN_metric_ms_keys_are_unrolled():
+    # Current vllm bench serve writes percentiles as flat keys, not lists.
+    # Both p50_ttft_ms and p95_ttft_ms should land in the namespaced form.
+    payload = {
+        "p50_ttft_ms": 138.0,
+        "p95_ttft_ms": 226.1,
+        "p99_tpot_ms": 7.94,
+        "p95_e2el_ms": 2400.0,
+        # red herrings -- must be ignored
+        "p50_unknown_ms": 999.0,        # metric not in known set
+        "p1000_ttft_ms": True,           # bool value, must be skipped
+    }
+    out = _project_vllm_bench_serve(_serve_spec("svc"), payload)
+    assert out == {
+        "svc.ttft_p50_ms": 138.0,
+        "svc.ttft_p95_ms": 226.1,
+        "svc.tpot_p99_ms": 7.94,
+        "svc.e2el_p95_ms": 2400.0,
+    }
+
+
 # ---- dispatch -------------------------------------------------------------
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pytest-dependency
 xlsxwriter
 pydantic >= 2.0
 pandas
+pyarrow
 tabulate
 
 # Docker SDK for container orchestration


### PR DESCRIPTION
## Scope

Implements the DTNI Validation Tracker §"PERFORMANCE BENCHMARK METRICS" rows for vLLM that a single `vllm bench serve` invocation can produce. One harness run yields the whole multi-scalar family at once.

### Tracker rows covered

| # | Metric | Where it lands |
|---|---|---|
| 33 | TTFT p50/p95 | `<bench>.ttft_p50_ms`, `<bench>.ttft_p95_ms` |
| 34 | TPOT p50/p95 | `<bench>.tpot_p50_ms`, `<bench>.tpot_p95_ms` |
| 35 | Prefill latency (~= TTFT for random dataset) | `<bench>.ttft_*` from `serve_synth_long` |
| 36 | Normalized TTFT | `<bench>.ttft_*` / known `random_input_len` |
| 37 | P99/P50 decode latency ratio | derivable from `<bench>.tpot_p99_ms` / `tpot_p50_ms` |
| 39 | E2E latency P50/P90/P95/P99 | `<bench>.e2el_p<NN>_ms` |
| 41 | Global token throughput | `<bench>.output_throughput`, `total_token_throughput` |
| 42 | Decode throughput | `<bench>.output_throughput` |
| 43 | Per-GPU throughput | `output_throughput` / GPU count (verdict-side divide) |
| 51 | Goodput | `<bench>.request_goodput` (SLO `ttft:2000 tpot:200` on short bench) |

### Deferred to v2 (see `jobs/ec849125 v2 harness plan`)

Rows that need different infrastructure than a one-shot harness CLI:
- **Sampler-derived**: row 46 (peak VRAM), 47 (KV cache footprint), 49 (mem BW %), 50 (MFU), 48 (model load time) — need a `rocm-smi` / prometheus sidecar started around the workload window.
- **Sweep-derived**: row 40 (latency-vs-load curve), 44 (max concurrent @ SLA), 45 (scaling efficiency) — need a sweep runner that orchestrates N inner invocations.
- **Cross-precision**: row 52 (quantization parity) — needs a paired-run comparator.
- **ShareGPT** (tracker row 22) — registry entry is parked; needs the v2 per-benchmark `extras` mechanism to thread `dataset_path`.

## What's in this PR

### New module

- `cvs/lib/benchmarks/projectors.py`
  - Per-harness JSON → scalar projection, factored out of `runner.py`.
  - `PROJECTORS` dispatch parallels `HARNESS_INVOKERS`.
  - vllm-bench-serve projector unrolls `BenchmarkMetrics` into `<bench_id>.<field>` + `<bench_id>.<metric>_p<NN>_ms` so `threshold.json` names them directly.
  - **Bool guard** in `_is_real_number`: `True`/`False` are not coerced to `1.0`/`0.0` scalars (review finding — `bool` is a subclass of `int`).

### Registry

- `BenchmarkSpec.score_metric` / `dataset_id` are now optional (lm-eval-only fields).
- Two new perf entries:
  - `serve_synth_short` (200 prompts @ 128 in / 256 out, conc 32, SLOs `ttft:2000 tpot:200`)
  - `serve_synth_long` (64 prompts @ 2048 in / 256 out, conc 8 — prefill stress)

### Harness invoker

- `_vllm_bench_serve` builds the CLI: `--save-result --result-dir <subdir>/<id> --result-filename result.json`, plus optional `--max-concurrency` / `--request-rate` / `--metric-percentiles` / `--goodput KEY:VALUE ...`.
- Required-extras validation raises `ConfigError` at command build (per dataset_name).

### Runner

- Per-harness result-file glob dispatch (`results*.json` for lm-eval, `result.json` for vllm-bench-serve).
- Delegates scalar projection to `projectors.project()`.

### Workload configs

One per catalog model — `<model>/<model>_perf/{config,threshold}.json`:

- `llama_3_1_8b_bf16_single_1_perf`
- `llama_3_1_70b_fp8_single_8_perf`
- `llama_3_3_70b_bf16_single_8_perf`
- `deepseek_r1_fp8_single_8_perf` (sets `VLLM_ROCM_USE_AITER=1`, `ROCM_AITER_MLA=1`)
- `qwen3_next_80b_bf16_single_8_perf`

Each enables `[serve_synth_short, serve_synth_long]` with regression-floor thresholds only (`request_throughput >= 0.5`, `output_throughput >= 50 tok/s`, `ttft_p95 <= 60s` on short). **Calibrated targets follow once nodes return** and we have a measured baseline.

## Tests

- `test_projectors.py` (15): lm-eval filter walking, vllm-bench-serve scalar + percentile unroll, malformed-input skipping, bool-guard, dispatch.
- `test_harness_invokers.py` (+8): vllm-bench-serve CLI invariants, required-extras `ConfigError`, optional flags omitted when absent.
- `test_benchmark_registry.py`: perf entries + perf-spec shape.
- `test_benchmark_runner.py` rewritten: mixed accuracy + perf in one call.

**All 78 unit tests pass** (Python 3.8 + `eval_type_backport`).

## Live verification

**Deferred — nodes down.** Code-only PR; threshold values are conservative regression floors only.

## Base

Branched from `atnair/cvs-dtni-v1-step4`; targets `atnair/cvs-dtni-v1` (NOT `main`). Step-4 PR (#215) merges first.
