### PR TITLE
Skip in-container sshd setup for single-node container runs

### DIFF
--- a/cvs/core/orchestrators/container.py
+++ b/cvs/core/orchestrators/container.py
@@ -446,14 +446,26 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         - Starts sshd on port 2224
         - Validates SSH daemon started successfully
 
+        The in-container sshd exists solely so MPI (mpirun's ``plm_rsh_args -p
+        2224``) can reach peer ranks on other nodes. A single-node run never
+        distributes over MPI -- it execs directly via ``docker exec`` -- so sshd
+        is dead weight there. On a single-host cluster this is a no-op, which
+        also lets minimal images that ship no ``/usr/sbin/sshd`` run single-node
+        without tripping the start/validate steps below.
+
         Returns:
-            bool: True if SSH setup succeeded on all nodes, False otherwise
+            bool: True if SSH setup succeeded on all nodes (or was skipped as
+            unnecessary for a single-node run), False otherwise
 
         Raises:
             RuntimeError: If no containers are currently running
         """
         if not self.container_id:
             raise RuntimeError("No containers running. Call setup_containers() first.")
+
+        if len(self.hosts) <= 1:
+            self.log.info("Single-node run: skipping in-container sshd setup (no inter-node MPI/SSH needed)")
+            return True
 
         self.log.info(f"Setting up SSH daemon in containers: {self.container_id}")
 

--- a/cvs/core/orchestrators/unittests/test_container.py
+++ b/cvs/core/orchestrators/unittests/test_container.py
@@ -223,6 +223,43 @@ class TestContainerOrchestrator(unittest.TestCase):
         self.assertEqual(probe_failed, ["h_gone"])
 
     # ------------------------------------------------------------------
+    # setup_sshd single-node guard
+    # ------------------------------------------------------------------
+
+    def test_setup_sshd_single_node_skips_and_returns_true(self):
+        # The in-container sshd is only needed for multinode MPI. On a single-host
+        # cluster setup_sshd must short-circuit: no exec into the container, no
+        # dependency on the image shipping /usr/sbin/sshd.
+        orch, runtime = self._make(lifetime="per_run")
+        orch.hosts = ["10.0.0.1"]
+        orch.container_id = "cvs_iter_test"
+        self.assertTrue(orch.setup_sshd())
+        runtime.exec.assert_not_called()
+
+    def test_setup_sshd_requires_container_even_single_node(self):
+        # The container_id precondition is checked BEFORE the single-node guard,
+        # so a single-node orch with no running container still raises rather than
+        # silently returning True.
+        orch, _ = self._make(lifetime="per_run")
+        orch.hosts = ["10.0.0.1"]
+        self.assertIsNone(orch.container_id)
+        with self.assertRaises(RuntimeError):
+            orch.setup_sshd()
+
+    @patch("time.sleep", lambda *_a, **_k: None)
+    def test_setup_sshd_multinode_attempts_setup(self):
+        # The guard must NOT skip a genuine multinode run: every setup command and
+        # the final validation probe are exec'd into the container.
+        orch, runtime = self._make(lifetime="per_run")
+        orch.container_id = "cvs_iter_test"
+        runtime.exec.return_value = {
+            "10.0.0.1": {"exit_code": 0},
+            "10.0.0.2": {"exit_code": 0},
+        }
+        self.assertTrue(orch.setup_sshd())
+        self.assertTrue(runtime.exec.called)
+
+    # ------------------------------------------------------------------
     # teardown_containers lifetime branching
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`ContainerOrchestrator.setup_sshd()` ran a fixed command list ending in
`/usr/sbin/sshd -p2224` and asserted every step exited 0 — for **every**
container run, regardless of node count (`cvs/tests/conftest.py` calls it
unconditionally). The in-container sshd exists solely so MPI (`mpirun`'s
`plm_rsh_args -p 2224`, see `BaremetalOrchestrator.get_mpi_command`) can reach
peer ranks on other nodes. A single-node run execs directly via `docker exec`
and never distributes over MPI, so the sshd setup is dead weight on one host.

Consequences before this change:
- A single-node run on a minimal image without `/usr/sbin/sshd` failed the whole
  `orch` fixture (`pytest.fail("Failed to setup sshd in container")`) and never
  ran the workload — surfaced only as the generic `SSH setup command failed`.
- Single-node, no-SSH suites on sshd-equipped images still paid a pointless step
  that can fail on unrelated edge cases (e.g. empty `~/.ssh` mount).

## Change

- Guard `setup_sshd()` to return `True` early when `len(self.hosts) <= 1`,
  placed **after** the `container_id` precondition. Host count lives on the
  orchestrator, so the decision belongs there; the fixture stays unchanged and
  any future caller inherits the behavior.
- Multinode runs are unaffected — they still set up and validate sshd.

## Tests

- `cvs/core/orchestrators/unittests/test_container.py`: single-node skips (no
  `runtime.exec`), `container_id` precondition still raises even single-node,
  multinode still attempts setup.

## Out of scope

- Multinode + no-sshd image still fails (correctly — MPI needs sshd); its error
  message could be clearer, tracked separately.
- No new config key; behavior keys purely off node count.

## Gate

`make test` (mirrors CI `.github/workflows/ci.yml`, Python 3.10): `make fmt`
clean (213 files unchanged), `Ran 370 tests ... OK`, 42 CLI tests passed.