### PR TITLE
feat(vllm): wire unified vLLM suite into inference report engine

### DIFF
--- a/cvs/lib/inference/unittests/test_vllm_report_preset.py
+++ b/cvs/lib/inference/unittests/test_vllm_report_preset.py
@@ -1,0 +1,102 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+'''
+
+import unittest
+
+from cvs.lib.inference.utils.vllm_parsing import (
+    CLIENT_METRICS,
+    GATED_METRICS,
+    METRIC_TIER_ORDER,
+    METRIC_TIERS,
+    VLLM_RESULTS_COLUMNS,
+    tier_metric_specs,
+)
+from cvs.lib.report.presets.vllm import VLLM_REPORT_CONFIG
+
+
+class TestVllmReportPreset(unittest.TestCase):
+    def test_results_columns_fixed_positional_prefix(self):
+        fixed = VLLM_RESULTS_COLUMNS[:7]
+        self.assertEqual(
+            fixed,
+            (
+                ("Model", None),
+                ("GPU", None),
+                ("ISL", None),
+                ("OSL", None),
+                ("Policy", None),
+                ("Conc", None),
+                ("Host", None),
+            ),
+        )
+
+    def test_metric_tiers_subset_of_tier_order(self):
+        self.assertTrue(set(METRIC_TIERS) <= set(METRIC_TIER_ORDER))
+
+    def test_gated_metrics_partitioned_exactly_once(self):
+        tiered = [m for names in METRIC_TIERS.values() for m in names]
+        # No duplicates across tiers.
+        self.assertEqual(len(tiered), len(set(tiered)))
+        # Every gated metric lands in exactly one non-record tier.
+        self.assertEqual(set(tiered), set(GATED_METRICS))
+
+    def test_gated_metrics_subset_of_client_metrics(self):
+        client_short = {short for short, _unit in CLIENT_METRICS}
+        missing = GATED_METRICS - client_short
+        self.assertEqual(missing, set(), f"GATED_METRICS not in CLIENT_METRICS: {missing}")
+
+    def test_tier_metric_specs_throughput(self):
+        cell = {
+            "client.output_throughput": {"kind": "min_tok_s", "value": 1},
+            "client.mean_ttft_ms": {"kind": "max_ms", "value": 2},
+        }
+        specs = tier_metric_specs(cell, "throughput")
+        self.assertIn("client.output_throughput", specs)
+        self.assertNotIn("client.mean_ttft_ms", specs)
+
+    def test_tier_metric_specs_record_includes_non_tiered(self):
+        cell = {
+            "client.num_prompts": {"kind": "within", "value": 100},
+            "client.output_throughput": {"kind": "min_tok_s", "value": 1},
+        }
+        specs = tier_metric_specs(cell, "record")
+        self.assertIn("client.num_prompts", specs)
+        self.assertNotIn("client.output_throughput", specs)
+
+    def test_preset_config_identity(self):
+        self.assertEqual(VLLM_REPORT_CONFIG.suite_id, "vllm")
+        self.assertEqual(VLLM_REPORT_CONFIG.inference_test_substring, "test_vllm_inference")
+        self.assertEqual(VLLM_REPORT_CONFIG.row_card_test_names, ("test_metric",))
+
+    def test_preset_lifecycle_labels_match_what_suite_records(self):
+        # Guard against drift: the vLLM suite (cvs/tests/inference/vllm/vllm.py)
+        # records exactly these session-level stages via lifecycle.record(...).
+        suite_recorded = {
+            "container_launch",
+            "topology_discovery",
+            "model_fetch",
+            "server_ready",
+            "teardown",
+        }
+        self.assertTrue(set(VLLM_REPORT_CONFIG.session_lifecycle_labels) <= suite_recorded)
+        self.assertTrue(set(VLLM_REPORT_CONFIG.cell_lifecycle_labels) <= suite_recorded)
+
+    def test_auto_register_resolves_vllm_stem(self):
+        from cvs.lib.report.auto_register import try_auto_register_inference_suite_report
+        from cvs.lib.report.registry import get_suite_report_config
+
+        class _FakeConfig:
+            pass
+
+        cfg = _FakeConfig()
+        cfg._suite_name = "vllm"
+        cfg._suite_report_config = None
+        registered = try_auto_register_inference_suite_report(cfg)
+        self.assertTrue(registered)
+        self.assertIs(get_suite_report_config(cfg), VLLM_REPORT_CONFIG)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/inference/utils/vllm_parsing.py
+++ b/cvs/lib/inference/utils/vllm_parsing.py
@@ -181,3 +181,85 @@ GATED_METRICS = {
     "success_rate",
     "failed",
 }
+
+# `(label, client.* key)` columns for the report's results table and the
+# console table in `_shared.py::test_print_results_table` -- kept in sync
+# with that table's headers. First 7 are the fixed positional columns
+# `inference_payload.build_results_table` always emits (Model, GPU, ISL, OSL,
+# Policy, Conc, Host); only `metric_keys[7:]` are looked up per host.
+VLLM_RESULTS_COLUMNS = (
+    ("Model", None),
+    ("GPU", None),
+    ("ISL", None),
+    ("OSL", None),
+    ("Policy", None),
+    ("Conc", None),
+    ("Host", None),
+    ("Req/s", "client.request_throughput"),
+    ("Total tok/s", "client.total_token_throughput"),
+    ("Mean TTFT (ms)", "client.mean_ttft_ms"),
+    ("P95 TTFT (ms)", "client.p95_ttft_ms"),
+    ("Mean TPOT (ms)", "client.mean_tpot_ms"),
+    ("P95 TPOT (ms)", "client.p95_tpot_ms"),
+    ("P99 ITL (ms)", "client.p99_itl_ms"),
+    ("Goodput (req/s)", "client.goodput"),
+)
+
+# Report gate-matrix tiers. Membership is seeded from GATED_METRICS so the
+# report's tier partition exactly mirrors what the suite enforces: every name
+# in GATED_METRICS must land in exactly one non-record tier (pinned by a unit
+# test), and `set(METRIC_TIERS) <= set(METRIC_TIER_ORDER)` must hold (true by
+# construction below) or `cell_build.tier_status` would silently drop metrics
+# whose tier isn't iterated.
+METRIC_TIERS: dict[str, tuple[str, ...]] = {
+    "throughput": (
+        "total_token_throughput",
+        "output_throughput",
+    ),
+    "ttft": (
+        "mean_ttft_ms",
+        "median_ttft_ms",
+        "p90_ttft_ms",
+        "p95_ttft_ms",
+        "p99_ttft_ms",
+    ),
+    "tpot": (
+        "mean_tpot_ms",
+        "median_tpot_ms",
+        "p90_tpot_ms",
+        "p95_tpot_ms",
+        "p99_tpot_ms",
+    ),
+    "latency": (
+        "mean_itl_ms",
+        "median_itl_ms",
+        "p95_itl_ms",
+        "p99_itl_ms",
+        "mean_e2el_ms",
+        "median_e2el_ms",
+        "p90_e2el_ms",
+        "p95_e2el_ms",
+        "p99_e2el_ms",
+    ),
+    "health": (
+        "success_rate",
+        "failed",
+    ),
+}
+
+METRIC_TIER_ORDER: tuple[str, ...] = tuple(METRIC_TIERS.keys()) + ("record",)
+
+_tiered = {m for names in METRIC_TIERS.values() for m in names}
+RECORD_METRICS: tuple[str, ...] = tuple(short for short, _unit in CLIENT_METRICS if short not in _tiered)
+
+
+def tier_metric_specs(thresholds_cell: dict, tier: str) -> dict[str, dict]:
+    """Return ``client.*`` threshold specs for one tier in a sweep cell."""
+    names = RECORD_METRICS if tier == "record" else METRIC_TIERS.get(tier, ())
+    specs = {}
+    for short in names:
+        full = f"client.{short}"
+        spec = thresholds_cell.get(full)
+        if spec is not None:
+            specs[full] = spec
+    return specs

--- a/cvs/lib/report/presets/vllm.py
+++ b/cvs/lib/report/presets/vllm.py
@@ -1,0 +1,51 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Auto-loaded when running ``cvs run vllm`` (stem matches this filename -- see
+``cvs.lib.report.auto_register``). Wires the unified single-node/distributed
+vLLM suite (``cvs/tests/inference/vllm/vllm.py``) into the generic inference
+report engine. Render-only: does not change pass/fail or threshold enforcement.
+'''
+
+from __future__ import annotations
+
+from cvs.lib.inference.utils.vllm_parsing import (
+    CLIENT_METRIC_UNITS,
+    METRIC_TIER_ORDER,
+    VLLM_RESULTS_COLUMNS,
+    tier_metric_specs,
+)
+from cvs.lib.report.chart_presets import DEFAULT_PERF_CHART_SERIES
+from cvs.lib.report.presets.builder import make_inference_report_config
+
+# The suite records these lifecycle stages (cvs/tests/inference/vllm/vllm.py);
+# it does NOT record "sshd_setup" or "client_complete" (the builder defaults
+# assume both). Using the builder defaults here would leave two permanently
+# empty timeline slots and silently drop the real "topology_discovery" stage.
+VLLM_SESSION_LIFECYCLE_LABELS = (
+    "container_launch",
+    "topology_discovery",
+    "model_fetch",
+    "server_ready",
+    "teardown",
+)
+VLLM_CELL_LIFECYCLE_LABELS = ("server_ready",)
+
+VLLM_REPORT_CONFIG = make_inference_report_config(
+    suite_id="vllm",
+    report_basename="vllm_run_deck",
+    title="vLLM Run Deck",
+    subtitle="vLLM · single-node & PP-distributed lab performance summary",
+    footer="CVS vllm · render-only · does not affect gates",
+    link_name="vLLM Run Deck",
+    results_columns=VLLM_RESULTS_COLUMNS,
+    metric_units=CLIENT_METRIC_UNITS,
+    tier_metric_specs=tier_metric_specs,
+    metric_tier_order=METRIC_TIER_ORDER,
+    chart_series=DEFAULT_PERF_CHART_SERIES,
+    inference_test_substring="test_vllm_inference",
+    row_card_test_names=("test_metric",),
+    session_lifecycle_labels=VLLM_SESSION_LIFECYCLE_LABELS,
+    cell_lifecycle_labels=VLLM_CELL_LIFECYCLE_LABELS,
+)

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -148,35 +148,6 @@ def pytest_collection_modifyitems(items):
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """Attach THIS test's recorded rows to its HTML report detail panel.
-
-    Renders only the rows recorded against the current item's nodeid (so each
-    stage shows its own timings, not every stage's), and reads the unit per row
-    (durations in `s`, the fetch size in `GB`) instead of a fixed "seconds"
-    header. Guarded: a no-op when pytest-html is not installed (the `extras`
-    plugin attribute is absent), so the suite still runs under a bare pytest.
-    """
-    outcome = yield
-    report = outcome.get_result()
-    if report.when != "call":
-        return
-    lc = item.funcargs.get("lifecycle")
-    rows = getattr(lc, "report", {}).get(item.nodeid) if lc else None
-    if not rows:
-        return
-    try:
-        import pytest_html
-    except ImportError:
-        return
-    body = "".join(f"<tr><td>{label}</td><td>{value:.1f}</td><td>{unit}</td></tr>" for label, value, unit in rows)
-    html = f"<table><tr><th>stage</th><th>value</th><th>unit</th></tr>{body}</table>"
-    extras = getattr(report, "extras", [])
-    extras.append(pytest_html.extras.html(html))
-    report.extras = extras
-
-
 def pytest_html_results_table_header(cells):
     """Add Value + Unit columns just before the trailing Links column.
 

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -59,7 +59,7 @@ class _Lifecycle:
     code. They share this object: `failed` lets a broken stage skip the rest
     instead of cascading; `torn_down` lets the explicit teardown test suppress
     the fixture's leak-guard finalizer; `report` maps a test's nodeid to the
-    rows it recorded, each carrying its own unit, so pytest_runtest_makereport
+    rows it recorded, each carrying its own unit, so attach_inference_suite_lifecycle_table
     renders only that test's stages -- not every stage on every row.
     """
 


### PR DESCRIPTION
## Summary
- PR #257 already brings in the generic inference report engine (`cvs/lib/report/`) via the `dev/dtni` merge, but no suite preset exists for `vllm`, so `cvs run vllm` never rendered a run deck (HTML/JSON dashboard, viewer, CI summary).
- Adds the missing preset (`cvs/lib/report/presets/vllm.py`) plus vLLM-specific tier/column glue in `vllm_parsing.py`: `VLLM_RESULTS_COLUMNS` (mirrors the existing console table in `_shared.py`), `METRIC_TIERS`/`METRIC_TIER_ORDER` seeded from the existing `GATED_METRICS` set (pinned by a unit test as an exact bijection), and `tier_metric_specs()`.
- The preset overrides the report engine's default lifecycle labels (`sshd_setup`/`client_complete`), since the unified vLLM suite instead records `topology_discovery` and has no `client_complete` stage.
- Removes the suite-local `pytest_runtest_makereport` lifecycle-table hookwrapper in `cvs/tests/inference/vllm/conftest.py` — confirmed byte-for-byte equivalent to the shared `attach_inference_suite_lifecycle_table` that root `conftest.py` now invokes automatically once the preset registers, so keeping both would have rendered a duplicate table per test row.
- Render-only: none of this changes pass/fail or threshold enforcement.

## Test plan
- [x] New unit tests (`cvs/lib/inference/unittests/test_vllm_report_preset.py`, 9 cases) — pin the tier partition against `GATED_METRICS`, lifecycle label correctness, and end-to-end auto-register resolution for stem `vllm`.
- [x] Offline dry render: synthesized a `VariantConfig` + 2-cell `inf_res_dict`, called `write_report()` directly — confirmed `vllm_run_deck.html`/`.json`/`_viewer.html`/`_summary.html` all generate, gate matrix tiers compute correctly, and the lifecycle timeline shows only the stages this suite actually records (no empty legacy `sshd_setup`/`client_complete` slots).
- [x] `make ut` equivalent (`run_all_unittests.py`): 659 tests, only the same 2 pre-existing/unrelated failures present on the unmodified branch tip (`test_inferencing_config_loader.py`).
- [x] `make test` CLI suite (`test_cli.sh`): all 46 checks pass, including `cvs list vllm`.
- [x] `ruff check`/`ruff format --check` on all touched files: clean. (Repo-wide `make fmt-check`/`make lint` currently fail on 3 unrelated pre-existing files (`gpu.py`, ray-backend files) already broken on the unmodified branch tip — out of scope here.)

## Jira
- [AIMVT-260](https://amd-hub.atlassian.net/browse/AIMVT-260): tracks this vLLM run-deck report generation work (parent epic AIMVT-202).

## Known follow-up
- Live TensorWave smoke test of this preset surfaced 4 caught-but-logged `shutil.SameFileError`s (one per run-deck artifact) in the shared inference report engine's `add_html_to_report()` — pre-existing bug from PR #257, non-fatal, out of scope for this PR. Not yet filed separately.
