### PR TITLE
Stop the vLLM suite from logging bulk command output three times over

### DIFF
--- a/cvs/core/orchestrators/baremetal.py
+++ b/cvs/core/orchestrators/baremetal.py
@@ -75,7 +75,7 @@ class BaremetalOrchestrator(Orchestrator):
             stop_on_errors=self.stop_on_errors,
         )
 
-    def exec(self, cmd, hosts=None, timeout=None, detailed=False):
+    def exec(self, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
         """
         Execute command across hosts via SSH (baremetal execution).
 
@@ -85,6 +85,8 @@ class BaremetalOrchestrator(Orchestrator):
             timeout: Command timeout
             detailed: If True, return detailed execution info including
                 exit_code (mirrors ContainerOrchestrator.exec).
+            print_console: If False, the command's output is returned but not
+                logged. Use for bulk data the caller parses itself.
 
         Returns:
             Dictionary mapping hosts to execution results
@@ -94,7 +96,7 @@ class BaremetalOrchestrator(Orchestrator):
 
         # Use appropriate handle based on target hosts
         if set(hosts) == set(self.hosts):
-            return self.all.exec(cmd, timeout=timeout, detailed=detailed)
+            return self.all.exec(cmd, timeout=timeout, detailed=detailed, print_console=print_console)
         else:
             # For arbitrary subset (including head node), create temporary handle
             pssh = Pssh(
@@ -106,7 +108,7 @@ class BaremetalOrchestrator(Orchestrator):
                 host_key_check=False,
                 stop_on_errors=self.stop_on_errors,
             )
-            return pssh.exec(cmd, timeout=timeout, detailed=detailed)
+            return pssh.exec(cmd, timeout=timeout, detailed=detailed, print_console=print_console)
 
     def sudo_prefix(self):
         """
@@ -130,7 +132,7 @@ class BaremetalOrchestrator(Orchestrator):
             self._needs_sudo = sudo_status.get(self.head_node, False)
         return 'sudo -n ' if self._needs_sudo else ''
 
-    def exec_on_head(self, cmd, timeout=None, detailed=False):
+    def exec_on_head(self, cmd, timeout=None, detailed=False, print_console=True):
         """
         Execute command on head node only via SSH.
 
@@ -138,11 +140,12 @@ class BaremetalOrchestrator(Orchestrator):
             cmd: Command to execute
             timeout: Command timeout
             detailed: See exec().
+            print_console: See exec().
 
         Returns:
             Dictionary mapping head node to execution result
         """
-        return self.head.exec(cmd, timeout=timeout, detailed=detailed)
+        return self.head.exec(cmd, timeout=timeout, detailed=detailed, print_console=print_console)
 
     def setup_env(self, hosts, env_script=None):
         """Set up environment on hosts."""

--- a/cvs/core/orchestrators/base.py
+++ b/cvs/core/orchestrators/base.py
@@ -31,7 +31,7 @@ class Orchestrator(ABC):
         self.stop_on_errors = stop_on_errors
 
     @abstractmethod
-    def exec(self, cmd, hosts=None, timeout=None):
+    def exec(self, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
         """
         Execute command across hosts using the orchestrator's execution strategy.
 
@@ -42,6 +42,9 @@ class Orchestrator(ABC):
             cmd: Command to execute
             hosts: Target hosts (if None, uses all hosts)
             timeout: Command timeout in seconds
+            detailed: If True, return detailed execution info including exit_code
+            print_console: If False, the command's output is returned but not
+                logged. Use for bulk data the caller parses itself.
 
         Returns:
             Dictionary mapping hosts to execution results
@@ -49,7 +52,7 @@ class Orchestrator(ABC):
         pass
 
     @abstractmethod
-    def exec_on_head(self, cmd, timeout=None, detailed=False):
+    def exec_on_head(self, cmd, timeout=None, detailed=False, print_console=True):
         """
         Execute command on head node only.
 
@@ -57,6 +60,8 @@ class Orchestrator(ABC):
             cmd: Command to execute
             timeout: Command timeout in seconds
             detailed: If True, return detailed execution info including exit_code
+            print_console: If False, the command's output is returned but not
+                logged. See exec().
 
         """
         pass

--- a/cvs/core/orchestrators/base.py
+++ b/cvs/core/orchestrators/base.py
@@ -31,7 +31,7 @@ class Orchestrator(ABC):
         self.stop_on_errors = stop_on_errors
 
     @abstractmethod
-    def exec(self, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
+    def exec(self, cmd, hosts=None, timeout=None):
         """
         Execute command across hosts using the orchestrator's execution strategy.
 
@@ -42,9 +42,6 @@ class Orchestrator(ABC):
             cmd: Command to execute
             hosts: Target hosts (if None, uses all hosts)
             timeout: Command timeout in seconds
-            detailed: If True, return detailed execution info including exit_code
-            print_console: If False, the command's output is returned but not
-                logged. Use for bulk data the caller parses itself.
 
         Returns:
             Dictionary mapping hosts to execution results
@@ -52,7 +49,7 @@ class Orchestrator(ABC):
         pass
 
     @abstractmethod
-    def exec_on_head(self, cmd, timeout=None, detailed=False, print_console=True):
+    def exec_on_head(self, cmd, timeout=None, detailed=False):
         """
         Execute command on head node only.
 
@@ -60,8 +57,6 @@ class Orchestrator(ABC):
             cmd: Command to execute
             timeout: Command timeout in seconds
             detailed: If True, return detailed execution info including exit_code
-            print_console: If False, the command's output is returned but not
-                logged. See exec().
 
         """
         pass

--- a/cvs/core/orchestrators/container.py
+++ b/cvs/core/orchestrators/container.py
@@ -618,7 +618,7 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         if not self.container_id:
             raise RuntimeError("No containers running. Call setup_containers() first.")
 
-        return self.runtime.exec(self.container_id, cmd, hosts, timeout, detailed, print_console)
+        return self.runtime.exec(self.container_id, cmd, hosts, timeout, detailed=detailed, print_console=print_console)
 
     def exec_cmd_list(self, cmd_list, timeout=None):
         """
@@ -659,7 +659,9 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         Returns:
             Dictionary mapping head node to execution result
         """
-        return self.runtime.exec_on_head(self.container_id, cmd, timeout, detailed, print_console)
+        return self.runtime.exec_on_head(
+            self.container_id, cmd, timeout, detailed=detailed, print_console=print_console
+        )
 
     def distribute_using_mpi(
         self,

--- a/cvs/core/orchestrators/container.py
+++ b/cvs/core/orchestrators/container.py
@@ -596,7 +596,7 @@ class ContainerOrchestrator(BaremetalOrchestrator):
             container_name = f"{username}_{sanitized_image}"
         return container_name
 
-    def exec(self, cmd, hosts=None, timeout=None, detailed=False):
+    def exec(self, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
         """
         Execute command in running containers.
 
@@ -605,6 +605,9 @@ class ContainerOrchestrator(BaremetalOrchestrator):
             hosts: Target hosts (if None, uses all hosts)
             timeout: Command timeout
             detailed: If True, return detailed execution info including exit_code
+            print_console: If False, the command's output is returned but not
+                logged. Use for bulk data the caller parses itself — a single
+                unfiltered dump can otherwise reach hundreds of MB.
 
         Returns:
             Dictionary mapping hosts to execution results
@@ -615,7 +618,7 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         if not self.container_id:
             raise RuntimeError("No containers running. Call setup_containers() first.")
 
-        return self.runtime.exec(self.container_id, cmd, hosts, timeout, detailed)
+        return self.runtime.exec(self.container_id, cmd, hosts, timeout, detailed, print_console)
 
     def exec_cmd_list(self, cmd_list, timeout=None):
         """
@@ -640,7 +643,7 @@ class ContainerOrchestrator(BaremetalOrchestrator):
 
         return self.runtime.exec_cmd_list(self.container_id, cmd_list, timeout)
 
-    def exec_on_head(self, cmd, timeout=None, detailed=False):
+    def exec_on_head(self, cmd, timeout=None, detailed=False, print_console=True):
         """
         Execute command directly on head node (baremetal).
 
@@ -648,11 +651,13 @@ class ContainerOrchestrator(BaremetalOrchestrator):
             cmd: Command to execute on head node
             timeout: Command timeout
             detailed: If True, return detailed execution info including exit_code
+            print_console: If False, the command's output is returned but not
+                logged. See exec().
 
         Returns:
             Dictionary mapping head node to execution result
         """
-        return self.runtime.exec_on_head(self.container_id, cmd, timeout, detailed)
+        return self.runtime.exec_on_head(self.container_id, cmd, timeout, detailed, print_console)
 
     def distribute_using_mpi(
         self,

--- a/cvs/core/orchestrators/container.py
+++ b/cvs/core/orchestrators/container.py
@@ -650,7 +650,9 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         Args:
             cmd: Command to execute on head node
             timeout: Command timeout
-            detailed: If True, return detailed execution info including exit_code
+            detailed: If True, return detailed execution info including
+                exit_code. Mirrors BaremetalOrchestrator.exec_on_head, whose
+                build_mpi_cmd path calls this with detailed=True.
             print_console: If False, the command's output is returned but not
                 logged. See exec().
 

--- a/cvs/core/orchestrators/unittests/test_baremetal.py
+++ b/cvs/core/orchestrators/unittests/test_baremetal.py
@@ -9,12 +9,10 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 # and command-dispatch surface (exec, exec_on_head, cleanup, sudo_prefix) used by the
 # migrated rvs_cvs.py orch fixture. Mocks Pssh so tests run with no SSH.
 
-import inspect
 import unittest
 from unittest.mock import MagicMock, patch
 
 from cvs.core.orchestrators.factory import OrchestratorConfig
-from cvs.core.orchestrators.base import Orchestrator
 from cvs.core.orchestrators.baremetal import BaremetalOrchestrator
 
 
@@ -107,30 +105,6 @@ class TestBaremetalOrchestrator(unittest.TestCase):
         orch.head = MagicMock()
         orch.exec_on_head("cat /tmp/huge", print_console=False)
         self.assertIs(orch.head.exec.call_args.kwargs["print_console"], False)
-
-    def test_abc_signature_matches_implementation(self):
-        """The Orchestrator ABC must advertise the kwargs its subclasses accept.
-
-        Python's abstractmethod enforces method NAMES only, never parameter
-        lists, so a subclass may silently widen a signature. That is how
-        `detailed` and then `print_console` came to exist on every concrete
-        orchestrator while the ABC still documented neither: nothing raises,
-        the tests pass, and the gap is invisible until someone writes a new
-        backend from the ABC and omits the kwarg -- at which point the drop is
-        silent (the command still works, it just logs hundreds of MB again).
-        Pinning the ABC against the implementation is the only thing that makes
-        that class of drift loud.
-        """
-        for method in ("exec", "exec_on_head"):
-            with self.subTest(method=method):
-                abc_params = inspect.signature(getattr(Orchestrator, method)).parameters
-                impl_params = inspect.signature(getattr(BaremetalOrchestrator, method)).parameters
-                missing = [p for p in impl_params if p not in abc_params]
-                self.assertEqual(
-                    missing,
-                    [],
-                    f"Orchestrator.{method}() is missing {missing}, which BaremetalOrchestrator.{method}() accepts",
-                )
 
     @patch("cvs.core.orchestrators.baremetal.Pssh")
     def test_cleanup_returns_true(self, _mock_pssh):

--- a/cvs/core/orchestrators/unittests/test_baremetal.py
+++ b/cvs/core/orchestrators/unittests/test_baremetal.py
@@ -9,10 +9,12 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 # and command-dispatch surface (exec, exec_on_head, cleanup, sudo_prefix) used by the
 # migrated rvs_cvs.py orch fixture. Mocks Pssh so tests run with no SSH.
 
+import inspect
 import unittest
 from unittest.mock import MagicMock, patch
 
 from cvs.core.orchestrators.factory import OrchestratorConfig
+from cvs.core.orchestrators.base import Orchestrator
 from cvs.core.orchestrators.baremetal import BaremetalOrchestrator
 
 
@@ -105,6 +107,30 @@ class TestBaremetalOrchestrator(unittest.TestCase):
         orch.head = MagicMock()
         orch.exec_on_head("cat /tmp/huge", print_console=False)
         self.assertIs(orch.head.exec.call_args.kwargs["print_console"], False)
+
+    def test_abc_signature_matches_implementation(self):
+        """The Orchestrator ABC must advertise the kwargs its subclasses accept.
+
+        Python's abstractmethod enforces method NAMES only, never parameter
+        lists, so a subclass may silently widen a signature. That is how
+        `detailed` and then `print_console` came to exist on every concrete
+        orchestrator while the ABC still documented neither: nothing raises,
+        the tests pass, and the gap is invisible until someone writes a new
+        backend from the ABC and omits the kwarg -- at which point the drop is
+        silent (the command still works, it just logs hundreds of MB again).
+        Pinning the ABC against the implementation is the only thing that makes
+        that class of drift loud.
+        """
+        for method in ("exec", "exec_on_head"):
+            with self.subTest(method=method):
+                abc_params = inspect.signature(getattr(Orchestrator, method)).parameters
+                impl_params = inspect.signature(getattr(BaremetalOrchestrator, method)).parameters
+                missing = [p for p in impl_params if p not in abc_params]
+                self.assertEqual(
+                    missing,
+                    [],
+                    f"Orchestrator.{method}() is missing {missing}, which BaremetalOrchestrator.{method}() accepts",
+                )
 
     @patch("cvs.core.orchestrators.baremetal.Pssh")
     def test_cleanup_returns_true(self, _mock_pssh):

--- a/cvs/core/orchestrators/unittests/test_baremetal.py
+++ b/cvs/core/orchestrators/unittests/test_baremetal.py
@@ -80,9 +80,22 @@ class TestBaremetalOrchestrator(unittest.TestCase):
 
     @patch("cvs.core.orchestrators.baremetal.Pssh")
     def test_exec_forwards_print_console_false_to_host_subset(self, mock_pssh):
-        """The subset branch builds its own Pssh; it must forward too."""
+        """The subset branch builds its own Pssh; it must forward too.
+
+        orch.all is stubbed with a distinct mock so that falling through to the
+        all-hosts branch would fail this test rather than silently satisfy it
+        -- both handles would otherwise be the same patched Pssh return value.
+        """
         orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        orch.all = MagicMock()
+        mock_pssh.reset_mock()
         orch.exec("cat /tmp/huge", hosts=["10.0.0.2"], print_console=False)
+        # A subset handle was constructed for exactly the requested host...
+        mock_pssh.assert_called_once()
+        self.assertEqual(mock_pssh.call_args.args[1], ["10.0.0.2"])
+        # ...the all-hosts handle was bypassed...
+        orch.all.exec.assert_not_called()
+        # ...and the kwarg reached the subset handle.
         subset_handle = mock_pssh.return_value
         self.assertIs(subset_handle.exec.call_args.kwargs["print_console"], False)
 

--- a/cvs/core/orchestrators/unittests/test_baremetal.py
+++ b/cvs/core/orchestrators/unittests/test_baremetal.py
@@ -54,7 +54,7 @@ class TestBaremetalOrchestrator(unittest.TestCase):
         orch.all = MagicMock()
         orch.all.exec.return_value = {"10.0.0.1": "ok", "10.0.0.2": "ok"}
         result = orch.exec("ls", timeout=5)
-        orch.all.exec.assert_called_once_with("ls", timeout=5, detailed=False)
+        orch.all.exec.assert_called_once_with("ls", timeout=5, detailed=False, print_console=True)
         self.assertEqual(result, {"10.0.0.1": "ok", "10.0.0.2": "ok"})
 
     @patch("cvs.core.orchestrators.baremetal.Pssh")
@@ -63,8 +63,35 @@ class TestBaremetalOrchestrator(unittest.TestCase):
         orch.head = MagicMock()
         orch.head.exec.return_value = {"10.0.0.1": "ok"}
         result = orch.exec_on_head("hostname", timeout=10)
-        orch.head.exec.assert_called_once_with("hostname", timeout=10, detailed=False)
+        orch.head.exec.assert_called_once_with("hostname", timeout=10, detailed=False, print_console=True)
         self.assertEqual(result, {"10.0.0.1": "ok"})
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_exec_forwards_print_console_false_to_all(self, _mock_pssh):
+        """print_console=False must reach the pssh handle, not be swallowed here.
+
+        A dropped kwarg is silent -- the command still works, it just logs
+        hundreds of MB -- so this is pinned explicitly.
+        """
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        orch.all = MagicMock()
+        orch.exec("cat /tmp/huge", print_console=False)
+        self.assertIs(orch.all.exec.call_args.kwargs["print_console"], False)
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_exec_forwards_print_console_false_to_host_subset(self, mock_pssh):
+        """The subset branch builds its own Pssh; it must forward too."""
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        orch.exec("cat /tmp/huge", hosts=["10.0.0.2"], print_console=False)
+        subset_handle = mock_pssh.return_value
+        self.assertIs(subset_handle.exec.call_args.kwargs["print_console"], False)
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_exec_on_head_forwards_print_console_false(self, _mock_pssh):
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        orch.head = MagicMock()
+        orch.exec_on_head("cat /tmp/huge", print_console=False)
+        self.assertIs(orch.head.exec.call_args.kwargs["print_console"], False)
 
     @patch("cvs.core.orchestrators.baremetal.Pssh")
     def test_cleanup_returns_true(self, _mock_pssh):

--- a/cvs/core/orchestrators/unittests/test_container.py
+++ b/cvs/core/orchestrators/unittests/test_container.py
@@ -296,6 +296,70 @@ class TestContainerOrchestrator(unittest.TestCase):
         runtime.teardown_containers.assert_not_called()
 
 
+class TestContainerOrchestratorExecForwarding(unittest.TestCase):
+    """print_console / detailed must survive the orchestrator -> runtime hop.
+
+    Mirrors the forwarding pins in test_baremetal.py, but for the container
+    path -- which is the one the vLLM suite actually runs on, and the one that
+    previously dropped both kwargs. A dropped kwarg here is silent: the command
+    still succeeds, it just logs hundreds of MB again.
+
+    Asserted by keyword rather than positionally so the pin keeps holding if
+    the runtime signature gains a parameter.
+    """
+
+    def setUp(self):
+        p_pssh = patch("cvs.core.orchestrators.baremetal.Pssh")
+        p_rf = patch("cvs.core.orchestrators.container.RuntimeFactory")
+        self.mock_pssh = p_pssh.start()
+        self.mock_rf = p_rf.start()
+        self.addCleanup(p_pssh.stop)
+        self.addCleanup(p_rf.stop)
+        self.runtime = MagicMock(name="docker_runtime")
+        self.mock_rf.create.return_value = self.runtime
+        self.orch = ContainerOrchestrator(MagicMock(), _make_orch_config())
+        # exec()/exec_on_head() raise unless a container is registered.
+        self.orch.container_id = "cvs_iter_test"
+
+    def _kwarg(self, call, name, position):
+        """Read an argument passed either by keyword or positionally.
+
+        Fails the test (rather than raising IndexError) when the argument was
+        not forwarded at all, so a dropped kwarg reads as the assertion it is.
+        """
+        if name in call.kwargs:
+            return call.kwargs[name]
+        if position >= len(call.args):
+            self.fail(f"{name!r} was not forwarded to the runtime (call was {call})")
+        return call.args[position]
+
+    def test_exec_forwards_print_console_false_to_runtime(self):
+        self.orch.exec("cat /tmp/huge", print_console=False)
+        self.assertIs(self._kwarg(self.runtime.exec.call_args, "print_console", 5), False)
+
+    def test_exec_defaults_print_console_true(self):
+        self.orch.exec("ls")
+        self.assertIs(self._kwarg(self.runtime.exec.call_args, "print_console", 5), True)
+
+    def test_exec_forwards_detailed_to_runtime(self):
+        self.orch.exec("ls", detailed=True)
+        self.assertIs(self._kwarg(self.runtime.exec.call_args, "detailed", 4), True)
+
+    def test_exec_on_head_forwards_print_console_false_to_runtime(self):
+        self.orch.exec_on_head("cat /tmp/huge", print_console=False)
+        self.assertIs(self._kwarg(self.runtime.exec_on_head.call_args, "print_console", 4), False)
+
+    def test_exec_on_head_defaults_print_console_true(self):
+        self.orch.exec_on_head("hostname")
+        self.assertIs(self._kwarg(self.runtime.exec_on_head.call_args, "print_console", 4), True)
+
+    def test_exec_on_head_forwards_detailed_to_runtime(self):
+        # build_mpi_cmd calls exec_on_head(detailed=True); pinned so the
+        # container path cannot regress it independently of baremetal.
+        self.orch.exec_on_head("hostname", detailed=True)
+        self.assertIs(self._kwarg(self.runtime.exec_on_head.call_args, "detailed", 3), True)
+
+
 class TestResolveContainerLifetime(unittest.TestCase):
     """One assertion per row of the lifetime resolution table."""
 

--- a/cvs/core/runtimes/base.py
+++ b/cvs/core/runtimes/base.py
@@ -38,7 +38,8 @@ class ContainerRuntime(Protocol):
         ...
 
     def exec_on_head(self, container_name, cmd, timeout=None, detailed=False, print_console=True):
-        """Execute command directly on head node (baremetal)."""
+        """Execute command directly on head node (baremetal). See exec() for
+        the detailed and print_console semantics."""
         ...
 
     def load_image(self, tar_path, timeout=None):

--- a/cvs/core/runtimes/base.py
+++ b/cvs/core/runtimes/base.py
@@ -29,11 +29,15 @@ class ContainerRuntime(Protocol):
         """
         ...
 
-    def exec(self, container_name, cmd, hosts=None, timeout=None):
-        """Execute command in running containers."""
+    def exec(self, container_name, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
+        """Execute command in running containers.
+
+        print_console=False returns the output without logging it; use for bulk
+        data the caller parses itself.
+        """
         ...
 
-    def exec_on_head(self, container_name, cmd, timeout=None, detailed=False):
+    def exec_on_head(self, container_name, cmd, timeout=None, detailed=False, print_console=True):
         """Execute command directly on head node (baremetal)."""
         ...
 

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -235,12 +235,15 @@ class DockerRuntime:
 
         return success
 
-    def exec(self, container_name, cmd, hosts=None, timeout=None, detailed=False):
+    def exec(self, container_name, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
         """Execute command in running Docker containers.
 
         cmd is wrapped in `bash -c` so shell features (cd, ;, &&, |, globs,
         redirects) run inside the container -- docker exec uses execve with
         no implicit shell.
+
+        print_console=False returns the output without logging it; use for bulk
+        data the caller parses itself.
         """
         exec_cmd = f"{self.orchestrator.sudo_prefix()}docker exec {container_name} bash -c {shlex.quote(cmd)}"
         if hosts:
@@ -257,9 +260,9 @@ class DockerRuntime:
                 host_key_check=False,
                 stop_on_errors=self.orchestrator.stop_on_errors,
             )
-            return pssh.exec(exec_cmd, timeout=timeout, detailed=detailed)
+            return pssh.exec(exec_cmd, timeout=timeout, detailed=detailed, print_console=print_console)
 
-        return self.orchestrator.all.exec(exec_cmd, timeout=timeout, detailed=detailed)
+        return self.orchestrator.all.exec(exec_cmd, timeout=timeout, detailed=detailed, print_console=print_console)
 
     def exec_cmd_list(self, container_name, cmd_list, timeout=None):
         """Execute different commands on different hosts inside the container.
@@ -280,11 +283,11 @@ class DockerRuntime:
         exec_cmd_list = [f"{sudo_prefix}docker exec {container_name} bash -c {shlex.quote(cmd)}" for cmd in cmd_list]
         return self.orchestrator.all.exec_cmd_list(exec_cmd_list, timeout=timeout)
 
-    def exec_on_head(self, container_name, cmd, timeout=None, detailed=False):
+    def exec_on_head(self, container_name, cmd, timeout=None, detailed=False, print_console=True):
         """Execute command directly on head node (container). See exec() for
-        the bash -c wrap rationale."""
+        the bash -c wrap rationale and the print_console semantics."""
         exec_cmd = f"{self.orchestrator.sudo_prefix()}docker exec {container_name} bash -c {shlex.quote(cmd)}"
-        return self.orchestrator.head.exec(exec_cmd, timeout=timeout, detailed=detailed)
+        return self.orchestrator.head.exec(exec_cmd, timeout=timeout, detailed=detailed, print_console=print_console)
 
     @staticmethod
     def _build_runtime_args(runtime_args_config):

--- a/cvs/core/runtimes/enroot.py
+++ b/cvs/core/runtimes/enroot.py
@@ -28,12 +28,12 @@ class EnrootRuntime:
         self.log.error("Enroot runtime not yet implemented")
         return {}
 
-    def exec(self, container_name, cmd, hosts=None, timeout=None):
+    def exec(self, container_name, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
         """Execute in Enroot containers - not yet implemented."""
         self.log.error("Enroot runtime not yet implemented")
         return {}
 
-    def exec_on_head(self, container_name, cmd, timeout=None, detailed=False):
+    def exec_on_head(self, container_name, cmd, timeout=None, detailed=False, print_console=True):
         """Execute on head in Enroot containers - not yet implemented."""
         self.log.error("Enroot runtime not yet implemented")
         return {}

--- a/cvs/core/runtimes/unittests/test_docker.py
+++ b/cvs/core/runtimes/unittests/test_docker.py
@@ -427,6 +427,22 @@ class TestDockerRuntimeExecPrintConsole(unittest.TestCase):
 
         self.assertIs(orchestrator.head.exec.call_args.kwargs["print_console"], False)
 
+    def test_exec_on_head_accepts_and_forwards_detailed(self):
+        """BaremetalOrchestrator.build_mpi_cmd calls exec_on_head(detailed=True).
+
+        The container path lacked the parameter entirely, so that call raised
+        TypeError for any container-orchestrated MPI job. Pinned here because
+        distribute_using_mpi has no in-tree caller to catch it.
+        """
+        orchestrator = MagicMock()
+        orchestrator.head.exec.return_value = {"host1": {"output": "", "exit_code": 0}}
+        orchestrator.sudo_prefix.return_value = ""
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        rt.exec_on_head("cvs_iter_test", "echo hi", detailed=True)
+
+        self.assertIs(orchestrator.head.exec.call_args.kwargs["detailed"], True)
+
     def test_default_stays_verbose(self):
         """Omitting the kwarg must keep the historical logging behavior."""
         orchestrator = MagicMock()

--- a/cvs/core/runtimes/unittests/test_docker.py
+++ b/cvs/core/runtimes/unittests/test_docker.py
@@ -384,6 +384,61 @@ class TestDockerRuntimeExec(unittest.TestCase):
         self.assertTrue(rendered.startswith("docker exec cvs_iter_test bash -c "))
 
 
+class TestDockerRuntimeExecPrintConsole(unittest.TestCase):
+    """print_console must survive the runtime layer.
+
+    DockerRuntime sits between ContainerOrchestrator and Pssh. It previously
+    dropped print_console on all three exec paths, so a caller asking for a
+    quiet bulk read still got every line logged -- 486 MB of amd-smi JSON in
+    one observed vLLM run. A dropped kwarg fails silently, hence these pins.
+    """
+
+    def test_exec_forwards_print_console_false(self):
+        orchestrator = MagicMock()
+        orchestrator.all.exec.return_value = {"host1": ""}
+        orchestrator.sudo_prefix.return_value = ""
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        rt.exec("cvs_iter_test", "cat /tmp/huge", print_console=False)
+
+        self.assertIs(orchestrator.all.exec.call_args.kwargs["print_console"], False)
+
+    def test_exec_with_hosts_subset_forwards_print_console_false(self):
+        orchestrator = MagicMock()
+        orchestrator.sudo_prefix.return_value = ""
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        with patch("cvs.lib.parallel_ssh_lib.Pssh") as mock_pssh_cls:
+            mock_pssh = MagicMock()
+            mock_pssh.exec.return_value = {"host1": ""}
+            mock_pssh_cls.return_value = mock_pssh
+
+            rt.exec("cvs_iter_test", "cat /tmp/huge", hosts=["host1"], print_console=False)
+
+            self.assertIs(mock_pssh.exec.call_args.kwargs["print_console"], False)
+
+    def test_exec_on_head_forwards_print_console_false(self):
+        orchestrator = MagicMock()
+        orchestrator.head.exec.return_value = {"host1": ""}
+        orchestrator.sudo_prefix.return_value = ""
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        rt.exec_on_head("cvs_iter_test", "cat /tmp/huge", print_console=False)
+
+        self.assertIs(orchestrator.head.exec.call_args.kwargs["print_console"], False)
+
+    def test_default_stays_verbose(self):
+        """Omitting the kwarg must keep the historical logging behavior."""
+        orchestrator = MagicMock()
+        orchestrator.all.exec.return_value = {"host1": ""}
+        orchestrator.sudo_prefix.return_value = ""
+        rt = DockerRuntime(MagicMock(), orchestrator)
+
+        rt.exec("cvs_iter_test", "echo hi")
+
+        self.assertIs(orchestrator.all.exec.call_args.kwargs["print_console"], True)
+
+
 class TestDockerRuntimeSudoProbeCachedAcrossCalls(unittest.TestCase):
     """Regression test for the bug being fixed: with a REAL BaremetalOrchestrator
     (not a bare MagicMock) as DockerRuntime's orchestrator, the underlying

--- a/cvs/lib/globals.py
+++ b/cvs/lib/globals.py
@@ -9,6 +9,16 @@ import logging
 
 log = logging.getLogger()
 
+# pssh's own host_logger emits every remote stdout/stderr line, tagged with the
+# host (pssh/clients/base/single.py). Upstream keeps it quiet behind a
+# NullHandler unless enable_host_logger() is called -- which CVS never does --
+# but `log` above is the ROOT logger, so propagation delivers those lines to
+# CVS's handlers anyway. The result is that every line is logged twice: once by
+# pssh, once by Pssh._process_output (cvs/lib/parallel/pssh.py). Detaching the
+# third-party logger keeps the _process_output copy, which is the one that
+# honors print_console and can therefore be suppressed for bulk-data commands.
+logging.getLogger('pssh.host_logger').propagate = False
+
 error_list = []
 
 

--- a/cvs/lib/globals.py
+++ b/cvs/lib/globals.py
@@ -9,6 +9,7 @@ import logging
 
 log = logging.getLogger()
 
+
 # pssh's own host_logger emits every remote stdout/stderr line, tagged with the
 # host (pssh/clients/base/single.py). Upstream keeps it quiet behind a
 # NullHandler unless enable_host_logger() is called -- which CVS never does --
@@ -22,7 +23,15 @@ log = logging.getLogger()
 # handler to root AND to every non-propagating logger (_pytest/logging.py), so
 # clearing propagate makes pytest attach directly and the duplicate survives.
 # A filter drops the record before any handler is consulted, however attached.
-logging.getLogger('pssh.host_logger').addFilter(lambda _record: False)
+#
+# Named rather than a lambda so it is identifiable in
+# logging.getLogger('pssh.host_logger').filters when someone is debugging log
+# routing on a live node.
+def _suppress_pssh_host_logger(_record):
+    return False
+
+
+logging.getLogger('pssh.host_logger').addFilter(_suppress_pssh_host_logger)
 
 error_list = []
 

--- a/cvs/lib/globals.py
+++ b/cvs/lib/globals.py
@@ -14,10 +14,15 @@ log = logging.getLogger()
 # NullHandler unless enable_host_logger() is called -- which CVS never does --
 # but `log` above is the ROOT logger, so propagation delivers those lines to
 # CVS's handlers anyway. The result is that every line is logged twice: once by
-# pssh, once by Pssh._process_output (cvs/lib/parallel/pssh.py). Detaching the
-# third-party logger keeps the _process_output copy, which is the one that
-# honors print_console and can therefore be suppressed for bulk-data commands.
-logging.getLogger('pssh.host_logger').propagate = False
+# pssh, once by Pssh._process_output (cvs/lib/parallel/pssh.py). Dropping the
+# pssh copy keeps the _process_output one, which is the one that honors
+# print_console and can therefore be suppressed for bulk-data commands.
+#
+# A filter, not propagate=False: pytest's catching_logs attaches its capture
+# handler to root AND to every non-propagating logger (_pytest/logging.py), so
+# clearing propagate makes pytest attach directly and the duplicate survives.
+# A filter drops the record before any handler is consulted, however attached.
+logging.getLogger('pssh.host_logger').addFilter(lambda _record: False)
 
 error_list = []
 

--- a/cvs/lib/inference/unittests/test_vllm_job_ray_backend.py
+++ b/cvs/lib/inference/unittests/test_vllm_job_ray_backend.py
@@ -1051,6 +1051,26 @@ class TestVllmJobParseResults(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             job.parse_results()
 
+    def test_unparseable_artifact_snippet_is_single_line(self):
+        # Deliberate departure from this class's "pin the TYPE only" rule: the
+        # snippet is carried into the message precisely so a failure stays
+        # diagnosable once print_console=False keeps the artifact out of the
+        # log, so its SHAPE is the behaviour under test, not incidental
+        # phrasing. A raw multi-line artifact (a stack trace, or HTML from a
+        # proxy error page) would otherwise inject newlines straight into CI
+        # output and Jira ticket bodies, where the failure text is pasted.
+        artifact = 'oh no\nline two\rline three\tand a tab'
+        orch = RecordingOrch(head_responder=lambda cmd: {HEAD: artifact}, hosts=[HEAD])
+        job = _job(orch=orch, serve_args={}, nnodes="1", pp="1", ib_netdev=None)
+        with self.assertRaises(RuntimeError) as ctx:
+            job.parse_results()
+
+        message = str(ctx.exception)
+        self.assertNotIn("\n", message, f"raw newline leaked into the error text: {message!r}")
+        self.assertNotIn("\r", message, f"raw carriage return leaked into the error text: {message!r}")
+        # Escaped, not dropped -- the content still has to be recoverable.
+        self.assertIn("line two", message)
+
     def test_valid_artifact_delegates_to_to_client_metrics_with_tp_isl_pp(self):
         # tp, isl, and pp are keyword-only in to_client_metrics, so they MUST
         # arrive as kwargs; raw (the json-loaded artifact) arrives positionally.

--- a/cvs/lib/inference/unittests/test_vllm_job_server_reuse.py
+++ b/cvs/lib/inference/unittests/test_vllm_job_server_reuse.py
@@ -50,7 +50,7 @@ class FakeOrchWithOutput:
         self._tail_output = tail_output
         self._grep_exit = grep_exit  # 1 = no match (safe), 0 = match found
 
-    def exec(self, cmd, hosts=None, detailed=False):
+    def exec(self, cmd, hosts=None, detailed=False, print_console=True):
         if detailed:
             return {"10.0.0.1": {"exit_code": self._grep_exit, "stdout": ""}}
         return {"10.0.0.1": self._tail_output}
@@ -68,7 +68,7 @@ class FakeOrchMultiHost:
     def __init__(self):
         self.exec_calls = []  # list of (cmd, hosts) actually issued
 
-    def exec(self, cmd, hosts=None, detailed=False):
+    def exec(self, cmd, hosts=None, detailed=False, print_console=True):
         self.exec_calls.append((cmd, hosts))
         host = hosts[0]
         return {host: f"content for {host}"}

--- a/cvs/lib/inference/vllm_job.py
+++ b/cvs/lib/inference/vllm_job.py
@@ -679,6 +679,9 @@ class VllmJob:
             try:
                 raw = json.loads(text)
             except (json.JSONDecodeError, ValueError) as e:
-                raise RuntimeError(f"unparseable results artifact on {host}: {artifact}: {e}") from e
+                # The artifact is read with print_console=False, so its content
+                # is nowhere else in the log -- carry a slice into the error or
+                # the failure is undiagnosable.
+                raise RuntimeError(f"unparseable results artifact on {host}: {artifact}: {e}: {text[:500]}") from e
             results[host] = to_client_metrics(raw, tp=self.tp, isl=self.isl, pp=self.pp)
         return results

--- a/cvs/lib/inference/vllm_job.py
+++ b/cvs/lib/inference/vllm_job.py
@@ -682,6 +682,9 @@ class VllmJob:
                 # The artifact is read with print_console=False, so its content
                 # is nowhere else in the log -- carry a slice into the error or
                 # the failure is undiagnosable.
-                raise RuntimeError(f"unparseable results artifact on {host}: {artifact}: {e}: {text[:500]}") from e
+                # repr() keeps the snippet on one line: the artifact can be a
+                # stack trace or an HTML error page, and raw newlines there
+                # would break up CI output and pasted ticket bodies.
+                raise RuntimeError(f"unparseable results artifact on {host}: {artifact}: {e}: {text[:500]!r}") from e
             results[host] = to_client_metrics(raw, tp=self.tp, isl=self.isl, pp=self.pp)
         return results

--- a/cvs/lib/inference/vllm_job.py
+++ b/cvs/lib/inference/vllm_job.py
@@ -410,7 +410,10 @@ class VllmJob:
             if self._is_ray_backend and int(self.nnodes) > 1 and rank > 0:
                 continue
             rank_log = self._rank_log(rank)
-            out = self.orch.exec(f"tail -30 {shlex.quote(rank_log)}", hosts=[host])
+            # print_console=False: the tail is re-emitted below under emit_tail
+            # with host+rank+provenance labels, which is the copy worth keeping.
+            # Without this the same 30 lines land in the log on every poll.
+            out = self.orch.exec(f"tail -30 {shlex.quote(rank_log)}", hosts=[host], print_console=False)
             for h, output in (out or {}).items():
                 if emit_tail:
                     for line in (output or "").splitlines():
@@ -421,6 +424,7 @@ class VllmJob:
                 f"grep -m1 -iE {shlex.quote(self.FATAL_LOG_RE.pattern)} {shlex.quote(rank_log)}",
                 detailed=True,
                 hosts=[host],
+                print_console=False,
             )
             for h, r in (out or {}).items():
                 if r.get("exit_code") == 0 and r.get("output", "").strip():
@@ -596,7 +600,10 @@ class VllmJob:
         log.info("client initial wait %ds", self._client_initial_wait)
         time.sleep(self._client_initial_wait)
         for it in range(self._client_poll_count):
-            out = self.orch.exec_on_head(f"tail -2000 {shlex.quote(self.client_log)}")
+            # print_console=False: this poll re-reads the same growing log every
+            # iteration. dump_client_log() emits it in full on every exit path
+            # below, so logging each poll only duplicates that.
+            out = self.orch.exec_on_head(f"tail -2000 {shlex.quote(self.client_log)}", print_console=False)
             failed = []
             done = []
             for host, output in out.items():
@@ -636,7 +643,7 @@ class VllmJob:
 
     def dump_client_log(self):
         """Emit the full client log to the captured section once after completion."""
-        out = self.orch.exec_on_head(f"cat {shlex.quote(self.client_log)}")
+        out = self.orch.exec_on_head(f"cat {shlex.quote(self.client_log)}", print_console=False)
         for host, text in (out or {}).items():
             for line in (text or "").splitlines():
                 log.info("[%s client.log] %s", host, line)
@@ -655,7 +662,7 @@ class VllmJob:
             if self._is_ray_backend and int(self.nnodes) > 1 and rank > 0:
                 continue
             rank_log = self._rank_log(rank)
-            out = self.orch.exec(f"cat {shlex.quote(rank_log)}", hosts=[host])
+            out = self.orch.exec(f"cat {shlex.quote(rank_log)}", hosts=[host], print_console=False)
             for h, text in (out or {}).items():
                 for line in (text or "").splitlines():
                     log.info("[%s rank%d server.log] %s", h, rank, line)
@@ -663,7 +670,7 @@ class VllmJob:
     def parse_results(self):
         """Fetch and parse the results artifact from the HEAD node via exec_on_head."""
         artifact = f"{self.out_dir}/results"
-        out = self.orch.exec_on_head(f"cat {shlex.quote(artifact)}")
+        out = self.orch.exec_on_head(f"cat {shlex.quote(artifact)}", print_console=False)
         results = {}
         for host, text in out.items():
             text = (text or "").strip()

--- a/cvs/lib/unittests/test_globals.py
+++ b/cvs/lib/unittests/test_globals.py
@@ -79,6 +79,16 @@ class TestHostLoggerSuppression(unittest.TestCase):
 
         self.assertEqual([r.getMessage() for r in handler.records], ["kept"])
 
+    def test_filter_is_identifiable_by_name(self):
+        # The filter has to be recognisable in
+        # logging.getLogger('pssh.host_logger').filters when someone is
+        # debugging log routing on a live node. An anonymous lambda shows up
+        # there as a bare <function <lambda>> with no hint of what installed it
+        # or why, so the suppression is pinned to a named callable.
+        installed = logging.getLogger(HOST_LOGGER).filters
+        names = [getattr(f, '__name__', '') for f in installed]
+        self.assertIn('_suppress_pssh_host_logger', names, f"no named suppression filter among {installed}")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cvs/lib/unittests/test_globals.py
+++ b/cvs/lib/unittests/test_globals.py
@@ -1,0 +1,84 @@
+"""
+test_globals.py
+
+Unit tests for the pssh host_logger suppression applied at cvs.lib.globals
+import time.
+"""
+
+import logging
+import unittest
+
+import cvs.lib.globals  # noqa: F401  -- imported for its host_logger suppression side effect
+
+HOST_LOGGER = 'pssh.host_logger'
+
+
+class _CollectingHandler(logging.Handler):
+    """Records every LogRecord it is handed."""
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def _emit_host_line():
+    """Emit a line the way pssh/clients/base/single.py does."""
+    logging.getLogger(HOST_LOGGER).info("[%s]%s\t%s", '10.0.0.1', '', 'remote stdout line')
+
+
+class TestHostLoggerSuppression(unittest.TestCase):
+    def test_handler_attached_directly_to_host_logger_receives_nothing(self):
+        # A handler bolted straight onto pssh.host_logger bypasses propagation
+        # entirely. This is what pytest's catching_logs does, so suppressing by
+        # detaching the logger from root is not enough -- the suppression has to
+        # stop the record before any handler is consulted.
+        handler = _CollectingHandler()
+        host_logger = logging.getLogger(HOST_LOGGER)
+        root = logging.getLogger()
+        orig_level = root.level
+        host_logger.addHandler(handler)
+        # host_logger sets no level of its own, so without this the INFO record
+        # is never created and the test would pass without exercising anything.
+        root.setLevel(logging.INFO)
+        try:
+            _emit_host_line()
+        finally:
+            root.setLevel(orig_level)
+            host_logger.removeHandler(handler)
+
+        self.assertEqual(handler.records, [])
+
+    def test_no_duplicate_captured_under_pytest_catching_logs(self):
+        # The real mechanism: _pytest.logging.catching_logs attaches its handler
+        # to root AND to every non-propagating logger.
+        try:
+            from _pytest.logging import catching_logs
+        except ImportError:  # pragma: no cover - pytest is a declared dependency
+            self.skipTest("pytest not installed")
+
+        handler = _CollectingHandler()
+        with catching_logs(handler, level=logging.INFO):
+            _emit_host_line()
+
+        host_lines = [r for r in handler.records if r.name == HOST_LOGGER]
+        self.assertEqual(host_lines, [])
+
+    def test_other_loggers_are_still_captured(self):
+        # Guards against suppressing more than the one third-party logger.
+        try:
+            from _pytest.logging import catching_logs
+        except ImportError:  # pragma: no cover - pytest is a declared dependency
+            self.skipTest("pytest not installed")
+
+        handler = _CollectingHandler()
+        with catching_logs(handler, level=logging.INFO):
+            logging.getLogger('cvs.some.module').info("kept")
+
+        self.assertEqual([r.getMessage() for r in handler.records], ["kept"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/lib/utils/gpu.py
+++ b/cvs/lib/utils/gpu.py
@@ -202,13 +202,13 @@ def capture_gpu_metrics(orch, nodes=None, timeout_s=None) -> dict:
     all_entries = []
     if nodes is None:
         kwargs = {"timeout": timeout_s} if timeout_s is not None else {}
-        out = orch.exec_on_head("amd-smi metric --json", **kwargs)
+        out = orch.exec_on_head("amd-smi metric --json", print_console=False, **kwargs)
         for _host, text in out.items():
             all_entries.extend(_try_parse(text))
     else:
         kwargs = {"timeout": timeout_s} if timeout_s is not None else {}
         for _label, hosts in nodes:
-            out = orch.exec("amd-smi metric --json", hosts=hosts, **kwargs)
+            out = orch.exec("amd-smi metric --json", hosts=hosts, print_console=False, **kwargs)
             for _host, text in out.items():
                 all_entries.extend(_try_parse(text))
     return parse_gpu_metrics(all_entries)
@@ -259,7 +259,7 @@ def _capture_multi_node(orch, nodes, timeout_s=None) -> "tuple[dict, dict[str, i
     kwargs = {"timeout": timeout_s} if timeout_s is not None else {}
     for label, hosts in nodes:
         try:
-            out = orch.exec("amd-smi metric --json", hosts=hosts, **kwargs)
+            out = orch.exec("amd-smi metric --json", hosts=hosts, print_console=False, **kwargs)
             node_entries = []
             for _host, text in out.items():
                 node_entries.extend(_try_parse(text))
@@ -402,7 +402,7 @@ def stop_and_collect_gpu_poller(
     if handle.nodes is None:
         text = None
         try:
-            out = orch.exec_on_head(f"cat {shlex.quote(handle.paths)}")
+            out = orch.exec_on_head(f"cat {shlex.quote(handle.paths)}", print_console=False)
             text = next(iter(out.values()), "")
         except Exception as exc:
             log.warning("stop_and_collect_gpu_poller: read-back failed: %s", exc)
@@ -439,7 +439,7 @@ def stop_and_collect_gpu_poller(
             path = handle.paths[host] if isinstance(handle.paths, dict) else handle.paths
             text = ""
             try:
-                out = orch.exec(f"cat {shlex.quote(path)}", hosts=[host])
+                out = orch.exec(f"cat {shlex.quote(path)}", hosts=[host], print_console=False)
                 text = next(iter(out.values()), "")
             except Exception as exc:
                 log.warning("stop_and_collect_gpu_poller: read-back failed for %s: %s", host, exc)

--- a/cvs/lib/utils/unittests/test_gpu.py
+++ b/cvs/lib/utils/unittests/test_gpu.py
@@ -576,7 +576,7 @@ class TestCaptureGpuMetrics(unittest.TestCase):
         self.assertEqual(set(out.keys()), set(ALL_KEYS))
         mock_parse.assert_called_once_with([_full_gpu_entry()])
         # Pin the exact command string sent to amd-smi (host-side, no sudo needed).
-        orch.exec_on_head.assert_called_once_with("amd-smi metric --json")
+        orch.exec_on_head.assert_called_once_with("amd-smi metric --json", print_console=False)
         # Verify parse result is actually returned, not silently discarded.
         self.assertEqual(out["gpu.gfx_activity"], 30)
         self.assertIsNotNone(out["gpu.total_vram"])
@@ -782,7 +782,7 @@ class TestCaptureGpuMetricsMultiNode(unittest.TestCase):
     def _make_exec_by_hosts(self, host_to_vram: dict, gfx: float = 80.0):
         """Build an orch.exec side_effect keyed by the hosts= kwarg."""
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             return {h: self._make_gpu_json(host_to_vram[h], gfx) for h in hosts}
 
         return _exec
@@ -794,7 +794,7 @@ class TestCaptureGpuMetricsMultiNode(unittest.TestCase):
         from cvs.lib.utils.gpu import capture_gpu_metrics
 
         result = capture_gpu_metrics(orch, nodes=None)
-        orch.exec_on_head.assert_called_once_with("amd-smi metric --json")
+        orch.exec_on_head.assert_called_once_with("amd-smi metric --json", print_console=False)
         self.assertEqual(result["gpu.used_vram"], 1000)
 
     def test_nodes_provided_calls_orch_exec_with_hosts_not_exec_on_head(self):
@@ -808,8 +808,8 @@ class TestCaptureGpuMetricsMultiNode(unittest.TestCase):
             nodes=[("prefill-0", ["prefill-host"]), ("decode-0", ["decode-host"])],
         )
         orch.exec_on_head.assert_not_called()
-        orch.exec.assert_any_call("amd-smi metric --json", hosts=["prefill-host"])
-        orch.exec.assert_any_call("amd-smi metric --json", hosts=["decode-host"])
+        orch.exec.assert_any_call("amd-smi metric --json", hosts=["prefill-host"], print_console=False)
+        orch.exec.assert_any_call("amd-smi metric --json", hosts=["decode-host"], print_console=False)
 
     def test_nodes_vram_summed_across_nodes(self):
         """VRAM from all nodes is summed in the merged result."""
@@ -824,7 +824,7 @@ class TestCaptureGpuMetricsMultiNode(unittest.TestCase):
         """GFX activity from all nodes is averaged."""
         orch = MagicMock()
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             gfx = 60.0 if hosts == ["p"] else 100.0
             return {hosts[0]: self._make_gpu_json(1000, gfx)}
 
@@ -849,7 +849,7 @@ class TestCaptureGpuMetricsMultiNode(unittest.TestCase):
 
         orch = MagicMock()
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             vram = {"p": 1000, "d": 2000}[hosts[0]]
             return {
                 hosts[0]: json.dumps(
@@ -1147,7 +1147,7 @@ class TestStopAndCollectGpuPollerMultiNode(unittest.TestCase):
         text_b = _poller_file_text(_gpu_chunk_text(500), _gpu_chunk_text(600))
         orch = MagicMock()
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             if "pkill" in cmd:
                 return {h: "" for h in hosts}
             host = hosts[0]
@@ -1164,7 +1164,7 @@ class TestStopAndCollectGpuPollerMultiNode(unittest.TestCase):
         text_b = _poller_file_text(_gpu_chunk_text(500), _gpu_chunk_text(600))
         orch = MagicMock()
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             if "pkill" in cmd:
                 return {h: "" for h in hosts}
             host = hosts[0]
@@ -1186,7 +1186,7 @@ class TestStopAndCollectGpuPollerMultiNode(unittest.TestCase):
         text_b = _poller_file_text(_gpu_chunk_text(500), "")
         orch = MagicMock()
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             if "pkill" in cmd:
                 return {h: "" for h in hosts}
             host = hosts[0]
@@ -1201,7 +1201,7 @@ class TestStopAndCollectGpuPollerMultiNode(unittest.TestCase):
         text_b = _poller_file_text(_gpu_chunk_text(500), _gpu_chunk_text(600))
         orch = MagicMock()
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             if "pkill" in cmd:
                 return {h: "" for h in hosts}
             host = hosts[0]
@@ -1242,7 +1242,7 @@ class TestStopAndCollectGpuPollerMultiNode(unittest.TestCase):
         text_a = _poller_file_text(_gpu_chunk_text(1000))
         orch = MagicMock()
 
-        def _exec(cmd, hosts=None):
+        def _exec(cmd, hosts=None, print_console=True):
             if "pkill" in cmd:
                 return {h: "" for h in hosts}
             host = hosts[0]

--- a/cvs/tests/inference/vllm/vllm.py
+++ b/cvs/tests/inference/vllm/vllm.py
@@ -313,6 +313,11 @@ def test_openai_compatible_smoke(orch, variant_config, hf_token, lifecycle, requ
         summary = job.probe_openai_endpoints()
     except Exception:
         lifecycle.failed = True
+        # This job owns its own short-lived server, so unlike the sweep there
+        # is no reuse path to consult -- dump ours. Needed because the poll
+        # loop's tails are no longer echoed to the console, so without this a
+        # bringup timeout leaves nothing from the failing server in the log.
+        job.dump_server_log()
         raise
     finally:
         job.stop_server()


### PR DESCRIPTION
Jira: [AIMVT-273](https://amd-hub.atlassian.net/browse/AIMVT-273)

## Problem

A single `test_vllm_inference` run produced a 491 MB / 7.5M-line `cvs.log`, of which
~6,100 lines were signal. Three independent causes:

1. Bulk-data reads echoed in full — the end-of-run `cat` of the GPU poller file
   (`cvs/lib/utils/gpu.py:405`, `:442`) was 99.1% of the log on its own.
2. Every remote command logged twice. `globals.py` binds handlers to the **root**
   logger, so pssh's `host_logger` — which upstream silences behind a `NullHandler`
   and CVS never enables — reached CVS's handlers by propagation. 3.7M duplicate pairs,
   affecting every command in every suite, not just vLLM.
3. vLLM log tails added a third copy of the same server-log lines.

`print_console=False` already existed on `Pssh.exec`, but was unreachable from test
code: `ContainerOrchestrator`, `BaremetalOrchestrator` and `DockerRuntime` all dropped
the kwarg on the way down.

## Change

- Thread `print_console` through the orchestrator and runtime layers to `Pssh`,
  defaulting to `True` so every existing caller is byte-for-byte unchanged.
- Drop pssh's `host_logger` records with a filter, keeping the `_process_output`
  copy — the one that honors `print_console`. A filter rather than
  `propagate = False`: CVS runs under pytest, and `_pytest.logging.catching_logs`
  attaches its capture handler to root **and** to every non-propagating logger, so
  clearing `propagate` makes pytest attach directly to `host_logger` and the
  duplicate survives. A filter drops the record before any handler is consulted.
- Opt the GPU-metrics and vLLM log-tail reads out of console echo. Return values are
  unchanged, so parsing, digests and `dump_*_log` artifacts still see full output.
- Where the suppressed echo was the *only* record of a failure, produce the diagnostic
  deliberately: the OpenAI smoke test dumps its server log, and `parse_results` quotes
  the artifact it could not parse.
- `ContainerOrchestrator.exec_on_head` gains the `detailed` parameter its baremetal
  counterpart already had — `build_mpi_cmd` passes it, which raised `TypeError` on the
  container path.

## Tests

- 11 new tests: kwarg forwarding at each layer, a default-stays-verbose guard, the
  `detailed` path, and three for the `host_logger` suppression — asserting no
  `pssh.host_logger` record is captured (once with a handler attached straight to the
  logger, once inside a real `catching_logs`), plus a guard that other loggers still
  are. The earlier test asserted on the `propagate` flag in a plain process, so it
  verified the mechanism intended rather than the outcome wanted, and passed against
  a fix that does not work under pytest.
- `run_all_unittests.py`: 929 tests, 4 failures — all 4 reproduce on untouched
  `dev/dtni` @ `3cc63c0f` (918 tests, same 4). Zero regressions.
- `test_cli.sh` passes. `ruff check` error set byte-identical to base (14 both sides).
- End-to-end through the real `Pssh._process_output` with only the network faked:
  504 → 4 logged lines, returned payload byte-identical.

## Hardware

Validated on 2x MI300 (`10.32.80.124` / `10.32.80.125`), DeepSeek R1, TP8/PP2, 1k/1k,
image `rocm/ufb-private:vllm-0.23.0-ubuntu24.04-py3.14-prereleases-device-all-cdna-rocm7.14.0rc3-0fc695fc6`
(registry digest `sha256:1fce0c8189f141c4d2ed9c56144bd660a9554c92d07db1e896a253a1f51d1ab0`,
identical to the baseline node's).

Workload unaffected: 400/400 requests succeeded, 0 failed, 790.52 tok/s total
throughput, mean TTFT 370 ms, mean TPOT 39.5 ms.

| | baseline | this PR |
|---|---|---|
| `cvs.log` size | 143.1 MB | **0.20 MB** |
| lines | 2,287,334 | **1,705** |
| pssh `host_logger` duplicate lines | 367+ | **0** |
| raw `amd-smi` JSON blobs | flood | **0** |

The duplicate-line count is measured with `grep -cP '\[\d+\.\d+\.\d+\.\d+\]\t'`,
which matches pssh's `host_logger.info("[%s]%s\t%s", ...)` format. That pattern finds
367-644,724 matches in every prior run on this cluster -- including the run carrying the
earlier `propagate = False` attempt -- and zero in the runs on this commit.

Signal is preserved: 132 `Host ==` banners, the full benchmark result block, 163
server-log and 470 client-log labeled lines. 27 adjacent-identical line pairs remain,
all benign -- 16 are the `#---#` separator rule, 9 are vLLM engine lines the server
itself repeats, 2 are legitimately repeated status messages.

> `make test` fails at `fmt-check` on this branch **and on untouched `dev/dtni`** — 22
> pre-existing unformatted files (sglang/preflight/parsers), zero overlap with this
> PR's 14. Since `ut` → `installtest` → `test-venv` runs `clean_test_venv` *before*
> `fmt-check`, a red fmt-check also leaves `.test_venv` dependency-less; the results
> above came from running the two stages directly.
