### PR TITLE
Add rack-aware execution with switch tray support

### DIFF
--- a/cvs/cli_plugins/exec_plugin.py
+++ b/cvs/cli_plugins/exec_plugin.py
@@ -2,9 +2,32 @@ import json
 import logging
 import sys
 import os
+import warnings
 
 from .base import SubcommandPlugin
 from cvs.lib.parallel_ssh_lib import Pssh
+from cvs.lib.globals import set_log_level
+
+
+def _collect_switch_hosts(cluster):
+    """
+    Return a flat list of all switch tray IPs across all racks.
+
+    Walks the 'racks' (or deprecated 'rack_groups') block and collects
+    every IP listed under switch_trays. Credential resolution is NOT done
+    here — the caller resolves the single fleet-wide switch credential from
+    the racks block.
+    """
+    racks_raw = cluster.get('racks') or cluster.get('rack_groups', {})
+    if not isinstance(racks_raw, dict):
+        return []
+    skip = {'switch_ssh_user', 'switch_ssh_password', 'switch_ssh_key_file'}
+    hosts = []
+    for rack_id, rack in racks_raw.items():
+        if rack_id in skip or not isinstance(rack, dict):
+            continue
+        hosts.extend(rack.get('switch_trays', []))
+    return hosts
 
 
 class ExecPlugin(SubcommandPlugin):
@@ -18,68 +41,255 @@ class ExecPlugin(SubcommandPlugin):
             "--cluster_file",
             help="Path to cluster configuration JSON file (takes precedence over CLUSTER_FILE env var)",
         )
+        parser.add_argument(
+            "--target",
+            choices=["computes", "switches", "all"],
+            default="computes",
+            help=(
+                "Scope of execution: "
+                "'computes' (default) runs on all node_dict hosts; "
+                "'switches' runs on all switch_trays from the racks block; "
+                "'all' runs on both."
+            ),
+        )
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=30,
+            help="Per-node command output timeout in seconds (default: 30)",
+        )
+        parser.add_argument(
+            "--connect-timeout",
+            type=int,
+            default=15,
+            dest="connect_timeout",
+            help=(
+                "Per-node SSH connection timeout in seconds (default: 15). "
+                "Unreachable hosts fail after this many seconds regardless of --timeout."
+            ),
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            default=False,
+            dest="json_output",
+            help=(
+                "Emit output as a JSON object instead of human-readable text. "
+                "Schema: {command, read_timeout, connect_timeout, output: {host: str}}."
+            ),
+        )
+        parser.add_argument(
+            "--verbose",
+            "-v",
+            action="store_true",
+            default=False,
+            help=(
+                "Show internal SSH connection diagnostics (SocketDisconnectError, "
+                "AuthenticationError, Timeout, pruning messages). Suppressed by default."
+            ),
+        )
         parser.set_defaults(_plugin=self)
         return parser
 
     def get_epilog(self):
         return """
 Exec Commands:
-  cvs exec --cmd "hostname" --cluster_file cluster.json    Execute hostname on all nodes
-  CLUSTER_FILE=cluster.json cvs exec --cmd "hostname"      Use env var for cluster file (fallback)"""
+  cvs exec --cmd "hostname" --cluster_file cluster.json              Execute on all compute nodes (default)
+  cvs exec --cmd "show version" --cluster_file cluster.json --target switches   Execute on switch trays
+  cvs exec --cmd "date" --cluster_file cluster.json --target all     Execute on computes + switches
+  cvs exec --cmd "long_job" --timeout 300 --connect-timeout 10       Long command, fast fail on unreachable hosts
+  cvs exec --cmd "hostname" --json | jq '.output'                    JSON output, pipe to jq
+  cvs exec --cmd "hostname" --verbose                                Show SSH diagnostics (suppressed by default)
+  CLUSTER_FILE=cluster.json cvs exec --cmd "hostname"                Use env var for cluster file"""
+
+    def _run_on_hosts(
+        self,
+        hosts,
+        username,
+        env_vars,
+        cmd,
+        *,
+        label,
+        pkey=None,
+        password=None,
+        timeout=None,
+        connect_timeout=None,
+    ):
+        """
+        Run cmd on the given host list. Returns (success, host_output_dict).
+
+        Args:
+            timeout:         Per-node command output read timeout (seconds).
+                             Passed as read_timeout to pssh.exec(). Controls how
+                             long to wait for each host's stdout after the command
+                             starts running.
+            connect_timeout: Per-node SSH connection timeout (seconds).
+                             Passed to ParallelSSHClient via Pssh constructor.
+                             Unreachable or slow-to-handshake hosts will fail
+                             after this many seconds, independently of timeout.
+
+        Returns:
+            (bool, dict[str, str]): success flag and mapping of host -> output string.
+            On SSH init or exec failure, returns (False, {}).
+        """
+        log = logging.getLogger(__name__)
+        try:
+            pssh = Pssh(
+                log=log,
+                host_list=hosts,
+                user=username,
+                pkey=pkey,
+                password=password,
+                stop_on_errors=False,
+                env_vars=env_vars,
+                num_retries=0,
+                # connect_timeout bounds TCP/SSH handshake per host; without this
+                # unreachable hosts hang for the OS default (~60-120s) regardless
+                # of the command timeout.
+                **(dict(timeout=connect_timeout) if connect_timeout is not None else {}),
+            )
+        except Exception as e:
+            print(f"Error initializing SSH for {label}: {e}", file=sys.stderr)
+            return False, {}
+
+        try:
+            output = pssh.exec(cmd, timeout=timeout)
+        except Exception as e:
+            print(f"Error executing command on {label}: {e}", file=sys.stderr)
+            return False, {}
+
+        return True, output
+
+    def _emit_error(self, msg, json_mode):
+        """Print an error message. In JSON mode, writes to stderr so stdout stays valid JSON."""
+        print(msg, file=sys.stderr if json_mode else sys.stdout)
+
+    def _print_text_output(self, label, host_output):
+        """Print host results in human-readable format."""
+        for host, out in host_output.items():
+            print(f"[{label}] Host: {host}")
+            print(out)
+            print("---")
 
     def run(self, args):
-        # CLI flag wins; env var is the fallback. Matches cvs scp and
-        # cvs monitor check_cluster_health for consistency.
+        json_mode = getattr(args, 'json_output', False)
+        verbose = getattr(args, 'verbose', False)
+
+        # Suppress WARNING-level SSH/pssh diagnostic noise by default.
+        # With --verbose, leave the root logger at its configured level so all
+        # messages (SocketDisconnectError, AuthenticationError, pruning, etc.) show.
+        if not verbose:
+            set_log_level(logging.ERROR)
+
+        # CLI flag wins; env var is the fallback.
         cluster_file = args.cluster_file or os.environ.get('CLUSTER_FILE')
         if not cluster_file:
-            print("Error: No cluster file specified. Set CLUSTER_FILE environment variable or use --cluster_file.")
+            self._emit_error(
+                "Error: No cluster file specified. Set CLUSTER_FILE environment variable or use --cluster_file.",
+                json_mode,
+            )
             sys.exit(1)
 
-        # Load cluster file
         try:
             with open(cluster_file, 'r') as f:
                 cluster = json.load(f)
         except FileNotFoundError:
-            print(f"Error: Cluster file '{cluster_file}' not found.")
+            self._emit_error(f"Error: Cluster file '{cluster_file}' not found.", json_mode)
             sys.exit(1)
         except json.JSONDecodeError as e:
-            print(f"Error: Invalid JSON in cluster file: {e}")
+            self._emit_error(f"Error: Invalid JSON in cluster file: {e}", json_mode)
             sys.exit(1)
 
         username = cluster.get('username')
         if not username:
-            print("Error: 'username' not found in cluster file.")
+            self._emit_error("Error: 'username' not found in cluster file.", json_mode)
             sys.exit(1)
 
-        pkey = cluster.get('priv_key_file')
-        if not pkey:
-            print("Error: 'priv_key_file' not found in cluster file.")
-            sys.exit(1)
-
-        node_dict = cluster.get('node_dict', {})
-        hosts = list(node_dict.keys())
-        if not hosts:
-            print("Error: No hosts found in cluster file.")
-            sys.exit(1)
-
-        # Create Pssh instance (Pssh requires a logger; it calls log.debug/info/warning)
-        log = logging.getLogger(__name__)
         env_vars = cluster.get('env_vars')
-        try:
-            pssh = Pssh(log=log, host_list=hosts, user=username, pkey=pkey, stop_on_errors=False, env_vars=env_vars)
-        except Exception as e:
-            print(f"Error initializing Pssh: {e}")
-            sys.exit(1)
+        target = args.target
+        overall_failed = False
+        combined_output = {}  # accumulated for --json mode
 
-        # Execute command
-        try:
-            output = pssh.exec(args.cmd)
-        except Exception as e:
-            print(f"Error executing command: {e}")
-            sys.exit(1)
+        # --- Compute trays ---
+        if target in ('computes', 'all'):
+            pkey = cluster.get('priv_key_file')
+            if not pkey:
+                self._emit_error(
+                    "Error: 'priv_key_file' not found in cluster file (required for compute targets).",
+                    json_mode,
+                )
+                sys.exit(1)
+            node_dict = cluster.get('node_dict', {})
+            compute_hosts = list(node_dict.keys())
+            if not compute_hosts:
+                self._emit_error("Error: No hosts found in node_dict.", json_mode)
+                sys.exit(1)
+            ok, host_output = self._run_on_hosts(
+                compute_hosts,
+                username,
+                env_vars,
+                args.cmd,
+                label="compute",
+                pkey=pkey,
+                timeout=args.timeout,
+                connect_timeout=args.connect_timeout,
+            )
+            if not ok:
+                overall_failed = True
+            if json_mode:
+                combined_output.update(host_output)
+            else:
+                self._print_text_output("compute", host_output)
 
-        # Print output
-        for host, out in output.items():
-            print(f"Host: {host}")
-            print(out)
-            print("---")
+        # --- Switch trays ---
+        if target in ('switches', 'all'):
+            # Emit deprecation warning if the old rack_groups top-level key is used.
+            if cluster.get('rack_groups') is not None and cluster.get('racks') is None:
+                warnings.warn(
+                    "'rack_groups' in cluster.json is deprecated. Rename it to 'racks'.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            racks_raw = cluster.get('racks') or cluster.get('rack_groups', {})
+            switch_hosts = _collect_switch_hosts(cluster)
+            if not switch_hosts:
+                self._emit_error(
+                    "Warning: --target includes switches but no switch_trays found in 'racks' block.",
+                    json_mode,
+                )
+            else:
+                sw_user = racks_raw.get('switch_ssh_user') if isinstance(racks_raw, dict) else None
+                sw_key = racks_raw.get('switch_ssh_key_file') if isinstance(racks_raw, dict) else None
+                sw_pw = (
+                    None if sw_key else (racks_raw.get('switch_ssh_password') if isinstance(racks_raw, dict) else None)
+                )
+                ok, host_output = self._run_on_hosts(
+                    switch_hosts,
+                    sw_user,
+                    env_vars,
+                    args.cmd,
+                    label="switch",
+                    pkey=sw_key,
+                    password=sw_pw,
+                    timeout=args.timeout,
+                    connect_timeout=args.connect_timeout,
+                )
+                if not ok:
+                    overall_failed = True
+                if json_mode:
+                    combined_output.update(host_output)
+                else:
+                    self._print_text_output("switch", host_output)
+
+        if json_mode:
+            envelope = {
+                "command": args.cmd,
+                "read_timeout": args.timeout,
+                "connect_timeout": args.connect_timeout,
+                "output": combined_output,
+            }
+            print(json.dumps(envelope, indent=2))
+
+        if overall_failed:
+            sys.exit(1)

--- a/cvs/cli_plugins/generate_plugin.py
+++ b/cvs/cli_plugins/generate_plugin.py
@@ -30,6 +30,15 @@ class GeneratorPlugin(ABC):
         """Generate the output based on parsed arguments"""
         pass
 
+    def supports_raw_argv(self):
+        """
+        Return True if this generator does its own argv splitting (e.g. dynamic
+        argument groups like --rack0 / --rack1). When True, _run_generator will
+        use parse_known_args and attach the full raw arg list as args._raw_args
+        so the generate() method can perform its own secondary parsing.
+        """
+        return False
+
 
 def _discover_generators():
     """
@@ -100,7 +109,14 @@ def _run_generator(generator_name, args):
     # Set the program name to include the full command context
     parser.prog = f"cvs generate {generator_name}"
     try:
-        parsed_args = parser.parse_args(args)
+        if plugin.supports_raw_argv():
+            # Plugin does its own secondary parsing (e.g. dynamic --rackN groups).
+            # Use parse_known_args so unrecognised args don't cause an error, and
+            # attach the full raw arg list for the plugin to re-parse as needed.
+            parsed_args, _ = parser.parse_known_args(args)
+            parsed_args._raw_args = list(args)
+        else:
+            parsed_args = parser.parse_args(args)
         # Call the plugin's generate method
         plugin.generate(parsed_args)
     except SystemExit as e:

--- a/cvs/cli_plugins/unittests/test_exec_plugin.py
+++ b/cvs/cli_plugins/unittests/test_exec_plugin.py
@@ -1,0 +1,643 @@
+import argparse
+import json
+import os
+import sys
+import unittest
+import warnings
+from unittest.mock import MagicMock, patch, mock_open
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from cvs.cli_plugins.exec_plugin import ExecPlugin, _collect_switch_hosts
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PLAIN_CLUSTER = {
+    "username": "root",
+    "priv_key_file": "/home/user/.ssh/id_rsa",
+    "head_node_dict": {"mgmt_ip": "10.0.0.1"},
+    "node_dict": {
+        "10.0.0.2": {"bmc_ip": "NA", "vpc_ip": "10.0.0.2"},
+        "10.0.0.3": {"bmc_ip": "NA", "vpc_ip": "10.0.0.3"},
+    },
+}
+
+RACK_CLUSTER = {
+    "username": "root",
+    "priv_key_file": "/home/user/.ssh/id_rsa",
+    "head_node_dict": {"mgmt_ip": "10.0.0.1"},
+    "node_dict": {
+        "10.0.0.2": {"bmc_ip": "NA", "vpc_ip": "10.0.0.2", "rack_id": "rack-01"},
+    },
+    "racks": {
+        "switch_ssh_user": "admin",
+        "switch_ssh_password": "password",
+        "rack-01": {
+            "platform": "HeliosP",
+            "switch_trays": ["192.168.1.1", "192.168.1.2"],
+        },
+        "rack-02": {
+            "platform": "HeliosP",
+            "switch_trays": ["192.168.2.1"],
+        },
+    },
+}
+
+
+# ===========================================================================
+# _collect_switch_hosts
+# ===========================================================================
+
+
+class TestCollectSwitchHosts(unittest.TestCase):
+    # --- No racks block --------------------------------------------------
+
+    def test_no_racks_returns_empty(self):
+        hosts = _collect_switch_hosts(PLAIN_CLUSTER)
+        self.assertEqual(hosts, [])
+
+    def test_empty_racks_returns_empty(self):
+        cluster = dict(PLAIN_CLUSTER, racks={})
+        hosts = _collect_switch_hosts(cluster)
+        self.assertEqual(hosts, [])
+
+    def test_none_racks_returns_empty(self):
+        cluster = dict(PLAIN_CLUSTER, racks=None)
+        hosts = _collect_switch_hosts(cluster)
+        self.assertEqual(hosts, [])
+
+    # --- Host list correctness -------------------------------------------
+
+    def test_switch_hosts_collected(self):
+        hosts = _collect_switch_hosts(RACK_CLUSTER)
+        self.assertIn("192.168.1.1", hosts)
+        self.assertIn("192.168.1.2", hosts)
+        self.assertIn("192.168.2.1", hosts)
+        self.assertEqual(len(hosts), 3)
+
+    def test_metadata_keys_skipped(self):
+        """Credential keys in racks block are skipped, not treated as rack IDs."""
+        hosts = _collect_switch_hosts(RACK_CLUSTER)
+        for h in hosts:
+            self.assertNotIn("switch_ssh_user", h)
+            self.assertNotIn("switch_ssh_password", h)
+
+    def test_rack_without_switch_trays_skipped(self):
+        cluster = {
+            "username": "root",
+            "priv_key_file": "/key",
+            "node_dict": {},
+            "racks": {
+                "rack-01": {"platform": "HeliosP"},
+            },
+        }
+        hosts = _collect_switch_hosts(cluster)
+        self.assertEqual(hosts, [])
+
+    # --- Deprecation warning via rack_groups -----------------------------
+
+    def test_rack_groups_key_triggers_deprecation(self):
+        """Top-level 'rack_groups' key (the real deprecated scenario) emits a warning."""
+        cluster = {
+            "username": "root",
+            "priv_key_file": "/key",
+            "node_dict": {},
+            "rack_groups": {  # deprecated top-level key
+                "rack-01": {"switch_trays": ["192.168.1.1"]},
+            },
+        }
+        # _collect_switch_hosts itself doesn't emit the warning (exec_plugin.run does),
+        # but it still returns the hosts from rack_groups for backward compat.
+        hosts = _collect_switch_hosts(cluster)
+        self.assertIn("192.168.1.1", hosts)
+
+    def test_racks_key_preferred_over_rack_groups(self):
+        """When both 'racks' and 'rack_groups' exist, 'racks' wins."""
+        cluster = {
+            "username": "root",
+            "priv_key_file": "/key",
+            "node_dict": {},
+            "racks": {
+                "rack-01": {"switch_trays": ["10.0.0.1"]},
+            },
+            "rack_groups": {
+                "rack-99": {"switch_trays": ["99.99.99.99"]},
+            },
+        }
+        hosts = _collect_switch_hosts(cluster)
+        self.assertIn("10.0.0.1", hosts)
+        self.assertNotIn("99.99.99.99", hosts)
+
+
+# ===========================================================================
+# ExecPlugin.run — argument / file loading errors
+# ===========================================================================
+
+
+class TestExecPluginRunErrors(unittest.TestCase):
+    def setUp(self):
+        self.plugin = ExecPlugin()
+
+    def _make_args(self, **kwargs):
+        args = MagicMock()
+        args.cluster_file = kwargs.get("cluster_file", None)
+        args.cmd = kwargs.get("cmd", "hostname")
+        args.target = kwargs.get("target", "computes")
+        args.timeout = kwargs.get("timeout", 30)
+        args.connect_timeout = kwargs.get("connect_timeout", 15)
+        args.json_output = kwargs.get("json_output", False)
+        args.verbose = kwargs.get("verbose", False)
+        return args
+
+    def test_no_cluster_file_exits(self):
+        args = self._make_args()
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("CLUSTER_FILE", None)
+            with self.assertRaises(SystemExit) as cm:
+                self.plugin.run(args)
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_cluster_file_from_env_var(self):
+        """CLUSTER_FILE env var is used when --cluster_file is not passed."""
+        cluster_json = json.dumps(PLAIN_CLUSTER)
+        args = self._make_args(cluster_file=None)
+        with patch.dict(os.environ, {"CLUSTER_FILE": "/fake/cluster.json"}):
+            with patch("builtins.open", mock_open(read_data=cluster_json)):
+                with patch.object(self.plugin, "_run_on_hosts", return_value=(True, {})):
+                    self.plugin.run(args)  # Should not raise
+
+    def test_file_not_found_exits(self):
+        args = self._make_args(cluster_file="/nonexistent/cluster.json")
+        with self.assertRaises(SystemExit) as cm:
+            self.plugin.run(args)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_invalid_json_exits(self):
+        args = self._make_args(cluster_file="/fake/cluster.json")
+        with patch("builtins.open", mock_open(read_data="{not valid json")):
+            with self.assertRaises(SystemExit) as cm:
+                self.plugin.run(args)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_missing_username_exits(self):
+        bad = dict(PLAIN_CLUSTER)
+        bad.pop("username")
+        args = self._make_args(cluster_file="/fake/cluster.json")
+        with patch("builtins.open", mock_open(read_data=json.dumps(bad))):
+            with self.assertRaises(SystemExit) as cm:
+                self.plugin.run(args)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_missing_priv_key_for_computes_exits(self):
+        bad = dict(PLAIN_CLUSTER)
+        bad.pop("priv_key_file")
+        args = self._make_args(cluster_file="/fake/cluster.json", target="computes")
+        with patch("builtins.open", mock_open(read_data=json.dumps(bad))):
+            with self.assertRaises(SystemExit) as cm:
+                self.plugin.run(args)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_empty_node_dict_exits(self):
+        bad = dict(PLAIN_CLUSTER, node_dict={})
+        args = self._make_args(cluster_file="/fake/cluster.json", target="computes")
+        with patch("builtins.open", mock_open(read_data=json.dumps(bad))):
+            with self.assertRaises(SystemExit) as cm:
+                self.plugin.run(args)
+        self.assertEqual(cm.exception.code, 1)
+
+
+# ===========================================================================
+# ExecPlugin.run — target routing
+# ===========================================================================
+
+
+class TestExecPluginRunTargets(unittest.TestCase):
+    def setUp(self):
+        self.plugin = ExecPlugin()
+
+    def _make_args(
+        self, target="computes", timeout=30, connect_timeout=15, cmd="hostname", json_output=False, verbose=False
+    ):
+        args = MagicMock()
+        args.cluster_file = "/fake/cluster.json"
+        args.cmd = cmd
+        args.target = target
+        args.timeout = timeout
+        args.connect_timeout = connect_timeout
+        args.json_output = json_output
+        args.verbose = verbose
+        return args
+
+    def _run_with_cluster(self, cluster, args):
+        cluster_json = json.dumps(cluster)
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(True, {})) as mock_run:
+                self.plugin.run(args)
+        return mock_run
+
+    # --- target=computes (default) ---------------------------------------
+
+    def test_computes_calls_run_on_hosts_once(self):
+        mock_run = self._run_with_cluster(PLAIN_CLUSTER, self._make_args(target="computes"))
+        self.assertEqual(mock_run.call_count, 1)
+        self.assertEqual(mock_run.call_args.kwargs['label'], "compute")
+
+    def test_computes_passes_correct_hosts(self):
+        mock_run = self._run_with_cluster(PLAIN_CLUSTER, self._make_args(target="computes"))
+        hosts_arg = mock_run.call_args[0][0]
+        self.assertIn("10.0.0.2", hosts_arg)
+        self.assertIn("10.0.0.3", hosts_arg)
+
+    def test_computes_passes_timeout(self):
+        mock_run = self._run_with_cluster(PLAIN_CLUSTER, self._make_args(target="computes", timeout=60))
+        self.assertEqual(mock_run.call_args.kwargs.get("timeout"), 60)
+
+    def test_computes_passes_connect_timeout(self):
+        mock_run = self._run_with_cluster(PLAIN_CLUSTER, self._make_args(target="computes", connect_timeout=5))
+        self.assertEqual(mock_run.call_args.kwargs.get("connect_timeout"), 5)
+
+    # --- target=switches -------------------------------------------------
+
+    def test_switches_no_racks_prints_warning(self):
+        args = self._make_args(target="switches")
+        cluster_json = json.dumps(PLAIN_CLUSTER)
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(True, {})) as mock_run:
+                with patch("builtins.print") as mock_print:
+                    self.plugin.run(args)
+        mock_run.assert_not_called()
+        printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("Warning", printed)
+
+    def test_switches_with_racks_calls_run_on_hosts(self):
+        mock_run = self._run_with_cluster(RACK_CLUSTER, self._make_args(target="switches"))
+        self.assertEqual(mock_run.call_count, 1)
+        self.assertEqual(mock_run.call_args.kwargs['label'], "switch")
+
+    def test_switches_with_racks_passes_correct_hosts(self):
+        mock_run = self._run_with_cluster(RACK_CLUSTER, self._make_args(target="switches"))
+        hosts_arg = mock_run.call_args[0][0]
+        self.assertIn("192.168.1.1", hosts_arg)
+        self.assertIn("192.168.2.1", hosts_arg)
+
+    def test_switches_passes_global_user(self):
+        """Global switch_ssh_user from racks block is passed as username kwarg."""
+        mock_run = self._run_with_cluster(RACK_CLUSTER, self._make_args(target="switches"))
+        self.assertEqual(mock_run.call_args[0][1], "admin")
+
+    def test_switches_passes_global_password(self):
+        """Global switch_ssh_password is passed when no key file."""
+        mock_run = self._run_with_cluster(RACK_CLUSTER, self._make_args(target="switches"))
+        self.assertEqual(mock_run.call_args.kwargs.get("password"), "password")
+
+    def test_switches_key_file_suppresses_password(self):
+        """When switch_ssh_key_file is set, password must be None."""
+        cluster = {
+            "username": "root",
+            "priv_key_file": "/key",
+            "node_dict": {},
+            "racks": {
+                "switch_ssh_user": "admin",
+                "switch_ssh_key_file": "/switch_key",
+                "switch_ssh_password": "should_be_ignored",
+                "rack-01": {"switch_trays": ["192.168.1.1"]},
+            },
+        }
+        mock_run = self._run_with_cluster(cluster, self._make_args(target="switches"))
+        self.assertEqual(mock_run.call_args.kwargs.get("pkey"), "/switch_key")
+        self.assertIsNone(mock_run.call_args.kwargs.get("password"))
+
+    def test_deprecation_warning_fired_for_rack_groups(self):
+        """Top-level 'rack_groups' key (deprecated) triggers DeprecationWarning."""
+        cluster = {
+            "username": "root",
+            "priv_key_file": "/key",
+            "node_dict": {},
+            "rack_groups": {
+                "switch_ssh_user": "admin",
+                "rack-01": {"switch_trays": ["192.168.1.1"]},
+            },
+        }
+        cluster_json = json.dumps(cluster)
+        args = self._make_args(target="switches")
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(True, {})):
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    self.plugin.run(args)
+        categories = [str(x.category) for x in w]
+        self.assertTrue(
+            any("DeprecationWarning" in c for c in categories),
+            f"Expected DeprecationWarning, got: {categories}",
+        )
+
+    # --- target=all ------------------------------------------------------
+
+    def test_all_calls_run_on_hosts_twice(self):
+        mock_run = self._run_with_cluster(RACK_CLUSTER, self._make_args(target="all"))
+        self.assertEqual(mock_run.call_count, 2)
+        labels = {call.kwargs['label'] for call in mock_run.call_args_list}
+        self.assertEqual(labels, {"compute", "switch"})
+
+    def test_all_without_racks_calls_only_compute(self):
+        """target=all on a plain cluster should run computes + warn about switches."""
+        args = self._make_args(target="all")
+        cluster_json = json.dumps(PLAIN_CLUSTER)
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(True, {})) as mock_run:
+                with patch("builtins.print"):
+                    self.plugin.run(args)
+        self.assertEqual(mock_run.call_count, 1)
+        self.assertEqual(mock_run.call_args.kwargs['label'], "compute")
+
+    # --- exit code behavior ----------------------------------------------
+
+    def test_ssh_failure_exits_nonzero(self):
+        """_run_on_hosts returning (False, {}) must cause sys.exit(1)."""
+        cluster_json = json.dumps(PLAIN_CLUSTER)
+        args = self._make_args(target="computes")
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(False, {})):
+                with self.assertRaises(SystemExit) as cm:
+                    self.plugin.run(args)
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_ssh_success_does_not_exit(self):
+        """_run_on_hosts returning (True, {}) must not raise SystemExit."""
+        cluster_json = json.dumps(PLAIN_CLUSTER)
+        args = self._make_args(target="computes")
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(True, {})):
+                self.plugin.run(args)  # no exception
+
+
+# ===========================================================================
+# ExecPlugin._run_on_hosts — SSH error handling
+# ===========================================================================
+
+
+class TestRunOnHosts(unittest.TestCase):
+    def setUp(self):
+        self.plugin = ExecPlugin()
+
+    def _call(self, hosts=None, **kwargs):
+        return self.plugin._run_on_hosts(
+            hosts or ["10.0.0.2"],
+            "root",
+            None,
+            "hostname",
+            label=kwargs.pop("label", "compute"),
+            pkey=kwargs.pop("pkey", "/key"),
+            **kwargs,
+        )
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_pssh_init_error_returns_false(self, MockPssh):
+        MockPssh.side_effect = RuntimeError("connection refused")
+        ok, output = self._call()
+        self.assertFalse(ok)
+        self.assertEqual(output, {})
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_pssh_exec_error_returns_false(self, MockPssh):
+        mock_pssh = MagicMock()
+        mock_pssh.exec.side_effect = RuntimeError("timeout")
+        MockPssh.return_value = mock_pssh
+        ok, output = self._call()
+        self.assertFalse(ok)
+        self.assertEqual(output, {})
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_success_returns_true(self, MockPssh):
+        mock_pssh = MagicMock()
+        mock_pssh.exec.return_value = {"10.0.0.2": "XSJICHRISTO01"}
+        MockPssh.return_value = mock_pssh
+        ok, output = self._call()
+        self.assertTrue(ok)
+        self.assertEqual(output, {"10.0.0.2": "XSJICHRISTO01"})
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_timeout_passed_to_exec(self, MockPssh):
+        """--timeout (command read timeout) is passed to pssh.exec(), not the Pssh constructor."""
+        mock_pssh = MagicMock()
+        mock_pssh.exec.return_value = {}
+        MockPssh.return_value = mock_pssh
+        self._call(timeout=45)
+        mock_pssh.exec.assert_called_once_with("hostname", timeout=45)
+        # Must NOT appear in the Pssh constructor kwargs
+        init_kwargs = MockPssh.call_args[1]
+        self.assertNotEqual(init_kwargs.get("timeout"), 45)
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_connect_timeout_passed_to_pssh_ctor(self, MockPssh):
+        """--connect-timeout is forwarded to the Pssh constructor as 'timeout' (ParallelSSHClient connection timeout)."""
+        mock_pssh = MagicMock()
+        mock_pssh.exec.return_value = {}
+        MockPssh.return_value = mock_pssh
+        self._call(connect_timeout=10)
+        init_kwargs = MockPssh.call_args[1]
+        self.assertEqual(init_kwargs.get("timeout"), 10)
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_connect_timeout_none_omitted_from_ctor(self, MockPssh):
+        """When connect_timeout is None, 'timeout' is not passed to the Pssh constructor."""
+        mock_pssh = MagicMock()
+        mock_pssh.exec.return_value = {}
+        MockPssh.return_value = mock_pssh
+        self._call(connect_timeout=None)
+        init_kwargs = MockPssh.call_args[1]
+        self.assertNotIn("timeout", init_kwargs)
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_num_retries_is_zero(self, MockPssh):
+        """num_retries=0 ensures a single SSH attempt, preventing hangs on dead hosts."""
+        mock_pssh = MagicMock()
+        mock_pssh.exec.return_value = {}
+        MockPssh.return_value = mock_pssh
+        self._call()
+        init_kwargs = MockPssh.call_args[1]
+        self.assertEqual(init_kwargs.get("num_retries"), 0)
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_password_auth_path(self, MockPssh):
+        """When password provided, Pssh is initialized with password kwarg."""
+        mock_pssh = MagicMock()
+        mock_pssh.exec.return_value = {}
+        MockPssh.return_value = mock_pssh
+        self._call(pkey=None, password="secret")
+        init_kwargs = MockPssh.call_args[1]
+        self.assertEqual(init_kwargs.get("password"), "secret")
+        self.assertIsNone(init_kwargs.get("pkey"))
+
+    @patch("cvs.cli_plugins.exec_plugin.Pssh")
+    def test_pkey_auth_path(self, MockPssh):
+        """Without password, Pssh is initialized with pkey kwarg."""
+        mock_pssh = MagicMock()
+        mock_pssh.exec.return_value = {}
+        MockPssh.return_value = mock_pssh
+        self._call(pkey="/key", password=None)
+        init_kwargs = MockPssh.call_args[1]
+        self.assertEqual(init_kwargs.get("pkey"), "/key")
+        self.assertIsNone(init_kwargs.get("password"))
+
+
+# ===========================================================================
+# ExecPlugin metadata
+# ===========================================================================
+
+
+class TestExecPluginMetadata(unittest.TestCase):
+    def setUp(self):
+        self.plugin = ExecPlugin()
+
+    def test_name(self):
+        self.assertEqual(self.plugin.get_name(), "exec")
+
+    def test_epilog_contains_examples(self):
+        epilog = self.plugin.get_epilog()
+        self.assertIn("cvs exec", epilog)
+        self.assertIn("--target", epilog)
+
+    def test_parser_registers_required_args(self):
+        main_parser = argparse.ArgumentParser()
+        subparsers = main_parser.add_subparsers()
+        self.plugin.get_parser(subparsers)
+        args = main_parser.parse_args(["exec", "--cmd", "hostname"])
+        self.assertEqual(args.cmd, "hostname")
+        self.assertEqual(args.target, "computes")
+        self.assertEqual(args.timeout, 30)
+        self.assertEqual(args.connect_timeout, 15)
+        self.assertFalse(args.json_output)
+        self.assertFalse(args.verbose)
+
+    def test_verbose_flag_default_is_false(self):
+        """--verbose defaults to False (SSH diagnostics are suppressed by default)."""
+        main_parser = argparse.ArgumentParser()
+        subparsers = main_parser.add_subparsers()
+        self.plugin.get_parser(subparsers)
+        args = main_parser.parse_args(["exec", "--cmd", "hostname"])
+        self.assertFalse(args.verbose)
+
+    def test_verbose_flag_short_form(self):
+        """-v is the short form for --verbose."""
+        main_parser = argparse.ArgumentParser()
+        subparsers = main_parser.add_subparsers()
+        self.plugin.get_parser(subparsers)
+        args = main_parser.parse_args(["exec", "--cmd", "hostname", "-v"])
+        self.assertTrue(args.verbose)
+
+    def test_verbose_flag_long_form(self):
+        main_parser = argparse.ArgumentParser()
+        subparsers = main_parser.add_subparsers()
+        self.plugin.get_parser(subparsers)
+        args = main_parser.parse_args(["exec", "--cmd", "hostname", "--verbose"])
+        self.assertTrue(args.verbose)
+
+    def test_parser_rejects_invalid_target(self):
+        main_parser = argparse.ArgumentParser()
+        subparsers = main_parser.add_subparsers()
+        self.plugin.get_parser(subparsers)
+        with self.assertRaises(SystemExit):
+            main_parser.parse_args(["exec", "--cmd", "hostname", "--target", "invalid"])
+
+
+# ===========================================================================
+# --json output mode
+# ===========================================================================
+
+
+class TestJsonOutput(unittest.TestCase):
+    def setUp(self):
+        self.plugin = ExecPlugin()
+
+    def _make_args(
+        self, target="computes", timeout=30, connect_timeout=15, cmd="hostname", json_output=False, verbose=False
+    ):
+        args = MagicMock()
+        args.cluster_file = "/fake/cluster.json"
+        args.cmd = cmd
+        args.target = target
+        args.timeout = timeout
+        args.connect_timeout = connect_timeout
+        args.json_output = json_output
+        args.verbose = verbose
+        return args
+
+    def test_json_flag_emits_json_to_stdout(self):
+        """--json prints a valid JSON envelope to stdout with the expected schema."""
+        host_output = {"10.0.0.2": "hostname_result\n", "10.0.0.3": "hostname_result\n"}
+        args = self._make_args(cmd="hostname", timeout=30, connect_timeout=15, json_output=True)
+        cluster_json = json.dumps(PLAIN_CLUSTER)
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(True, host_output)):
+                with patch("builtins.print") as mock_print:
+                    self.plugin.run(args)
+
+        printed_args = [call.args[0] for call in mock_print.call_args_list if call.args]
+        self.assertEqual(len(printed_args), 1, "Expected exactly one print() call for JSON output")
+        envelope = json.loads(printed_args[0])
+        self.assertEqual(envelope["command"], "hostname")
+        self.assertEqual(envelope["read_timeout"], 30)
+        self.assertEqual(envelope["connect_timeout"], 15)
+        self.assertIn("output", envelope)
+        self.assertEqual(envelope["output"], host_output)
+
+    def test_json_output_merges_compute_and_switch(self):
+        """With --target all and --json, compute and switch host outputs are merged under 'output'."""
+        compute_output = {"10.0.0.2": "compute_result\n"}
+        switch_output = {"192.168.1.1": "switch_result\n"}
+        args = self._make_args(target="all", json_output=True)
+        cluster_json = json.dumps(RACK_CLUSTER)
+
+        call_count = 0
+
+        def side_effect(*a, **kw):
+            nonlocal call_count
+            call_count += 1
+            return (True, compute_output) if call_count == 1 else (True, switch_output)
+
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", side_effect=side_effect):
+                with patch("builtins.print") as mock_print:
+                    self.plugin.run(args)
+
+        printed_args = [call.args[0] for call in mock_print.call_args_list if call.args]
+        envelope = json.loads(printed_args[0])
+        self.assertIn("10.0.0.2", envelope["output"])
+        self.assertIn("192.168.1.1", envelope["output"])
+
+    def test_json_flag_default_is_false(self):
+        """--json flag defaults to False (text mode is the default)."""
+        main_parser = argparse.ArgumentParser()
+        subparsers = main_parser.add_subparsers()
+        self.plugin.get_parser(subparsers)
+        args = main_parser.parse_args(["exec", "--cmd", "hostname"])
+        self.assertFalse(args.json_output)
+
+    def test_text_mode_unchanged(self):
+        """Without --json, per-host text format is still printed (not JSON)."""
+        host_output = {"10.0.0.2": "myhost\n"}
+        args = self._make_args(json_output=False)
+        cluster_json = json.dumps(PLAIN_CLUSTER)
+        with patch("builtins.open", mock_open(read_data=cluster_json)):
+            with patch.object(self.plugin, "_run_on_hosts", return_value=(True, host_output)):
+                with patch("builtins.print") as mock_print:
+                    self.plugin.run(args)
+
+        all_printed = " ".join(str(c) for c in mock_print.call_args_list)
+        self.assertIn("[compute] Host:", all_printed)
+        # Must NOT be a JSON envelope
+        for call in mock_print.call_args_list:
+            if call.args:
+                try:
+                    parsed = json.loads(call.args[0])
+                    self.assertNotIn("command", parsed, "Unexpected JSON envelope in text mode")
+                except (json.JSONDecodeError, TypeError):
+                    pass  # non-JSON output is expected in text mode
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/input/cluster_file/cluster_rack.json
+++ b/cvs/input/cluster_file/cluster_rack.json
@@ -1,0 +1,132 @@
+{
+    "_comment": "Rack-aware cluster.json — extends cluster.json with a 'racks' block for switch tray targeting.",
+
+    "_user_comment": " user-id will be resolved to current username in runtime. You can also change to your user-id here.",
+    "username": "{user-id}",
+
+    "_key_comment": " Change <priv_key_file> to your private key if it is different.",
+    "priv_key_file": "/home/{user-id}/.ssh/id_rsa",
+
+    "head_node_dict": {
+        "mgmt_ip": "{xx.xx.xx.xx|hostname}"
+    },
+
+    "_env_vars_comment": "Custom env variables to be exported before executing each command",
+    "_env_vars_example": {
+        "PATH": "/shared/apps/ubuntu/opt/rocm-7.11.0/bin:$PATH"
+    },
+    "env_vars": {},
+
+    "_node_comment": " Change to your node IPs. The Public IPs of the nodes will be the keys of the node_dict.",
+    "_vpc_comment": "If your cluster has a dedicated VPC IP that is reachable from other nodes in the cluster, set it to that (or) else set the same as the main host IP/Name",
+    "_rack_id_comment": "rack_id associates each compute node with a rack entry in the 'racks' block below.",
+    "node_dict": {
+        "10.0.0.1": {
+            "bmc_ip": "10.0.1.1",
+            "vpc_ip": "10.0.0.1",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.2": {
+            "bmc_ip": "10.0.1.2",
+            "vpc_ip": "10.0.0.2",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.3": {
+            "bmc_ip": "10.0.1.3",
+            "vpc_ip": "10.0.0.3",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.4": {
+            "bmc_ip": "10.0.1.4",
+            "vpc_ip": "10.0.0.4",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.5": {
+            "bmc_ip": "10.0.1.5",
+            "vpc_ip": "10.0.0.5",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.6": {
+            "bmc_ip": "10.0.1.6",
+            "vpc_ip": "10.0.0.6",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.7": {
+            "bmc_ip": "10.0.1.7",
+            "vpc_ip": "10.0.0.7",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.8": {
+            "bmc_ip": "10.0.1.8",
+            "vpc_ip": "10.0.0.8",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.9": {
+            "bmc_ip": "10.0.1.9",
+            "vpc_ip": "10.0.0.9",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.10": {
+            "bmc_ip": "10.0.1.10",
+            "vpc_ip": "10.0.0.10",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.11": {
+            "bmc_ip": "10.0.1.11",
+            "vpc_ip": "10.0.0.11",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.12": {
+            "bmc_ip": "10.0.1.12",
+            "vpc_ip": "10.0.0.12",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.13": {
+            "bmc_ip": "10.0.1.13",
+            "vpc_ip": "10.0.0.13",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.14": {
+            "bmc_ip": "10.0.1.14",
+            "vpc_ip": "10.0.0.14",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.15": {
+            "bmc_ip": "10.0.1.15",
+            "vpc_ip": "10.0.0.15",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.16": {
+            "bmc_ip": "10.0.1.16",
+            "vpc_ip": "10.0.0.16",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.17": {
+            "bmc_ip": "10.0.1.17",
+            "vpc_ip": "10.0.0.17",
+            "rack_id": "rack-01"
+        },
+        "10.0.0.18": {
+            "bmc_ip": "10.0.1.18",
+            "vpc_ip": "10.0.0.18",
+            "rack_id": "rack-01"
+        }
+    },
+
+    "_racks_comment": "Rack block.",
+    "racks": {
+        "switch_ssh_user": "admin",
+        "switch_ssh_password": "password",
+        "rack-01": {
+            "platform": "HeliosP",
+            "switch_trays": [
+                "10.0.2.1",
+                "10.0.2.2",
+                "10.0.2.3",
+                "10.0.2.4",
+                "10.0.2.5",
+                "10.0.2.6"
+            ]
+        }
+    }
+}

--- a/cvs/input/generate/rack_cluster_json.py
+++ b/cvs/input/generate/rack_cluster_json.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication
+and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from importlib import resources
+from typing import Dict, List, Optional
+
+from jinja2 import Template
+
+from cvs.input.generate.cluster_json import ClusterJsonGenerator
+
+
+# ---------------------------------------------------------------------------
+# Data model for a single parsed rack group
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RackEntry:
+    rack_id: str
+    compute_nodes: List[str] = field(default_factory=list)
+    switch_trays: List[str] = field(default_factory=list)
+    platform: str = "HeliosP"
+
+
+# ---------------------------------------------------------------------------
+# argv pre-processor: split on --rack0 / --rack1 / ... --rackN markers
+# ---------------------------------------------------------------------------
+
+
+def split_rack_groups(argv: List[str]):
+    """
+    Split argv into global args and per-rack arg groups.
+
+    Everything before the first --rackN marker is treated as a global arg.
+    Each --rackN marker starts a new rack group; args that follow (until the
+    next --rackN marker or end of argv) belong to that rack.
+
+    Returns:
+        global_args  (list[str])  – args before the first --rackN
+        rack_groups  (dict[str, list[str]])  – {"--rack0": [...], "--rack1": [...], ...}
+                     ordered by marker name
+    """
+    global_args: List[str] = []
+    rack_groups: Dict[str, List[str]] = {}
+    current: Optional[str] = None
+
+    for arg in argv:
+        if re.match(r'^--rack\d+$', arg):
+            current = arg
+            rack_groups[current] = []
+        elif current is not None:
+            rack_groups[current].append(arg)
+        else:
+            global_args.append(arg)
+
+    return global_args, rack_groups
+
+
+def _rack_sort_key(marker: str) -> int:
+    """Sort --rackN markers numerically."""
+    m = re.match(r'^--rack(\d+)$', marker)
+    return int(m.group(1)) if m else 0
+
+
+def build_rack_parser() -> argparse.ArgumentParser:
+    """Return an ArgumentParser for per-rack sub-args (used after split_rack_groups)."""
+    p = argparse.ArgumentParser(prog='--rackN', add_help=False)
+    p.add_argument(
+        '--id',
+        dest='rack_id',
+        default=None,
+        help="Rack identifier, e.g. 'rack-01'. Defaults to rack-00, rack-01, ... by index.",
+    )
+    p.add_argument(
+        '--computes',
+        required=True,
+        help="Comma-separated compute node IPs/hostnames; supports ranges like 10.0.0.1-5 and node[1-10]",
+    )
+    p.add_argument(
+        '--switches', default='', help="Comma-separated switch tray IPs; supports same range syntax as --computes"
+    )
+    p.add_argument('--platform', default='HeliosP', help="ARC platform name (default: HeliosP)")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Generator plugin
+# ---------------------------------------------------------------------------
+
+
+class RackClusterJsonGenerator(ClusterJsonGenerator):
+    """
+    Generator plugin for rack-aware cluster.json files.
+
+    Inherits IP/hostname range expansion from ClusterJsonGenerator so that
+    --computes and --switches accept the same range notation as --hosts:
+      10.0.0.1,10.0.0.2-7     (IP range with dash)
+      node[01-10]                       (bracket hostname range)
+
+    CLI usage (single rack):
+      cvs generate rack_cluster_json \\
+        --username ichristo --key_file ~/.ssh/id_rsa \\
+        --switch_ssh_user admin --switch_ssh_password password \\
+        --output_json_file cluster.json \\
+        --rack0 --id rack-01 --computes 10.0.0.1,10.0.0.2 \\
+                --switches 10.0.2.1,10.0.2.2,10.0.2.3
+
+    CLI usage (multi-rack):
+      cvs generate rack_cluster_json \\
+        --username ichristo --key_file ~/.ssh/id_rsa \\
+        --switch_ssh_user admin --switch_ssh_password password \\
+        --output_json_file cluster.json \\
+        --rack0 --id rack-01 --computes 10.0.0.1-5 --switches 10.0.1.1,10.0.1.2 \\
+        --rack1 --id rack-02 --computes 10.0.0.6-10 --switches 10.0.1.3
+    """
+
+    def supports_raw_argv(self) -> bool:
+        return True
+
+    def get_name(self) -> str:
+        return "rack_cluster_json"
+
+    def get_description(self) -> str:
+        return "Generate rack-aware cluster JSON with compute and switch tray topology"
+
+    def get_parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(
+            description="Generate rack-aware cluster.json from --rackN argument groups",
+            epilog=(
+                "Each --rackN group accepts: --id --computes --switches --platform. "
+                "N is zero-based and must be contiguous (--rack0, --rack1, ...). "
+                "Global switch credentials (--switch_ssh_user, --switch_ssh_password, "
+                "--switch_ssh_key_file) apply uniformly to all racks."
+            ),
+        )
+        parser.add_argument('--username', required=True, help="SSH username for compute nodes")
+        parser.add_argument('--key_file', required=True, help="Path to SSH private key for compute nodes")
+        parser.add_argument('--switch_ssh_user', default=None, help="SSH username for all switch trays")
+        parser.add_argument('--switch_ssh_password', default=None, help="SSH password for all switch trays")
+        parser.add_argument(
+            '--switch_ssh_key_file',
+            default=None,
+            help="Global SSH private key path for all switch trays; takes priority over --switch_ssh_password",
+        )
+        parser.add_argument(
+            '--head_node', default=None, help="IP of the head node (defaults to first compute node across all racks)"
+        )
+        parser.add_argument('--output_json_file', required=True, help="Output cluster JSON file path")
+        return parser
+
+    def generate(self, args) -> None:
+        # 1. Split raw generator args on --rackN boundaries.
+        #    _raw_args is injected by _run_generator when supports_raw_argv() is True.
+        #    Fall back to sys.argv[3:] when invoked as a standalone script.
+        raw_argv = getattr(args, '_raw_args', None) or sys.argv[3:]
+        global_argv, rack_groups_raw = split_rack_groups(raw_argv)
+
+        if not rack_groups_raw:
+            print("ERROR: No rack groups found. Provide at least --rack0 with --computes and --switches.")
+            sys.exit(1)
+
+        # 2. Parse global args
+        main_args = self.get_parser().parse_args(global_argv)
+
+        # 3. Parse each rack group in numeric order
+        rack_parser = build_rack_parser()
+        racks: Dict[str, RackEntry] = {}
+        all_compute_nodes: List[str] = []
+
+        for idx, marker in enumerate(sorted(rack_groups_raw.keys(), key=_rack_sort_key)):
+            rack_argv = rack_groups_raw[marker]
+            try:
+                rack_args = rack_parser.parse_args(rack_argv)
+            except SystemExit:
+                print(f"ERROR: Failed to parse args for {marker}.")
+                sys.exit(1)
+
+            rack_id = rack_args.rack_id or f"rack-{idx:02d}"
+
+            compute_nodes = self.parse_hosts_list(rack_args.computes)
+            if not compute_nodes:
+                print(f"ERROR: {marker} --computes produced no hosts.")
+                sys.exit(1)
+
+            switch_trays = self.parse_hosts_list(rack_args.switches) if rack_args.switches else []
+
+            entry = RackEntry(
+                rack_id=rack_id,
+                compute_nodes=compute_nodes,
+                switch_trays=switch_trays,
+                platform=rack_args.platform,
+            )
+            racks[rack_id] = entry
+            all_compute_nodes.extend(compute_nodes)
+
+        # 4. Determine head node
+        head_node_ip = main_args.head_node or (all_compute_nodes[0] if all_compute_nodes else "")
+
+        # 5. Render Jinja2 template
+        template_content = (
+            resources.files('cvs.input.templates.cluster_file').joinpath('rack_cluster_json.template').read_text()
+        )
+        template = Template(template_content)
+        rendered = template.render(
+            username=main_args.username,
+            priv_key_file=main_args.key_file,
+            head_node_ip=head_node_ip,
+            switch_ssh_user=main_args.switch_ssh_user or "",
+            switch_ssh_password=main_args.switch_ssh_password or "",
+            switch_ssh_key_file=main_args.switch_ssh_key_file or "",
+            racks=racks,
+        )
+
+        # 6. Write output
+        with open(main_args.output_json_file, 'w') as fp:
+            fp.write(rendered)
+
+        print(f"Generated rack cluster JSON: {main_args.output_json_file}")
+        print(f"Head node: {head_node_ip}")
+        print(f"Total compute nodes: {len(all_compute_nodes)}")
+        for rack_id, entry in racks.items():
+            print(
+                f"  {rack_id}: {len(entry.compute_nodes)} compute, {len(entry.switch_trays)} switches "
+                f"(platform={entry.platform})"
+            )
+
+
+def main():
+    generator = RackClusterJsonGenerator()
+    parser = generator.get_parser()
+    args = parser.parse_args()
+    generator.generate(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cvs/input/templates/cluster_file/rack_cluster_json.template
+++ b/cvs/input/templates/cluster_file/rack_cluster_json.template
@@ -1,0 +1,41 @@
+{
+  "username": "{{ username }}",
+  "priv_key_file": "{{ priv_key_file }}",
+  "head_node_dict": {
+    "mgmt_ip": "{{ head_node_ip }}"
+  },
+  "node_dict": {
+{%- set all_nodes = namespace(items=[]) %}
+{%- for rack_id, rack in racks.items() %}
+{%- for node in rack.compute_nodes %}
+{%- set _ = all_nodes.items.append((node, rack_id)) %}
+{%- endfor %}
+{%- endfor %}
+{%- for node, rack_id in all_nodes.items %}
+    "{{ node }}": {
+      "bmc_ip": "NA",
+      "vpc_ip": "{{ node }}",
+      "rack_id": "{{ rack_id }}"
+    }{% if not loop.last %},{% endif %}
+{%- endfor %}
+  },
+  "racks": {
+{%- if switch_ssh_user %}
+    "switch_ssh_user": "{{ switch_ssh_user }}",
+{%- endif %}
+{%- if switch_ssh_password %}
+    "switch_ssh_password": "{{ switch_ssh_password }}",
+{%- endif %}
+{%- if switch_ssh_key_file %}
+    "switch_ssh_key_file": "{{ switch_ssh_key_file }}",
+{%- endif %}
+{%- for rack_id, rack in racks.items() %}
+    "{{ rack_id }}": {
+      "platform": "{{ rack.platform }}"
+{%- if rack.switch_trays %},
+      "switch_trays": {{ rack.switch_trays | tojson }}
+{%- endif %}
+    }{% if not loop.last %},{% endif %}
+{%- endfor %}
+  }
+}

--- a/cvs/lib/globals.py
+++ b/cvs/lib/globals.py
@@ -10,3 +10,18 @@ import logging
 log = logging.getLogger()
 
 error_list = []
+
+
+def set_log_level(level):
+    """
+    Set the global CVS log level.
+
+    Args:
+        level: A logging level constant (e.g. logging.ERROR, logging.WARNING).
+
+    Example:
+        from cvs.lib.globals import set_log_level
+        set_log_level(logging.ERROR)   # suppress SSH/pssh WARNING noise
+        set_log_level(logging.DEBUG)   # enable full debug output
+    """
+    log.setLevel(level)

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -237,7 +237,7 @@ class AortaBenchmarkResult(BaseModel):
 class ClusterNodeConfig(BaseModel):
     """Schema for a single node entry in cluster.json node_dict."""
 
-    model_config = ConfigDict(extra="allow")  # Allow extra fields like bmc_ip
+    model_config = ConfigDict(extra="allow")  # Allow extra fields like bmc_ip, rack_id
 
     vpc_ip: str = Field(description="VPC IP or hostname for inter-node communication")
     bmc_ip: Optional[str] = Field(default=None, description="BMC IP for out-of-band management")
@@ -249,6 +249,66 @@ class HeadNodeConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     mgmt_ip: str = Field(description="Management IP of head node")
+
+
+class RackConfig(BaseModel):
+    """
+    Schema for a single rack entry inside the 'racks' block of cluster.json.
+
+    A rack groups compute trays (referenced via node_dict rack_id) and the
+    switch trays physically associated with that rack.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    platform: Optional[str] = Field(default=None, description="ARC platform name, e.g. 'HeliosP' or 'HeliosR'")
+    arc_controller: Optional[str] = Field(
+        default=None,
+        description="IP of the ARC controller node. Defaults to first sorted node_dict entry with matching rack_id.",
+    )
+    switch_trays: List[str] = Field(
+        default_factory=list,
+        description="IPs of switch trays in this rack",
+    )
+    rmc: Optional[str] = Field(default=None, description="IP of the Rack Management Controller")
+
+
+class RacksBlock(BaseModel):
+    """
+    Schema for the top-level 'racks' field in cluster.json.
+
+    Holds optional global switch credentials and one RackConfig entry per rack
+    (keyed by rack ID, e.g. 'rack-01'). Extra keys (rack IDs) are accepted via
+    extra='allow' and retrieved via get_racks().
+
+    Switch credentials are fleet-wide (homogeneous across all racks). Per-rack
+    overrides are not supported in the current exec path; add them to RackConfig
+    when that need arises.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    switch_ssh_user: Optional[str] = Field(
+        default=None,
+        description="SSH username for all switch trays in every rack.",
+    )
+    switch_ssh_password: Optional[str] = Field(
+        default=None,
+        description="SSH password for all switch trays. Ignored when switch_ssh_key_file is set.",
+    )
+    switch_ssh_key_file: Optional[str] = Field(
+        default=None,
+        description="Path to SSH private key for all switch trays. Takes priority over switch_ssh_password when set.",
+    )
+
+    def get_racks(self) -> Dict[str, RackConfig]:
+        """Return only the rack entries, excluding credential fields."""
+        skip = {'switch_ssh_user', 'switch_ssh_password', 'switch_ssh_key_file'}
+        result = {}
+        for key, value in (self.__pydantic_extra__ or {}).items():
+            if key not in skip and isinstance(value, dict):
+                result[key] = RackConfig(**value)
+        return result
 
 
 class ClusterConfigFile(BaseModel):
@@ -270,6 +330,18 @@ class ClusterConfigFile(BaseModel):
     )
     head_node_dict: Optional[HeadNodeConfig] = Field(default=None, description="Head node configuration")
 
+    racks: Optional[RacksBlock] = Field(
+        default=None,
+        description=(
+            "Rack topology block. Contains optional global switch credentials and one entry per rack "
+            "(keyed by rack ID) listing switch_trays and platform."
+        ),
+    )
+    rack_groups: Optional[RacksBlock] = Field(
+        default=None,
+        description="Deprecated alias for 'racks'. Use 'racks' instead.",
+    )
+
     # Optional fields that may be present
     home_mount_dir_name: Optional[str] = Field(default="home")
     node_dir_name: Optional[str] = Field(default="root")
@@ -287,6 +359,23 @@ class ClusterConfigFile(BaseModel):
         if not self.node_dict:
             raise ValueError("No nodes configured in 'node_dict' - at least one node is required")
         return self
+
+    @model_validator(mode='after')
+    def warn_rack_groups_deprecated(self):
+        """Emit a deprecation warning when the old 'rack_groups' key is used."""
+        import warnings
+
+        if self.rack_groups is not None and self.racks is None:
+            warnings.warn(
+                "'rack_groups' in cluster.json is deprecated. Rename it to 'racks'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return self
+
+    def get_racks_block(self) -> Optional[RacksBlock]:
+        """Return the active racks block, preferring 'racks' over the deprecated 'rack_groups'."""
+        return self.racks if self.racks is not None else self.rack_groups
 
     @field_validator('username')
     @classmethod

--- a/docs/how-to/execute-cluster-commands.rst
+++ b/docs/how-to/execute-cluster-commands.rst
@@ -1,10 +1,10 @@
 .. meta::
-  :description: Execute arbitrary commands on cluster nodes using CVS
-  :keywords: CVS, cluster, commands, exec, SSH, arbitrary
+  :description: Run ad-hoc commands across all nodes and switches in a CVS cluster
+  :keywords: CVS, cluster, commands, exec, SSH, ad-hoc, cluster-wide
 
-*********************************************
-Execute Arbitrary Commands on Cluster Nodes
-*********************************************
+*********************************
+Run ad-hoc cluster-wide commands
+*********************************
 
 CVS provides an ``exec`` command to execute arbitrary shell commands on all nodes in the cluster simultaneously using parallel SSH. This is useful for gathering system information, running diagnostics, or performing administrative tasks across all cluster nodes at once.
 
@@ -32,6 +32,47 @@ The ``exec`` command supports these options:
 
 - ``--cmd``: The shell command to execute on all nodes (required)
 - ``--cluster_file``: Path to cluster configuration JSON file (optional if ``CLUSTER_FILE`` environment variable is set)
+- ``--target``: Scope of execution — ``computes`` (default), ``switches``, or ``all``
+- ``--timeout``: Per-node command output timeout in seconds (default: ``30``). Controls how long to wait for each host's stdout after the SSH connection is established.
+- ``--connect-timeout``: Per-node SSH connection timeout in seconds (default: ``15``). Unreachable hosts fail fast after this many seconds regardless of ``--timeout``.
+- ``--json``: Emit results as a single JSON object instead of human-readable text. Useful for scripting and piping to ``jq``.
+- ``--verbose`` / ``-v``: Show internal SSH diagnostics (``SocketDisconnectError``, ``AuthenticationError``, pruning messages). Suppressed by default to keep output clean.
+
+Target scope
+============
+
+By default ``cvs exec`` runs on every host in ``node_dict`` (compute nodes). Use ``--target`` to change the scope:
+
+.. list-table::
+   :widths: 2 6
+   :header-rows: 1
+
+   * - ``--target``
+     - Hosts targeted
+   * - ``computes`` (default)
+     - All entries in ``node_dict``
+   * - ``switches``
+     - All ``switch_trays`` listed in the ``racks`` block (requires a rack-aware cluster file)
+   * - ``all``
+     - Both compute nodes and switch trays
+
+.. code:: bash
+
+  # Compute nodes only (default — identical to old behaviour)
+  cvs exec --cmd "hostname" --cluster_file input/cluster_file/cluster.json
+
+  # Switch trays only
+  cvs exec --cmd "show version" --cluster_file input/cluster_file/cluster_rack.json --target switches
+
+  # Both compute nodes and switch trays
+  cvs exec --cmd "date" --cluster_file input/cluster_file/cluster_rack.json --target all
+
+Rack-aware cluster file
+=======================
+
+``--target switches`` and ``--target all`` require a ``racks`` block in the cluster file that lists the switch tray IPs and (optionally) per-rack SSH credentials. A reference template is provided at ``input/cluster_file/cluster_rack.json``.
+
+If ``--target switches`` is used with a plain cluster file (no ``racks`` block), CVS prints a warning and exits without executing any command.
 
 Examples
 ========
@@ -114,18 +155,101 @@ Process and service information
 Output format
 =============
 
-The command output is displayed with each node's hostname followed by the command output, making it easy to identify which output came from which node:
+Each result is prefixed with the target type (``compute`` or ``switch``) and the host IP or hostname, making it easy to identify which output came from which node:
 
 .. code:: text
 
-  Host: node01
+  [compute] Host: 10.0.0.2
   Linux node01 5.15.0-91-generic #101-Ubuntu SMP Tue Nov 14 13:30:08 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
   ---
-  Host: node02
+  [compute] Host: 10.0.0.3
   Linux node02 5.15.0-91-generic #101-Ubuntu SMP Tue Nov 14 13:30:08 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
   ---
 
-This format helps you quickly identify which node produced which output when troubleshooting or gathering information across the cluster.
+When ``--target all`` is used, switch tray output follows the compute output with a ``[switch]`` prefix:
+
+.. code:: text
+
+  [switch] Host: 192.168.1.1
+  SONiC Software Version: SONiC.HEAD.xxx
+  ---
+
+This format helps you quickly distinguish compute and switch output when troubleshooting or gathering information across the cluster.
+
+JSON output
+===========
+
+Pass ``--json`` to receive a single structured JSON object on stdout. All SSH diagnostics are automatically suppressed so the output is pipe-safe.
+
+.. code:: bash
+
+  cvs exec --cmd "hostname" --cluster_file cluster.json --json
+
+Output schema:
+
+.. code:: json
+
+  {
+    "command": "hostname",
+    "read_timeout": 30,
+    "connect_timeout": 15,
+    "output": {
+      "10.0.0.2": "node01\n",
+      "10.0.0.3": "node02\n",
+      "10.0.0.4": "ABORT: Host Unreachable Error"
+    }
+  }
+
+- ``output`` is a flat ``host → string`` map. Error and timeout strings appear as values for unreachable hosts.
+- For ``--target all``, compute and switch hosts are merged into the same ``output`` dict.
+
+Pipe directly to ``jq`` for filtering:
+
+.. code:: bash
+
+  # Print only the output dict
+  cvs exec --cmd "hostname" --json | jq '.output'
+
+  # Get a single host's output (use bracket notation — IPs contain dots)
+  cvs exec --cmd "hostname" --json | jq -r '.output["10.0.0.2"]'
+
+  # List only hosts that succeeded (no error strings)
+  cvs exec --cmd "hostname" --json | jq '[.output | to_entries[] | select(.value | test("ABORT|Error") | not) | .key]'
+
+Timeout behaviour
+=================
+
+``--timeout`` and ``--connect-timeout`` control two distinct phases of the per-node SSH operation:
+
+.. list-table::
+   :widths: 3 3 4
+   :header-rows: 1
+
+   * - Flag
+     - Phase controlled
+     - Default
+   * - ``--connect-timeout``
+     - TCP/SSH handshake per host
+     - ``15`` s
+   * - ``--timeout``
+     - Command output reading after connection
+     - ``30`` s
+
+For short diagnostic commands, set both to the same value to ensure unreachable hosts fail within that window:
+
+.. code:: bash
+
+  cvs exec --cmd "uptime" --timeout 10 --connect-timeout 10
+
+For long-running operations (benchmarks, firmware updates), keep ``--connect-timeout`` small and raise ``--timeout`` only:
+
+.. code:: bash
+
+  cvs exec --cmd "./run_benchmark.sh" --timeout 600 --connect-timeout 10
+
+.. note::
+
+  When TCP packets to target hosts are silently dropped (e.g. no VPN/sshuttle tunnel), the effective per-host timeout is governed by ``--timeout`` (the socket-level IO timeout), not ``--connect-timeout``. Set ``--timeout`` equal to ``--connect-timeout`` for the fastest failure in that scenario.
 
 Troubleshooting
 ===============
@@ -143,6 +267,22 @@ If commands fail on specific nodes:
 - Verify user permissions for executing the command
 - Check if required packages or tools are installed on all nodes
 
+If ``--target switches`` produces a warning and no output:
+
+- Verify that the cluster file contains a ``racks`` block with ``switch_trays`` entries
+- Use ``input/cluster_file/cluster_rack.json`` as a reference template
+
+If SSH connections hang or time out:
+
+- Reduce ``--connect-timeout`` (default ``15`` s) to fail unreachable hosts faster
+- Reduce ``--timeout`` (default ``30`` s) if commands should complete quickly
+- Confirm network reachability to all target hosts before running (e.g. via sshuttle or VPN)
+
+If the output contains unexpected SSH diagnostic messages:
+
+- These are suppressed by default; they appear only when ``--verbose`` / ``-v`` is passed
+- If they still appear, check that the root logger level has not been overridden elsewhere
+
 .. tip::
 
-  Use simple commands first (like ``hostname`` or ``uptime``) to verify connectivity before running more complex commands.
+  Use ``--json | jq '.output'`` to get a clean, machine-readable summary. Combine with ``--verbose`` only when debugging connection issues.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ CVS requires only SSH connectivity to the cluster nodes — no Slurm, no Kuberne
 
 The component public repository is located at `https://github.com/ROCm/cvs <https://github.com/ROCm/cvs>`_.
 
-.. grid:: 3
+.. grid:: 2
   :gutter: 3
 
   .. grid-item-card:: Overview
@@ -25,12 +25,9 @@ The component public repository is located at `https://github.com/ROCm/cvs <http
   .. grid-item-card:: How to
 
     * :doc:`Run tests <how-to/run-cvs-tests>`
-    * :doc:`Execute arbitrary commands on cluster nodes <how-to/execute-cluster-commands>`
+    * :doc:`Run ad-hoc cluster-wide commands <how-to/execute-cluster-commands>`
     * :doc:`Copy files and directories to cluster nodes <how-to/copy-to-cluster>`
     * :doc:`Monitor the health of GPU clusters <how-to/run-cluster>`
-
-.. grid:: 1
-  :gutter: 3
 
   .. grid-item-card:: Reference
 


### PR DESCRIPTION
Extends cvs exec and cvs generate to handle heterogeneous cluster topologies with separate compute and switch tray targets.

exec_plugin.py
- Add --target {computes,switches,all} (default: computes, no regression)
- Add --timeout (default 30s): per-node command output read timeout
- Add --connect-timeout (default 15s): per-node SSH handshake timeout; unreachable hosts fail independently of --timeout
- Add --json: emit structured JSON envelope {command, read_timeout, connect_timeout, output: {host: str}}
- Add --verbose / -v: show SSH diagnostics (suppressed at ERROR level by default to avoid noisy SocketDisconnectError/pruning output)
- Add _collect_switch_hosts(): returns flat list of switch IPs; credential resolution is NOT done here
- Add _run_on_hosts(): shared SSH exec helper; num_retries=0 to prevent hangs on unreachable hosts
- Add _emit_error(): stderr-aware error printer for --json mode
- Add _print_text_output(): human-readable per-host result printer
- Resolve switch credentials fleet-wide from the racks block top-level (switch_ssh_key_file takes priority over switch_ssh_password)
- Emit DeprecationWarning when legacy rack_groups key is used

parsers/schemas.py
- Add RackConfig model: per-rack schema (platform, arc_controller, switch_trays, rmc)
- Add RacksBlock model: fleet-wide switch credentials + rack entries; switch creds are homogeneous across all racks (no per-rack overrides)
- Add optional racks field to ClusterConfigFile (rack_groups deprecated)

generate_plugin.py
- Add supports_raw_argv() hook for plugins with dynamic argument groups

New files
- input/generate/rack_cluster_json.py: generator with dynamic --rackN groups
- input/templates/cluster_file/rack_cluster_json.template: Jinja2 template
- input/cluster_file/cluster_rack.json: example rack-aware cluster file
- cli_plugins/unittests/test_exec_plugin.py: 41 unit tests

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
