### PR TITLE
Add optional Docker registry login for private image pulls

### DIFF
--- a/cvs/core/orchestrators/factory.py
+++ b/cvs/core/orchestrators/factory.py
@@ -84,7 +84,8 @@ class OrchestratorConfig:
                 "network": "host",
                 "ipc": "host",
                 "ulimit": ["memlock=-1"],
-                "privileged": true
+                "privileged": true,
+                "registry": {"username": "myuser", "password_file": "/home/myuser/.docker_token"}
               }
             },
             "image": "rocm/cvs:latest",

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -22,6 +22,41 @@ class DockerRuntime:
         # If grep succeeds (exit 0), image exists; if not, not found
         return all(res.get('exit_code') == 0 for res in result.values())
 
+    def registry_login(self, registry_config):
+        """Log in to a Docker registry on all nodes ahead of a pull.
+
+        Args:
+            registry_config: dict with ``username`` and ``password_file`` (path
+                to a file on each remote host containing the password/token) and
+                optional ``server`` (registry hostname; omit for Docker Hub).
+                The password is piped via stdin (``--password-stdin``) so it
+                never appears in a command line, process list, or log line.
+
+        Returns:
+            bool: True if login succeeded on every host.
+        """
+        username = registry_config.get('username')
+        password_file = registry_config.get('password_file')
+        if not username or not password_file:
+            self.log.error("registry_login requires 'username' and 'password_file'")
+            return False
+
+        server = registry_config.get('server', '')
+        # `docker login` (the stage that needs sudo for daemon-socket access) is
+        # the SECOND stage of this pipe, so wrap the whole pipeline in `sh -c`
+        # and prefix that so sudo applies to all of it, not just the first token.
+        inner = (
+            f"cat {shlex.quote(password_file)} | docker login {shlex.quote(server)} "
+            f"--username {shlex.quote(username)} --password-stdin"
+        )
+        cmd = f"sudo sh -c {shlex.quote(inner)}"
+        result = self.orchestrator.all.exec(cmd, timeout=30, print_console=False, detailed=True)
+        success = all(res.get('exit_code') == 0 for res in result.values())
+        if not success:
+            failed = [host for host, res in result.items() if res.get('exit_code') != 0]
+            self.log.error(f"docker login failed on hosts: {failed}")
+        return success
+
     def setup_containers(
         self,
         container_config,
@@ -120,6 +155,12 @@ class DockerRuntime:
                     return False
             else:
                 self.log.info(f"Image {container_config['image']} already exists, skipping tar load")
+        elif runtime_args_config.get('registry'):
+            # No local tar to load: this run needs a registry pull, so log in
+            # first for private images (e.g. rocm/ufb-private).
+            self.log.info("Logging in to Docker registry before pulling image")
+            if not self.registry_login(runtime_args_config['registry']):
+                return False
 
         cmd = f"sudo docker run -d --name {container_name} {all_args_str} {image} sleep infinity"
 

--- a/cvs/core/runtimes/unittests/test_docker.py
+++ b/cvs/core/runtimes/unittests/test_docker.py
@@ -131,5 +131,121 @@ class TestDockerRuntimeSetupContainers(unittest.TestCase):
                 )
 
 
+class TestDockerRuntimeRegistryLogin(unittest.TestCase):
+    def test_registry_login_requires_username_and_password_file(self):
+        captured = []
+        rt = _make_runtime(captured)
+        self.assertFalse(rt.registry_login({}))
+        self.assertFalse(rt.registry_login({"username": "u"}))
+        self.assertFalse(rt.registry_login({"password_file": "/tmp/pw"}))
+
+    def test_registry_login_sudo_covers_entire_pipeline(self):
+        # Regression test: `docker login` is the SECOND stage of the
+        # `cat pwfile | docker login ...` pipe. The whole pipeline is wrapped
+        # in `sh -c '...'` so `sudo` governs all of it, never just the first
+        # token of the pipe.
+        login_cmds = []
+
+        def _fake_exec(cmd, timeout=None, detailed=False, print_console=True):
+            login_cmds.append(cmd)
+            return {"host1": {"output": "", "exit_code": 0}}
+
+        orchestrator = MagicMock()
+        orchestrator.hosts = ["host1"]
+        orchestrator.all.exec.side_effect = _fake_exec
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        rt.registry_login({"username": "u", "password_file": "/tmp/pw"})
+
+        self.assertEqual(len(login_cmds), 1)
+        cmd = login_cmds[0]
+        # The pipeline must be wrapped as a single command (`sh -c '...'`)
+        # immediately after `sudo`, so sudo governs the whole pipeline -- not
+        # `sudo cat ... | docker login ...` with docker login left as a
+        # trailing, unprivileged pipe stage outside sudo's reach.
+        self.assertRegex(cmd, r"^sudo (sh|bash) -c ")
+
+    def test_registry_login_pipes_password_file_via_stdin_not_command_line(self):
+        # The password/token must never appear as a --password flag: only the
+        # *path* to the credential file appears in the rendered command, piped
+        # into `docker login --password-stdin`.
+        login_cmds = []
+
+        def _fake_exec(cmd, timeout=None, detailed=False, print_console=True):
+            login_cmds.append(cmd)
+            return {"host1": {"output": "", "exit_code": 0}}
+
+        orchestrator = MagicMock()
+        orchestrator.hosts = ["host1"]
+        orchestrator.all.exec.side_effect = _fake_exec
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        result = rt.registry_login({"username": "myuser", "password_file": "/home/myuser/.docker_token"})
+
+        self.assertTrue(result)
+        self.assertEqual(len(login_cmds), 1)
+        cmd = login_cmds[0]
+        self.assertIn("cat /home/myuser/.docker_token", cmd)
+        self.assertIn("--password-stdin", cmd)
+        self.assertIn("--username myuser", cmd)
+        self.assertNotIn("--password ", cmd)
+
+    def test_registry_login_reports_failure_on_bad_exit_code(self):
+        orchestrator = MagicMock()
+        orchestrator.hosts = ["host1"]
+        orchestrator.all.exec.return_value = {"host1": {"output": "", "exit_code": 1}}
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        self.assertFalse(rt.registry_login({"username": "u", "password_file": "/tmp/pw"}))
+
+    def test_setup_containers_logs_in_before_pull_when_registry_configured(self):
+        calls = []
+
+        def _fake_exec(cmd, timeout=None, detailed=False, print_console=True):
+            calls.append(cmd)
+            return {"host1": {"output": "", "exit_code": 0}}
+
+        orchestrator = MagicMock()
+        orchestrator.hosts = ["host1"]
+        orchestrator.all.exec.side_effect = _fake_exec
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        cfg = _container_config(
+            image="rocm/ufb-private:latest",
+            extra_runtime_args={"registry": {"username": "myuser", "password_file": "/tmp/token"}},
+        )
+        result = rt.setup_containers(container_config=cfg, container_name="cvs_iter_test", volumes=[])
+
+        self.assertTrue(result)
+        login_calls = [c for c in calls if "docker login" in c]
+        run_calls = [c for c in calls if "docker run" in c]
+        self.assertEqual(len(login_calls), 1)
+        self.assertEqual(len(run_calls), 1)
+        # Login must happen before the run that needs the pull.
+        self.assertLess(calls.index(login_calls[0]), calls.index(run_calls[0]))
+
+    def test_setup_containers_skips_login_when_image_tar_present(self):
+        # A tar load never needs a registry pull, so no login should be attempted
+        # even if 'registry' is configured (e.g. left over from another profile).
+        calls = []
+
+        def _fake_exec(cmd, timeout=None, detailed=False, print_console=True):
+            calls.append(cmd)
+            return {"host1": {"output": "", "exit_code": 0}}
+
+        orchestrator = MagicMock()
+        orchestrator.hosts = ["host1"]
+        orchestrator.all.exec.side_effect = _fake_exec
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        cfg = _container_config(
+            extra_runtime_args={"registry": {"username": "myuser", "password_file": "/tmp/token"}},
+            image_tar="/tmp/image.tar",
+        )
+        rt.setup_containers(container_config=cfg, container_name="cvs_iter_test", volumes=[])
+
+        self.assertFalse(any("docker login" in c for c in calls))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/input/cluster_file/README.md
+++ b/cvs/input/cluster_file/README.md
@@ -68,6 +68,7 @@ RDMA-ready container; the keys below are only needed to extend or override.
 | `security_opt` | list | `["seccomp=unconfined","apparmor=unconfined"]` (appended) | Security profile relaxations needed for RDMA + ptrace. |
 | `group_add` | list | `["video"]` (appended) | Supplementary groups inside the container. |
 | `ulimit` | list | `["memlock=-1"]` (appended) | Per-process resource limits. `memlock=-1` is required for RDMA. |
+| `registry` | dict | none | Optional registry login before pulling a private image (e.g. `rocm/ufb-private`). Keys: `username` (str), `password_file` (str, path *on each remote host* to a file containing the password/token), `server` (str, optional; omit for Docker Hub). Runs `docker login` via `--password-stdin` so the credential never appears in a command line or log. Only applied when `image_tar` is not set (a tar load never needs a pull). |
 
 ## `lifetime` truth table (setup + teardown semantics)
 

--- a/cvs/input/cluster_file/cluster_container.json
+++ b/cvs/input/cluster_file/cluster_container.json
@@ -45,6 +45,12 @@
             "name": "docker",
 
             "_args_comment": "Backend-specific runtime arguments. Defaults from cvs/core/orchestrators/container.py:DEFAULT_CONTAINER_ARGS apply for any key omitted here. List args (volumes/devices/cap_add/security_opt/group_add/ulimit) append to defaults; scalars (network/ipc/privileged) override.",
+            "_registry_comment": "Optional: log in to a private registry (e.g. rocm/ufb-private) before pulling. Omit entirely if the image is public or already loaded locally. password_file is a path ON EACH REMOTE HOST to a file containing the password/token -- never put the credential itself in this file. server is the registry hostname; omit/empty for Docker Hub. See README.md for the full schema.",
+            "_registry_example": {
+                "username": "myuser",
+                "password_file": "/home/{user-id}/.docker_token",
+                "server": ""
+            },
             "args": {
                 "network": "host",
                 "ipc": "host",


### PR DESCRIPTION
## Summary
- Adds optional Docker registry login (`runtime.args.registry: {username, password_file, server}`) so `setup_containers()` can log in before pulling a private image (e.g. `rocm/ufb-private`). Password is piped via `--password-stdin` from a file path, never embedded in cluster-file JSON. Skipped when `image_tar` is set.
- Updates cluster file templates and README to document the new `registry` key.

Split out of #260, where it was reviewed as unrelated scope creep on top of that branch's sudo-fallback fix.

Jira: AIMVT-265

## Test plan
- [x] `make fmt-check && make lint && make test` — all clean