### PR TITLE
Integrating nodesmoke tier 1 tests using Primus cli

### DIFF
--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -12,6 +12,7 @@ The preflight checks system validates essential cluster health before running pe
 4. **Interface Name Consistency** - Validates RDMA interface naming patterns
 5. **IFoE L2 Connectivity (AIMVT-180; opt-in)** - Runs `afmctl test ping`
    on each node and enforces per-port and Summary pass/fail accounting
+6. **Primus Node Smoke (opt-in)** - Per-node host / GPU / RDMA roll-call via `primus-cli direct -- node_smoke`
 
 ## Configuration File Structure
 
@@ -37,6 +38,13 @@ The preflight configuration file follows this structure:
         "inter_full_mesh_group_pairs_per_wave": "auto"
       }
     },
+    "node_smoke": {
+      "connectivity_mode": "skip",
+      "auto_setup": true,
+      "primus_dir": "/home/{user-id}/INSTALL/Primus",
+      "venv_activate": "/home/{user-id}/envs/preflight/.venv/bin/activate",
+      "gpus_per_node": 8
+    },
     "reporting": {
       "generate_html_report": "true",
       "artifacts_root_dir": "/tmp/{user-id}/preflight",
@@ -59,6 +67,7 @@ preflight/
 ├── connectivity_check/   # Inter-node connectivity tests
 │   ├── rdma/             # RDMA-specific parameters (including nodes_per_full_mesh_group)
 │   └── ifoe/             # IFoE L2 ping parameters (AIMVT-180; opt-in)
+├── node_smoke/           # Primus node_smoke per-node health screening (opt-in)
 └── reporting/           # Output and report generation
 ```
 
@@ -199,6 +208,52 @@ pass/fail table plus the aggregate `Summary:` block in afmctl's output.
 - **`ssh_timeout`** (default: `180`)
   - Per-invocation SSH timeout (seconds); raise for high `pings_per_port`
 
+#### Node Smoke Settings (`node_smoke`) — opt-in (Primus Tier 1)
+
+Runs Primus `node_smoke` on each reachable node via `primus-cli direct --single -- node_smoke`
+over parallel SSH (no Slurm required). Reference: Primus `docs/node-smoke-test-instruction.md`
+on branch `dev/preflight-direct-test`.
+
+- **`connectivity_mode`** (default: `"skip"`)
+  - `"run"` — execute node_smoke on every reachable node
+  - `"skip"` — preflight records a SKIPPED result and does not invoke Primus
+- **`auto_setup`** (default: `true`)
+  - Clone/update Primus and create the venv with minimal deps (ROCm PyTorch) before node_smoke
+- **`setup_timeout`** (default: `600`)
+  - SSH timeout (seconds) for the per-node Primus auto_setup step
+- **`force_reclone`** (default: `false`)
+  - Remove `primus_dir` and clone fresh on every run (destructive)
+- **`shared_install`** (default: `true`)
+  - Leader node clones/installs on shared NFS home; other nodes wait (recommended for shared home)
+- **`pip_install_mode`** (default: `"minimal"`)
+  - `"minimal"` — ROCm PyTorch only; `"requirements"` — `pip install -r requirements.txt`; `"skip"` — venv only
+- **`torch_pip_index_url`** (default: `"https://download.pytorch.org/whl/rocm6.2"`)
+  - PyTorch wheel index for minimal install; match your ROCm version
+- **`primus_git_url`** (default: `"https://github.com/AMD-AIG-AIMA/Primus.git"`)
+- **`primus_git_branch`** (default: `"dev/preflight-direct-test"`)
+- **`primus_git_recurse_submodules`** (default: `false`)
+- **`primus_dir`** (default: `"/home/{user-id}/INSTALL/Primus"`)
+  - Required when `connectivity_mode` is `"run"`; `{user-id}` is resolved at runtime
+- **`venv_activate`** (default: `"/home/{user-id}/envs/preflight/.venv/bin/activate"`)
+  - Required when `connectivity_mode` is `"run"`
+- **`gpus_per_node`** (default: `8`)
+- **`master_port`** (default: `1234`)
+- **`dump_path`** (default: `""`)
+  - Per-node smoke JSON output; empty uses `<reporting.artifacts_root_dir>/node_smoke`
+- **`expected_rdma_nics`** (default: `null`)
+  - Defaults to `len(node_check.rdma_interfaces)` when null
+- **`ulimit_l_min_gb`** (default: `32`) — FAIL below this memlock limit; `0` disables
+- **`shm_min_gb`** (default: `8`) — FAIL below this `/dev/shm` size; `0` disables
+- **`skip_dmesg`** (default: `false`)
+- **`allow_foreign_procs`** (default: `false`)
+- **`allowed_procs`** (default: `"gpuagent,rocm-smi-daemon,amd-smi,dcgm-exporter"`)
+- **`require_tools`** (default: `""`) — empty = warn only
+- **`nccl_socket_ifname`** / **`gloo_socket_ifname`** (default: `""`)
+- **`nccl_ib_hca`** (default: `""`) — defaults to comma-joined `node_check.rdma_interfaces`
+- **`nccl_ib_gid_index`** (default: `null`) — defaults to `node_check.gid_index`
+- **`ssh_timeout`** (default: `300`)
+- **`extra_args`** (default: `[]`) — additional flags forwarded to primus-cli
+
 ### Reporting Settings (`reporting`)
 
 - **`generate_html_report`** (default: "true")
@@ -277,6 +332,28 @@ pass/fail table plus the aggregate `Summary:` block in afmctl's output.
 }
 ```
 
+### Enable Primus Node Smoke
+
+```json
+{
+  "preflight": {
+    "node_check": {
+      "gid_index": "3",
+      "expected_rocm_version": "6.4.2",
+      "rdma_interfaces": ["rdma0", "rdma1", "rdma2", "rdma3", "rdma4", "rdma5", "rdma6", "rdma7"]
+    },
+    "node_smoke": {
+      "connectivity_mode": "run",
+      "auto_setup": true,
+      "shared_install": true,
+      "primus_dir": "/home/{user-id}/INSTALL/Primus",
+      "venv_activate": "/home/{user-id}/envs/preflight/.venv/bin/activate",
+      "gpus_per_node": 8
+    }
+  }
+}
+```
+
 ### Advanced Configuration with Debug and Tuning
 
 ```json
@@ -317,6 +394,11 @@ pass/fail table plus the aggregate `Summary:` block in afmctl's output.
 # Basic usage with default config
 cvs run preflight_checks --cluster_file cluster.json --config_file preflight_config.json
 
+# Run only the node_smoke check
+cvs run preflight_checks test_node_smoke \
+  --cluster_file cluster.json \
+  --config_file preflight_config.json
+
 # With custom HTML output
 cvs run preflight_checks \
   --cluster_file cluster.json \
@@ -351,12 +433,23 @@ cvs run preflight_checks \
    - Update rdma_interfaces list to match your cluster setup
    - Ensure all expected interfaces are present on each node
 
+5. **Node Smoke Failures**
+   - Set `node_smoke.connectivity_mode` to `"run"` (default is `"skip"`)
+   - Verify `primus_dir` and `venv_activate`, or enable `auto_setup: true`
+   - On shared NFS home, use `shared_install: true` to avoid parallel clone races
+   - Match `torch_pip_index_url` to your ROCm version
+   - Review per-node fail reasons in the preflight HTML report
+
 ### Performance Considerations
 
 **RDMA Connectivity Testing Times:**
 - **Basic mode**: ~30 seconds for 8 nodes
 - **Full mesh mode**: ~5-10 minutes for 8 nodes
 - **Skip mode**: fastest path when validating only node-local checks
+
+**Node Smoke Testing Times:**
+- **First run with auto_setup**: several minutes per node (clone + ROCm PyTorch install)
+- **Subsequent runs**: ~30–60 seconds per node
 
 **Parallel Processing Impact:**
 - **Small nodes_per_full_mesh_group (16-32)**: More rounds, less resource usage per node, better for resource-constrained environments

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -12,7 +12,7 @@
       "_comment_expected_rocm_version": "Expected ROCm version across all cluster nodes. Must match the output of 'amd-smi version' on all nodes. Format: 'major.minor.patch' (e.g., '6.2.0', '5.7.1').",
       
       "_example_rdma_interfaces": ["rocep28s0", "rocep62s0", "rocep79s0", "rocep96s0", "rocep158s0", "rocep190s0", "rocep206s0", "rocep222s0"],
-      "rdma_interfaces": ["<changeme>"],
+      "rdma_interfaces": "[<changeme>]",
       "_comment_rdma_interfaces": "List of specific RDMA interface names that should be present on all cluster nodes. Examples: ['rocep28s0', 'rocep62s0'] for standard setup, ['mlx5_0', 'mlx5_1'] for Mellanox, ['ib0', 'ib1'] for generic InfiniBand."
     },
     

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -12,7 +12,7 @@
       "_comment_expected_rocm_version": "Expected ROCm version across all cluster nodes. Must match the output of 'amd-smi version' on all nodes. Format: 'major.minor.patch' (e.g., '6.2.0', '5.7.1').",
       
       "_example_rdma_interfaces": ["rocep28s0", "rocep62s0", "rocep79s0", "rocep96s0", "rocep158s0", "rocep190s0", "rocep206s0", "rocep222s0"],
-      "rdma_interfaces": "[<changeme>]",
+      "rdma_interfaces": ["<changeme>"],
       "_comment_rdma_interfaces": "List of specific RDMA interface names that should be present on all cluster nodes. Examples: ['rocep28s0', 'rocep62s0'] for standard setup, ['mlx5_0', 'mlx5_1'] for Mellanox, ['ib0', 'ib1'] for generic InfiniBand."
     },
     
@@ -90,6 +90,100 @@
         "ssh_timeout": 180,
         "_comment_ssh_timeout": "Overall SSH timeout (seconds) for each afmctl invocation. Increase for large port counts or high pings_per_port values."
       }
+    },
+
+    "node_smoke": {
+      "_comment": "Primus node_smoke checks via primus-cli direct (opt-in; default skip). See Primus docs/node-smoke-test-instruction.md",
+
+      "_setup_comment": "Primus clone/venv setup runs automatically when auto_setup is true (default). Manual equivalent:",
+      "_setup_step_1": "git clone --recurse-submodules https://github.com/AMD-AIG-AIMA/Primus.git /home/{user-id}/INSTALL/Primus",
+      "_setup_step_2": "cd /home/{user-id}/INSTALL/Primus && git checkout dev/preflight-direct-test",
+      "_setup_step_3": "python3 -m venv /home/{user-id}/envs/preflight/.venv && pip install torch --index-url https://download.pytorch.org/whl/rocm6.2",
+      "_setup_note": "Paths use {user-id} resolved at runtime. Set auto_setup to false to skip automatic install.",
+
+      "auto_setup": true,
+      "_comment_auto_setup": "When true, clone/update Primus and create venv with minimal deps (torch) on each node before node_smoke.",
+
+      "setup_timeout": 600,
+      "_comment_setup_timeout": "SSH timeout (seconds) for the per-node Primus auto_setup step (clone + pip install).",
+
+      "force_reclone": false,
+      "_comment_force_reclone": "When true, rm -rf primus_dir and clone fresh on every run (destructive). With shared_install (default), only the leader node reclones.",
+
+      "shared_install": true,
+      "_comment_shared_install": "When true (default), only the first node clones/updates Primus and installs the venv on shared NFS home; other nodes wait. Set false only if primus_dir and venv_activate are local per node.",
+
+      "pip_install_mode": "minimal",
+      "_comment_pip_install_mode": "Venv deps after clone: 'minimal' (torch only), 'requirements' (pip install -r requirements.txt), or 'skip' (venv only).",
+
+      "torch_pip_index_url": "https://download.pytorch.org/whl/rocm6.2",
+      "_comment_torch_pip_index_url": "PyTorch wheel index for minimal install. Match your ROCm version (e.g. rocm6.2, rocm7.1).",
+
+      "primus_git_url": "https://github.com/AMD-AIG-AIMA/Primus.git",
+      "_comment_primus_git_url": "Primus repository URL for one-time clone.",
+
+      "primus_git_branch": "dev/preflight-direct-test",
+      "_comment_primus_git_branch": "Git branch to checkout after clone. node_smoke and primus-cli direct preflight live on this branch.",
+
+      "primus_git_recurse_submodules": false,
+      "_comment_primus_git_recurse_submodules": "Clone submodules (Megatron, etc.). false is recommended for node_smoke — submodules are not required and slow setup.",
+
+      "primus_dir": "/home/{user-id}/INSTALL/Primus",
+      "_comment_primus_dir": "Path where Primus is cloned on each cluster node. Must match the clone target in setup step 1. Required when connectivity_mode is 'run'.",
+
+      "venv_activate": "/home/{user-id}/envs/preflight/.venv/bin/activate",
+      "_comment_venv_activate": "Path to the Python virtualenv activate script used by primus-cli direct. Required when connectivity_mode is 'run'.",
+
+      "connectivity_mode": "skip",
+      "_comment_connectivity_mode": "Options: 'run' (host/GPU/RDMA roll-call via node_smoke) or 'skip' (default).",
+
+      "gpus_per_node": 8,
+      "_comment_gpus_per_node": "Expected GPU count per node (exported as GPUS_PER_NODE and passed to node_smoke --expected-gpus).",
+
+      "master_port": 1234,
+      "_comment_master_port": "MASTER_PORT for the distributed env primus-cli sets up across SSH-launched ranks.",
+
+      "dump_path": "",
+      "_comment_dump_path": "Directory for per-node smoke/*.json output. Leave empty to use <reporting.artifacts_root_dir>/node_smoke.",
+
+      "expected_rdma_nics": null,
+      "_comment_expected_rdma_nics": "Hard-fail when training RDMA NIC count differs. null defaults to len(node_check.rdma_interfaces). Example: 8.",
+
+      "ulimit_l_min_gb": 32,
+      "_comment_ulimit_l_min_gb": "FAIL when RLIMIT_MEMLOCK is below this many GiB. 0 disables.",
+
+      "shm_min_gb": 8,
+      "_comment_shm_min_gb": "FAIL when /dev/shm is below this many GiB. 0 disables.",
+
+      "skip_dmesg": false,
+      "_comment_skip_dmesg": "Skip the dmesg recent-error scan (use inside unprivileged containers).",
+
+      "allow_foreign_procs": false,
+      "_comment_allow_foreign_procs": "Do not FAIL on foreign GPU processes. Recommended inside containers where proc names resolve to N/A.",
+
+      "allowed_procs": "gpuagent,rocm-smi-daemon,amd-smi,dcgm-exporter",
+      "_comment_allowed_procs": "Comma-separated process names allowed to hold GPUs without failing the node.",
+
+      "require_tools": "",
+      "_comment_require_tools": "Comma-separated tools that must exist in PATH for PASS (amd-smi, rocm-smi, lsof). Empty = warn only.",
+
+      "nccl_socket_ifname": "",
+      "_comment_nccl_socket_ifname": "Optional NCCL_SOCKET_IFNAME / GLOO_SOCKET_IFNAME override for node_smoke.",
+
+      "gloo_socket_ifname": "",
+      "_comment_gloo_socket_ifname": "Optional GLOO_SOCKET_IFNAME override (defaults to nccl_socket_ifname when empty).",
+
+      "nccl_ib_hca": "",
+      "_comment_nccl_ib_hca": "Optional NCCL_IB_HCA override. Defaults to comma-joined node_check.rdma_interfaces.",
+
+      "nccl_ib_gid_index": null,
+      "_comment_nccl_ib_gid_index": "Optional NCCL_IB_GID_INDEX override. Defaults to node_check.gid_index.",
+
+      "ssh_timeout": 300,
+      "_comment_ssh_timeout": "SSH timeout in seconds for each node's node_smoke invocation (~30s; increase for slow nodes).",
+
+      "extra_args": [],
+      "_comment_extra_args": "Additional node_smoke CLI flags forwarded to primus-cli. Example: [\"--no-clean-dump-path\"]."
     },
     
     "reporting": {

--- a/cvs/lib/preflight/node_smoke.py
+++ b/cvs/lib/preflight/node_smoke.py
@@ -1,0 +1,420 @@
+"""
+Primus node_smoke preflight check.
+
+Launches ``primus-cli direct -- node_smoke`` on each reachable cluster node in
+parallel (no Slurm required) for host / GPU / RDMA roll-call screening.
+
+Reference: Primus ``docs/node-smoke-test-instruction.md`` on branch
+``dev/preflight-direct-test``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from typing import Any, Dict, List, Optional, Tuple
+
+from cvs.lib.preflight.base import PreflightCheck
+
+_JSON_BEGIN = "---CVS_NODE_SMOKE_JSON_BEGIN---"
+_JSON_END = "---CVS_NODE_SMOKE_JSON_END---"
+_STATUS_RE = re.compile(r"\bstatus=(PASS|FAIL)\b", re.IGNORECASE)
+
+
+def get_nested_config(config_dict, section, key, default):
+    """Read a nested preflight config value (``section.key`` or dotted section)."""
+    if not config_dict:
+        return default
+
+    sections = section.split(".")
+    current = config_dict
+    for sec in sections:
+        if isinstance(current, dict) and sec in current:
+            current = current[sec]
+        else:
+            return default
+
+    if isinstance(current, dict) and key in current:
+        return current[key]
+    return default
+
+
+def _config_flag_enabled(value, default=False):
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+def _normalize_mode(mode) -> str:
+    if isinstance(mode, str):
+        return mode.strip().lower()
+    return "skip" if not mode else "run"
+
+
+def _resolve_dump_path(cfg: dict) -> str:
+    """Return node_smoke dump directory; empty config uses reporting artifacts root."""
+    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", "/tmp/preflight")
+    default_dump = f"{str(artifacts_root).rstrip('/')}/node_smoke"
+    configured = get_nested_config(cfg, "node_smoke", "dump_path", default_dump)
+    configured_s = str(configured or "").strip()
+    return configured_s if configured_s else default_dump
+
+
+def build_node_smoke_flags(
+    *,
+    dump_path: str = "output/preflight",
+    expected_gpus: Optional[int] = None,
+    expected_rdma_nics: Optional[int] = None,
+    rdma_nic_allowlist: Optional[str] = None,
+    ulimit_l_min_gb: Optional[float] = None,
+    shm_min_gb: Optional[float] = None,
+    skip_dmesg: bool = False,
+    allow_foreign_procs: bool = False,
+    allowed_procs: Optional[str] = None,
+    require_tools: Optional[str] = None,
+    extra_args: Optional[List[str]] = None,
+) -> str:
+    """Build primus-cli ``node_smoke`` CLI flags."""
+    effective_dump = str(dump_path or "").strip() or "output/preflight"
+    flags: List[str] = [f"--dump-path {shlex.quote(effective_dump)}"]
+
+    if expected_gpus is not None and int(expected_gpus) > 0:
+        flags.append(f"--expected-gpus {int(expected_gpus)}")
+
+    if expected_rdma_nics is not None and int(expected_rdma_nics) > 0:
+        flags.append(f"--expected-rdma-nics {int(expected_rdma_nics)}")
+
+    if rdma_nic_allowlist:
+        flags.append(f"--rdma-nic-allowlist {shlex.quote(str(rdma_nic_allowlist))}")
+
+    if ulimit_l_min_gb is not None:
+        flags.append(f"--ulimit-l-min-gb {float(ulimit_l_min_gb)}")
+
+    if shm_min_gb is not None:
+        flags.append(f"--shm-min-gb {float(shm_min_gb)}")
+
+    if skip_dmesg:
+        flags.append("--skip-dmesg")
+
+    if allow_foreign_procs:
+        flags.append("--allow-foreign-procs")
+
+    if allowed_procs is not None:
+        flags.append(f"--allowed-procs {shlex.quote(str(allowed_procs))}")
+
+    if require_tools:
+        flags.append(f"--require-tools {shlex.quote(str(require_tools))}")
+
+    if extra_args:
+        for arg in extra_args:
+            if arg:
+                flags.append(str(arg))
+
+    return " ".join(flags)
+
+
+def build_remote_node_smoke_command(
+    *,
+    primus_dir: str,
+    venv_activate: str,
+    node_rank: int,
+    nnodes: int,
+    master_addr: str,
+    master_port: int,
+    gpus_per_node: int,
+    dump_path: str,
+    smoke_flags: str,
+    nccl_socket_ifname: Optional[str] = None,
+    gloo_socket_ifname: Optional[str] = None,
+    nccl_ib_hca: Optional[str] = None,
+    nccl_ib_gid_index: Optional[int] = None,
+) -> str:
+    """Build the remote shell command for one node's node_smoke run."""
+    primus_q = shlex.quote(primus_dir)
+    venv_q = shlex.quote(venv_activate)
+    effective_dump = str(dump_path or "").strip() or "output/preflight"
+    dump_q = shlex.quote(effective_dump)
+
+    env_lines = [
+        f"export VENV_ACTIVATE={venv_q}",
+        f"export NNODES={nnodes}",
+        f"export NODE_RANK={node_rank}",
+        f"export MASTER_ADDR={shlex.quote(master_addr)}",
+        f"export MASTER_PORT={master_port}",
+        f"export GPUS_PER_NODE={gpus_per_node}",
+    ]
+    if nccl_socket_ifname:
+        env_lines.append(f"export NCCL_SOCKET_IFNAME={shlex.quote(nccl_socket_ifname)}")
+    if gloo_socket_ifname:
+        env_lines.append(f"export GLOO_SOCKET_IFNAME={shlex.quote(gloo_socket_ifname)}")
+    if nccl_ib_hca:
+        env_lines.append(f"export NCCL_IB_HCA={shlex.quote(nccl_ib_hca)}")
+    if nccl_ib_gid_index is not None:
+        env_lines.append(f"export NCCL_IB_GID_INDEX={int(nccl_ib_gid_index)}")
+
+    primus_cli = f"{primus_q}/runner/primus-cli"
+    json_cat = (
+        f"echo '{_JSON_BEGIN}'; "
+        f"json=$(ls -1 {dump_q}/smoke/*.json 2>/dev/null | head -1); "
+        f'if [ -n "$json" ]; then cat "$json"; fi; '
+        f"echo '{_JSON_END}'"
+    )
+
+    return (
+        f"cd {primus_q} && "
+        f"{' && '.join(env_lines)} && "
+        f"{primus_cli} direct --single -- node_smoke {smoke_flags}; "
+        f"rc=$?; {json_cat}; exit $rc"
+    )
+
+
+def parse_node_smoke_output(output: str) -> Dict[str, Any]:
+    """Parse node_smoke stdout for status and optional embedded JSON payload."""
+    result: Dict[str, Any] = {
+        "status": "UNKNOWN",
+        "fail_reasons": [],
+        "node_payload": None,
+        "raw_status_line": None,
+    }
+
+    if not output or not str(output).strip():
+        result["fail_reasons"].append("empty output from node_smoke")
+        result["status"] = "FAIL"
+        return result
+
+    text = str(output)
+
+    begin = text.find(_JSON_BEGIN)
+    end = text.find(_JSON_END)
+    if begin != -1 and end != -1 and end > begin:
+        json_blob = text[begin + len(_JSON_BEGIN) : end].strip()
+        if json_blob:
+            try:
+                payload = json.loads(json_blob)
+                result["node_payload"] = payload
+                result["status"] = str(payload.get("status", "UNKNOWN")).upper()
+                result["fail_reasons"] = list(payload.get("fail_reasons") or [])
+            except json.JSONDecodeError as exc:
+                result["fail_reasons"].append(f"failed to parse node_smoke JSON: {exc}")
+
+    if result["status"] == "UNKNOWN":
+        matches = _STATUS_RE.findall(text)
+        if matches:
+            result["raw_status_line"] = matches[-1]
+            result["status"] = matches[-1].upper()
+        elif "ABORT: Host Unreachable Error" in text:
+            result["status"] = "FAIL"
+            result["fail_reasons"].append("SSH unreachable")
+        elif "argument --dump-path: expected one argument" in text:
+            result["status"] = "FAIL"
+            result["fail_reasons"].append(
+                "invalid --dump-path (set node_smoke.dump_path or leave it empty to use artifacts_root_dir/node_smoke)"
+            )
+        else:
+            result["status"] = "FAIL"
+            result["fail_reasons"].append("could not determine node_smoke status from output")
+
+    return result
+
+
+class NodeSmokeCheck(PreflightCheck):
+    """Run Primus node_smoke checks across cluster nodes via parallel SSH."""
+
+    def __init__(self, phdl, node_list: List[str], config_dict=None):
+        super().__init__(phdl, config_dict)
+        self.node_list = list(node_list)
+        self._load_settings()
+
+    def _load_settings(self):
+        cfg = self.config_dict or {}
+        node_check = cfg.get("node_check") or {}
+
+        self.mode = _normalize_mode(get_nested_config(cfg, "node_smoke", "connectivity_mode", "skip"))
+        self.primus_dir = get_nested_config(cfg, "node_smoke", "primus_dir", "")
+        self.venv_activate = get_nested_config(cfg, "node_smoke", "venv_activate", "")
+        self.gpus_per_node = int(get_nested_config(cfg, "node_smoke", "gpus_per_node", 8))
+        self.master_port = int(get_nested_config(cfg, "node_smoke", "master_port", 1234))
+        self.ssh_timeout = int(get_nested_config(cfg, "node_smoke", "ssh_timeout", 300))
+
+        artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", "/tmp/preflight")
+        self.dump_path = _resolve_dump_path(cfg)
+
+        rdma_ifaces = node_check.get("rdma_interfaces") or []
+        default_rdma_nics = len(rdma_ifaces) if rdma_ifaces else None
+        expected_rdma = get_nested_config(cfg, "node_smoke", "expected_rdma_nics", default_rdma_nics)
+        self.expected_rdma_nics = int(expected_rdma) if expected_rdma not in (None, "", 0) else None
+
+        self.ulimit_l_min_gb = float(get_nested_config(cfg, "node_smoke", "ulimit_l_min_gb", 32.0))
+        self.shm_min_gb = float(get_nested_config(cfg, "node_smoke", "shm_min_gb", 8.0))
+        self.skip_dmesg = _config_flag_enabled(get_nested_config(cfg, "node_smoke", "skip_dmesg", False))
+        self.allow_foreign_procs = _config_flag_enabled(
+            get_nested_config(cfg, "node_smoke", "allow_foreign_procs", False)
+        )
+        self.allowed_procs = get_nested_config(
+            cfg,
+            "node_smoke",
+            "allowed_procs",
+            "gpuagent,rocm-smi-daemon,amd-smi,dcgm-exporter",
+        )
+        self.require_tools = get_nested_config(cfg, "node_smoke", "require_tools", "")
+
+        self.nccl_socket_ifname = get_nested_config(cfg, "node_smoke", "nccl_socket_ifname", "") or None
+        self.gloo_socket_ifname = get_nested_config(
+            cfg, "node_smoke", "gloo_socket_ifname", self.nccl_socket_ifname
+        ) or None
+
+        rdma_allowlist = get_nested_config(cfg, "node_smoke", "rdma_nic_allowlist", None)
+        if not rdma_allowlist and rdma_ifaces:
+            rdma_allowlist = ",".join(rdma_ifaces)
+        self.rdma_nic_allowlist = rdma_allowlist or None
+
+        nccl_ib_hca = get_nested_config(cfg, "node_smoke", "nccl_ib_hca", None)
+        if not nccl_ib_hca and rdma_ifaces:
+            nccl_ib_hca = ",".join(rdma_ifaces)
+        self.nccl_ib_hca = nccl_ib_hca or None
+
+        gid_index = get_nested_config(cfg, "node_smoke", "nccl_ib_gid_index", None)
+        if gid_index is None:
+            gid_index = node_check.get("gid_index")
+        self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
+
+        extra = get_nested_config(cfg, "node_smoke", "extra_args", [])
+        self.extra_args = [str(arg) for arg in extra if arg] if isinstance(extra, (list, tuple)) else []
+        self.auto_setup = _config_flag_enabled(get_nested_config(cfg, "node_smoke", "auto_setup", True), default=True)
+
+    def _validate_prerequisites(self) -> Optional[str]:
+        if not self.primus_dir:
+            return "node_smoke.primus_dir is required when connectivity_mode is 'run'"
+        if not self.venv_activate:
+            return "node_smoke.venv_activate is required when connectivity_mode is 'run'"
+        if not self.node_list:
+            return "no reachable nodes available for node_smoke"
+        return None
+
+    def _smoke_flags(self) -> str:
+        return build_node_smoke_flags(
+            dump_path=self.dump_path,
+            expected_gpus=self.gpus_per_node,
+            expected_rdma_nics=self.expected_rdma_nics,
+            rdma_nic_allowlist=self.rdma_nic_allowlist,
+            ulimit_l_min_gb=self.ulimit_l_min_gb,
+            shm_min_gb=self.shm_min_gb,
+            skip_dmesg=self.skip_dmesg,
+            allow_foreign_procs=self.allow_foreign_procs,
+            allowed_procs=self.allowed_procs,
+            require_tools=self.require_tools,
+            extra_args=self.extra_args,
+        )
+
+    def run(self) -> Dict[str, Any]:
+        if self.mode in ("skip", "off", "disabled", "false", "0"):
+            return {
+                "mode": self.mode,
+                "skipped": True,
+                "message": "Primus node_smoke check skipped by configuration",
+                "node_results": {},
+            }
+
+        err = self._validate_prerequisites()
+        if err:
+            return {
+                "mode": self.mode,
+                "skipped": True,
+                "message": err,
+                "node_results": {},
+            }
+
+        hosts = [h for h in self.node_list if h in self.phdl.reachable_hosts]
+        if not hosts:
+            return {
+                "mode": self.mode,
+                "skipped": True,
+                "message": "no reachable hosts remain for node_smoke",
+                "node_results": {},
+            }
+
+        setup_results = None
+        if self.auto_setup:
+            from cvs.lib.preflight.primus_setup import PrimusSetup
+
+            setup = PrimusSetup(self.phdl, hosts, self.config_dict)
+            setup_results = setup.run()
+            if setup_results.get("status") == "FAIL":
+                return {
+                    "mode": self.mode,
+                    "skipped": True,
+                    "status": "FAIL",
+                    "message": "Primus auto_setup failed — fix setup errors before node_smoke",
+                    "setup_results": setup_results,
+                    "node_results": {},
+                }
+
+        nnodes = len(hosts)
+        master_addr = hosts[0]
+        smoke_flags = self._smoke_flags()
+
+        self.log_info(
+            f"Launching Primus node_smoke on {nnodes} node(s) "
+            f"(primus_dir={self.primus_dir}, dump_path={self.dump_path})"
+        )
+
+        commands: List[str] = []
+        for rank, host in enumerate(hosts):
+            commands.append(
+                build_remote_node_smoke_command(
+                    primus_dir=self.primus_dir,
+                    venv_activate=self.venv_activate,
+                    node_rank=rank,
+                    nnodes=nnodes,
+                    master_addr=master_addr,
+                    master_port=self.master_port,
+                    gpus_per_node=self.gpus_per_node,
+                    dump_path=self.dump_path,
+                    smoke_flags=smoke_flags,
+                    nccl_socket_ifname=self.nccl_socket_ifname,
+                    gloo_socket_ifname=self.gloo_socket_ifname,
+                    nccl_ib_hca=self.nccl_ib_hca,
+                    nccl_ib_gid_index=self.nccl_ib_gid_index,
+                )
+            )
+
+        out_dict = self.phdl.exec_cmd_list(commands, timeout=self.ssh_timeout)
+
+        node_results: Dict[str, Any] = {}
+        for host, output in out_dict.items():
+            parsed = parse_node_smoke_output(output)
+            node_results[host] = {
+                "status": parsed["status"],
+                "fail_reasons": parsed["fail_reasons"],
+                "node_rank": hosts.index(host) if host in hosts else -1,
+                "node_payload": parsed.get("node_payload"),
+            }
+            if parsed["status"] == "FAIL":
+                for reason in parsed["fail_reasons"]:
+                    self.log_error(f"Node {host} node_smoke: {reason}")
+
+        failed_nodes = [n for n, r in node_results.items() if r.get("status") == "FAIL"]
+        passing_nodes = [n for n, r in node_results.items() if r.get("status") == "PASS"]
+        unknown_nodes = [n for n, r in node_results.items() if r.get("status") not in ("PASS", "FAIL")]
+
+        summary_status = "FAIL" if failed_nodes or unknown_nodes else "PASS"
+        self.results = {
+            "mode": self.mode,
+            "skipped": False,
+            "status": summary_status,
+            "total_nodes": len(node_results),
+            "passing_nodes": passing_nodes,
+            "failed_nodes": failed_nodes,
+            "unknown_nodes": unknown_nodes,
+            "node_results": node_results,
+            "dump_path": self.dump_path,
+            "primus_dir": self.primus_dir,
+        }
+        if setup_results is not None:
+            self.results["setup_results"] = setup_results
+        return self.results

--- a/cvs/lib/preflight/node_smoke.py
+++ b/cvs/lib/preflight/node_smoke.py
@@ -357,6 +357,8 @@ class NodeSmokeCheck(PreflightCheck):
         nnodes = len(hosts)
         master_addr = hosts[0]
         smoke_flags = self._smoke_flags()
+        hosts_set = set(hosts)
+        host_ranks = {host: rank for rank, host in enumerate(hosts)}
 
         self.log_info(
             f"Launching Primus node_smoke on {nnodes} node(s) "
@@ -364,34 +366,39 @@ class NodeSmokeCheck(PreflightCheck):
         )
 
         commands: List[str] = []
-        for rank, host in enumerate(hosts):
-            commands.append(
-                build_remote_node_smoke_command(
-                    primus_dir=self.primus_dir,
-                    venv_activate=self.venv_activate,
-                    node_rank=rank,
-                    nnodes=nnodes,
-                    master_addr=master_addr,
-                    master_port=self.master_port,
-                    gpus_per_node=self.gpus_per_node,
-                    dump_path=self.dump_path,
-                    smoke_flags=smoke_flags,
-                    nccl_socket_ifname=self.nccl_socket_ifname,
-                    gloo_socket_ifname=self.gloo_socket_ifname,
-                    nccl_ib_hca=self.nccl_ib_hca,
-                    nccl_ib_gid_index=self.nccl_ib_gid_index,
+        for h in self.phdl.reachable_hosts:
+            if h not in hosts_set:
+                commands.append("true")
+            else:
+                commands.append(
+                    build_remote_node_smoke_command(
+                        primus_dir=self.primus_dir,
+                        venv_activate=self.venv_activate,
+                        node_rank=host_ranks[h],
+                        nnodes=nnodes,
+                        master_addr=master_addr,
+                        master_port=self.master_port,
+                        gpus_per_node=self.gpus_per_node,
+                        dump_path=self.dump_path,
+                        smoke_flags=smoke_flags,
+                        nccl_socket_ifname=self.nccl_socket_ifname,
+                        gloo_socket_ifname=self.gloo_socket_ifname,
+                        nccl_ib_hca=self.nccl_ib_hca,
+                        nccl_ib_gid_index=self.nccl_ib_gid_index,
+                    )
                 )
-            )
 
         out_dict = self.phdl.exec_cmd_list(commands, timeout=self.ssh_timeout)
 
         node_results: Dict[str, Any] = {}
         for host, output in out_dict.items():
+            if host not in hosts_set:
+                continue
             parsed = parse_node_smoke_output(output)
             node_results[host] = {
                 "status": parsed["status"],
                 "fail_reasons": parsed["fail_reasons"],
-                "node_rank": hosts.index(host) if host in hosts else -1,
+                "node_rank": host_ranks[host],
                 "node_payload": parsed.get("node_payload"),
             }
             if parsed["status"] == "FAIL":
@@ -418,3 +425,4 @@ class NodeSmokeCheck(PreflightCheck):
         if setup_results is not None:
             self.results["setup_results"] = setup_results
         return self.results
+

--- a/cvs/lib/preflight/primus_setup.py
+++ b/cvs/lib/preflight/primus_setup.py
@@ -1,0 +1,355 @@
+"""
+Automatic Primus repository and virtualenv setup for node_smoke preflight.
+
+When ``node_smoke.auto_setup`` is enabled (default), clones or updates Primus
+on each reachable node and ensures the configured venv has the minimal deps
+for ``node_smoke`` (ROCm PyTorch).  Primus on ``dev/preflight-direct-test``
+is run from the git checkout via ``runner/primus-cli`` — there is no
+``setup.py`` / ``pyproject.toml`` to ``pip install -e .``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from typing import Any, Dict, List, Optional
+
+from cvs.lib.preflight.base import PreflightCheck
+from cvs.lib.preflight.node_smoke import get_nested_config, _config_flag_enabled
+
+_GIT_ERROR_RE = re.compile(r"(?:^|\n)(?:fatal:|error:\s+pathspec)", re.IGNORECASE)
+_PIP_ERROR_RE = re.compile(r"(?:^|\n)ERROR:\s(?!.*pathspec)", re.IGNORECASE)
+_SHELL_ERROR_RE = re.compile(
+    r"(?:^|\n)(?:bash:\s|/bin/bash:\s|syntax error:|fatal: timed out waiting)",
+    re.IGNORECASE,
+)
+
+# Primus preflight-direct docs: node_smoke needs torch (ROCm build) only.
+_DEFAULT_TORCH_INDEX = "https://download.pytorch.org/whl/rocm6.2"
+_SETUP_OK_MARKER = "CVS_PRIMUS_SETUP_OK"
+
+
+def _venv_root_from_activate(venv_activate: str) -> str:
+    """Return venv root directory from ``.../.venv/bin/activate`` path."""
+    parts = venv_activate.rstrip("/").split("/")
+    if len(parts) >= 3 and parts[-1] == "activate" and parts[-2] == "bin":
+        return "/".join(parts[:-2])
+    if len(parts) >= 2 and parts[-2] == "bin":
+        return "/".join(parts[:-2])
+    return venv_activate.rstrip("/")
+
+
+def _remove_broken_primus_dir(primus_q: str) -> str:
+    """Remove a partial clone (directory exists but .git is missing or incomplete)."""
+    return f"if [ -e {primus_q} ] && [ ! -d {primus_q}/.git ]; then rm -rf {primus_q}; fi"
+
+
+def _setup_lock_path(primus_dir: str) -> str:
+    """Lock file beside primus_dir (parent must exist before clone creates primus_dir)."""
+    parent = os.path.dirname(primus_dir.rstrip("/")) or "."
+    return os.path.join(parent, ".cvs_primus_setup.lock")
+
+
+def _with_setup_lock(primus_dir: str, body: str) -> str:
+    """Serialize clone/venv on shared storage (NFS home) via flock."""
+    parent_q = shlex.quote(os.path.dirname(primus_dir.rstrip("/")) or ".")
+    lock_q = shlex.quote(_setup_lock_path(primus_dir))
+    return f"mkdir -p {parent_q} && ( flock -w 900 9 || exit 1; {body} ) 9>{lock_q}"
+
+
+def _git_sync_existing_repo(primus_q: str, branch_q: str, recurse_submodules: bool) -> str:
+    """Fetch, checkout, and optionally update submodules on an existing clone."""
+    submodule_cmd = (
+        "git submodule update --init --recursive"
+        if recurse_submodules
+        else "true"
+    )
+    return (
+        f"git fetch origin {branch_q} && "
+        f"(git checkout {branch_q} || git checkout -B {branch_q} origin/{branch_q}) && "
+        f"git pull --ff-only origin {branch_q} 2>/dev/null || true && "
+        f"{submodule_cmd}"
+    )
+
+
+def build_primus_clone_or_update_command(
+    *,
+    primus_dir: str,
+    git_url: str,
+    git_branch: str,
+    recurse_submodules: bool = False,
+    force_reclone: bool = False,
+) -> str:
+    """Shell snippet: clone Primus or update an existing checkout."""
+    primus_q = shlex.quote(primus_dir)
+    url_q = shlex.quote(git_url)
+    branch_q = shlex.quote(git_branch)
+    parent_q = shlex.quote(os.path.dirname(primus_dir.rstrip("/")) or ".")
+    recurse_flag = "--recurse-submodules" if recurse_submodules else ""
+    clone_flags = f"--branch {branch_q} --single-branch {recurse_flag}".strip()
+    sync_existing = _git_sync_existing_repo(primus_q, branch_q, recurse_submodules)
+
+    cleanup = _remove_broken_primus_dir(primus_q)
+
+    if force_reclone:
+        return (
+            f"rm -rf {primus_q} && "
+            f"mkdir -p {parent_q} && "
+            f"git clone {clone_flags} {url_q} {primus_q}"
+        )
+
+    return (
+        f"if [ -d {primus_q}/.git ]; then "
+        f"bash -c 'cd {primus_q} && {sync_existing}'; "
+        f"else "
+        f"{cleanup} && mkdir -p {parent_q} && "
+        f"git clone {clone_flags} {url_q} {primus_q}; "
+        f"fi"
+    )
+
+
+def build_primus_verify_command(*, primus_dir: str, venv_activate: str) -> str:
+    """Shell snippet: verify Primus checkout and torch in venv."""
+    primus_q = shlex.quote(primus_dir)
+    activate_q = shlex.quote(venv_activate)
+    return (
+        f"test -f {primus_q}/runner/primus-cli && test -f {activate_q} && "
+        f"bash -c 'source {activate_q} && cd {primus_q} && python -c \"import torch\"'"
+    )
+
+
+def _finish_setup_command(cmd: str) -> str:
+    """Append a stdout marker so silent successful exits (e.g. follower wait) parse as PASS."""
+    return f"{cmd} && echo {_SETUP_OK_MARKER}"
+
+
+def build_wait_for_shared_primus_command(
+    *,
+    primus_dir: str,
+    venv_activate: str,
+    poll_interval: int = 5,
+    max_wait: int = 900,
+) -> str:
+    """Wait until another node finishes clone/venv on shared NFS home."""
+    primus_q = shlex.quote(primus_dir)
+    activate_q = shlex.quote(venv_activate)
+    attempts = max(1, max_wait // max(1, poll_interval))
+    # Flat shell (no nested bash -c) so SSH quoting stays intact across nodes.
+    return (
+        f"i=0; while [ $i -lt {attempts} ]; do "
+        f"test -f {primus_q}/runner/primus-cli && test -f {activate_q} && "
+        f". {activate_q} && python -c \"import torch\" 2>/dev/null && "
+        f"echo {_SETUP_OK_MARKER} && exit 0; "
+        f"i=$((i+1)); sleep {poll_interval}; done; "
+        f"echo \"fatal: timed out waiting for shared Primus install\"; exit 1"
+    )
+
+
+def build_primus_venv_install_command(
+    *,
+    primus_dir: str,
+    venv_activate: str,
+    pip_install_mode: str = "minimal",
+    torch_pip_index_url: str = _DEFAULT_TORCH_INDEX,
+) -> str:
+    """Shell snippet: create venv and install deps for node_smoke."""
+    primus_q = shlex.quote(primus_dir)
+    activate_q = shlex.quote(venv_activate)
+    venv_root_q = shlex.quote(_venv_root_from_activate(venv_activate))
+    venv_parent_q = shlex.quote(os.path.dirname(_venv_root_from_activate(venv_activate)) or ".")
+    index_q = shlex.quote(torch_pip_index_url)
+
+    create_venv = (
+        f"if [ ! -f {activate_q} ]; then "
+        f"mkdir -p {venv_parent_q} && python3 -m venv {venv_root_q}; "
+        f"fi"
+    )
+
+    mode = (pip_install_mode or "minimal").strip().lower()
+    if mode == "skip":
+        install = "true"
+    elif mode == "requirements":
+        install = (
+            f"bash -c 'source {activate_q} && cd {primus_q} && "
+            f"pip install -r requirements.txt --no-cache-dir'"
+        )
+    else:
+        # minimal: ROCm torch only (Primus node_smoke). No pip install -e .
+        install = (
+            f"bash -c 'source {activate_q} && "
+            f"if ! python -c \"import torch\" 2>/dev/null; then "
+            f"pip install torch --index-url {index_q} --no-cache-dir; "
+            f"fi'"
+        )
+
+    verify = build_primus_verify_command(primus_dir=primus_dir, venv_activate=venv_activate)
+
+    return f"{create_venv} && {install} && {verify}"
+
+
+def parse_setup_output(output: str) -> Dict[str, Any]:
+    """Classify setup command output as PASS/FAIL."""
+    text = (output or "").strip()
+    if "ABORT: Host Unreachable Error" in text:
+        return {"status": "FAIL", "errors": ["SSH unreachable during setup"]}
+    if _SHELL_ERROR_RE.search(text):
+        return {"status": "FAIL", "errors": ["shell error during Primus setup"]}
+    if "fatal: timed out waiting for shared Primus install" in text:
+        return {"status": "FAIL", "errors": ["timed out waiting for shared Primus install"]}
+    if _GIT_ERROR_RE.search(text):
+        if "could not lock config file" in text.lower():
+            return {
+                "status": "FAIL",
+                "errors": [
+                    "git clone conflict on shared storage — enable shared_install "
+                    "(default) so only one node clones Primus"
+                ],
+            }
+        return {"status": "FAIL", "errors": ["git error during Primus setup"]}
+    if _PIP_ERROR_RE.search(text) or re.search(r"\bpip\b.*\berror\b", text, re.IGNORECASE):
+        return {"status": "FAIL", "errors": ["pip install failed during Primus setup"]}
+    if "No module named 'torch'" in text or "ModuleNotFoundError" in text:
+        return {"status": "FAIL", "errors": ["torch not available in venv after setup"]}
+    if _SETUP_OK_MARKER in text:
+        return {"status": "PASS", "errors": []}
+    if not text:
+        return {"status": "FAIL", "errors": ["empty setup output"]}
+    return {"status": "FAIL", "errors": ["setup did not report success"]}
+
+
+class PrimusSetup(PreflightCheck):
+    """Clone/update Primus and prepare the preflight venv on cluster nodes."""
+
+    def __init__(self, phdl, node_list: List[str], config_dict=None):
+        super().__init__(phdl, config_dict)
+        self.node_list = list(node_list)
+        self._load_settings()
+
+    def _load_settings(self):
+        cfg = self.config_dict or {}
+        self.primus_dir = get_nested_config(cfg, "node_smoke", "primus_dir", "")
+        self.venv_activate = get_nested_config(cfg, "node_smoke", "venv_activate", "")
+        self.git_url = get_nested_config(
+            cfg, "node_smoke", "primus_git_url", "https://github.com/AMD-AIG-AIMA/Primus.git"
+        )
+        self.git_branch = get_nested_config(cfg, "node_smoke", "primus_git_branch", "dev/preflight-direct-test")
+        self.recurse_submodules = _config_flag_enabled(
+            get_nested_config(cfg, "node_smoke", "primus_git_recurse_submodules", False), default=False
+        )
+        self.force_reclone = _config_flag_enabled(get_nested_config(cfg, "node_smoke", "force_reclone", False))
+        self.pip_install_mode = get_nested_config(cfg, "node_smoke", "pip_install_mode", "minimal")
+        self.torch_pip_index_url = get_nested_config(
+            cfg, "node_smoke", "torch_pip_index_url", _DEFAULT_TORCH_INDEX
+        )
+        self.setup_timeout = int(get_nested_config(cfg, "node_smoke", "setup_timeout", 600))
+        self.shared_install = _config_flag_enabled(
+            get_nested_config(cfg, "node_smoke", "shared_install", True), default=True
+        )
+
+    def _validate(self) -> Optional[str]:
+        if not self.primus_dir:
+            return "node_smoke.primus_dir is required for auto_setup"
+        if not self.venv_activate:
+            return "node_smoke.venv_activate is required for auto_setup"
+        if not self.git_url:
+            return "node_smoke.primus_git_url is required for auto_setup"
+        if not self.git_branch:
+            return "node_smoke.primus_git_branch is required for auto_setup"
+        if not self.node_list:
+            return "no reachable nodes for Primus auto_setup"
+        return None
+
+    def run(self) -> Dict[str, Any]:
+        err = self._validate()
+        if err:
+            return {"status": "FAIL", "skipped": True, "message": err, "node_results": {}}
+
+        hosts = [h for h in self.phdl.reachable_hosts if h in self.node_list]
+        if not hosts:
+            return {
+                "status": "FAIL",
+                "skipped": True,
+                "message": "no reachable hosts for Primus auto_setup",
+                "node_results": {},
+            }
+
+        clone_cmd = build_primus_clone_or_update_command(
+            primus_dir=self.primus_dir,
+            git_url=self.git_url,
+            git_branch=self.git_branch,
+            recurse_submodules=self.recurse_submodules,
+            force_reclone=self.force_reclone,
+        )
+        venv_cmd = build_primus_venv_install_command(
+            primus_dir=self.primus_dir,
+            venv_activate=self.venv_activate,
+            pip_install_mode=self.pip_install_mode,
+            torch_pip_index_url=self.torch_pip_index_url,
+        )
+        setup_body = _finish_setup_command(f"{clone_cmd} && {venv_cmd}")
+        per_node_setup = _with_setup_lock(self.primus_dir, setup_body)
+        follower_setup = build_wait_for_shared_primus_command(
+            primus_dir=self.primus_dir,
+            venv_activate=self.venv_activate,
+            max_wait=self.setup_timeout,
+        )
+
+        use_shared = self.shared_install and len(hosts) > 1
+        leader = hosts[0]
+        if use_shared:
+            setup_mode = f"shared (leader={leader})"
+        else:
+            setup_mode = "per-node"
+
+        commands: List[str] = []
+        for h in self.phdl.reachable_hosts:
+            if h not in hosts:
+                commands.append("true")
+            elif use_shared and h != leader:
+                commands.append(follower_setup)
+            else:
+                commands.append(per_node_setup)
+
+        self.log_info(
+            f"Primus auto_setup on {len(hosts)} node(s) [{setup_mode}]: "
+            f"dir={self.primus_dir}, branch={self.git_branch}, "
+            f"venv={self.venv_activate}, pip_mode={self.pip_install_mode}"
+        )
+
+        out_dict = self.phdl.exec_cmd_list(commands, timeout=self.setup_timeout)
+
+        hosts_set = set(hosts)
+        node_results: Dict[str, Any] = {}
+        failed_nodes: List[str] = []
+        for host, output in out_dict.items():
+            if host not in hosts_set:
+                continue
+            parsed = parse_setup_output(output)
+            node_results[host] = {
+                "status": parsed["status"],
+                "errors": parsed["errors"],
+            }
+            if parsed["status"] == "FAIL":
+                failed_nodes.append(host)
+                for e in parsed["errors"]:
+                    self.log_error(f"Node {host} Primus setup: {e}")
+                snippet = (output or "").strip()[-800:]
+                if snippet:
+                    self.log_error(f"Node {host} setup output (tail): {snippet}")
+
+        status = "FAIL" if failed_nodes else "PASS"
+        self.results = {
+            "status": status,
+            "skipped": False,
+            "primus_dir": self.primus_dir,
+            "git_branch": self.git_branch,
+            "venv_activate": self.venv_activate,
+            "pip_install_mode": self.pip_install_mode,
+            "shared_install": self.shared_install,
+            "setup_leader": leader if use_shared else None,
+            "total_nodes": len(node_results),
+            "failed_nodes": failed_nodes,
+            "node_results": node_results,
+        }
+        return self.results

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -100,6 +100,7 @@ class PreflightReportGenerator(PreflightCheck):
         rocm_results = self.results.get('rocm_versions', {})
         interface_results = self.results.get('interface_names', {})
         ifoe_l2_results = self.results.get('ifoe_l2_connectivity', {})
+        node_smoke_results = self.results.get('node_smoke', {})
         reachability_results = self.results.get('node_reachability')
         ssh_connectivity_results = self.results.get('ssh_connectivity')
         summary = {
@@ -107,6 +108,7 @@ class PreflightReportGenerator(PreflightCheck):
             'checks': {
                 'ssh_reachability': self._summarize_reachability_results(reachability_results),
                 'gid_consistency': self._summarize_gid_results(gid_results),
+                'node_smoke': self._summarize_node_smoke_results(node_smoke_results),
                 'ifoe_l2_connectivity': self._summarize_ifoe_l2_results(ifoe_l2_results),
                 'rdma_connectivity': self._summarize_connectivity_results(connectivity_results),
                 'rocm_versions': self._summarize_rocm_results(rocm_results),
@@ -144,6 +146,15 @@ class PreflightReportGenerator(PreflightCheck):
 
         if summary['checks']['interface_names']['status'] == 'FAIL':
             summary['recommendations'].append("Standardize RDMA interface naming across cluster nodes")
+
+        if summary['checks']['node_smoke']['status'] == 'FAIL':
+            summary['recommendations'].append(
+                "Review Primus node_smoke failures (GPU health, RDMA roll-call, host limits) before benchmarking"
+            )
+        elif summary['checks']['node_smoke']['status'] == 'SKIPPED':
+            summary['recommendations'].append(
+                "Consider enabling node_smoke.connectivity_mode='run' for per-node GPU/RDMA health screening"
+            )
 
         if summary['overall_status'] == 'PASS':
             summary['recommendations'].append("All preflight checks passed - cluster is ready for performance testing")
@@ -330,6 +341,46 @@ class PreflightReportGenerator(PreflightCheck):
             'summary': summary_text,
         }
 
+    def _summarize_node_smoke_results(self, node_smoke_results):
+        """Summarize Primus node_smoke check results."""
+        if not node_smoke_results or node_smoke_results.get('skipped'):
+            msg = (
+                node_smoke_results.get('message')
+                if isinstance(node_smoke_results, dict)
+                else 'Primus node_smoke check not performed'
+            )
+            return {
+                'status': 'SKIPPED',
+                'total_nodes': 0,
+                'passing_nodes': 0,
+                'failed_nodes': [],
+                'summary': msg or 'Primus node_smoke check skipped',
+            }
+
+        node_results = node_smoke_results.get('node_results') or {}
+        total_nodes = len(node_results)
+        failed_nodes = list(
+            node_smoke_results.get('failed_nodes')
+            or [n for n, r in node_results.items() if r.get('status') == 'FAIL']
+        )
+        unknown_nodes = list(
+            node_smoke_results.get('unknown_nodes')
+            or [n for n, r in node_results.items() if r.get('status') not in ('PASS', 'FAIL')]
+        )
+        passing_nodes = total_nodes - len(failed_nodes) - len(unknown_nodes)
+        status = 'FAIL' if failed_nodes or unknown_nodes else 'PASS'
+        summary_text = f"{passing_nodes}/{total_nodes} nodes passed Primus node_smoke"
+        if unknown_nodes:
+            summary_text += f"; {len(unknown_nodes)} unknown"
+        return {
+            'status': status,
+            'total_nodes': total_nodes,
+            'passing_nodes': passing_nodes,
+            'failed_nodes': failed_nodes,
+            'unknown_nodes': unknown_nodes,
+            'summary': summary_text,
+        }
+
     def _summarize_reachability_results(self, reachability_results):
         """Summarize SSH reachability check results."""
         if not reachability_results:
@@ -431,6 +482,7 @@ class PreflightReportGenerator(PreflightCheck):
 
             {self._generate_executive_summary_html(summary)}
             {self._generate_gid_consistency_html(results.get('gid_consistency', {}))}
+            {self._generate_node_smoke_html(results.get('node_smoke', {}))}
             {self._generate_ifoe_l2_html(results.get('ifoe_l2_connectivity', {}))}
             {self._generate_connectivity_html(results.get('rdma_connectivity', {}))}
             {self._generate_ssh_connectivity_html(results.get('ssh_connectivity', {}))}
@@ -844,6 +896,78 @@ class PreflightReportGenerator(PreflightCheck):
         </section>
         """
         return html
+
+    def _generate_node_smoke_html(self, node_smoke_results):
+        """Generate Primus node_smoke section — failed nodes and fail reasons."""
+        if not node_smoke_results:
+            return ""
+
+        if node_smoke_results.get('skipped'):
+            msg = node_smoke_results.get('message', 'Primus node_smoke check skipped')
+            return f"""
+        <section>
+            <h2>Primus Node Smoke</h2>
+            <p><em>{html.escape(msg)}</em></p>
+        </section>
+        """
+
+        node_results = node_smoke_results.get('node_results') or {}
+        if not node_results:
+            return ""
+
+        failed_nodes = {
+            n: r for n, r in node_results.items() if r.get('status') in ('FAIL', 'UNKNOWN')
+        }
+        dump_path = node_smoke_results.get('dump_path', '')
+
+        if not failed_nodes:
+            passing = len([n for n, r in node_results.items() if r.get('status') == 'PASS'])
+            return f"""
+        <section>
+            <h2>Primus Node Smoke</h2>
+            <p>All <code>{passing}</code> node(s) passed Primus node_smoke.</p>
+        </section>
+        """
+
+        html_out = f"""
+        <section>
+            <h2>Primus Node Smoke — Failures</h2>
+            <p class="error-summary">The following nodes failed Primus node_smoke checks:</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Node</th>
+                        <th>Status</th>
+                        <th>Fail Reasons</th>
+                    </tr>
+                </thead>
+                <tbody>
+        """
+
+        for node, result in sorted(failed_nodes.items()):
+            reasons = result.get('fail_reasons') or []
+            if not reasons and result.get('node_payload'):
+                reasons = list(result['node_payload'].get('fail_reasons') or [])
+            reasons_str = html.escape('; '.join(str(r) for r in reasons) if reasons else 'See node logs')
+            status = html.escape(str(result.get('status', 'FAIL')))
+            html_out += f"""
+                <tr>
+                    <td>{html.escape(node)}</td>
+                    <td>{status}</td>
+                    <td>{reasons_str}</td>
+                </tr>
+            """
+
+        html_out += """
+                </tbody>
+            </table>
+        """
+        if dump_path:
+            html_out += f"<p>Per-node JSON written under <code>{html.escape(str(dump_path))}/smoke/</code> on each node.</p>"
+        html_out += """
+        </section>
+        """
+        return html_out
 
     def _generate_ifoe_l2_html(self, ifoe_results):
         """Generate IFoE L2 connectivity section - failure details and a per-node breakdown."""

--- a/cvs/lib/preflight/unittests/test_node_smoke.py
+++ b/cvs/lib/preflight/unittests/test_node_smoke.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import unittest
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
 
@@ -10,6 +11,7 @@ from cvs.lib.preflight.node_smoke import (
     _JSON_BEGIN,
     _JSON_END,
     _resolve_dump_path,
+    NodeSmokeCheck,
     build_node_smoke_flags,
     build_remote_node_smoke_command,
     parse_node_smoke_output,
@@ -98,5 +100,42 @@ class TestParseNodeSmokeOutput(unittest.TestCase):
         self.assertEqual(parsed["status"], "FAIL")
 
 
+class TestNodeSmokeCheckRun(unittest.TestCase):
+    def _config(self):
+        return {
+            "node_smoke": {
+                "connectivity_mode": "run",
+                "auto_setup": False,
+                "primus_dir": "/home/testuser/Primus",
+                "venv_activate": "/home/testuser/envs/preflight/.venv/bin/activate",
+            }
+        }
+
+    def test_exec_cmd_list_aligns_with_reachable_hosts_subset(self):
+        """cmd_list[i] must match reachable_hosts[i]; non-target hosts get 'true'."""
+        phdl = MagicMock()
+        phdl.reachable_hosts = ["node0", "node1", "node2"]
+        phdl.exec_cmd_list.return_value = {
+            "node0": "wrote /tmp/smoke/a.json status=PASS\n",
+            "node1": "skipped",
+            "node2": "wrote /tmp/smoke/c.json status=PASS\n",
+        }
+
+        checker = NodeSmokeCheck(phdl, ["node0", "node2"], self._config())
+        results = checker.run()
+
+        cmd_list = phdl.exec_cmd_list.call_args[0][0]
+        self.assertEqual(len(cmd_list), len(phdl.reachable_hosts))
+        self.assertEqual(cmd_list[1], "true")
+        self.assertIn("primus-cli", cmd_list[0])
+        self.assertIn("primus-cli", cmd_list[2])
+        self.assertIn("export NODE_RANK=0", cmd_list[0])
+        self.assertIn("export NODE_RANK=1", cmd_list[2])
+        self.assertEqual(set(results["node_results"]), {"node0", "node2"})
+        self.assertEqual(results["node_results"]["node0"]["node_rank"], 0)
+        self.assertEqual(results["node_results"]["node2"]["node_rank"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/cvs/lib/preflight/unittests/test_node_smoke.py
+++ b/cvs/lib/preflight/unittests/test_node_smoke.py
@@ -1,0 +1,102 @@
+"""Unit tests for Primus node_smoke preflight integration."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+
+from cvs.lib.preflight.node_smoke import (
+    _JSON_BEGIN,
+    _JSON_END,
+    _resolve_dump_path,
+    build_node_smoke_flags,
+    build_remote_node_smoke_command,
+    parse_node_smoke_output,
+)
+
+
+class TestBuildNodeSmokeFlags(unittest.TestCase):
+    def test_default_flags_include_dump_path(self):
+        flags = build_node_smoke_flags(dump_path="/tmp/smoke")
+        self.assertIn("--dump-path /tmp/smoke", flags)
+
+    def test_empty_dump_path_uses_default(self):
+        flags = build_node_smoke_flags(dump_path="")
+        self.assertIn("--dump-path output/preflight", flags)
+
+    def test_resolve_dump_path_from_empty_config_value(self):
+        cfg = {
+            "reporting": {"artifacts_root_dir": "/tmp/{user-id}/preflight"},
+            "node_smoke": {"dump_path": ""},
+        }
+        self.assertEqual(_resolve_dump_path(cfg), "/tmp/{user-id}/preflight/node_smoke")
+
+    def test_rdma_and_host_limits(self):
+        flags = build_node_smoke_flags(
+            dump_path="/home/testuser/preflight",
+            expected_rdma_nics=8,
+            ulimit_l_min_gb=64,
+            shm_min_gb=16,
+            allow_foreign_procs=True,
+        )
+        self.assertIn("--expected-rdma-nics 8", flags)
+        self.assertIn("--ulimit-l-min-gb 64", flags)
+        self.assertIn("--shm-min-gb 16", flags)
+        self.assertIn("--allow-foreign-procs", flags)
+
+    def test_extra_args_forwarded(self):
+        flags = build_node_smoke_flags(
+            dump_path="/tmp/smoke",
+            extra_args=["--no-clean-dump-path", "--allow-foreign-procs"],
+        )
+        self.assertIn("--no-clean-dump-path", flags)
+        self.assertIn("--allow-foreign-procs", flags)
+
+
+class TestBuildRemoteCommand(unittest.TestCase):
+    def test_includes_distributed_env_and_json_markers(self):
+        cmd = build_remote_node_smoke_command(
+            primus_dir="/home/testuser/Primus",
+            venv_activate="/home/testuser/envs/preflight/.venv/bin/activate",
+            node_rank=1,
+            nnodes=4,
+            master_addr="node0",
+            master_port=1234,
+            gpus_per_node=8,
+            dump_path="/tmp/preflight/node_smoke",
+            smoke_flags="--dump-path /tmp/preflight/node_smoke",
+            nccl_ib_hca="rdma0,rdma1",
+            nccl_ib_gid_index=3,
+        )
+        self.assertIn("export NODE_RANK=1", cmd)
+        self.assertIn("export NNODES=4", cmd)
+        self.assertIn("export MASTER_ADDR=node0", cmd)
+        self.assertIn("/home/testuser/Primus/runner/primus-cli direct --single -- node_smoke", cmd)
+        self.assertIn(_JSON_BEGIN, cmd)
+        self.assertIn(_JSON_END, cmd)
+        self.assertIn("NCCL_IB_HCA=rdma0,rdma1", cmd)
+        self.assertIn("NCCL_IB_GID_INDEX=3", cmd)
+
+
+class TestParseNodeSmokeOutput(unittest.TestCase):
+    def test_parse_status_from_log_line(self):
+        output = "some log\nwrote /tmp/smoke/host.json status=PASS duration=12.3s\n"
+        parsed = parse_node_smoke_output(output)
+        self.assertEqual(parsed["status"], "PASS")
+
+    def test_parse_embedded_json(self):
+        payload = '{"host": "node0", "status": "FAIL", "fail_reasons": ["gpu_processes: pid=99"]}'
+        output = f"log line\n{_JSON_BEGIN}\n{payload}\n{_JSON_END}\n"
+        parsed = parse_node_smoke_output(output)
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertEqual(parsed["fail_reasons"], ["gpu_processes: pid=99"])
+        self.assertIsNotNone(parsed["node_payload"])
+
+    def test_empty_output_fails(self):
+        parsed = parse_node_smoke_output("")
+        self.assertEqual(parsed["status"], "FAIL")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/preflight/unittests/test_primus_setup.py
+++ b/cvs/lib/preflight/unittests/test_primus_setup.py
@@ -1,0 +1,135 @@
+"""Unit tests for Primus auto_setup preflight helper."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+
+from cvs.lib.preflight.primus_setup import (
+    build_primus_clone_or_update_command,
+    build_primus_venv_install_command,
+    build_wait_for_shared_primus_command,
+    parse_setup_output,
+    _venv_root_from_activate,
+)
+
+
+class TestPrimusSetupCommands(unittest.TestCase):
+    def test_clone_command_uses_branch_single_branch(self):
+        cmd = build_primus_clone_or_update_command(
+            primus_dir="/home/user/Primus",
+            git_url="https://github.com/AMD-AIG-AIMA/Primus.git",
+            git_branch="dev/preflight-direct-test",
+            recurse_submodules=False,
+        )
+        self.assertIn("--branch dev/preflight-direct-test", cmd)
+        self.assertIn("--single-branch", cmd)
+        self.assertNotIn("--recurse-submodules", cmd)
+        self.assertIn("git fetch origin", cmd)
+
+    def test_clone_with_submodules_when_enabled(self):
+        cmd = build_primus_clone_or_update_command(
+            primus_dir="/home/user/Primus",
+            git_url="https://github.com/AMD-AIG-AIMA/Primus.git",
+            git_branch="dev/preflight-direct-test",
+            recurse_submodules=True,
+        )
+        self.assertIn("--recurse-submodules", cmd)
+
+    def test_force_reclone_removes_existing(self):
+        cmd = build_primus_clone_or_update_command(
+            primus_dir="/home/user/Primus",
+            git_url="https://github.com/AMD-AIG-AIMA/Primus.git",
+            git_branch="dev/preflight-direct-test",
+            force_reclone=True,
+        )
+        self.assertIn("rm -rf", cmd)
+
+    def test_clone_removes_broken_partial_directory(self):
+        cmd = build_primus_clone_or_update_command(
+            primus_dir="/home/user/Primus",
+            git_url="https://github.com/AMD-AIG-AIMA/Primus.git",
+            git_branch="dev/preflight-direct-test",
+        )
+        self.assertIn("[ ! -d /home/user/Primus/.git ]", cmd)
+        self.assertIn("rm -rf /home/user/Primus", cmd)
+
+    def test_wait_for_shared_primus_polls(self):
+        cmd = build_wait_for_shared_primus_command(
+            primus_dir="/home/user/Primus",
+            venv_activate="/home/user/envs/preflight/.venv/bin/activate",
+            max_wait=60,
+        )
+        self.assertIn("runner/primus-cli", cmd)
+        self.assertIn("import torch", cmd)
+        self.assertIn("while [ $i -lt 12 ]", cmd)
+        self.assertIn("CVS_PRIMUS_SETUP_OK", cmd)
+        self.assertNotIn("bash -c", cmd)
+
+    def test_venv_minimal_installs_torch_not_editable(self):
+        activate = "/home/user/envs/preflight/.venv/bin/activate"
+        cmd = build_primus_venv_install_command(
+            primus_dir="/home/user/Primus",
+            venv_activate=activate,
+            pip_install_mode="minimal",
+        )
+        self.assertEqual(_venv_root_from_activate(activate), "/home/user/envs/preflight/.venv")
+        self.assertIn("python3 -m venv", cmd)
+        self.assertIn("pip install torch", cmd)
+        self.assertNotIn("pip install -e .", cmd)
+        self.assertIn("runner/primus-cli", cmd)
+        self.assertIn("import torch", cmd)
+
+    def test_pathspec_error_is_git_not_pip(self):
+        parsed = parse_setup_output("error: pathspec 'dev/preflight-direct-test' did not match any file(s) known to git\n")
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertIn("git", parsed["errors"][0])
+
+    def test_pip_error_not_classified_as_git_error(self):
+        parsed = parse_setup_output(
+            "Already on 'dev/preflight-direct-test'\n"
+            "ERROR: file:///home/user%40example.com/Primus does not appear to be a Python project\n"
+        )
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertIn("pip", parsed["errors"][0])
+
+
+class TestParseSetupOutput(unittest.TestCase):
+    def test_git_fatal_fails(self):
+        parsed = parse_setup_output("Cloning...\nfatal: repository not found\n")
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertIn("git", parsed["errors"][0])
+
+    def test_git_lock_config_suggests_shared_install(self):
+        parsed = parse_setup_output(
+            "error: could not lock config file /home/user/Primus/.git/config: No such file or directory\n"
+            "fatal: could not set 'core.repositoryformatversion' to '0'\n"
+        )
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertIn("shared_install", parsed["errors"][0])
+
+    def test_bash_lock_redirect_error_fails(self):
+        parsed = parse_setup_output(
+            "bash: line 1: /home/user/Primus/.cvs_primus_setup.lock: No such file or directory\n"
+        )
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertIn("shell error", parsed["errors"][0])
+
+    def test_clean_output_passes_with_marker(self):
+        parsed = parse_setup_output("Successfully installed torch\nCVS_PRIMUS_SETUP_OK\n")
+        self.assertEqual(parsed["status"], "PASS")
+
+    def test_output_without_marker_fails(self):
+        parsed = parse_setup_output("Successfully installed torch\n")
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertIn("did not report success", parsed["errors"][0])
+
+    def test_empty_output_fails(self):
+        parsed = parse_setup_output("")
+        self.assertEqual(parsed["status"], "FAIL")
+        self.assertIn("empty setup output", parsed["errors"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -896,6 +896,112 @@ class PreflightConnectivityCheckConfig(BaseModel):
     rdma: PreflightRdmaConfig = Field(default_factory=PreflightRdmaConfig, description="RDMA connectivity settings")
 
 
+class PreflightNodeSmokeConfig(BaseModel):
+    """Primus node_smoke settings (primus-cli direct -- node_smoke)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connectivity_mode: str = Field(
+        default="skip",
+        description="Primus node_smoke mode: 'run' (host/GPU/RDMA roll-call) or 'skip' (default)",
+    )
+    auto_setup: bool = Field(
+        default=True,
+        description="Clone/update Primus and prepare venv on each node before node_smoke",
+    )
+    setup_timeout: int = Field(default=600, ge=60, description="SSH timeout in seconds for Primus auto_setup")
+    force_reclone: bool = Field(
+        default=False,
+        description="Remove primus_dir and clone fresh on every run (destructive)",
+    )
+    shared_install: bool = Field(
+        default=True,
+        description=(
+            "When true (default), clone and venv setup run only on the first reachable node; "
+            "other nodes wait for the shared NFS home install. Set false only if each node has "
+            "a local primus_dir/venv_activate path."
+        ),
+    )
+    pip_install_mode: str = Field(
+        default="minimal",
+        description="Venv deps: minimal (torch only), requirements, or skip",
+    )
+    torch_pip_index_url: str = Field(
+        default="https://download.pytorch.org/whl/rocm6.2",
+        description="PyTorch ROCm wheel index URL for minimal pip_install_mode",
+    )
+    primus_git_url: str = Field(
+        default="https://github.com/AMD-AIG-AIMA/Primus.git",
+        description="Primus repository URL for auto_setup clone",
+    )
+    primus_git_branch: str = Field(
+        default="dev/preflight-direct-test",
+        description="Git branch to checkout during auto_setup",
+    )
+    primus_git_recurse_submodules: bool = Field(
+        default=False,
+        description="Clone git submodules during auto_setup (not required for node_smoke)",
+    )
+    primus_dir: str = Field(
+        default="/home/{user-id}/INSTALL/Primus",
+        description="Path to cloned Primus repo under the user's home directory (required when connectivity_mode is 'run')",
+    )
+    venv_activate: str = Field(
+        default="/home/{user-id}/envs/preflight/.venv/bin/activate",
+        description="Path to Python venv activate script on each node (required when connectivity_mode is 'run')",
+    )
+    gpus_per_node: int = Field(default=8, ge=1, description="GPUs per node for node_smoke")
+    master_port: int = Field(default=1234, ge=1024, le=65535, description="Distributed master port for node_smoke")
+    dump_path: str = Field(
+        default="",
+        description="Per-node dump directory for smoke JSON (default: <artifacts_root_dir>/node_smoke)",
+    )
+    expected_rdma_nics: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Hard-fail when training RDMA NIC count differs (default: len(node_check.rdma_interfaces))",
+    )
+    ulimit_l_min_gb: float = Field(default=32.0, ge=0, description="Minimum RLIMIT_MEMLOCK in GiB (0 disables)")
+    shm_min_gb: float = Field(default=8.0, ge=0, description="Minimum /dev/shm size in GiB (0 disables)")
+    skip_dmesg: bool = Field(default=False, description="Skip dmesg error scan (e.g. unprivileged containers)")
+    allow_foreign_procs: bool = Field(
+        default=False,
+        description="Do not FAIL nodes with foreign GPU processes (still reported)",
+    )
+    allowed_procs: str = Field(
+        default="gpuagent,rocm-smi-daemon,amd-smi,dcgm-exporter",
+        description="Comma-separated process names allowed to hold GPUs",
+    )
+    require_tools: str = Field(
+        default="",
+        description="Comma-separated CLI tools that must exist in PATH (empty = warn only)",
+    )
+    nccl_socket_ifname: str = Field(default="", description="NCCL_SOCKET_IFNAME override for node_smoke")
+    gloo_socket_ifname: str = Field(default="", description="GLOO_SOCKET_IFNAME override (defaults to nccl_socket_ifname)")
+    nccl_ib_hca: str = Field(default="", description="NCCL_IB_HCA override (defaults to node_check.rdma_interfaces)")
+    nccl_ib_gid_index: Optional[int] = Field(
+        default=None,
+        description="NCCL_IB_GID_INDEX override (defaults to node_check.gid_index)",
+    )
+    rdma_nic_allowlist: str = Field(
+        default="",
+        description="Training NIC allowlist for node_smoke (defaults to node_check.rdma_interfaces)",
+    )
+    ssh_timeout: int = Field(default=300, ge=30, description="SSH timeout in seconds for each node_smoke run")
+    extra_args: List[str] = Field(
+        default_factory=list,
+        description="Additional node_smoke CLI flags forwarded to primus-cli",
+    )
+
+    @field_validator("connectivity_mode")
+    @classmethod
+    def validate_node_smoke_mode(cls, v: str) -> str:
+        valid_modes = ["run", "skip"]
+        if v not in valid_modes:
+            raise ValueError(f"node_smoke.connectivity_mode must be one of: {', '.join(valid_modes)}")
+        return v
+
+
 class PreflightReportingConfig(BaseModel):
     """Report generation and output settings."""
 
@@ -935,6 +1041,9 @@ class PreflightConfigFile(BaseModel):
     )
     connectivity_check: PreflightConnectivityCheckConfig = Field(
         default_factory=PreflightConnectivityCheckConfig, description="Inter-node connectivity tests"
+    )
+    node_smoke: PreflightNodeSmokeConfig = Field(
+        default_factory=PreflightNodeSmokeConfig, description="Primus node_smoke checks"
     )
     reporting: PreflightReportingConfig = Field(
         default_factory=PreflightReportingConfig, description="Report generation and output settings"

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -13,6 +13,7 @@ from cvs.lib.preflight.gid_consistency import GidConsistencyCheck
 from cvs.lib.preflight.version_check import RocmVersionCheck
 from cvs.lib.preflight.interface_consistency import InterfaceConsistencyCheck
 from cvs.lib.preflight.ifoe_l2_connectivity import IfoeL2ConnectivityCheck
+from cvs.lib.preflight.node_smoke import NodeSmokeCheck
 
 # RdmaConnectivityCheck not used - using legacy function temporarily
 from cvs.lib.preflight.report import PreflightReportGenerator
@@ -455,6 +456,58 @@ def test_gid_consistency(phdl, config_dict):
     preflight_update_test_result()
 
 
+def test_node_smoke(phdl, config_dict):
+    """
+    Run Primus ``node_smoke`` checks on each reachable node via primus-cli.
+
+    Opt-in via ``node_smoke.connectivity_mode`` in the preflight config (default
+    ``skip``).  Uses parallel SSH — no Slurm required.
+
+    Nodes that fail are reported but are **not** pruned from ``phdl``.
+    """
+    global preflight_results
+
+    if not phdl.reachable_hosts:
+        log.warning("Primus node_smoke skipped: no reachable hosts remain after earlier preflight pruning")
+        preflight_results['node_smoke'] = {
+            'mode': 'skip',
+            'skipped': True,
+            'message': 'No reachable nodes available for Primus node_smoke',
+            'node_results': {},
+        }
+        preflight_update_test_result()
+        return
+
+    node_list = list(phdl.reachable_hosts)
+    log.info("Running Primus node_smoke on %d reachable host(s)", len(node_list))
+
+    checker = NodeSmokeCheck(phdl, node_list, config_dict)
+    results = checker.run()
+    preflight_results['node_smoke'] = results
+
+    if results.get('skipped'):
+        log.info("Primus node_smoke: %s", results.get('message', 'skipped'))
+        preflight_update_test_result()
+        return
+
+    failed_nodes = results.get('failed_nodes') or []
+    unknown_nodes = results.get('unknown_nodes') or []
+    total = results.get('total_nodes', 0)
+    passing = len(results.get('passing_nodes') or [])
+
+    if failed_nodes or unknown_nodes:
+        log.warning(
+            "Primus node_smoke FAIL on %d/%d node(s): %s",
+            len(failed_nodes) + len(unknown_nodes),
+            total,
+            ", ".join(failed_nodes + unknown_nodes),
+        )
+    else:
+        log.info("Primus node_smoke PASS on %d/%d nodes", passing, total)
+
+    preflight_update_test_result()
+
+
 def test_ifoe_l2_connectivity(phdl, config_dict):
     """
     Test IFoE L2 connectivity using ``afmctl test ping`` (AIMVT-180).
@@ -727,6 +780,7 @@ def test_generate_preflight_report(phdl, config_dict, request):
         'gid_consistency',
         'rocm_versions',
         'interface_names',
+        'node_smoke',
         'ifoe_l2_connectivity',
         'rdma_connectivity',
     ]


### PR DESCRIPTION
## Motivation

Integrate Primus node_smoke Tier 1 into CVS preflight checks so clusters can run per-node GPU, host, and RDMA health screening through the existing cvs run preflight_checks workflow 
Goals:

Add an opt-in test_node_smoke preflight step that launches primus-cli direct --single -- node_smoke on each reachable node via parallel SSH
Automate Primus clone/venv setup on cluster nodes (with NFS-safe shared install)
Surface node_smoke results in the preflight HTML report and summary alongside existing checks (reachability, ROCm, interfaces, GID, IFoE, RDMA)

## Technical Details

cvs/tests/preflight/preflight_checks.py — adds test_node_smoke wired into the preflight pytest suite; opt-in via node_smoke.connectivity_mode ("run" / "skip", default "skip"); failing nodes are reported but not pruned from phdl
cvs/lib/preflight/report.py — adds executive summary, recommendations, and HTML section for node_smoke failures (per-node fail reasons, dump path)
cvs/parsers/schemas.py — adds PreflightNodeSmokeConfig with validation for all node_smoke settings
cvs/input/config_file/preflight/preflight_config.json — adds full node_smoke config block with documented defaults

## Test Plan

Unit tests: python3 -m unittest cvs.lib.preflight.unittests.test_node_smoke cvs.lib.preflight.unittests.test_primus_setup (23 tests, all pass)

 Config validation: preflight_config.json parses and schema accepts PreflightNodeSmokeConfig

 Manual cluster run on 2-node test cluster

Verified auto-setup (clone, branch sync, shared NFS install, torch venv) on shared home

 Verified node_smoke PASS on both nodes after setting node_smoke.connectivity_mode: "run" and cluster-specific gid_index, expected_rocm_version, rdma_interfaces

 Verified preflight HTML report includes node_smoke summary section

 Full preflight suite run with default config (connectivity_mode: "skip") — node_smoke correctly reported as SKIPPED

## Test Result


Unit tests (test_node_smoke, test_primus_setup) | PASS — 23/23
test_node_smoke on 2-node cluster (with connectivity_mode: "run") | PASS — 2/2 nodes
Primus auto_setup (shared NFS install) | PASS
Preflight HTML report (node_smoke section) | PASS
Default config (connectivity_mode: "skip") | SKIPPED (expected)

Test reports are uploaded,

http://10.7.54.167/cvs/preflight_checks_html/

