### PR TITLE
AIMVT-257: Containerize CVS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.cvs_venv
+.doc_venv
+.ruff_venv
+.test_venv
+dist
+docs/_build
+*.egg-info
+**/__pycache__
+**/*.py[cod]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,19 @@ jobs:
           *.log
           .coverage
         retention-days: 2
+
+  container-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build CVS container image
+      run: docker build --tag cvs:ci .
+
+    - name: Verify container entrypoint and packaged configuration
+      run: |
+        docker run --rm cvs:ci --version
+        docker run --rm cvs:ci copy-config --list
+        docker run --rm --entrypoint /bin/sh cvs:ci -c 'command -v ssh && command -v ip'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+#
+# CVS is a head-node CLI: it connects to the cluster over SSH and runs the
+# requested test suite remotely. The image intentionally does not include
+# ROCm or the workload binaries; those belong on the cluster nodes (or in the
+# workload images used by CVS's container backend).
+
+ARG PYTHON_IMAGE=python:3.11-slim-bookworm
+
+FROM ${PYTHON_IMAGE} AS builder
+
+WORKDIR /build
+
+# Wheels cover the normal installation path, while these packages provide a
+# portable fallback for dependencies with native extensions (for example
+# parallel-ssh/libssh2 and cryptography).
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        libssh2-1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Keep dependency installation cacheable when only CVS source changes.
+COPY requirements.txt setup.py MANIFEST.in README.md LICENSE pytest.ini version.txt ./
+COPY cvs ./cvs
+
+# pytest.ini is not package data, but cvs run needs it while pytest discovers
+# installed test modules and their CVS-specific CLI options.
+RUN python -m venv /opt/cvs-venv \
+    && /opt/cvs-venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/cvs-venv/bin/pip install --no-cache-dir . \
+    && site_packages=$(/opt/cvs-venv/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])') \
+    && install --mode=0644 pytest.ini "$site_packages/cvs/pytest.ini"
+
+FROM ${PYTHON_IMAGE} AS runtime
+
+LABEL org.opencontainers.image.title="Cluster Validation Suite" \
+      org.opencontainers.image.description="Head-node CLI for validating AMD AI clusters" \
+      org.opencontainers.image.source="https://github.com/ROCm/cvs" \
+      org.opencontainers.image.licenses="MIT"
+
+# CVS uses Python SSH libraries, and the CLI utilities are retained for
+# operator workflows and diagnostic commands launched from the image.
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        iproute2 \
+        libffi8 \
+        libssh2-1 \
+        libssl3 \
+        openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/cvs-venv /opt/cvs-venv
+
+ENV VIRTUAL_ENV=/opt/cvs-venv \
+    PATH="/opt/cvs-venv/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# /workspace receives user-provided cluster and suite configuration; /results
+# is a convenient bind-mount target for reports and logs. The existing CVS
+# defaults remain available for callers that use /tmp/cvs or /var/www/html/cvs.
+RUN mkdir -p /workspace /results /tmp/cvs /var/www/html/cvs
+
+WORKDIR /workspace
+
+ENTRYPOINT ["cvs"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ cvs list       # Should list available test suites
 
 The `cvs` command will now be available globally in your environment. You can run tests from anywhere, not just from the CVS source directory.
 
+## Method 3: Run CVS in a container
+
+The repository provides a Docker image for running CVS as the cluster head-node CLI. Build it from the repository root:
+
+```bash
+docker build --tag cvs:local .
+docker run --rm cvs:local --version
+```
+
+Bind mount your cluster/configuration files, SSH key, and a results directory when running a suite. The cluster file must refer to the in-container, read-only key path. See the [container installation guide](https://rocm.docs.amd.com/projects/cvs/en/latest/install/cvs-install.html#run-cvs-in-a-container) for a complete example and notes on the container backend.
+
 # How to upgrade
 
 To upgrade CVS to the latest version:

--- a/docs/install/cvs-install.rst
+++ b/docs/install/cvs-install.rst
@@ -131,6 +131,73 @@ After installation, verify CVS is available:
 
 If you see a list of available test suites, CVS is installed correctly.
 
+Run CVS in a container
+=======================
+
+CVS can run as the head-node CLI in a Docker container. The image connects to
+the cluster over SSH; it does not contain ROCm or the workloads that CVS
+launches on cluster nodes.
+
+Prerequisites
+-------------
+
+- Docker Engine on the system from which you run CVS.
+- Network access from that system to every cluster node over SSH.
+- A cluster file and test configuration file prepared as described below.
+- An SSH private key that the cluster file references. Do not copy the key into
+  the image; mount it read-only at runtime.
+
+Build and verify the image
+--------------------------
+
+From the repository root, build the image and verify the installed CLI:
+
+.. code:: bash
+
+  docker build --tag cvs:local .
+  docker run --rm cvs:local --version
+  docker run --rm cvs:local copy-config --list
+
+Run a test suite
+----------------
+
+Copy the required configuration files to a directory outside the repository
+and update the cluster file to use the path where the key will be mounted in
+the container:
+
+.. code:: json
+
+  {
+    "priv_key_file": "/run/secrets/cvs_ssh_key"
+  }
+
+The following example runs the platform suite. It keeps input files and the
+private key read-only, while reports and logs are written to the host
+``results`` directory:
+
+.. code:: bash
+
+  mkdir -p results
+  docker run --rm --init --network host \
+    --mount type=bind,src="$(pwd)/cluster.json",dst=/workspace/cluster.json,readonly \
+    --mount type=bind,src="$(pwd)/host_config.json",dst=/workspace/host_config.json,readonly \
+    --mount type=bind,src="$HOME/.ssh/id_ed25519",dst=/run/secrets/cvs_ssh_key,readonly \
+    --mount type=bind,src="$(pwd)/results",dst=/results \
+    cvs:local run host_configs_cvs \
+      --cluster_file /workspace/cluster.json \
+      --config_file /workspace/host_config.json \
+      --html /results/host.html \
+      --self-contained-html \
+      --log-file /results/host.log \
+      --capture=tee-sys -vvv -s
+
+``--network host`` gives CVS the same network reachability as the Docker host
+on Linux. Remove it only after confirming the bridge network can reach all
+cluster nodes. CVS's normal bare-metal execution does not need a Docker socket
+inside this image. When the cluster file selects the CVS container backend,
+the image still communicates with the remote nodes over SSH; those remote SSH
+users need Docker access as documented in :doc:`/how-to/run-with-containers`.
+
 
 Configure the CVS cluster file
 ==============================


### PR DESCRIPTION
## Summary
- add a multi-stage Docker image for the CVS head-node CLI
- document secure configuration, SSH-key, and results bind mounts
- add a pull-request container build and CLI smoke check

## Validation
- `git diff --check`
- clean-environment `pip install .`
- `cvs --version`
- `cvs list`
- `cvs copy-config --list`
- `cvs run host_configs_cvs --collect-only` (13 tests collected)

The local Docker daemon is not accessible in this workspace, so the new GitHub Actions `container-smoke` job verifies the actual image build and runtime commands.