### PR TITLE
use dmabuf option when the ibperf binaries have them configured

### DIFF
--- a/cvs/lib/ibperf_lib.py
+++ b/cvs/lib/ibperf_lib.py
@@ -85,6 +85,12 @@ def check_perftest_dmabuf_support(shdl, binary_path, head_node):
     cmd = f'{binary_path} --help 2>&1 | grep use_rocm_dmabuf | wc -l'
     log.info("Checking dmabuf support: %s", cmd)
     dmabuf_available = False
+
+    # if head_node is None, that would be a programming error
+    # but we still cover the edge case
+    if head_node is None:
+        log.warning("ibperf dmabuf check failed: head_node is None, check programming and re-run")
+        return dmabuf_available
     try:
         dmabuf_check_out = shdl.exec(cmd)
         dmabuf_available = int(dmabuf_check_out[head_node].strip()) > 0
@@ -234,7 +240,10 @@ def run_ib_perf_bw_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
-    head_node = cluster_node_list[0]
+
+    # if cluster_node_list is None that would be programming error
+    if cluster_node_list:
+        head_node = cluster_node_list[0]
     dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{bw_test}', head_node)
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
@@ -343,7 +352,9 @@ def run_ib_perf_lat_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
-    head_node = cluster_node_list[0]
+    # if cluster_node_list is None that would be programming error
+    if cluster_node_list:
+        head_node = cluster_node_list[0]
     dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{lat_test}', head_node)
     for node in bck_nic_dict.keys():
         result_dict[node] = {}

--- a/cvs/lib/ibperf_lib.py
+++ b/cvs/lib/ibperf_lib.py
@@ -11,6 +11,10 @@ import xlsxwriter
 
 from cvs.lib.utils_lib import *
 
+from cvs.lib import globals
+
+log = globals.log
+
 
 def detect_rocm_path(phdl, config_rocm_path):
     """
@@ -64,7 +68,7 @@ def detect_rocm_path(phdl, config_rocm_path):
     return '/opt/rocm'
 
 
-def check_perftest_dmabuf_support(shdl, binary_path):
+def check_perftest_dmabuf_support(shdl, binary_path, head_node):
     """
     Check if the given perftest binary on the cluster node supports the
     --use_rocm_dmabuf flag by executing the binary's help output and
@@ -78,62 +82,17 @@ def check_perftest_dmabuf_support(shdl, binary_path):
         bool: True if the binary supports --use_rocm_dmabuf on any host,
               False otherwise.
     """
-    cmd = f"{binary_path} --help 2>&1 | grep use_rocm_dmabuf"
+    cmd = f'{binary_path} --help 2>&1 | grep use_rocm_dmabuf | wc -l'
     log.info("Checking dmabuf support: %s", cmd)
-
+    dmabuf_available = False
     try:
-        # detailed=True gives us exit_code per host
-        host_results = shdl.exec(cmd, detailed=True, print_console=False)
-        # host_results: {host: {"output": str, "exit_code": int}}
-
-        dmabuf_supported_any = False
-
-        for host, result in host_results.items():
-            # Some safety in case of unexpected shape
-            if not isinstance(result, dict):
-                log.warning("Unexpected exec result type for host %s: %r", host, result)
-                continue
-
-            exit_code = result.get("exit_code", -1)
-            output = result.get("output", "") or ""
-
-            log.debug(
-                "dmabuf check host=%s exit_code=%s, output=%r",
-                host,
-                exit_code,
-                output,
-            )
-
-            # Mirror your manual test: grep returns 0 on match
-            if "use_rocm_dmabuf" in output:
-                if exit_code != 0:
-                    log.warning(
-                        "Host %s: found 'use_rocm_dmabuf' in output but exit_code=%s; treating as supported.",
-                        host,
-                        exit_code,
-                    )
-                log.info(
-                    "Binary %s on host %s supports --use_rocm_dmabuf",
-                    binary_path,
-                    host,
-                )
-                dmabuf_supported_any = True
-            else:
-                log.info(
-                    "Binary %s on host %s does NOT support --use_rocm_dmabuf (no match in output).",
-                    binary_path,
-                    host,
-                )
-
-        return dmabuf_supported_any
-
-    except Exception as e:  # pylint: disable=broad-except
-        log.warning(
-            "Failed to check dmabuf support for %s: %s. Assuming no dmabuf support.",
-            binary_path,
-            str(e),
-        )
-        return False
+        dmabuf_check_out = shdl.exec(cmd)
+        dmabuf_available = int(dmabuf_check_out[head_node].strip()) > 0
+        log.info("dmabuf available in ibperf build" if dmabuf_available else "dmabuf not available in ibperf build")
+        return dmabuf_available
+    except Exception as e:
+        log.warning(f"ibperf dmabuf check failed: {e}")
+        return dmabuf_available
 
 
 def get_ib_bw_pps(phdl, msg_size, cmd):
@@ -262,6 +221,7 @@ def run_ib_perf_bw_test(
     port_no=1516,
     duration=60,
     rocm_path='',
+    cluster_node_list=None,
 ):
     app_port = port_no
     result_dict = {}
@@ -274,7 +234,8 @@ def run_ib_perf_bw_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
-    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{bw_test}')
+    head_node = cluster_node_list[0]
+    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{bw_test}', head_node)
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []
@@ -358,7 +319,18 @@ def run_ib_perf_bw_test(
 
 
 def run_ib_perf_lat_test(
-    shdl, phdl, lat_test, gpu_numa_dict, gpu_nic_dict, bck_nic_dict, app_path, msg_size, gid_index, port_no=1516, rocm_path=''
+    shdl,
+    phdl,
+    lat_test,
+    gpu_numa_dict,
+    gpu_nic_dict,
+    bck_nic_dict,
+    app_path,
+    msg_size,
+    gid_index,
+    port_no=1516,
+    rocm_path='',
+    cluster_node_list=None,
 ):
     app_port = port_no
     result_dict = {}
@@ -371,7 +343,8 @@ def run_ib_perf_lat_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
-    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{lat_test}')
+    head_node = cluster_node_list[0]
+    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{lat_test}', head_node)
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []

--- a/cvs/lib/ibperf_lib.py
+++ b/cvs/lib/ibperf_lib.py
@@ -64,6 +64,78 @@ def detect_rocm_path(phdl, config_rocm_path):
     return '/opt/rocm'
 
 
+def check_perftest_dmabuf_support(phdl, binary_path):
+    """
+    Check if the given perftest binary on the cluster node supports the
+    --use_rocm_dmabuf flag by executing the binary's help output and
+    grepping for the flag.
+
+    Args:
+        phdl: Pssh handle used to execute commands on one or more cluster nodes.
+        binary_path (str): Full path to the perftest binary on the node.
+
+    Returns:
+        bool: True if the binary supports --use_rocm_dmabuf on any host,
+              False otherwise.
+    """
+    cmd = f"{binary_path} --help 2>&1 | grep use_rocm_dmabuf"
+    log.info("Checking dmabuf support: %s", cmd)
+
+    try:
+        # detailed=True gives us exit_code per host
+        host_results = phdl.exec(cmd, detailed=True, print_console=False)
+        # host_results: {host: {"output": str, "exit_code": int}}
+
+        dmabuf_supported_any = False
+
+        for host, result in host_results.items():
+            # Some safety in case of unexpected shape
+            if not isinstance(result, dict):
+                log.warning("Unexpected exec result type for host %s: %r", host, result)
+                continue
+
+            exit_code = result.get("exit_code", -1)
+            output = result.get("output", "") or ""
+
+            log.debug(
+                "dmabuf check host=%s exit_code=%s, output=%r",
+                host,
+                exit_code,
+                output,
+            )
+
+            # Mirror your manual test: grep returns 0 on match
+            if "use_rocm_dmabuf" in output:
+                if exit_code != 0:
+                    log.warning(
+                        "Host %s: found 'use_rocm_dmabuf' in output but exit_code=%s; treating as supported.",
+                        host,
+                        exit_code,
+                    )
+                log.info(
+                    "Binary %s on host %s supports --use_rocm_dmabuf",
+                    binary_path,
+                    host,
+                )
+                dmabuf_supported_any = True
+            else:
+                log.info(
+                    "Binary %s on host %s does NOT support --use_rocm_dmabuf (no match in output).",
+                    binary_path,
+                    host,
+                )
+
+        return dmabuf_supported_any
+
+    except Exception as e:  # pylint: disable=broad-except
+        log.warning(
+            "Failed to check dmabuf support for %s: %s. Assuming no dmabuf support.",
+            binary_path,
+            str(e),
+        )
+        return False
+
+
 def get_ib_bw_pps(phdl, msg_size, cmd):
     res_dict = {}
 
@@ -201,6 +273,7 @@ def run_ib_perf_bw_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
+    dmabuf_supported = check_perftest_dmabuf_support(phdl, f'{app_path}/{bw_test}')
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []
@@ -215,7 +288,15 @@ def run_ib_perf_bw_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} -s {msg_size} -q {qp_count} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                if dmabuf_supported:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
+                            -s {msg_size} -q {qp_count} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                else:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
+                            -s {msg_size} -q {qp_count} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1
@@ -228,7 +309,14 @@ def run_ib_perf_bw_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} -s {msg_size} -q {qp_count} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                if dmabuf_supported:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
+                            -s {msg_size} -q {qp_count} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                else:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
+                            -s {msg_size} -q {qp_count} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1
@@ -282,6 +370,7 @@ def run_ib_perf_lat_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
+    dmabuf_supported = check_perftest_dmabuf_support(phdl, f'{app_path}/{lat_test}')
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []
@@ -296,7 +385,15 @@ def run_ib_perf_lat_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -F -p {port_no} -s {msg_size} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                if dmabuf_supported:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -F -p {port_no} \
+                            -s {msg_size} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                else:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -F -p {port_no} \
+                            -s {msg_size} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1
@@ -309,7 +406,14 @@ def run_ib_perf_lat_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -F -p {port_no} -s {msg_size} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                if dmabuf_supported:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -F -p {port_no} \
+                            -s {msg_size} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                else:
+                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
+                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -F -p {port_no} \
+                            -s {msg_size} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1

--- a/cvs/lib/ibperf_lib.py
+++ b/cvs/lib/ibperf_lib.py
@@ -64,7 +64,7 @@ def detect_rocm_path(phdl, config_rocm_path):
     return '/opt/rocm'
 
 
-def check_perftest_dmabuf_support(phdl, binary_path):
+def check_perftest_dmabuf_support(shdl, binary_path):
     """
     Check if the given perftest binary on the cluster node supports the
     --use_rocm_dmabuf flag by executing the binary's help output and
@@ -83,7 +83,7 @@ def check_perftest_dmabuf_support(phdl, binary_path):
 
     try:
         # detailed=True gives us exit_code per host
-        host_results = phdl.exec(cmd, detailed=True, print_console=False)
+        host_results = shdl.exec(cmd, detailed=True, print_console=False)
         # host_results: {host: {"output": str, "exit_code": int}}
 
         dmabuf_supported_any = False
@@ -249,6 +249,7 @@ def verify_expected_lat(lat_test, msg_size, res_dict, expected_res):
 
 
 def run_ib_perf_bw_test(
+    shdl,
     phdl,
     bw_test,
     gpu_numa_dict,
@@ -273,7 +274,7 @@ def run_ib_perf_bw_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
-    dmabuf_supported = check_perftest_dmabuf_support(phdl, f'{app_path}/{bw_test}')
+    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{bw_test}')
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []
@@ -357,7 +358,7 @@ def run_ib_perf_bw_test(
 
 
 def run_ib_perf_lat_test(
-    phdl, lat_test, gpu_numa_dict, gpu_nic_dict, bck_nic_dict, app_path, msg_size, gid_index, port_no=1516, rocm_path=''
+    shdl, phdl, lat_test, gpu_numa_dict, gpu_nic_dict, bck_nic_dict, app_path, msg_size, gid_index, port_no=1516, rocm_path=''
 ):
     app_port = port_no
     result_dict = {}
@@ -370,7 +371,7 @@ def run_ib_perf_lat_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
-    dmabuf_supported = check_perftest_dmabuf_support(phdl, f'{app_path}/{lat_test}')
+    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{lat_test}')
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []

--- a/cvs/lib/ibperf_lib.py
+++ b/cvs/lib/ibperf_lib.py
@@ -68,14 +68,14 @@ def detect_rocm_path(phdl, config_rocm_path):
     return '/opt/rocm'
 
 
-def check_perftest_dmabuf_support(shdl, binary_path, head_node):
+def check_perftest_dmabuf_support(shdl, binary_path):
     """
     Check if the given perftest binary on the cluster node supports the
     --use_rocm_dmabuf flag by executing the binary's help output and
     grepping for the flag.
 
     Args:
-        phdl: Pssh handle used to execute commands on one or more cluster nodes.
+        shdl: Pssh handle used to execute commands on one head node.
         binary_path (str): Full path to the perftest binary on the node.
 
     Returns:
@@ -84,21 +84,12 @@ def check_perftest_dmabuf_support(shdl, binary_path, head_node):
     """
     cmd = f'{binary_path} --help 2>&1 | grep use_rocm_dmabuf | wc -l'
     log.info("Checking dmabuf support: %s", cmd)
+    dmabuf_check_out = shdl.exec(cmd)
     dmabuf_available = False
-
-    # if head_node is None, that would be a programming error
-    # but we still cover the edge case
-    if head_node is None:
-        log.warning("ibperf dmabuf check failed: head_node is None, check programming and re-run")
-        return dmabuf_available
-    try:
-        dmabuf_check_out = shdl.exec(cmd)
-        dmabuf_available = int(dmabuf_check_out[head_node].strip()) > 0
-        log.info("dmabuf available in ibperf build" if dmabuf_available else "dmabuf not available in ibperf build")
-        return dmabuf_available
-    except Exception as e:
-        log.warning(f"ibperf dmabuf check failed: {e}")
-        return dmabuf_available
+    for node in dmabuf_check_out.keys():
+        dmabuf_available = int(dmabuf_check_out[node].strip()) > 0
+    log.info("dmabuf available in ibperf build" if dmabuf_available else "dmabuf not available in ibperf build")
+    return dmabuf_available
 
 
 def get_ib_bw_pps(phdl, msg_size, cmd):
@@ -227,7 +218,6 @@ def run_ib_perf_bw_test(
     port_no=1516,
     duration=60,
     rocm_path='',
-    cluster_node_list=None,
 ):
     app_port = port_no
     result_dict = {}
@@ -239,12 +229,8 @@ def run_ib_perf_bw_test(
     if rocm_path:
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
+    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{bw_test}')
     server_addr = None
-
-    # if cluster_node_list is None that would be programming error
-    if cluster_node_list:
-        head_node = cluster_node_list[0]
-    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{bw_test}', head_node)
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []
@@ -259,15 +245,30 @@ def run_ib_perf_bw_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                if dmabuf_supported:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
-                            -s {msg_size} -q {qp_count} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
-                else:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
-                            -s {msg_size} -q {qp_count} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
-
+                cmd_parts = [
+                    "numactl",
+                    f'--physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]}',
+                    "--localalloc",
+                    f"{app_path}/{bw_test}",
+                    "-d",
+                    rdma_dev,
+                    f"--use_rocm={gpu_no}",
+                    *(["--use_rocm_dmabuf"] if dmabuf_supported else []),
+                    "-x",
+                    str(gid_index),
+                    "--report_gbits",
+                    "-b",
+                    "-F",
+                    "-D",
+                    str(duration),
+                    "-p",
+                    str(port_no),
+                    "-s",
+                    str(msg_size),
+                    "-q",
+                    str(qp_count),
+                ]
+                cmd = " ".join(cmd_parts) + f" > /tmp/ib_perf_{inst_count}_logs 2>&1 &"
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1
@@ -280,14 +281,31 @@ def run_ib_perf_bw_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                if dmabuf_supported:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
-                            -s {msg_size} -q {qp_count} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
-                else:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{bw_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -b -F -D {duration} -p {port_no} \
-                            -s {msg_size} -q {qp_count} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                cmd_parts = [
+                    "numactl",
+                    f'--physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]}',
+                    "--localalloc",
+                    f"{app_path}/{bw_test}",
+                    "-d",
+                    rdma_dev,
+                    f"--use_rocm={gpu_no}",
+                    *(["--use_rocm_dmabuf"] if dmabuf_supported else []),
+                    "-x",
+                    str(gid_index),
+                    "--report_gbits",
+                    "-b",
+                    "-F",
+                    "-D",
+                    str(duration),
+                    "-p",
+                    str(port_no),
+                    "-s",
+                    str(msg_size),
+                    "-q",
+                    str(qp_count),
+                    server_addr,
+                ]
+                cmd = " ".join(cmd_parts) + f" > /tmp/ib_perf_{inst_count}_logs 2>&1 &"
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1
@@ -339,7 +357,6 @@ def run_ib_perf_lat_test(
     gid_index,
     port_no=1516,
     rocm_path='',
-    cluster_node_list=None,
 ):
     app_port = port_no
     result_dict = {}
@@ -352,10 +369,7 @@ def run_ib_perf_lat_test(
         log.info(f'Setting LD_LIBRARY_PATH to {rocm_path}/lib for perftest binaries')
         phdl.exec(f'echo "export LD_LIBRARY_PATH={rocm_path}/lib:$LD_LIBRARY_PATH" >> /tmp/ib_cmds_file.txt')
     server_addr = None
-    # if cluster_node_list is None that would be programming error
-    if cluster_node_list:
-        head_node = cluster_node_list[0]
-    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{lat_test}', head_node)
+    dmabuf_supported = check_perftest_dmabuf_support(shdl, f'{app_path}/{lat_test}')
     for node in bck_nic_dict.keys():
         result_dict[node] = {}
         cmd_dict[node] = []
@@ -370,15 +384,30 @@ def run_ib_perf_lat_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                if dmabuf_supported:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -F -p {port_no} \
-                            -s {msg_size} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
-                else:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -F -p {port_no} \
-                            -s {msg_size} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
-
+                cmd_parts = [
+                    "numactl",
+                    f'--physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]}',
+                    "--localalloc",
+                    f"{app_path}/{bw_test}",
+                    "-d",
+                    rdma_dev,
+                    f"--use_rocm={gpu_no}",
+                    *(["--use_rocm_dmabuf"] if dmabuf_supported else []),
+                    "-x",
+                    str(gid_index),
+                    "--report_gbits",
+                    "-b",
+                    "-F",
+                    "-D",
+                    str(duration),
+                    "-p",
+                    str(port_no),
+                    "-s",
+                    str(msg_size),
+                    "-q",
+                    str(qp_count),
+                ]
+                cmd = " ".join(cmd_parts) + f" > /tmp/ib_perf_{inst_count}_logs 2>&1 &"
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1
@@ -391,14 +420,31 @@ def run_ib_perf_lat_test(
             for gpu_no in range(0, 8):
                 card_no = 'card' + str(gpu_no)
                 rdma_dev = gpu_nic_dict[node][card_no]['rdma_dev']
-                if dmabuf_supported:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} --use_rocm_dmabuf -x {gid_index} --report_gbits -F -p {port_no} \
-                            -s {msg_size} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
-                else:
-                    cmd = f'numactl --physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]} --localalloc {app_path}/{lat_test} \
-                            -d {rdma_dev} --use_rocm={gpu_no} -x {gid_index} --report_gbits -F -p {port_no} \
-                            -s {msg_size} {server_addr} > /tmp/ib_perf_{inst_count}_logs &  2>&1'
+                cmd_parts = [
+                    "numactl",
+                    f'--physcpubind={gpu_numa_dict[node][card_no]["local_cpulist"]}',
+                    "--localalloc",
+                    f"{app_path}/{bw_test}",
+                    "-d",
+                    rdma_dev,
+                    f"--use_rocm={gpu_no}",
+                    *(["--use_rocm_dmabuf"] if dmabuf_supported else []),
+                    "-x",
+                    str(gid_index),
+                    "--report_gbits",
+                    "-b",
+                    "-F",
+                    "-D",
+                    str(duration),
+                    "-p",
+                    str(port_no),
+                    "-s",
+                    str(msg_size),
+                    "-q",
+                    str(qp_count),
+                    server_addr,
+                ]
+                cmd = " ".join(cmd_parts) + f" > /tmp/ib_perf_{inst_count}_logs 2>&1 &"
                 cmd_dict[node].append(f'echo "{cmd}" >> /tmp/ib_cmds_file.txt')
                 inst_count = inst_count + 1
                 port_no = port_no + 1

--- a/cvs/tests/ibperf/ib_perf_bw_test.py
+++ b/cvs/tests/ibperf/ib_perf_bw_test.py
@@ -204,7 +204,7 @@ def vpc_node_list(cluster_dict):
 
 
 @pytest.mark.parametrize("bw_test", ["ib_write_bw", "ib_read_bw", "ib_send_bw"])
-def test_ib_bw_perf(phdl, bw_test, config_dict):
+def test_ib_bw_perf(shdl, phdl, bw_test, config_dict):
     # Get IB_backend_nics for each node
     # Get the NIC to GPU mapping dict
     # Generate the command list for all nodes
@@ -237,6 +237,7 @@ def test_ib_bw_perf(phdl, bw_test, config_dict):
             start_time = phdl.exec('date +"%a %b %e %H:%M"')
             phdl.exec(f'echo "Starting Test {bw_test} for {msg_size} and QP count {qp_count}" | sudo -n tee /dev/kmsg')
             ib_bw_dict[bw_test][msg_size][qp_count] = ibperf_lib.run_ib_perf_bw_test(
+                shdl,
                 phdl,
                 bw_test,
                 gpu_numa_dict,
@@ -267,7 +268,7 @@ def test_ib_bw_perf(phdl, bw_test, config_dict):
 
 
 @pytest.mark.parametrize("lat_test", ["ib_write_lat", "ib_send_lat"])
-def test_ib_lat_perf(phdl, lat_test, config_dict):
+def test_ib_lat_perf(shdl, phdl, lat_test, config_dict):
     globals.error_list = []
     ib_lat_dict[lat_test] = {}
 
@@ -296,6 +297,7 @@ def test_ib_lat_perf(phdl, lat_test, config_dict):
         start_time = phdl.exec('date +"%a %b %e %H:%M"')
         phdl.exec(f'echo "Starting Test {lat_test} for {msg_size}" | sudo -n tee /dev/kmsg')
         ib_lat_dict[lat_test][msg_size] = ibperf_lib.run_ib_perf_lat_test(
+            shdl,
             phdl,
             lat_test,
             gpu_numa_dict,

--- a/cvs/tests/ibperf/ib_perf_bw_test.py
+++ b/cvs/tests/ibperf/ib_perf_bw_test.py
@@ -204,7 +204,7 @@ def vpc_node_list(cluster_dict):
 
 
 @pytest.mark.parametrize("bw_test", ["ib_write_bw", "ib_read_bw", "ib_send_bw"])
-def test_ib_bw_perf(shdl, phdl, bw_test, config_dict):
+def test_ib_bw_perf(shdl, phdl, bw_test, config_dict, cluster_dict):
     # Get IB_backend_nics for each node
     # Get the NIC to GPU mapping dict
     # Generate the command list for all nodes
@@ -230,6 +230,7 @@ def test_ib_bw_perf(shdl, phdl, bw_test, config_dict):
                 bck_nic_dict[node][rdma_dev] = rdma_nic_dict[node][rdma_dev]
 
     rocm_path = ibperf_lib.detect_rocm_path(phdl, config_dict.get('rocm_dir', ''))
+    node_list = list(cluster_dict['node_dict'].keys())
     for msg_size in config_dict['msg_size_list']:
         ib_bw_dict[bw_test][msg_size] = {}
         for qp_count in config_dict['qp_count_list']:
@@ -250,6 +251,7 @@ def test_ib_bw_perf(shdl, phdl, bw_test, config_dict):
                 int(config_dict['port_no']),
                 int(config_dict['duration']),
                 rocm_path=rocm_path,
+                cluster_node_list=node_list,
             )
             end_time = phdl.exec('date +"%a %b %e %H:%M"')
             verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=True)
@@ -268,7 +270,7 @@ def test_ib_bw_perf(shdl, phdl, bw_test, config_dict):
 
 
 @pytest.mark.parametrize("lat_test", ["ib_write_lat", "ib_send_lat"])
-def test_ib_lat_perf(shdl, phdl, lat_test, config_dict):
+def test_ib_lat_perf(shdl, phdl, lat_test, config_dict, cluster_dict):
     globals.error_list = []
     ib_lat_dict[lat_test] = {}
 
@@ -291,6 +293,7 @@ def test_ib_lat_perf(shdl, phdl, lat_test, config_dict):
     log.info(f'%%%%%% gpu_numa_dict %%%%% {gpu_numa_dict}')
 
     rocm_path = ibperf_lib.detect_rocm_path(phdl, config_dict.get('rocm_dir', ''))
+    node_list = list(cluster_dict['node_dict'].keys())
     for msg_size in config_dict['msg_size_list']:
         ib_lat_dict[lat_test][msg_size] = {}
         # Log a message to Dmesg to create a timestamp record
@@ -308,6 +311,7 @@ def test_ib_lat_perf(shdl, phdl, lat_test, config_dict):
             config_dict['gid_index'],
             int(config_dict['port_no']),
             rocm_path=rocm_path,
+            cluster_node_list=node_list,
         )
         end_time = phdl.exec('date +"%a %b %e %H:%M"')
         verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=True)

--- a/cvs/tests/ibperf/ib_perf_bw_test.py
+++ b/cvs/tests/ibperf/ib_perf_bw_test.py
@@ -204,7 +204,7 @@ def vpc_node_list(cluster_dict):
 
 
 @pytest.mark.parametrize("bw_test", ["ib_write_bw", "ib_read_bw", "ib_send_bw"])
-def test_ib_bw_perf(shdl, phdl, bw_test, config_dict, cluster_dict):
+def test_ib_bw_perf(shdl, phdl, bw_test, config_dict):
     # Get IB_backend_nics for each node
     # Get the NIC to GPU mapping dict
     # Generate the command list for all nodes
@@ -230,7 +230,6 @@ def test_ib_bw_perf(shdl, phdl, bw_test, config_dict, cluster_dict):
                 bck_nic_dict[node][rdma_dev] = rdma_nic_dict[node][rdma_dev]
 
     rocm_path = ibperf_lib.detect_rocm_path(phdl, config_dict.get('rocm_dir', ''))
-    node_list = list(cluster_dict['node_dict'].keys())
     for msg_size in config_dict['msg_size_list']:
         ib_bw_dict[bw_test][msg_size] = {}
         for qp_count in config_dict['qp_count_list']:
@@ -251,7 +250,6 @@ def test_ib_bw_perf(shdl, phdl, bw_test, config_dict, cluster_dict):
                 int(config_dict['port_no']),
                 int(config_dict['duration']),
                 rocm_path=rocm_path,
-                cluster_node_list=node_list,
             )
             end_time = phdl.exec('date +"%a %b %e %H:%M"')
             verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=True)
@@ -270,7 +268,7 @@ def test_ib_bw_perf(shdl, phdl, bw_test, config_dict, cluster_dict):
 
 
 @pytest.mark.parametrize("lat_test", ["ib_write_lat", "ib_send_lat"])
-def test_ib_lat_perf(shdl, phdl, lat_test, config_dict, cluster_dict):
+def test_ib_lat_perf(shdl, phdl, lat_test, config_dict):
     globals.error_list = []
     ib_lat_dict[lat_test] = {}
 
@@ -293,7 +291,6 @@ def test_ib_lat_perf(shdl, phdl, lat_test, config_dict, cluster_dict):
     log.info(f'%%%%%% gpu_numa_dict %%%%% {gpu_numa_dict}')
 
     rocm_path = ibperf_lib.detect_rocm_path(phdl, config_dict.get('rocm_dir', ''))
-    node_list = list(cluster_dict['node_dict'].keys())
     for msg_size in config_dict['msg_size_list']:
         ib_lat_dict[lat_test][msg_size] = {}
         # Log a message to Dmesg to create a timestamp record
@@ -311,7 +308,6 @@ def test_ib_lat_perf(shdl, phdl, lat_test, config_dict, cluster_dict):
             config_dict['gid_index'],
             int(config_dict['port_no']),
             rocm_path=rocm_path,
-            cluster_node_list=node_list,
         )
         end_time = phdl.exec('date +"%a %b %e %H:%M"')
         verify_dmesg_for_errors(phdl, start_time, end_time, till_end_flag=True)


### PR DESCRIPTION
## Motivation

IBPERF test makes use of the binaries for which path is provided in the configuration file. It also has an option to install the `ibperf` tool and then to run the test. But during the run-time when it prepares the `ibperf` invocation command(s) it doesn't use the` --use_rocm_dmabuf` option and the run could be less performant.


## Technical Details

A function is added in the ibperf library. This function check to see whether the ibperf binary was configured with --use_rocm_dmabuf. If yes, it will use the flag for invocation, otherwise not.

## Test Plan

All ibperf test was run using ibperf binaries configured with --use_rocm_dmabuf and test passed.
All ibperf test was run using ibperf binaries not configured with --use_rocm_dmabuf and test passed.

## Test Result

In both the scenarios, all tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
