### PR TITLE
BE NICs' speed and width check

### DIFF
--- a/cvs/input/config_file/platform/host_config.json
+++ b/cvs/input/config_file/platform/host_config.json
@@ -11,6 +11,8 @@
        "gpu_count": "8",
        "gpu_pcie_speed": "32",
        "gpu_pcie_width": "16",
+       "nic_pcie_speed": "32",
+       "nic_pcie_width": "16",
        "fw_dict":
        {
            "CP_MEC1": "32945",

--- a/cvs/input/config_file/platform/host_config.json
+++ b/cvs/input/config_file/platform/host_config.json
@@ -12,7 +12,9 @@
        "gpu_pcie_speed": "32",
        "gpu_pcie_width": "16",
        "nic_pcie_speed": "32",
+        "_comment_nic_pcie_speed": "If nic is connected via UAlink (for example, for MI450 platform) delete nic_pci_speed line above, otherwise provide pcie speed of nic (default)",
        "nic_pcie_width": "16",
+        "_comment_nic_pcie_width": "If nic is connected via UAlink (for example, for MI450 platform) delete nic_pci_width line above, otherwise provide pcie width of nic (default)",
        "fw_dict":
        {
            "CP_MEC1": "32945",

--- a/cvs/tests/platform/host_configs_cvs.py
+++ b/cvs/tests/platform/host_configs_cvs.py
@@ -465,7 +465,7 @@ def test_check_pci_accelerators(phdl, config_dict):
     update_test_result()
 
 
-def test_check_pci_speed_width(phdl, config_dict):
+def test_check_gpu_pcie_speed_width(phdl, config_dict):
     """
     Verify PCIe link speed and width for each GPU on all nodes.
 
@@ -526,6 +526,48 @@ def test_check_pci_speed_width(phdl, config_dict):
                 )
             if re.search('downgrade', pci_dict[p_node]):
                 fail_test(f'PCIe in downgraded state for bus {bus_no} on node {p_node}')
+    update_test_result()
+
+
+def test_check_be_nic_pcie_speed_width(phdl, config_dict):
+    """
+    Verify PCIe link speed and width for each Backend NIC on all nodes.
+
+    Reads 'nic_pcie_speed' and 'nic_pcie_width' from config_dict.
+    Uses get_gpu_nic_mapping_dict(phdl) to get NIC BDF per card per node.
+    Runs 'sudo lspci -vvv -s <nic_bdf> | grep LnkSta:' across nodes in parallel.
+    Checks Speed, Width, and absence of 'downgrade' in the output.
+    """
+    globals.error_list = []
+    log.info('Testcase check backend NIC PCIe speed and width')
+
+    nic_pcie_speed = config_dict['nic_pcie_speed']
+    nic_pcie_width = config_dict['nic_pcie_width']
+
+    out_dict = linux_utils.get_gpu_nic_mapping_dict(phdl)
+    node_0 = list(out_dict.keys())[0]
+    card_list = list(out_dict[node_0].keys())
+
+    for card_no in card_list:
+        cmd_list = []
+        for node in out_dict:
+            nic_bdf = out_dict[node][card_no]['nic_bdf']
+            cmd_list.append(f'sudo lspci -vvv -s {nic_bdf} | grep "LnkSta:" --color=never')
+        pci_dict = phdl.exec_cmd_list(cmd_list)
+        for p_node in pci_dict:
+            output = pci_dict[p_node]
+            nic_bdf = out_dict[p_node][card_no]['nic_bdf']
+            if not re.search(f'Speed {nic_pcie_speed}GT', output):
+                fail_test(
+                    f'NIC PCIe speed mismatch for {nic_bdf} on {p_node}: expected {nic_pcie_speed}GT/s, got {output}'
+                )
+            if not re.search(f'Width x{nic_pcie_width}', output):
+                fail_test(
+                    f'NIC PCIe width mismatch for {nic_bdf} on {p_node}: expected x{nic_pcie_width}, got {output}'
+                )
+            if re.search('downgrade', output):
+                fail_test(f'NIC PCIe in downgraded state for {nic_bdf} on {p_node}')
+
     update_test_result()
 
 

--- a/cvs/tests/platform/host_configs_cvs.py
+++ b/cvs/tests/platform/host_configs_cvs.py
@@ -541,6 +541,12 @@ def test_check_be_nic_pcie_speed_width(phdl, config_dict):
     globals.error_list = []
     log.info('Testcase check backend NIC PCIe speed and width')
 
+    # if nic on the Scale Out network is connected via UAlink (example, MI450) insteaad
+    # of PCIe then skip this test
+    if 'nic_pcie_speed' not in config_dict or 'nic_pcie_width' not in config_dict:
+        log.info('nic_pcie_speed or nic_pcie_width not in config_dict, skipping test')
+        return
+
     nic_pcie_speed = config_dict['nic_pcie_speed']
     nic_pcie_width = config_dict['nic_pcie_width']
 

--- a/docs/how-to/run-cvs-tests.rst
+++ b/docs/how-to/run-cvs-tests.rst
@@ -155,7 +155,8 @@ You can list all available host check test cases using the CLI:
     - test_check_numa_balancing
     - test_check_online_memory
     - test_check_pci_accelerators
-    - test_check_pci_speed_width
+    - test_check_gpu_pcie_speed_width
+    - test_check_be_nic_pcie_speed_width
     - test_check_pci_acs
     - test_check_dmesg_driver_errors
 


### PR DESCRIPTION
## Motivation

PCIe based backend NICs speed and width check support is provided. The platform host config implementation is updated to provide this support.

## Technical Details

The platform test case pulls information from cluster and among other things it check the width and speed of GPUs (PCIe devices). It is equally important to check the same for the BE NICs. This feature was missing. This PR provides support for that.

## Test Plan

The host config test case was run on 2-node setup with Dell MI355x servers with AINIC.

## Test Result

The checks for BE NICs speed and width were performed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
