### PR TITLE
Add OpenAI-compatible smoke test to unified vllm suite

### DIFF
--- a/cvs/lib/inference/unittests/test_vllm_job_server_reuse.py
+++ b/cvs/lib/inference/unittests/test_vllm_job_server_reuse.py
@@ -8,8 +8,10 @@ Unit tests for cvs.lib.inference.vllm_job.VllmJob server-command construction:
   - _flatten_serve_args boolean handling and log-level pass-through
   - _check_early_failure tail emission and CLI parse error detection
   - RoleServer.serve_args log-level validator
+  - probe_openai_endpoints(), the OpenAI-compatible HTTP smoke probe
 '''
 
+import json
 import unittest
 import unittest.mock as mock
 from types import SimpleNamespace
@@ -270,6 +272,109 @@ class TestRoleServerLogLevelValidator(unittest.TestCase):
     def test_valid_log_level_accepted(self):
         rs = RoleServer(serve_args={"log-level": "debug"})
         self.assertEqual(rs.serve_args["log-level"], "debug")
+
+
+class FakeOrchWithHeadOutput:
+    """Single-rank fake orch whose exec_on_head returns a controllable string,
+    mirroring what `orch.exec_on_head` would ship back from the container."""
+
+    hosts = ["10.0.0.1"]
+
+    def __init__(self, head_output=""):
+        self.head_cmds = []
+        self._head_output = head_output
+
+    def exec(self, *a, **k):
+        return {}
+
+    def exec_on_head(self, cmd, *a, **k):
+        self.head_cmds.append(cmd)
+        return {"10.0.0.1": self._head_output}
+
+
+class TestProbeOpenAIEndpoints(unittest.TestCase):
+    """Unit tests for VllmJob.probe_openai_endpoints. No hardware: FakeOrchWithHeadOutput
+    returns a canned base64-decoded-script's stdout line (the JSON dict the
+    stdlib probe script prints), mirroring what `orch.exec_on_head` would ship back
+    from the container."""
+
+    _GOOD_BODY = {
+        "model": "amd/Llama-3.1-70B-Instruct-FP8-KV",
+        "choices": [{"message": {"content": "OK"}, "text": "Paris"}],
+    }
+    _BOOK_CONTENT = json.dumps({"title": "T", "author": "A", "year": 2000, "genre": "G"})
+
+    def _raw(self, results):
+        return json.dumps(results)
+
+    def _all_pass_results(self):
+        return {
+            "model_endpoint": [200, {"data": [{"id": "amd/Llama-3.1-70B-Instruct-FP8-KV"}]}],
+            "chat_completion_endpoint": [200, {**self._GOOD_BODY, "choices": [{"message": {"content": "OK"}}]}],
+            "completion_endpoint": [200, {**self._GOOD_BODY, "choices": [{"text": "Paris"}]}],
+            "structured_output_book": [
+                200,
+                {**self._GOOD_BODY, "choices": [{"message": {"content": self._BOOK_CONTENT}}]},
+            ],
+        }
+
+    def test_issues_single_head_exec_with_port_and_model(self):
+        orch = FakeOrchWithHeadOutput(head_output=self._raw(self._all_pass_results()))
+        job = _job("1024", "1024", 1, serve_args={"max-model-len": "16384"})
+        job.orch = orch
+        job.probe_openai_endpoints()
+        self.assertEqual(len(orch.head_cmds), 1)
+        cmd = orch.head_cmds[0]
+        self.assertIn("base64 -d", cmd)
+        self.assertIn("python3", cmd)
+
+    def test_all_pass_returns_summary_lines(self):
+        orch = FakeOrchWithHeadOutput(head_output=self._raw(self._all_pass_results()))
+        job = _job("1024", "1024", 1, serve_args={"max-model-len": "16384"})
+        job.orch = orch
+        summary = job.probe_openai_endpoints()
+        self.assertEqual(len(summary), 4)
+        for line in summary:
+            self.assertIn("-> Pass (200)", line)
+
+    def test_http_failure_raises(self):
+        results = self._all_pass_results()
+        results["model_endpoint"] = [500, {"error": "boom"}]
+        orch = FakeOrchWithHeadOutput(head_output=self._raw(results))
+        job = _job("1024", "1024", 1, serve_args={"max-model-len": "16384"})
+        job.orch = orch
+        with self.assertRaises(RuntimeError):
+            job.probe_openai_endpoints()
+
+    def test_empty_content_raises(self):
+        results = self._all_pass_results()
+        results["chat_completion_endpoint"][1]["choices"] = [{"message": {"content": ""}}]
+        orch = FakeOrchWithHeadOutput(head_output=self._raw(results))
+        job = _job("1024", "1024", 1, serve_args={"max-model-len": "16384"})
+        job.orch = orch
+        with self.assertRaises(RuntimeError):
+            job.probe_openai_endpoints()
+
+    def test_no_output_raises(self):
+        orch = FakeOrchWithHeadOutput(head_output="")
+        job = _job("1024", "1024", 1, serve_args={"max-model-len": "16384"})
+        job.orch = orch
+        with self.assertRaises(RuntimeError):
+            job.probe_openai_endpoints()
+
+    def test_unparseable_output_raises(self):
+        orch = FakeOrchWithHeadOutput(head_output="not json {{{")
+        job = _job("1024", "1024", 1, serve_args={"max-model-len": "16384"})
+        job.orch = orch
+        with self.assertRaises(RuntimeError):
+            job.probe_openai_endpoints()
+
+    def test_bad_shape_raises(self):
+        orch = FakeOrchWithHeadOutput(head_output=json.dumps({"model_endpoint": "not-a-pair"}))
+        job = _job("1024", "1024", 1, serve_args={"max-model-len": "16384"})
+        job.orch = orch
+        with self.assertRaises(RuntimeError):
+            job.probe_openai_endpoints()
 
 
 if __name__ == "__main__":

--- a/cvs/lib/inference/utils/AGENTS.md
+++ b/cvs/lib/inference/utils/AGENTS.md
@@ -219,12 +219,14 @@ Standard lifecycle order (pinned in `pytest_collection_modifyitems`):
 | Rank | Test | Action |
 |---|---|---|
 | 0 | `test_launch_container` | `setup_containers()`; asserts container is running |
-| 1 | `test_setup_sshd` | `setup_sshd()`; probes `:2224` for multinode only |
-| 2 | `test_model_fetch` | ensures model bytes present; polls or downloads if remote |
-| 3 | `test_vllm_inference` | benchmark loop per cell; stores results in `inf_res_dict` |
-| 4 | `test_metric` | one test per metric per cell; reads `inf_res_dict`; asserts verdict |
-| 5 | `test_print_results_table` | summary log; must run after all cells |
-| 6 | `test_teardown` | `teardown_containers()`; sets `lifecycle.torn_down`; **never skips** |
+| 1 | `test_setup_sshd` | no-op skip for vllm; distributed runs use NCCL/gloo, not sshd |
+| 2 | `test_discover_topology` | discovers IB HCA devices (distributed only; no-op on single-node) |
+| 3 | `test_model_fetch` | ensures model bytes present; polls or downloads if remote |
+| 4 | `test_openai_compatible_smoke` | brings up a short-lived server at a small fixed cell; probes GET/POST `/v1/*` via `VllmJob.probe_openai_endpoints()`; always stops its server |
+| 5 | `test_vllm_inference` | benchmark loop per cell; stores results in `inf_res_dict` |
+| 6 | `test_metric` | one test per metric per cell; reads `inf_res_dict`; asserts verdict |
+| 7 | `test_print_results_table` | summary log; must run after all cells |
+| 8 | `test_teardown` | `teardown_containers()`; sets `lifecycle.torn_down`; **never skips** |
 
 Rules:
 - Every test except `test_launch_container`, `test_teardown`, and `test_print_results_table`
@@ -232,6 +234,9 @@ Rules:
   and is itself responsible for setting `lifecycle.failed`; it has no prior stage to guard
   against. `test_teardown` must run even on failure. `test_print_results_table` guards only
   on whether `inf_res_dict` is empty and logs whatever results were recorded.
+- `test_openai_compatible_smoke` catches exceptions, sets `lifecycle.failed = True`, re-raises;
+  a `finally` always calls `job.stop_server()` so a smoke-server failure never leaves a stray
+  process for `test_vllm_inference`'s first cell to inherit
 - `test_vllm_inference` catches exceptions, sets `lifecycle.failed = True`, re-raises
 - `test_teardown` never skips — must run even on failure; sets `lifecycle.torn_down = True`
   to suppress the `orch` fixture's leak-guard finalizer (prevents double teardown)

--- a/cvs/lib/inference/vllm_job.py
+++ b/cvs/lib/inference/vllm_job.py
@@ -32,6 +32,7 @@ IB device config (distributed only):
 
 from __future__ import annotations
 
+import base64
 import json
 import math
 import re
@@ -41,6 +42,7 @@ from typing import Optional
 
 from cvs.lib import globals
 from cvs.lib.inference.utils.vllm_parsing import to_client_metrics
+from cvs.lib.utils.model_query_lib import OpenAIProbe
 
 log = globals.log
 
@@ -428,6 +430,61 @@ class VllmJob:
         time.sleep(5)
         if self._is_ray_backend and int(self.nnodes) > 1:
             self.orch.exec("ray stop")
+
+    # ---------- smoke ----------
+
+    def probe_openai_endpoints(self):
+        """Smoke-test the server's OpenAI-compatible HTTP API via `orch.exec_on_head`.
+
+        Reuses the framework-agnostic `OpenAIProbe` (shared with the sglang
+        suite's `docker exec`-based probe): GET /v1/models, POST
+        /v1/chat/completions, POST /v1/completions, and a structured-JSON
+        chat completion. The probe script is stdlib-only Python, base64'd
+        into a heredoc-free `exec` so no file needs staging/cleanup outside
+        the one temp path. Runs on the HEAD node only (like run_client /
+        parse_results): the client always talks to http://head:port, so
+        broadcasting the probe to every node would needlessly recheck the
+        same endpoint N times on multinode.
+
+        Returns the per-step "<title> -> Pass|Fail (<code>)" summary lines.
+        Raises RuntimeError on a malformed/missing probe response or a
+        failed check (mirrors parse_results: hard-fail rather than a
+        silently-green empty result).
+        """
+        probe_src = OpenAIProbe.probe_script(int(self.port_no), self.model_id)
+        b64 = base64.b64encode(probe_src.encode("utf-8")).decode("ascii")
+        probe_path = f"{self.out_dir}/openai_probe.py"
+        cmd = (
+            f"mkdir -p {shlex.quote(self.out_dir)} && "
+            f"echo {shlex.quote(b64)} | base64 -d > {shlex.quote(probe_path)} && "
+            f"python3 {shlex.quote(probe_path)}"
+        )
+        out = self.orch.exec_on_head("bash -c " + shlex.quote(cmd))
+
+        raw = next(iter(out.values()), None) if out else None
+        if not raw or not str(raw).strip():
+            raise RuntimeError(f"OpenAI-compatible probe produced no output: {out!r}")
+
+        last_line = str(raw).strip().splitlines()[-1]
+        try:
+            parsed = json.loads(last_line)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"OpenAI-compatible probe invalid JSON: {e!r} raw={raw!r}") from e
+        if not isinstance(parsed, dict):
+            raise RuntimeError(f"OpenAI-compatible probe expected JSON object, got {type(parsed).__name__!r}")
+
+        results = {}
+        for step, val in parsed.items():
+            if not (isinstance(val, (list, tuple)) and len(val) == 2):
+                raise RuntimeError(f"OpenAI-compatible probe bad shape at {step!r}: {val!r}")
+            results[step] = (int(val[0]), val[1])
+
+        OpenAIProbe.log_results(results, log)
+        ok, err = OpenAIProbe.check_results(results, port=self.port_no, logger=log)
+        summary = OpenAIProbe.summarize_results(results, ok, err)
+        if not ok:
+            raise RuntimeError(err)
+        return summary
 
     # ---------- client side (head-only) ----------
 

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -140,11 +140,12 @@ def pytest_collection_modifyitems(items):
         "test_setup_sshd": 1,
         "test_discover_topology": 2,
         "test_model_fetch": 3,
-        "test_vllm_inference": 4,
-        "test_metric": 5,
-        "test_gpu_metric": 5,
-        "test_print_results_table": 6,
-        "test_teardown": 7,
+        "test_openai_compatible_smoke": 4,
+        "test_vllm_inference": 5,
+        "test_metric": 6,
+        "test_gpu_metric": 6,
+        "test_print_results_table": 7,
+        "test_teardown": 8,
     }
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
 

--- a/cvs/tests/inference/vllm/vllm.py
+++ b/cvs/tests/inference/vllm/vllm.py
@@ -52,6 +52,12 @@ _FETCH_POLL_COUNT = 80
 _FETCH_POLL_WAIT_S = 30
 _FETCH_PRESENCE_RETRIES = 5
 
+# Smoke-probe cell: smallest isl/osl that gets a server up to answer
+# GET/POST /v1/* without spending sweep-scale time/GPU-minutes. concurrency/
+# num_prompts are irrelevant here -- the probe never calls run_client.
+_SMOKE_ISL = 128
+_SMOKE_OSL = 32
+
 
 def pytest_generate_tests(metafunc):
     """Parametrize test_vllm_inference from the sweep's named-combo + runs selector.
@@ -240,6 +246,47 @@ def _gpu_snap(orch):
         return capture_gpu_metrics(orch)
     except Exception:
         return {}
+
+
+def test_openai_compatible_smoke(orch, variant_config, hf_token, lifecycle, request):
+    """Stage: smoke-test the OpenAI-compatible HTTP API, once per module.
+
+    Independent of the sweep -- brings up its own short-lived server at a
+    small fixed cell (isl/osl above; concurrency/num_prompts are irrelevant,
+    the probe never runs the benchmark client) purely to answer GET/POST
+    /v1/models, /v1/chat/completions, /v1/completions, and a structured-JSON
+    chat completion. Runs before the sweep so a broken server/endpoint fails
+    fast instead of burning a full benchmark cell first. Always stops its
+    server afterward (success or failure) so test_vllm_inference's first
+    `job.stop_server()` isn't papering over a smoke server left running.
+    """
+    if lifecycle.failed:
+        pytest.skip("a prior lifecycle stage failed")
+    job = VllmJob(
+        orch=orch,
+        variant=variant_config,
+        hf_token=hf_token,
+        isl=_SMOKE_ISL,
+        osl=_SMOKE_OSL,
+        concurrency=1,
+        num_prompts=1,
+        ib_hcas=getattr(lifecycle, "ib_hcas", []),
+        client_poll_count=int(variant_config.params.client_poll_count),
+    )
+    t = time.monotonic()
+    try:
+        job.stop_server()
+        job.build_server_cmd()
+        job.start_server()
+        job.wait_ready()
+        summary = job.probe_openai_endpoints()
+    except Exception:
+        lifecycle.failed = True
+        raise
+    finally:
+        job.stop_server()
+    lifecycle.record(request.node.nodeid, "openai_smoke", time.monotonic() - t)
+    log.info("OpenAI-compatible smoke results:\n%s", "\n".join(summary))
 
 
 def test_vllm_inference(orch, variant_config, hf_token, seq_combo, concurrency, inf_res_dict, lifecycle, request):


### PR DESCRIPTION
## Summary
- Adds `VllmJob.probe_openai_endpoints()`, reusing the shared `OpenAIProbe` helper already used by the sglang suite, driven through `orch.exec_on_head` instead of `docker exec`/Pssh.
- Wires it in as a new lifecycle stage (`test_openai_compatible_smoke`, rank 4) that brings up a short-lived server at a small fixed cell (isl=128/osl=32) and probes GET `/v1/models`, POST `/v1/chat/completions`, POST `/v1/completions`, and structured-JSON output before the full sweep runs.
- Always stops its server in a `finally`, so a smoke failure can't leave a stray process for `test_vllm_inference`'s first cell to inherit.

Ticket: AIMVT-267

## Test plan
- [x] `python -m unittest cvs.lib.inference.unittests.test_vllm_job_server_reuse -v` — 23/23 pass (16 existing + 7 new `TestProbeOpenAIEndpoints` cases)
- [x] `python run_all_unittests.py` — 690 tests, same 2 pre-existing failures in `test_inferencing_config_loader.py` (unrelated to this change, present on `dev/dtni` HEAD)