### PR TITLE
metrics_exp: add nginx TLS overlay for public-IP deployments

### DIFF
--- a/cvs/monitors/metrics_exp/.env.example
+++ b/cvs/monitors/metrics_exp/.env.example
@@ -26,7 +26,14 @@ PROMETHEUS_RETENTION_SIZE=50GB
 GRAFANA_ADMIN_USER=admin
 # REQUIRED: Change this password before deploying
 GRAFANA_ADMIN_PASSWORD=change_this_password
-# Update this to match the public URL your users will access Grafana on
+# Public URL users access Grafana on. Used by nginx overlay (docker-compose.nginx.yml).
+# Options:
+#   Private/VPN-only deployment (no TLS proxy needed):
+#     GRAFANA_ROOT_URL=http://localhost:30030
+#   Public IP, Let's Encrypt via nip.io (test/staging — no DNS setup needed):
+#     GRAFANA_ROOT_URL=https://<ip>-<ip>-<ip>-<ip>.nip.io
+#   Public IP, AMD-issued cert (production — requires DNS + cert from dl.casbsecurity@amd.com):
+#     GRAFANA_ROOT_URL=https://chi-metrics-exp-mon.amd.com
 GRAFANA_ROOT_URL=http://localhost:30030
 # Optional: pre-provision a Grafana API key (leave blank to use admin credentials)
 GRAFANA_API_KEY=

--- a/cvs/monitors/metrics_exp/docker-compose.nginx.yml
+++ b/cvs/monitors/metrics_exp/docker-compose.nginx.yml
@@ -1,0 +1,38 @@
+# Nginx TLS overlay for fleet monitoring stack.
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.nginx.yml up -d
+# Rollback (nginx only, base stack untouched):
+#   docker compose -f docker-compose.yml -f docker-compose.nginx.yml rm -sf fleet-nginx
+#   docker compose up -d grafana   # restores original GF_SERVER_ROOT_URL
+
+services:
+
+  # Override Grafana root_url so assets load correctly behind the proxy.
+  # Set GRAFANA_ROOT_URL in .env, e.g.:
+  #   GRAFANA_ROOT_URL=https://137.220.56.231.nip.io   (public, nip.io + LE cert)
+  #   GRAFANA_ROOT_URL=https://chi-metrics-exp-mon.amd.com  (production, AMD cert)
+  grafana:
+    environment:
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL}
+      GF_SERVER_SERVE_FROM_SUB_PATH: 'false'
+
+  # Nginx TLS termination proxy
+  nginx:
+    image: nginx:alpine
+    container_name: fleet-nginx
+    restart: unless-stopped
+    ports:
+      - "0.0.0.0:443:443"
+      - "0.0.0.0:80:80"
+    volumes:
+      - ./server/config/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./server/config/nginx/ssl:/etc/nginx/ssl:ro
+      # Let's Encrypt certs (mounted when available; fallback to ssl/ self-signed)
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      # Certbot webroot for HTTP-01 ACME challenge
+      - /var/www/certbot:/var/www/certbot:ro
+    networks:
+      - monitoring
+    depends_on:
+      - grafana
+      - fleet-manager

--- a/cvs/monitors/metrics_exp/server/config/nginx/nginx.conf
+++ b/cvs/monitors/metrics_exp/server/config/nginx/nginx.conf
@@ -1,0 +1,79 @@
+# Fleet monitoring nginx reverse proxy
+# Terminates TLS on 443, proxies to Grafana and Fleet Manager over internal Docker network.
+#
+# Cert strategy (in order of preference):
+#   1. Let's Encrypt: /etc/letsencrypt/live/<domain>/fullchain.pem  (public deployments)
+#   2. AMD internal CA cert                                           (production)
+#   3. Self-signed fallback: /etc/nginx/ssl/cert.pem                 (dev/testing only)
+#
+# Rollback: docker compose -f docker-compose.yml -f docker-compose.nginx.yml rm -sf fleet-nginx
+
+upstream grafana {
+    server fleet-grafana:3000;
+    keepalive 32;
+}
+
+upstream fleet_manager {
+    server fleet-manager:8080;
+    keepalive 32;
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# HTTP — serve ACME challenge for Let's Encrypt, redirect everything else to HTTPS
+server {
+    listen 80 default_server;
+    server_name _;
+
+    # Let's Encrypt HTTP-01 challenge (certbot webroot)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    # --- TLS ---
+    # Let's Encrypt cert (auto-renews via certbot systemd timer, expires 2026-09-22)
+    # For AMD internal CA cert, replace these paths with the issued cert/key.
+    ssl_certificate     /etc/letsencrypt/live/137.220.56.231.nip.io/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/137.220.56.231.nip.io/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # Grafana (root)
+    location / {
+        proxy_pass http://grafana;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        # WebSocket support (Grafana live / alerting)
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 300s;
+    }
+
+    # Fleet Manager API
+    location /fleet/ {
+        proxy_pass http://fleet_manager/;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_read_timeout 300s;
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in nginx reverse proxy layer for `metrics_exp` monitoring VMs deployed on public IPs where Zscaler performs SSL inspection and blocks non-standard ports (30030, 30080).

> **Note:** This PR is intended to be reviewed alongside / merged after `venksrin/control-plane-monitoring`. Tagging @venksrin09 for coordination.

- Base stack (`docker-compose.yml`) is completely untouched — compose override is fully opt-in
- Validated on `chi-metrics-exp-mon` (Vultr Chicago ORD) with Let's Encrypt cert via `nip.io` — clears AMD Zscaler SSL inspection

## Files changed

- `docker-compose.nginx.yml` — compose override: adds `fleet-nginx` (nginx:alpine), overrides `GF_SERVER_ROOT_URL` via `GRAFANA_ROOT_URL` env var, mounts `/etc/letsencrypt` and `/var/www/certbot` for Let's Encrypt
- `server/config/nginx/nginx.conf` — TLS termination on 443, ACME HTTP-01 challenge on port 80, WebSocket headers for Grafana live, `/fleet/` path for Fleet Manager API
- `server/config/nginx/ssl/.gitkeep` — preserves `ssl/` dir in tree; certs are gitignored
- `.env.example` — documents three `GRAFANA_ROOT_URL` deployment tracks

## Usage

**Deploy with nginx overlay:**
```bash
# Set in .env:
GRAFANA_ROOT_URL=https://<your-domain>

docker compose -f docker-compose.yml -f docker-compose.nginx.yml up -d
```

**TLS cert tracks:**
| Deployment | Method |
|-----------|--------|
| Private/VPN-only | Skip overlay, use base stack on port 30030 |
| Public IP (staging) | Let's Encrypt via `<ip>.nip.io` — free, no DNS setup |
| Public IP (production) | AMD-issued cert — contact `dl.casbsecurity@amd.com` |

**Rollback (base stack untouched):**
```bash
docker compose -f docker-compose.yml -f docker-compose.nginx.yml rm -sf fleet-nginx
```

## Test plan

- [ ] `https://<domain>/login` loads Grafana correctly through Zscaler
- [ ] `https://<domain>/fleet/` proxies to Fleet Manager API
- [ ] HTTP → HTTPS redirect works (`http://` → `301`)
- [ ] Let's Encrypt cert auto-renews (certbot systemd timer active)
- [ ] Rollback: removing nginx container leaves base stack fully operational

🤖 Generated with [Claude Code](https://claude.com/claude-code)