### PR TITLE
Add early JSON validation of --cluster_file and --config_file 

### DIFF
--- a/cvs/cli_plugins/run_plugin.py
+++ b/cvs/cli_plugins/run_plugin.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import os
+import json
 
 from .list_plugin import ListPlugin
 
@@ -61,6 +62,26 @@ Run Commands:
             getattr(args, "extra_pytest_args", []),
         )
 
+    def _validate_json_config(self, path, label):
+        """Validate that a config file exists and is valid JSON."""
+        if not os.path.exists(path):
+            print(f"Error: {label} does not exist: {path}")
+            sys.exit(1)
+        if not os.path.isfile(path):
+            print(f"Error: {label} is not a file: {path}")
+            sys.exit(1)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"Error: {label} is not valid JSON: {path}")
+            print(f"  {e}")
+            sys.exit(1)
+        except OSError as e:
+            print(f"Error: unable to read {label}: {path}")
+            print(f"  {e}")
+            sys.exit(1)
+
     def run_test(
         self,
         test_name,
@@ -74,6 +95,10 @@ Run Commands:
         capture,
         extra_pytest_args,
     ):
+        # Pre-flight check: validate both JSON config files before pytest runs.
+        self._validate_json_config(cluster_file, "--cluster_file")
+        self._validate_json_config(config_file, "--config_file")
+
         module_path = self._find_test(test_name)
         if not module_path:
             print(f"Error: Unknown test '{test_name}'")

--- a/cvs/cli_plugins/unittests/test_run_plugin.py
+++ b/cvs/cli_plugins/unittests/test_run_plugin.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import MagicMock, patch
 import sys
 import os
+import tempfile
+import json
 
 # Add the parent directory to sys.path to import cli_plugins
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -32,7 +34,8 @@ class TestRunPlugin(unittest.TestCase):
         mock_pytest_main.return_value = 0  # Mock successful pytest run
 
         with patch.object(self.plugin, "get_test_file", return_value="/mock/path/test.py"):
-            self.plugin.run(args)
+            with patch.object(self.plugin, "_validate_json_config"):
+                self.plugin.run(args)
 
         # Verify pytest.main was called with correct arguments
         expected_args = [
@@ -64,7 +67,8 @@ class TestRunPlugin(unittest.TestCase):
         mock_pytest_main.return_value = 0
 
         with patch.object(self.plugin, "get_test_file", return_value="/mock/path/test.py"):
-            self.plugin.run(args)
+            with patch.object(self.plugin, "_validate_json_config"):
+                self.plugin.run(args)
 
         # Verify pytest.main was called with multiple function targets
         expected_args = [
@@ -78,6 +82,51 @@ class TestRunPlugin(unittest.TestCase):
         ]
         mock_pytest_main.assert_called_once_with(expected_args)
         mock_exit.assert_called_once_with(0)
+
+
+class TestRunPluginJsonValidation(unittest.TestCase):
+    """Tests for RunPlugin._validate_json_config pre-flight checks."""
+
+    def setUp(self):
+        self.plugin = RunPlugin()
+
+    @patch("cvs.cli_plugins.run_plugin.sys.exit", side_effect=SystemExit(1))
+    @patch("cvs.cli_plugins.run_plugin.print")
+    def test_missing_file(self, mock_print, mock_exit):
+        """A missing config file should print a clean error and exit."""
+        with self.assertRaises(SystemExit) as ctx:
+            self.plugin._validate_json_config("/nonexistent/path.json", "--cluster_file")
+        self.assertEqual(ctx.exception.code, 1)
+        printed = " ".join(str(c) for c in mock_print.call_args_list[0][0])
+        self.assertIn("does not exist", printed)
+        self.assertIn("/nonexistent/path.json", printed)
+
+    @patch("cvs.cli_plugins.run_plugin.sys.exit", side_effect=SystemExit(1))
+    @patch("cvs.cli_plugins.run_plugin.print")
+    def test_malformed_json(self, mock_print, mock_exit):
+        """A malformed JSON file should print a clean error and exit."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{not valid json")
+            path = f.name
+        try:
+            with self.assertRaises(SystemExit) as ctx:
+                self.plugin._validate_json_config(path, "--config_file")
+        finally:
+            os.unlink(path)
+        self.assertEqual(ctx.exception.code, 1)
+        messages = " ".join(str(c[0][0]) for c in mock_print.call_args_list)
+        self.assertIn("is not valid JSON", messages)
+        self.assertIn(path, messages)
+
+    def test_valid_json(self):
+        """A valid JSON file should pass validation without exiting."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"host": {}}, f)
+            path = f.name
+        try:
+            self.plugin._validate_json_config(path, "--config_file")
+        finally:
+            os.unlink(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When a config or cluster file JSON file is invalid, cvs will attempt to run the test. This results in a very verbose error wall of text. 
See https://gist.github.com/mikegreen-amd/6c99d9b8bd4344173fe29ea675b9799f for an example output when the preflight config JSON was invalid due to an errant character. 

This PR will bark at the user immediately and stop the run if the files have invalid JSON. 
Here is entire output post-PR here: 
```
$ cvs run preflight_checks --cluster_file=/tmp/cvs-configs/cluster_file/cluster.json --config_file=/tmp/cvs-configs/config_file/preflight/preflight_config.json
Error: --config_file is not valid JSON: /tmp/cvs-configs/config_file/preflight/preflight_config.json
  Expecting value: line 1 column 1 (char 0)
```

## Technical Details

Added `_validate_json_config` in run_plugin.py 

## Test Plan

#### For functionality change: 
1. Install CVS
2. Copy a cluster and config file
3. Edit the config file to make it invalid JSON (ie, add ABC to start of file), save
4. Run cvs pointing to that edited config file `$ cvs run preflight_checks --cluster_file=/tmp/cvs-configs/cluster_file/cluster.json --config_file=/tmp/cvs-configs/config_file/preflight/preflight_config.json`
5. Verify succient error message as exampled above, and that processing stops
6. Repeat with cluster json file

#### Unit test
1. Unit test is added as well. 

## Test Result

1. Above functional test passed. 
2. Repo tests passed:
   - make fmt-check
   - make lint
   - make test

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [ ] First PR here, be gentle if I screwed it up :-) 
