### PR TITLE
AIMVT-139: migrate remaining dmesg/journal scans to node-scraper

### DIFF
--- a/cvs/lib/unittests/test_verify_lib.py
+++ b/cvs/lib/unittests/test_verify_lib.py
@@ -198,8 +198,24 @@ class TestDmesgMigrations(unittest.TestCase):
         result = verify_lib.full_journalctl_scan(phdl)
 
         self.assertIn("journalctl -k -o short-iso", phdl.exec.call_args[0][0])
+        self.assertNotIn("--since", phdl.exec.call_args[0][0])
         self.assertTrue(result["node1"])
         mock_fail.assert_called()
+
+    @patch("cvs.lib.verify_lib.fail_test")
+    @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
+    def test_full_journalctl_scan_bounds_with_since(self, mock_parse, mock_fail):
+        os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
+        mock_parse.return_value = []
+        phdl = MagicMock()
+        phdl.exec.return_value = {"node1": "raw"}
+
+        verify_lib.full_journalctl_scan(phdl, start_time_dict={"node1": "Mon Jun  5 08:53:27"})
+
+        cmd = phdl.exec.call_args[0][0]
+        expected_year = datetime.datetime.now().astimezone().year
+        self.assertIn("journalctl -k -o short-iso", cmd)
+        self.assertIn(f'--since="{expected_year}-06-05 08:53:27"', cmd)
 
     @patch("cvs.lib.verify_lib.fail_test")
     @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")

--- a/cvs/lib/unittests/test_verify_lib.py
+++ b/cvs/lib/unittests/test_verify_lib.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -130,10 +131,15 @@ class TestDmesgMigrations(unittest.TestCase):
     def test_parse_cvs_time(self):
         dt = verify_lib._parse_cvs_time("Mon Jun  5 08:53")
         self.assertIsNotNone(dt)
-        self.assertEqual((dt.month, dt.day, dt.hour, dt.minute), (6, 5, 8, 53))
+        self.assertEqual((dt.month, dt.day, dt.hour, dt.minute, dt.second), (6, 5, 8, 53, 0))
         self.assertIsNotNone(dt.tzinfo)
         self.assertIsNone(verify_lib._parse_cvs_time(""))
         self.assertIsNone(verify_lib._parse_cvs_time("garbage"))
+
+    def test_parse_cvs_time_with_seconds(self):
+        dt = verify_lib._parse_cvs_time("Mon Jun  5 08:53:27")
+        self.assertIsNotNone(dt)
+        self.assertEqual((dt.month, dt.day, dt.hour, dt.minute, dt.second), (6, 5, 8, 53, 27))
 
     def test_cvs_dmesg_error_regex_shape(self):
         regexes = verify_lib.cvs_dmesg_error_regex()
@@ -148,9 +154,7 @@ class TestDmesgMigrations(unittest.TestCase):
     @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
     def test_verify_dmesg_for_errors_uses_time_range(self, mock_parse, mock_fail):
         os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
-        mock_parse.return_value = [
-            {"description": "GPU Reset", "match_content": "GPU reset begin", "category": "RAS"}
-        ]
+        mock_parse.return_value = [{"description": "GPU Reset", "match_content": "GPU reset begin", "category": "RAS"}]
         phdl = MagicMock()
         phdl.exec.return_value = {"node1": "raw"}
         start = {"node1": "Mon Jun  5 08:00"}
@@ -221,6 +225,34 @@ class TestDmesgMigrations(unittest.TestCase):
         self.assertEqual(len(result["node1"]), 1)
         self.assertIn("amdgpu", result["node1"][0].lower())
         mock_fail.assert_called_once()
+
+
+class TestNodeScraperTimeRangeFiltering(unittest.TestCase):
+    """Exercises the real node-scraper analyzer (no mocking of parse_dmesg) to
+    guard against analysis_range_end silently dropping events that occurred
+    before a test's true end time but after that time got truncated to whole
+    minutes.
+    """
+
+    def test_analysis_range_end_keeps_events_up_to_the_real_second(self):
+        dmesg = "2026-07-17T10:16:30,000000+00:00 kern  :err   : [1.0] GPU reset begin on card0\n"
+
+        end_with_seconds = datetime.datetime(2026, 7, 17, 10, 16, 45, tzinfo=datetime.timezone.utc)
+        events = verify_lib.node_scraper_adapter.parse_dmesg(
+            dmesg, analysis_args={"analysis_range_end": end_with_seconds}
+        )
+        self.assertEqual(len(events), 1, "event before the real (second-precision) end time must be kept")
+
+        end_truncated_to_minute = datetime.datetime(2026, 7, 17, 10, 16, 0, tzinfo=datetime.timezone.utc)
+        events = verify_lib.node_scraper_adapter.parse_dmesg(
+            dmesg, analysis_args={"analysis_range_end": end_truncated_to_minute}
+        )
+        self.assertEqual(
+            len(events),
+            0,
+            "minute-truncated analysis_range_end reproduces the historical bug "
+            "(demonstrates why _parse_cvs_time must preserve seconds)",
+        )
 
 
 class TestVerifyHostLspci(unittest.TestCase):

--- a/cvs/lib/unittests/test_verify_lib.py
+++ b/cvs/lib/unittests/test_verify_lib.py
@@ -146,8 +146,7 @@ class TestDmesgMigrations(unittest.TestCase):
 
     @patch("cvs.lib.verify_lib.fail_test")
     @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
-    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
-    def test_verify_dmesg_for_errors_uses_time_range(self, mock_avail, mock_parse, mock_fail):
+    def test_verify_dmesg_for_errors_uses_time_range(self, mock_parse, mock_fail):
         os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
         mock_parse.return_value = [
             {"description": "GPU Reset", "match_content": "GPU reset begin", "category": "RAS"}
@@ -168,8 +167,7 @@ class TestDmesgMigrations(unittest.TestCase):
 
     @patch("cvs.lib.verify_lib.fail_test")
     @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
-    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
-    def test_verify_dmesg_for_errors_till_end_omits_end(self, mock_avail, mock_parse, mock_fail):
+    def test_verify_dmesg_for_errors_till_end_omits_end(self, mock_parse, mock_fail):
         os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
         mock_parse.return_value = []
         phdl = MagicMock()
@@ -185,8 +183,7 @@ class TestDmesgMigrations(unittest.TestCase):
 
     @patch("cvs.lib.verify_lib.fail_test")
     @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
-    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
-    def test_full_journalctl_scan_node_scraper(self, mock_avail, mock_parse, mock_fail):
+    def test_full_journalctl_scan_node_scraper(self, mock_parse, mock_fail):
         os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
         mock_parse.return_value = [
             {"description": "Out of memory error", "match_content": "Out of memory: killed", "category": "OS"}
@@ -202,8 +199,7 @@ class TestDmesgMigrations(unittest.TestCase):
 
     @patch("cvs.lib.verify_lib.fail_test")
     @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
-    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
-    def test_verify_driver_errors_filters_to_driver(self, mock_avail, mock_parse, mock_fail):
+    def test_verify_driver_errors_filters_to_driver(self, mock_parse, mock_fail):
         os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
         mock_parse.return_value = [
             {

--- a/cvs/lib/unittests/test_verify_lib.py
+++ b/cvs/lib/unittests/test_verify_lib.py
@@ -123,6 +123,110 @@ class TestFullDmesgScan(unittest.TestCase):
         mock_fail_test.assert_called()
 
 
+class TestDmesgMigrations(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop(verify_lib.DMESG_PARSER_ENV, None)
+
+    def test_parse_cvs_time(self):
+        dt = verify_lib._parse_cvs_time("Mon Jun  5 08:53")
+        self.assertIsNotNone(dt)
+        self.assertEqual((dt.month, dt.day, dt.hour, dt.minute), (6, 5, 8, 53))
+        self.assertIsNotNone(dt.tzinfo)
+        self.assertIsNone(verify_lib._parse_cvs_time(""))
+        self.assertIsNone(verify_lib._parse_cvs_time("garbage"))
+
+    def test_cvs_dmesg_error_regex_shape(self):
+        regexes = verify_lib.cvs_dmesg_error_regex()
+        self.assertTrue(regexes)
+        for item in regexes:
+            self.assertIn("regex", item)
+            self.assertIn("message", item)
+            self.assertIn("event_category", item)
+            self.assertTrue(item["regex"].startswith("(?i)"))
+
+    @patch("cvs.lib.verify_lib.fail_test")
+    @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
+    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
+    def test_verify_dmesg_for_errors_uses_time_range(self, mock_avail, mock_parse, mock_fail):
+        os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
+        mock_parse.return_value = [
+            {"description": "GPU Reset", "match_content": "GPU reset begin", "category": "RAS"}
+        ]
+        phdl = MagicMock()
+        phdl.exec.return_value = {"node1": "raw"}
+        start = {"node1": "Mon Jun  5 08:00"}
+        end = {"node1": "Mon Jun  5 09:00"}
+
+        result = verify_lib.verify_dmesg_for_errors(phdl, start, end, till_end_flag=False)
+
+        self.assertIn("--time-format iso -x", phdl.exec.call_args[0][0])
+        passed_args = mock_parse.call_args.kwargs["analysis_args"]
+        self.assertIn("analysis_range_start", passed_args)
+        self.assertIn("analysis_range_end", passed_args)
+        self.assertTrue(result["node1"])
+        mock_fail.assert_called()
+
+    @patch("cvs.lib.verify_lib.fail_test")
+    @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
+    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
+    def test_verify_dmesg_for_errors_till_end_omits_end(self, mock_avail, mock_parse, mock_fail):
+        os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
+        mock_parse.return_value = []
+        phdl = MagicMock()
+        phdl.exec.return_value = {"node1": "raw"}
+        start = {"node1": "Mon Jun  5 08:00"}
+        end = {"node1": "Mon Jun  5 09:00"}
+
+        verify_lib.verify_dmesg_for_errors(phdl, start, end, till_end_flag=True)
+
+        passed_args = mock_parse.call_args.kwargs["analysis_args"]
+        self.assertIn("analysis_range_start", passed_args)
+        self.assertNotIn("analysis_range_end", passed_args)
+
+    @patch("cvs.lib.verify_lib.fail_test")
+    @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
+    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
+    def test_full_journalctl_scan_node_scraper(self, mock_avail, mock_parse, mock_fail):
+        os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
+        mock_parse.return_value = [
+            {"description": "Out of memory error", "match_content": "Out of memory: killed", "category": "OS"}
+        ]
+        phdl = MagicMock()
+        phdl.exec.return_value = {"node1": "raw"}
+
+        result = verify_lib.full_journalctl_scan(phdl)
+
+        self.assertIn("journalctl -k -o short-iso", phdl.exec.call_args[0][0])
+        self.assertTrue(result["node1"])
+        mock_fail.assert_called()
+
+    @patch("cvs.lib.verify_lib.fail_test")
+    @patch.object(verify_lib.node_scraper_adapter, "parse_dmesg")
+    @patch.object(verify_lib.node_scraper_adapter, "is_available", return_value=True)
+    def test_verify_driver_errors_filters_to_driver(self, mock_avail, mock_parse, mock_fail):
+        os.environ[verify_lib.DMESG_PARSER_ENV] = "node-scraper"
+        mock_parse.return_value = [
+            {
+                "description": "amdgpu Page Fault",
+                "match_content": "amdgpu 0000:01:00.0 page fault",
+                "category": "SW_DRIVER",
+            },
+            {
+                "description": "Filesystem corrupted!",
+                "match_content": "EXT4-fs error (device sda1):",
+                "category": "OS",
+            },
+        ]
+        phdl = MagicMock()
+        phdl.exec.return_value = {"node1": "raw"}
+
+        result = verify_lib.verify_driver_errors(phdl)
+
+        self.assertEqual(len(result["node1"]), 1)
+        self.assertIn("amdgpu", result["node1"][0].lower())
+        mock_fail.assert_called_once()
+
+
 class TestVerifyHostLspci(unittest.TestCase):
     def setUp(self):
         self.mock_phdl = MagicMock()

--- a/cvs/lib/verify_lib.py
+++ b/cvs/lib/verify_lib.py
@@ -83,16 +83,19 @@ def cvs_dmesg_error_regex():
 
 
 def _parse_cvs_time(time_str):
-    """Convert a `date +"%a %b %e %H:%M"` string to a tz-aware datetime.
+    """Convert a `date +"%a %b %e %H:%M"` or `date +"%a %b %e %H:%M:%S"` string
+    to a tz-aware datetime.
 
     Returns None if the string cannot be parsed. The year is assumed to be the
     current year and the timezone the local timezone (CVS already assumes the
-    cluster is NTP-synced with the head node).
+    cluster is NTP-synced with the head node). Seconds default to 0 when the
+    input string is minute-precision only, for backward compatibility with
+    callers that haven't been updated to capture seconds.
     """
     if not time_str:
         return None
     match = re.search(
-        r'([A-Za-z]{3})\s+([A-Za-z]{3})\s+(\d+)\s+(\d{1,2}):(\d{2})',
+        r'([A-Za-z]{3})\s+([A-Za-z]{3})\s+(\d+)\s+(\d{1,2}):(\d{2})(?::(\d{2}))?',
         time_str.strip(),
     )
     if not match:
@@ -108,6 +111,7 @@ def _parse_cvs_time(time_str):
         int(match.group(3)),
         int(match.group(4)),
         int(match.group(5)),
+        int(match.group(6) or 0),
         tzinfo=now_local.tzinfo,
     )
 
@@ -127,9 +131,7 @@ def _node_scraper_scan(output_dict, analysis_args=None, source_label='Dmesg'):
     err_dict = {}
     for node in output_dict.keys():
         err_dict[node] = []
-        events = node_scraper_adapter.parse_dmesg(
-            output_dict[node], node_name=node, analysis_args=analysis_args
-        )
+        events = node_scraper_adapter.parse_dmesg(output_dict[node], node_name=node, analysis_args=analysis_args)
         for line in node_scraper_adapter.event_match_lines(events):
             msg = f'ERROR - Failure pattern *** {line} *** seen in {source_label} on node {node}'
             fail_test(msg)
@@ -323,9 +325,7 @@ def verify_dmesg_for_errors(phdl, start_time_dict, end_time_dict, till_end_flag=
             end_dt = _parse_cvs_time(end_time_dict[node0])
             if end_dt:
                 analysis_args['analysis_range_end'] = end_dt
-        output_dict = phdl.exec(
-            "sudo dmesg --time-format iso -x | egrep -v 'ALLOWED|DENIED' --color=never"
-        )
+        output_dict = phdl.exec("sudo dmesg --time-format iso -x | egrep -v 'ALLOWED|DENIED' --color=never")
         return _node_scraper_scan(output_dict, analysis_args=analysis_args, source_label='Dmesg')
 
     err_dict = {}
@@ -694,9 +694,7 @@ def verify_driver_errors(phdl):
         # (amdgpu match or SW_DRIVER category) to preserve this check's
         # driver-error focus while reusing node-scraper's pattern table.
         err_dict = {}
-        output_dict = phdl.exec(
-            "sudo dmesg --time-format iso -x | egrep -v 'ALLOWED|DENIED' --color=never"
-        )
+        output_dict = phdl.exec("sudo dmesg --time-format iso -x | egrep -v 'ALLOWED|DENIED' --color=never")
         for node in output_dict.keys():
             err_dict[node] = []
             events = node_scraper_adapter.parse_dmesg(

--- a/cvs/lib/verify_lib.py
+++ b/cvs/lib/verify_lib.py
@@ -516,7 +516,7 @@ def verify_host_lspci(phdl, pcie_speed=32, pcie_width=16):
     return err_dict
 
 
-def full_journalctl_scan(phdl):
+def full_journalctl_scan(phdl, start_time_dict=None):
     """
     Scan kernel logs via journalctl across nodes for GPU/interrupt/error-related issues
     and fail if any known error patterns are detected.
@@ -526,6 +526,11 @@ def full_journalctl_scan(phdl):
             - exec(cmd: str) -> dict[node: str, output: str]
               Executes the given command on all relevant nodes and returns a mapping
               of node identifier to the command's stdout.
+      start_time_dict: Optional {node: cvs_time_str} (same format produced by
+            `date +"%a %b %e %H:%M"` / `...%H:%M:%S`, e.g. from the caller's own
+            start-of-run timestamp). When provided, journalctl is asked to only
+            return entries `--since` that time (derived from the first node's
+            entry), instead of collecting the entire kernel journal.
 
     Behavior:
       - Runs 'journalctl -k' (kernel messages) filtered through egrep for high-signal
@@ -549,11 +554,20 @@ def full_journalctl_scan(phdl):
         not containing those keywords if broader scanning is desired.
     """
 
+    since_clause = ''
+    if start_time_dict:
+        node0 = list(start_time_dict.keys())[0]
+        start_dt = _parse_cvs_time(start_time_dict[node0])
+        if start_dt:
+            since_clause = f' --since="{start_dt.strftime("%Y-%m-%d %H:%M:%S")}"'
+
     if use_node_scraper_dmesg():
-        # node-scraper path: scan the full kernel journal (ISO timestamps) with
-        # the node-scraper analyzer plus CVS's historical patterns, instead of
-        # the lossy egrep prefilter + per-line regex.
-        output_dict = phdl.exec('sudo journalctl -k -o short-iso')
+        # node-scraper path: scan the kernel journal (ISO timestamps) with the
+        # node-scraper analyzer plus CVS's historical patterns, instead of the
+        # lossy egrep prefilter + per-line regex. --since (when available) is
+        # applied server-side so journalctl itself, not just the analyzer,
+        # avoids transferring/parsing the entire historic journal.
+        output_dict = phdl.exec(f'sudo journalctl -k -o short-iso{since_clause}')
         return _node_scraper_scan(
             output_dict,
             analysis_args={'error_regex': cvs_dmesg_error_regex()},
@@ -562,7 +576,7 @@ def full_journalctl_scan(phdl):
 
     err_dict = {}
     # Fetch kernel logs filtered for likely error indicators across nodes
-    out_dict = phdl.exec('sudo journalctl -k | egrep "amdgpu|interrupt|error|fail|timeout|fault"')
+    out_dict = phdl.exec(f'sudo journalctl -k{since_clause} | egrep "amdgpu|interrupt|error|fail|timeout|fault"')
     for node in out_dict.keys():
         err_dict[node] = []
 

--- a/cvs/lib/verify_lib.py
+++ b/cvs/lib/verify_lib.py
@@ -5,6 +5,7 @@ The year included in the foregoing notice is the year of creation of the work.
 All code contained here is Property of Advanced Micro Devices, Inc.
 '''
 
+import datetime
 import os
 import re
 
@@ -48,6 +49,92 @@ def use_node_scraper_dmesg():
     if choice in ('legacy', 'cvs', '0', 'false', 'off', 'no'):
         return False
     return True
+
+
+# Map CVS's historical dmesg categories (err_patterns_dict) to node-scraper
+# event categories, so the legacy patterns can be preserved as analyzer
+# extensions on top of node-scraper's built-in pattern table.
+_CVS_DMESG_CATEGORY_MAP = {
+    'gpu_reset': 'RAS',
+    'crash': 'SW_DRIVER',
+    'test_fail': 'APPLICATION',
+    'fault': 'SW_DRIVER',
+    'driver': 'SW_DRIVER',
+    'hardware': 'RAS',
+    'network': 'NETWORK',
+}
+
+
+def cvs_dmesg_error_regex():
+    """Return CVS's err_patterns_dict as node-scraper error_regex extensions.
+
+    Each legacy pattern is wrapped as a case-insensitive node-scraper ErrorRegex
+    dict so the node-scraper path still flags everything the historical regex
+    caught, in addition to node-scraper's built-in pattern table.
+    """
+    return [
+        {
+            'regex': f'(?i){pattern}',
+            'message': f'CVS {name} pattern',
+            'event_category': _CVS_DMESG_CATEGORY_MAP.get(name, 'UNKNOWN'),
+        }
+        for name, pattern in err_patterns_dict.items()
+    ]
+
+
+def _parse_cvs_time(time_str):
+    """Convert a `date +"%a %b %e %H:%M"` string to a tz-aware datetime.
+
+    Returns None if the string cannot be parsed. The year is assumed to be the
+    current year and the timezone the local timezone (CVS already assumes the
+    cluster is NTP-synced with the head node).
+    """
+    if not time_str:
+        return None
+    match = re.search(
+        r'([A-Za-z]{3})\s+([A-Za-z]{3})\s+(\d+)\s+(\d{1,2}):(\d{2})',
+        time_str.strip(),
+    )
+    if not match:
+        return None
+    try:
+        month = datetime.datetime.strptime(match.group(2), '%b').month
+    except ValueError:
+        return None
+    now_local = datetime.datetime.now().astimezone()
+    return datetime.datetime(
+        now_local.year,
+        month,
+        int(match.group(3)),
+        int(match.group(4)),
+        int(match.group(5)),
+        tzinfo=now_local.tzinfo,
+    )
+
+
+def _node_scraper_scan(output_dict, analysis_args=None, source_label='Dmesg'):
+    """Scan per-node log text with node-scraper and report each detected error.
+
+    Args:
+        output_dict: {node: raw_log_text} as returned by phdl.exec.
+        analysis_args: optional dict of DmesgAnalyzerArgs fields (e.g.
+            error_regex, analysis_range_start/analysis_range_end).
+        source_label: label used in the failure message (e.g. 'Dmesg').
+
+    Returns:
+        {node: [matched lines]}; calls fail_test for each detected error.
+    """
+    err_dict = {}
+    for node in output_dict.keys():
+        err_dict[node] = []
+        events = node_scraper_adapter.parse_dmesg(
+            output_dict[node], node_name=node, analysis_args=analysis_args
+        )
+        for line in node_scraper_adapter.event_match_lines(events):
+            msg = f'ERROR - Failure pattern *** {line} *** seen in {source_label} on node {node}'
+            fail_test(msg)
+            err_dict[node].append(line)
+    return err_dict
 
 
 def verify_gpu_pcie_bus_width(phdl, expected_cards=8, gpu_pcie_speed=32, gpu_pcie_width=16):
@@ -222,6 +309,24 @@ def verify_dmesg_for_errors(phdl, start_time_dict, end_time_dict, till_end_flag=
     """
 
     log.info('scan dmesg')
+
+    if use_node_scraper_dmesg():
+        # node-scraper path: collect full dmesg with ISO timestamps and let the
+        # analyzer filter by time range, instead of sed/awk slicing on the
+        # human-readable timestamps. CVS's historical patterns are added too.
+        node0 = list(start_time_dict.keys())[0]
+        analysis_args = {'error_regex': cvs_dmesg_error_regex()}
+        start_dt = _parse_cvs_time(start_time_dict[node0])
+        if start_dt:
+            analysis_args['analysis_range_start'] = start_dt
+        if not till_end_flag:
+            end_dt = _parse_cvs_time(end_time_dict[node0])
+            if end_dt:
+                analysis_args['analysis_range_end'] = end_dt
+        output_dict = phdl.exec(
+            "sudo dmesg --time-format iso -x | egrep -v 'ALLOWED|DENIED' --color=never"
+        )
+        return _node_scraper_scan(output_dict, analysis_args=analysis_args, source_label='Dmesg')
 
     err_dict = {}
 
@@ -444,6 +549,17 @@ def full_journalctl_scan(phdl):
         not containing those keywords if broader scanning is desired.
     """
 
+    if use_node_scraper_dmesg():
+        # node-scraper path: scan the full kernel journal (ISO timestamps) with
+        # the node-scraper analyzer plus CVS's historical patterns, instead of
+        # the lossy egrep prefilter + per-line regex.
+        output_dict = phdl.exec('sudo journalctl -k -o short-iso')
+        return _node_scraper_scan(
+            output_dict,
+            analysis_args={'error_regex': cvs_dmesg_error_regex()},
+            source_label='journalctl',
+        )
+
     err_dict = {}
     # Fetch kernel logs filtered for likely error indicators across nodes
     out_dict = phdl.exec('sudo journalctl -k | egrep "amdgpu|interrupt|error|fail|timeout|fault"')
@@ -507,19 +623,16 @@ def full_dmesg_scan(
     if use_node_scraper_dmesg():
         # node-scraper path: collect with ISO timestamps + decoded level prefix
         # ('--time-format iso -x') so the analyzer's full pattern set and
-        # timestamp extraction apply, then flag every detected error.
-        err_dict = {}
+        # timestamp extraction apply, then flag every detected error. CVS's
+        # historical patterns are added as analyzer extensions.
         output_dict = phdl.exec(
             "sudo dmesg --time-format iso -x | grep -v initialized | egrep -v 'ALLOWED|DENIED' --color=never"
         )
-        for node in output_dict.keys():
-            err_dict[node] = []
-            events = node_scraper_adapter.parse_dmesg(output_dict[node], node_name=node)
-            for line in node_scraper_adapter.event_match_lines(events):
-                msg = f'ERROR - Failure pattern *** {line} *** seen in Dmesg on node {node}'
-                fail_test(msg)
-                err_dict[node].append(line)
-        return err_dict
+        return _node_scraper_scan(
+            output_dict,
+            analysis_args={'error_regex': cvs_dmesg_error_regex()},
+            source_label='Dmesg',
+        )
 
     # Legacy path: historical err_patterns_dict regex over human-readable dmesg.
     err_dict = {}
@@ -575,6 +688,35 @@ def verify_driver_errors(phdl):
     """
 
     log.info('Scan for AMD GPU driver errors')
+
+    if use_node_scraper_dmesg():
+        # node-scraper path: parse full dmesg, then report driver-related events
+        # (amdgpu match or SW_DRIVER category) to preserve this check's
+        # driver-error focus while reusing node-scraper's pattern table.
+        err_dict = {}
+        output_dict = phdl.exec(
+            "sudo dmesg --time-format iso -x | egrep -v 'ALLOWED|DENIED' --color=never"
+        )
+        for node in output_dict.keys():
+            err_dict[node] = []
+            events = node_scraper_adapter.parse_dmesg(
+                output_dict[node],
+                node_name=node,
+                analysis_args={'error_regex': cvs_dmesg_error_regex()},
+            )
+            for event in events:
+                match = event.get('match_content')
+                if isinstance(match, (list, tuple)):
+                    text = ' '.join(str(part) for part in match if part)
+                else:
+                    text = str(match or '')
+                if 'amdgpu' in text.lower() or event.get('category') == 'SW_DRIVER':
+                    lines = node_scraper_adapter.event_match_lines([event])
+                    line = lines[0] if lines else (event.get('description') or '')
+                    msg = f'ERROR !! amdgpu driver errors detected in dmesg on node {node}: {line}'
+                    fail_test(msg)
+                    err_dict[node].append(line)
+        return err_dict
 
     err_dict = {}
     # Collect AMDGPU-related kernel messages filtered for likely error terms

--- a/cvs/monitors/check_cluster_health.py
+++ b/cvs/monitors/check_cluster_health.py
@@ -68,6 +68,7 @@ def load_cluster_file(cluster_file_path):
 
 def general_health_checks(
     phdl,
+    start_time_dict=None,
 ):
     health_dict = {}
     print('Verify General Health Checks')
@@ -86,9 +87,10 @@ def general_health_checks(
         health_dict['driver_errors'] = verify_lib.verify_driver_errors(phdl)
     except Exception as e:
         print(f'ERROR running verify_driver_errors, due to exception {e}')
-    # journlctl scan
+    # journlctl scan - bounded to start_time_dict (via --since) when provided,
+    # instead of collecting the entire kernel journal since boot.
     try:
-        health_dict['journlctl_scan'] = verify_lib.full_journalctl_scan(phdl)
+        health_dict['journlctl_scan'] = verify_lib.full_journalctl_scan(phdl, start_time_dict=start_time_dict)
     except Exception as e:
         print(f'ERROR running full_journalctl_scan, due to exception {e}')
     # Check for any link flap evidence
@@ -281,7 +283,7 @@ def build_html_report(phdl, html_file, gen_health_dict, start_time, snapshot_err
 
     # Snapshot tables
     # Scan Dmesgs to see any new errors while running the passive health check
-    end_time = phdl.exec('date')
+    end_time = phdl.exec('date +"%a %b %e %H:%M:%S"')
     dmesg_diff_dict = verify_lib.verify_dmesg_for_errors(phdl, start_time, end_time)
     html_lib.build_err_log_table(
         html_file, dmesg_diff_dict, 'New Dmesg Errors during snapshotting', 'snapdmesgtable', 'snapdmesgid'
@@ -477,10 +479,10 @@ class CheckClusterHealthMonitor(MonitorPlugin):
         else:
             phdl = parallel_ssh_lib.Pssh(log, node_list, user=username, password=password)
 
-        start_time = phdl.exec('date')
+        start_time = phdl.exec('date +"%a %b %e %H:%M:%S"')
 
         # Run general health checks and scan historic errors
-        gen_health_dict = general_health_checks(phdl)
+        gen_health_dict = general_health_checks(phdl, start_time_dict=start_time)
 
         # Take cluster metrics snapshot before iterations
         snapshot_dict_before = verify_lib.create_cluster_metrics_snapshot(phdl)


### PR DESCRIPTION
## Summary
- Migrate `verify_dmesg_for_errors`, `full_journalctl_scan`, and `verify_driver_errors` to the node-scraper adapter behind `CVS_DMESG_PARSER` (builds on merged #221).
- Consolidate shared parsing into `_node_scraper_scan()` plus helpers: `cvs_dmesg_error_regex()` (legacy pattern extensions), `_parse_cvs_time()` (tz-aware time windows).
- Refactor `full_dmesg_scan` to reuse the shared helper and CVS pattern extensions.
- Add unit tests for time-range filtering, journalctl path, driver-only filtering, and helper shape.

## Test plan
- [ ] `python -m unittest cvs.lib.unittests.test_verify_lib.TestDmesgMigrations`
- [ ] `python -m unittest cvs.lib.unittests.test_verify_lib.TestFullDmesgScan`
- [ ] Confirm `CVS_DMESG_PARSER=legacy` still uses regex paths for all four scanners
- [ ] Confirm default node-scraper path uses ISO dmesg / `journalctl -k -o short-iso` collection commands


Made with [Cursor](https://cursor.com)