### PR TITLE
fix(cli): hide conftest.py and _-prefixed files from cvs list [AIMVT-237]

### DIFF
--- a/cvs/cli_plugins/list_plugin.py
+++ b/cvs/cli_plugins/list_plugin.py
@@ -44,7 +44,14 @@ class ListPlugin(SubcommandPlugin):
             test_map[pkg_name] = {}
             for root, dirs, files in os.walk(tests_dir):
                 for file in files:
-                    if file.endswith(".py") and file != "__init__.py":
+                    # Skip pytest infra (conftest.py) and private helpers
+                    # (e.g. _shared.py): they are not selectable suites.
+                    if (
+                        file.endswith(".py")
+                        and file != "__init__.py"
+                        and file != "conftest.py"
+                        and not file.startswith("_")
+                    ):
                         rel_path = os.path.relpath(os.path.join(root, file), tests_dir)
                         module_parts = os.path.splitext(rel_path)[0].split(os.sep)
                         # Module path: <tests_path>.<test_name>


### PR DESCRIPTION
## Summary
`cvs list` lists non-suite Python files in the test dropdown. `ListPlugin.discover_tests` (`cvs/cli_plugins/list_plugin.py`) walks the tests tree and registers every `.py` except `__init__.py`, so pytest infra (`conftest.py`) and private helpers (`_shared.py`, from the vllm_single suite) show up as runnable suites. The map is keyed by basename, so the two `conftest.py` files collide and only one survives.

This excludes `conftest.py` and `_`-prefixed files from discovery. Safe: real suites are named `vllm_single.py`, `rccl_perf.py`, etc.; extension unittests use `test_*.py` and are unaffected.

## Verification
- Gate: `python3 -m pytest cvs/cli_plugins/unittests/ --cluster_file=dummy --config_file=dummy` → 23 passed
- `discover_tests()` for the vllm area returns only `vllm_single` (was `_shared`, `conftest`, `vllm_single`)

## Test plan
- [x] `cvs/cli_plugins/unittests/` green
- [ ] `cvs list` reviewed — no `conftest` / `_shared` rows

Ticket: AIMVT-237
