### PR TITLE
feat(dtni): move vLLM bench client to stock vllm bench serve (Spec 0)

### DIFF
--- a/cvs/input/config_file/inference/vllm_single/w1_llama31_70b_fp8kv/w1_llama31_70b_fp8kv_config.json
+++ b/cvs/input/config_file/inference/vllm_single/w1_llama31_70b_fp8kv/w1_llama31_70b_fp8kv_config.json
@@ -56,7 +56,6 @@
     "tokenizer_mode": "auto",
     "percentile_metrics": "ttft,tpot,itl,e2el",
     "metric_percentiles": "99",
-    "bench_serv_script": "benchmark_serving.py",
     "num_prompts": "3200",
     "client_poll_count": "90"
   },

--- a/cvs/lib/dtni/config_loader.py
+++ b/cvs/lib/dtni/config_loader.py
@@ -123,7 +123,6 @@ class Params(_Forbid):
     tokenizer_mode: str = "auto"
     percentile_metrics: str = "ttft,tpot,itl,e2el"
     metric_percentiles: str = "99"
-    bench_serv_script: str = "benchmark_serving.py"
     num_prompts: str = "3200"
     # Completion-poll budget for the bench client = client_poll_count * 60s
     # (plus a 120s initial wait). Large-output cells (high osl) need a bigger

--- a/cvs/lib/inference/vllm_orch.py
+++ b/cvs/lib/inference/vllm_orch.py
@@ -73,13 +73,26 @@ class VllmJob:
     """
 
     READINESS_RE = re.compile(r"Application startup complete|Uvicorn running|Started server", re.I)
-    COMPLETION_RE = re.compile(r"End-to-end Latency", re.I)
+    # The "Serving Benchmark Result" banner is printed unconditionally at the end
+    # of every completed `vllm bench serve` run. Do NOT key off a metric header
+    # like "End-to-end Latency": stock prints those only when the metric is in
+    # --percentile-metrics, so a config omitting e2el would never complete.
+    COMPLETION_RE = re.compile(r"Serving Benchmark Result", re.I)
     # bench_serving ALWAYS prints "Failed requests: N" in its summary, so a bare
     # "Failed" match is a false positive on every successful run. Only a NONZERO
     # count is a real failure.
     FAILED_REQUESTS_RE = re.compile(r"Failed requests:\s+([0-9]+)", re.I)
     # A client-side crash (no summary at all) shows up as a Python traceback.
     CLIENT_CRASH_RE = re.compile(r"Traceback \(most recent call last\)", re.I)
+    # A launch failure (bad/renamed flag, missing `bench` subcommand, vllm not on
+    # PATH) makes the CLI exit before any summary. argparse errors are NOT Python
+    # tracebacks and carry no 'Failed requests:' line, so without this the poll
+    # loop would spin to its cap (~90 min) before failing. Patterns are narrow
+    # CLI-failure markers, not bare 'error:'.
+    CLIENT_LAUNCH_FAIL_RE = re.compile(
+        r"unrecognized arguments|invalid choice|error: argument |command not found|: No such file or directory",
+        re.I,
+    )
     # Narrow launch-failure markers only. Bare "error:"/"exception:"/"traceback" are
     # NOT included: vLLM/ROCm startup routinely logs benign lines containing them
     # (deprecation notes, ignored-exception handlers, optional-probe failures), and
@@ -179,7 +192,6 @@ class VllmJob:
             "export VLLM_USE_AITER_UNIFIED_ATTENTION=1",
             "export VLLM_ROCM_USE_AITER_MHA=0",
             "export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1",
-            "export RESULT_FILENAME=results",
             f"export PORT={shlex.quote(str(self.port_no))}",
         ]
         env_script = "\n".join(env_lines) + "\n"
@@ -295,8 +307,8 @@ class VllmJob:
             for host, output in out.items():
                 txt = output or ""
                 done.append(bool(self.COMPLETION_RE.search(txt)))
-                # A crash before the summary -> hard failure now.
-                if self.CLIENT_CRASH_RE.search(txt):
+                # A crash or launch failure before the summary -> hard failure now.
+                if self.CLIENT_CRASH_RE.search(txt) or self.CLIENT_LAUNCH_FAIL_RE.search(txt):
                     failed.append((host, txt[-500:]))
                 else:
                     # The summary always reports a failed-request count; only a

--- a/cvs/lib/inference/vllm_orch.py
+++ b/cvs/lib/inference/vllm_orch.py
@@ -136,7 +136,6 @@ class VllmJob:
         self.base_url = p.base_url
         self.dataset_name = p.dataset_name
         self.backend = p.backend
-        self.bench_serv_script = p.bench_serv_script
 
         self.model_id = variant.model.id
         self.server_script = variant.roles.server.server_script
@@ -153,7 +152,7 @@ class VllmJob:
         # Single-node: one output directory.
         self.out_dir = f"{self.log_dir}/{self.log_subdir}/out-node0"
         self.server_log = f"{self.out_dir}/{self.server_script}_server.log"
-        self.client_log = f"{self.out_dir}/bench_serv_script.log"
+        self.client_log = f"{self.out_dir}/client.log"
 
         self._precheck_wait = server_precheck_wait_s
         self._warmup_wait = server_warmup_wait_s
@@ -237,31 +236,14 @@ class VllmJob:
 
     # ---------- client side ----------
 
-    def _clone_bench_serving(self, clone_dir="/app"):
-        # bench_serving is a calibration-bearing fork (kimbochen), NOT stock vLLM:
-        # it carries a warmup phase + redefined random range-ratio/seq-length that
-        # our thresholds are tuned against, so the in-image vLLM scripts won't do.
-        # Hardcoded for parity with the legacy path (base.py's benchmark_script_repo
-        # default); cloned at HEAD (unpinned) -- pin if upstream drift ever bites.
-        cmd = (
-            f"bash -c 'mkdir -p {clone_dir} && cd {clone_dir} && "
-            f"(test -d bench_serving || git clone https://github.com/kimbochen/bench_serving.git)'"
-        )
-        out = self.orch.exec(cmd)
-        for host, output in out.items():
-            if re.search(r"(error|fatal):", output or "", re.I) and not re.search(
-                r"already exists", output or "", re.I
-            ):
-                raise RuntimeError(f"bench_serving clone failed on {host}: {output[-500:]}")
-
     def run_client(self):
-        self._clone_bench_serving("/app")
         # Build as an arg list and shlex.quote each token: a model id or path
         # containing a space or $ would otherwise break the inner bash layer
         # silently. Mirrors the per-field quoting on the server side.
         args = [
-            "python3",
-            f"bench_serving/{self.bench_serv_script}",
+            "vllm",
+            "bench",
+            "serve",
             "--model",
             self.model_id,
             "--backend",
@@ -300,9 +282,7 @@ class VllmJob:
             "results",
         ]
         bench_cmd = " ".join(shlex.quote(str(a)) for a in args)
-        client_cmd = (
-            f"source /tmp/server_env_script.sh && cd /app && {bench_cmd} > {shlex.quote(self.client_log)} 2>&1 &"
-        )
+        client_cmd = f"source /tmp/server_env_script.sh && {bench_cmd} > {shlex.quote(self.client_log)} 2>&1 &"
         self.orch.exec("bash -c " + shlex.quote(client_cmd))
 
     def wait_client_complete(self):


### PR DESCRIPTION
Jira: [AIMVT-238](https://amd-hub.atlassian.net/browse/AIMVT-238)

## Summary

Move the vLLM benchmark client from the unpinned `kimbochen/bench_serving`
fork to the **stock `vllm bench serve` CLI** already baked into the run image
(`rocm/vllm-dev:nightly-sshd`). This de-risks the perf series before anything
calibrates against it: the client is now pinned to the image tag instead of a
third-party `main`. Source change only — no new metrics, no percentile
widening, no threshold calibration (`enforce_thresholds=false` unchanged).

This is the zero-cost moment to switch: thresholds are placeholders and
nothing is calibrated against the fork to lose.

## Changes

**Move to stock (`vllm_orch.py`):**
- `run_client` invokes `vllm bench serve ...` instead of
  `python3 bench_serving/benchmark_serving.py ...`. All `--flag` args unchanged
  (all valid stock flags).
- Deleted `_clone_bench_serving()` — no fork to clone in-image. Its docstring
  also carried a false "calibration-bearing fork" claim; removed.
- Dropped the now-dead `cd /app &&` from `client_cmd`, the
  `self.bench_serv_script` assignment, the `export RESULT_FILENAME=results`
  env line (stock takes the name via `--result-filename`), and renamed
  `client_log` `bench_serv_script.log` -> `client.log`.
- `config_loader.py`: removed `Params.bench_serv_script` field.
- `w1_..._config.json`: removed `bench_serv_script` key (required — `Params`
  is `extra="forbid"`, field and key move in lockstep).

**Robustness for the stock output shape (`vllm_orch.py`):**
- `COMPLETION_RE`: `"End-to-end Latency"` -> `"Serving Benchmark Result"`.
  The old anchor was a per-metric header stock prints only when `e2el` is in
  `--percentile-metrics`; a config omitting e2el would never be detected as
  complete and spin to the poll cap (~90 min). The summary banner is printed
  unconditionally.
- Added `CLIENT_LAUNCH_FAIL_RE` (narrow argparse / not-found markers) and wired
  it into the poll loop. A launch failure (renamed flag, missing `bench`
  subcommand, `vllm` not on PATH) exits via argparse with no traceback and no
  `Failed requests:` line, so the existing crash detector misses it — without
  this the loop hangs to its cap on any launch typo.

## Out of scope (later specs)
- `client.*` metric namespace, percentile widening, goodput, derived metrics — Spec 1.
- `/metrics` server source — Spec 2. QPS sweep — Spec 3.
- The `inferencemax` path (`base.py`) still uses the fork — separate workload, untouched.

## Test plan
- [x] `ruff check` + `ruff format --check` clean; `py_compile` OK; config JSON valid.
- [x] `grep -rn "kimbochen|bench_serv_script|_clone_bench_serving"` clean on the dtni/vllm path.
- [x] Hardware run validated (W1, MI300X).

