### PR TITLE
rccl --mca pml option fix when openmpi with ucx is used for rccl-test

### DIFF
--- a/cvs/input/config_file/rccl/rccl_config.json
+++ b/cvs/input/config_file/rccl/rccl_config.json
@@ -6,7 +6,11 @@
             "_comment_mpi_pml": "MPI Point-to-Point Messaging Layer: 'auto' (auto-detect UCX support), 'ucx' (force UCX), or 'ob1' (force OpenIB/TCP fallback). This remains in config because it is an MPI launch option, not an env-script setting.",
             "mpi_pml": "auto",
             "mpi_dir": "/home/{user-id}/openmpi/bin",
-            "mpi_oob_port": "eth0"
+            "mpi_oob_port": "eth0",
+            "ucx_tls": "rc,self,sm,tcp",
+            "_comment_ucx_tls": "When user requested UCX either leave this parameter value blank for auto assignment or assign value tcp",
+            "net_dev_list": "",
+            "_comment_net_dev_list": "Leave empty for auto-detection from backend NICs, or set explicitly e.g. ens26np0,ens27np0"
         },
 
         "_comment_env_script": "RCCL/NCCL/UCX tuning parameters. Path configurations (mpi_dir, rccl_tests_dir) are now in mpi_params and rccl_test_params respectively.",

--- a/cvs/input/config_file/rccl/rccl_config.json
+++ b/cvs/input/config_file/rccl/rccl_config.json
@@ -8,9 +8,9 @@
             "mpi_dir": "/home/{user-id}/openmpi/bin",
             "mpi_oob_port": "eth0",
             "ucx_tls": "rc,self,sm,tcp",
-            "_comment_ucx_tls": "When user requested UCX either leave this parameter value blank for auto assignment or assign value tcp",
+            "_comment_ucx_tls": "When user requested UCX either leave this parameter value blank for auto assignment or assign values e.g. rc,self,sm,tcp..",
             "net_dev_list": "",
-            "_comment_net_dev_list": "Leave empty for auto-detection from backend NICs, or set explicitly e.g. ens26np0,ens27np0"
+            "_comment_net_dev_list": "Leave empty for auto-detection from backend NICs, or set explicitly e.g. bnxt_re0:1,bnxt_re1:1,.."
         },
 
         "_comment_env_script": "RCCL/NCCL/UCX tuning parameters. Path configurations (mpi_dir, rccl_tests_dir) are now in mpi_params and rccl_test_params respectively.",

--- a/cvs/lib/linux_utils.py
+++ b/cvs/lib/linux_utils.py
@@ -858,3 +858,32 @@ def get_gpu_numa_dict(phdl):
 
     log.info("%s", gpu_numa_dict)
     return gpu_numa_dict
+
+
+def get_ucx_net_devices(phdl):
+    """
+    Build UCX_NET_DEVICES string from backend NIC RDMA device names.
+
+    Uses get_gpu_nic_mapping_dict() which maps each GPU card to its nearest
+    backend NIC. The 'rdma_dev' key gives the IB/RDMA device name (e.g. bnxt_re0).
+    UCX_NET_DEVICES requires IB device names with port suffix ':1'
+    (e.g. bnxt_re0:1), NOT ethernet names (ens20np0).
+
+    Returns:
+        str: Comma-separated UCX_NET_DEVICES string,
+             e.g. 'bnxt_re0:1,bnxt_re1:1,bnxt_re2:1,...'
+    """
+    out_dict = get_gpu_nic_mapping_dict(phdl)
+
+    # Use node_0 as representative — NFS/homogeneous cluster, all nodes identical
+    node_0 = list(out_dict.keys())[0]
+    card_list = list(out_dict[node_0].keys())
+
+    ucx_net_devices_list = []
+    for card_no in card_list:
+        rdma_dev = out_dict[node_0][card_no]['rdma_dev']  # e.g. 'bnxt_re0'
+        ucx_net_devices_list.append(f'{rdma_dev}:1')  # UCX needs port suffix :1
+
+    ucx_net_devices = ','.join(ucx_net_devices_list)
+    log.info(f'Auto-detected UCX_NET_DEVICES: {ucx_net_devices}')
+    return ucx_net_devices

--- a/cvs/lib/linux_utils.py
+++ b/cvs/lib/linux_utils.py
@@ -869,20 +869,43 @@ def get_ucx_net_devices(phdl):
     UCX_NET_DEVICES requires IB device names with port suffix ':1'
     (e.g. bnxt_re0:1), NOT ethernet names (ens20np0).
 
+    Raises:
+        ValueError: if the GPU-NIC topology map is empty, if any card is
+            missing an rdma_dev mapping, or if the resulting device list
+            would be empty.
+
     Returns:
         str: Comma-separated UCX_NET_DEVICES string,
              e.g. 'bnxt_re0:1,bnxt_re1:1,bnxt_re2:1,...'
     """
     out_dict = get_gpu_nic_mapping_dict(phdl)
+    if not out_dict:
+        raise ValueError(
+            'get_gpu_nic_mapping_dict() returned an empty topology map; '
+            'cannot determine UCX_NET_DEVICES (no nodes found).'
+        )
 
     # Use node_0 as representative — NFS/homogeneous cluster, all nodes identical
-    node_0 = list(out_dict.keys())[0]
-    card_list = list(out_dict[node_0].keys())
+    node_0 = next(iter(out_dict))
+    card_dict = out_dict[node_0]
+    if not card_dict:
+        raise ValueError(
+            f'No GPU cards found for node {node_0!r} in the topology map; cannot determine UCX_NET_DEVICES.'
+        )
 
     ucx_net_devices_list = []
-    for card_no in card_list:
-        rdma_dev = out_dict[node_0][card_no]['rdma_dev']  # e.g. 'bnxt_re0'
+    for card_no, mapping in card_dict.items():
+        rdma_dev = mapping.get('rdma_dev')
+        if not rdma_dev:
+            raise ValueError(
+                f'Card {card_no!r} on node {node_0!r} has no rdma_dev mapping '
+                '(PCI-bus match to a backend NIC failed); cannot determine '
+                'UCX_NET_DEVICES.'
+            )
         ucx_net_devices_list.append(f'{rdma_dev}:1')  # UCX needs port suffix :1
+
+    if not ucx_net_devices_list:
+        raise ValueError('Resolved zero UCX net devices; refusing to build an empty UCX_NET_DEVICES value.')
 
     ucx_net_devices = ','.join(ucx_net_devices_list)
     log.info(f'Auto-detected UCX_NET_DEVICES: {ucx_net_devices}')

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -211,7 +211,7 @@ def detect_rccl_output_flag(shdl, rccl_test_binary_path, head_node):
         return '-x'
 
 
-def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, ucx_tls):
+def determine_mpi_pml_config(mpi_pml, shdl, mpi_dir, head_node, net_dev_list, ucx_tls):
     """
     Determine MPI PML (Point-to-Point Messaging Layer) configuration based on user config or auto-detection.
 
@@ -225,32 +225,33 @@ def determine_mpi_pml_config(mpi_pml, shdl, mpi_path, head_node, net_dev_list, u
 
     Returns:
       tuple: (pml_param, ucx_params) where:
-        - pml_param: MCA parameter string for mpirun (e.g., '--mca pml ob1' or '')
-        - ucx_params: UCX environment parameter string for mpirun (e.g., '-x UCX_...' or '')
+        - pml_param: MCA parameter string for mpirun (e.g., '--mca pml ob1' or '--mca pml ucx' or '')
+    UCX_TLS notes:
+      - 'rc,self,sm,tcp' — rc provides tag matching required by PML UCX
+      - 'tcp' alone causes pml init failure (no tag-capable transport)
+      - UCX_NET_DEVICES must use IB names with port suffix (e.g. bnxt_re0:1)
     """
-    if mpi_pml.lower() == "auto":
-        # Auto-detect UCX availability
-        ucx_available = is_ucx_available_in_mpi(shdl, mpi_path, head_node)
-        pml_param = "--mca pml ob1" if not ucx_available else ""
-    elif mpi_pml.lower() == "ucx":
-        # User explicitly requested UCX
-        ucx_available = True
-        pml_param = ""
-        log.info("Using UCX (user-specified)")
-    elif mpi_pml.lower() == "ob1":
-        # User explicitly requested ob1 fallback
-        ucx_available = False
-        pml_param = "--mca pml ob1"
-        log.info("Using pml ob1 (user-specified)")
+    if mpi_pml.lower() == 'ucx':
+        pml_param = '--mca pml ucx'
+        ucx_params = f'-x UCX_NET_DEVICES={net_dev_list} -x UCX_TLS={ucx_tls}'
+
+    elif mpi_pml.lower() == 'ob1':
+        pml_param = '--mca pml ob1'
+        ucx_params = ''
+
     else:
-        log.warning(f"Unknown mpi_pml value '{mpi_pml}', defaulting to auto-detection")
-        ucx_available = is_ucx_available_in_mpi(shdl, mpi_path, head_node)
-        pml_param = "--mca pml ob1" if not ucx_available else ""
+        # auto: check if UCX is linked into libmpi.so
+        ucx_available = is_ucx_available_in_mpi(shdl, mpi_dir, head_node)
+        if ucx_available:
+            log.info('UCX detected in libmpi.so — using pml ucx')
+            pml_param = '--mca pml ucx'
+            ucx_params = f'-x UCX_NET_DEVICES={net_dev_list} -x UCX_TLS={ucx_tls}'
+        else:
+            log.info('UCX not detected — falling back to pml ob1')
+            pml_param = '--mca pml ob1'
+            ucx_params = ''
 
-    ucx_params = (
-        f"-x UCX_UNIFIED_MODE=y -x UCX_NET_DEVICES={net_dev_list} -x UCX_TLS={ucx_tls} " if ucx_available else ""
-    )
-
+    log.info(f'PML: {pml_param}  UCX params: {ucx_params}')
     return pml_param, ucx_params
 
 
@@ -630,6 +631,7 @@ def rccl_regression(
     no_of_local_ranks = int(mpi_params.get('no_of_local_ranks', 8))
     mpi_pml = mpi_params.get('mpi_pml', 'auto')
     mpi_oob_port = mpi_params.get('mpi_oob_port', 'eth0')
+    ucx_tls = mpi_params.get('ucx_tls', 'rc,self,sm,tcp') or 'rc,self,sm,tcp'
 
     no_of_global_ranks = no_of_nodes * no_of_local_ranks
 
@@ -649,10 +651,16 @@ def rccl_regression(
     cmd = f'echo "{host_file_params}" > /tmp/rccl_hosts_file.txt'
     shdl.exec(cmd)
 
+    # Auto-detect backend NIC net devices if not provided in mpi_params
+    net_dev_list = mpi_params.get('net_dev_list', '')
+    if not net_dev_list:
+        log.info("'net_dev_list' missing or empty — auto-detecting from backend NICs...")
+        net_dev_list = linux_utils.get_ucx_net_devices(phdl)
+    else:
+        log.info(f"Using net_dev_list from mpi_params: {net_dev_list}")
+
     # Determine PML (Point-to-Point Messaging Layer) based on user config or auto-detection
-    pml_param, ucx_params = determine_mpi_pml_config(
-        mpi_pml, shdl, mpi_dir, head_node, mpi_params.get('net_dev_list', ''), mpi_params.get('ucx_tls', 'tcp')
-    )
+    pml_param, ucx_params = determine_mpi_pml_config(mpi_pml, shdl, mpi_dir, head_node, net_dev_list, ucx_tls)
 
     # Build RCCL test command
     rccl_tests_dir = rccl_test_params.get('rccl_tests_dir', '/usr/local/rccl-tests/build')
@@ -806,6 +814,7 @@ def rccl_perf(
     no_of_local_ranks = int(mpi_params.get('no_of_local_ranks', 8))
     mpi_pml = mpi_params.get('mpi_pml', 'auto')
     mpi_oob_port = mpi_params.get('mpi_oob_port', 'eth0')
+    ucx_tls = mpi_params.get('ucx_tls', 'rc,self,sm,tcp') or 'rc,self,sm,tcp'
 
     no_of_global_ranks = no_of_nodes * no_of_local_ranks
 
@@ -832,10 +841,16 @@ def rccl_perf(
     cmd = f'echo "{host_file_params}" > /tmp/rccl_hosts_file.txt'
     shdl.exec(cmd)
 
+    # Auto-detect backend NIC net devices if not provided in mpi_params
+    net_dev_list = mpi_params.get('net_dev_list', '')
+    if not net_dev_list:
+        log.info("'net_dev_list' missing or empty — auto-detecting from backend NICs...")
+        net_dev_list = linux_utils.get_ucx_net_devices(phdl)
+    else:
+        log.info(f"Using net_dev_list from mpi_params: {net_dev_list}")
+
     # Determine PML (Point-to-Point Messaging Layer) based on user config or auto-detection
-    pml_param, ucx_params = determine_mpi_pml_config(
-        mpi_pml, shdl, mpi_dir, head_node, mpi_params.get('net_dev_list', ''), mpi_params.get('ucx_tls', 'tcp')
-    )
+    pml_param, ucx_params = determine_mpi_pml_config(mpi_pml, shdl, mpi_dir, head_node, net_dev_list, ucx_tls)
 
     # Extract RCCL test parameters
     rccl_tests_dir = rccl_test_params.get('rccl_tests_dir', '/usr/local/rccl-tests/build')
@@ -884,7 +899,6 @@ def rccl_perf(
             # Always wrap in bash to interpret && shell operator
             test_cmd = f'bash -c "{test_cmd}"'
 
-        # Build mpirun command
         cmd = f'''{mpi_dir}/bin/mpirun --np {no_of_global_ranks} \
         --allow-run-as-root \
         --hostfile /tmp/rccl_hosts_file.txt \

--- a/cvs/lib/rccl_lib.py
+++ b/cvs/lib/rccl_lib.py
@@ -211,46 +211,63 @@ def detect_rccl_output_flag(shdl, rccl_test_binary_path, head_node):
         return '-x'
 
 
-def determine_mpi_pml_config(mpi_pml, shdl, mpi_dir, head_node, net_dev_list, ucx_tls):
+def determine_mpi_pml_config(mpi_pml, mpi_params, phdl, shdl, mpi_dir, head_node, ucx_tls):
     """
     Determine MPI PML (Point-to-Point Messaging Layer) configuration based on user config or auto-detection.
 
     Parameters:
       mpi_pml: User-specified PML mode ('auto', 'ucx', or 'ob1').
+      mpi_params: Dict containing MPI configuration
+      phdl: Parallel ssh handle to run commands on all nodes.
       shdl: SSH handle to execute commands on the remote node.
-      mpi_path: Path to the MPI installation directory.
+      mpi_dir: Path to the MPI installation directory.
       head_node: The head node hostname for retrieving command output.
-      net_dev_list: UCX network device(s) to use (UCX_NET_DEVICES).
       ucx_tls: UCX transport layer to use (UCX_TLS).
 
     Returns:
       tuple: (pml_param, ucx_params) where:
-        - pml_param: MCA parameter string for mpirun (e.g., '--mca pml ob1' or '--mca pml ucx' or '')
+        - pml_param: MCA parameter string for mpirun (e.g., '--mca pml ob1' or '--mca pml ucx')
+        - ucx_params: UCX parameter string when ucx (UCX_UNIFIED_MODE, UCX_NET_DEVICES and UCX_TLS) or ''
     UCX_TLS notes:
       - 'rc,self,sm,tcp' — rc provides tag matching required by PML UCX
       - 'tcp' alone causes pml init failure (no tag-capable transport)
       - UCX_NET_DEVICES must use IB names with port suffix (e.g. bnxt_re0:1)
     """
-    if mpi_pml.lower() == 'ucx':
-        pml_param = '--mca pml ucx'
-        ucx_params = f'-x UCX_NET_DEVICES={net_dev_list} -x UCX_TLS={ucx_tls}'
+    mpi_pml = mpi_pml.lower()
+    pml_ob1 = '--mca pml ob1'
 
-    elif mpi_pml.lower() == 'ob1':
-        pml_param = '--mca pml ob1'
-        ucx_params = ''
-
-    else:
-        # auto: check if UCX is linked into libmpi.so
-        ucx_available = is_ucx_available_in_mpi(shdl, mpi_dir, head_node)
-        if ucx_available:
-            log.info('UCX detected in libmpi.so — using pml ucx')
-            pml_param = '--mca pml ucx'
-            ucx_params = f'-x UCX_NET_DEVICES={net_dev_list} -x UCX_TLS={ucx_tls}'
+    # ob1 explicitly requested, or an unrecognized value — both fall back to ob1
+    if mpi_pml not in ('ucx', 'auto'):
+        if mpi_pml == 'ob1':
+            log.info('mpi_pml val in config is ob1')
         else:
-            log.info('UCX not detected — falling back to pml ob1')
-            pml_param = '--mca pml ob1'
-            ucx_params = ''
+            log.warning(f'mpi_pml val in config is {mpi_pml} (incorrect), falling back to pml ob1')
+        log.info(f'PML: {pml_ob1}  UCX params: ')
+        return pml_ob1, ''
 
+    # 'ucx' or 'auto' both require checking whether UCX is actually usable
+    log.info(f'mpi_pml val in config is {mpi_pml}')
+    if not is_ucx_available_in_mpi(shdl, mpi_dir, head_node):
+        log.warning('UCX not detected — falling back to pml ob1')
+        log.info(f'PML: {pml_ob1}  UCX params: ')
+        return pml_ob1, ''
+
+    log.info('UCX detected in libmpi.so — using pml ucx')
+    net_dev_list = mpi_params.get('net_dev_list', '')
+    if not net_dev_list:
+        log.warning("'net_dev_list' missing or empty — auto-detecting from backend NICs...")
+        try:
+            net_dev_list = linux_utils.get_ucx_net_devices(phdl)
+        except ValueError as exc:
+            log.error(f'UCX net device auto-detection failed: {exc}')
+            log.warning('Falling back to pml ob1 due to auto-detection failure')
+            log.info(f'PML: {pml_ob1}  UCX params: ')
+            return pml_ob1, ''
+    else:
+        log.info(f'Using net_dev_list from mpi_params: {net_dev_list}')
+
+    pml_param = '--mca pml ucx'
+    ucx_params = f'-x UCX_UNIFIED_MODE=y -x UCX_NET_DEVICES={net_dev_list} -x UCX_TLS={ucx_tls}'
     log.info(f'PML: {pml_param}  UCX params: {ucx_params}')
     return pml_param, ucx_params
 
@@ -651,16 +668,8 @@ def rccl_regression(
     cmd = f'echo "{host_file_params}" > /tmp/rccl_hosts_file.txt'
     shdl.exec(cmd)
 
-    # Auto-detect backend NIC net devices if not provided in mpi_params
-    net_dev_list = mpi_params.get('net_dev_list', '')
-    if not net_dev_list:
-        log.info("'net_dev_list' missing or empty — auto-detecting from backend NICs...")
-        net_dev_list = linux_utils.get_ucx_net_devices(phdl)
-    else:
-        log.info(f"Using net_dev_list from mpi_params: {net_dev_list}")
-
     # Determine PML (Point-to-Point Messaging Layer) based on user config or auto-detection
-    pml_param, ucx_params = determine_mpi_pml_config(mpi_pml, shdl, mpi_dir, head_node, net_dev_list, ucx_tls)
+    pml_param, ucx_params = determine_mpi_pml_config(mpi_pml, mpi_params, phdl, shdl, mpi_dir, head_node, ucx_tls)
 
     # Build RCCL test command
     rccl_tests_dir = rccl_test_params.get('rccl_tests_dir', '/usr/local/rccl-tests/build')
@@ -841,16 +850,8 @@ def rccl_perf(
     cmd = f'echo "{host_file_params}" > /tmp/rccl_hosts_file.txt'
     shdl.exec(cmd)
 
-    # Auto-detect backend NIC net devices if not provided in mpi_params
-    net_dev_list = mpi_params.get('net_dev_list', '')
-    if not net_dev_list:
-        log.info("'net_dev_list' missing or empty — auto-detecting from backend NICs...")
-        net_dev_list = linux_utils.get_ucx_net_devices(phdl)
-    else:
-        log.info(f"Using net_dev_list from mpi_params: {net_dev_list}")
-
     # Determine PML (Point-to-Point Messaging Layer) based on user config or auto-detection
-    pml_param, ucx_params = determine_mpi_pml_config(mpi_pml, shdl, mpi_dir, head_node, net_dev_list, ucx_tls)
+    pml_param, ucx_params = determine_mpi_pml_config(mpi_pml, mpi_params, phdl, shdl, mpi_dir, head_node, ucx_tls)
 
     # Extract RCCL test parameters
     rccl_tests_dir = rccl_test_params.get('rccl_tests_dir', '/usr/local/rccl-tests/build')


### PR DESCRIPTION
## Motivation
CVS's `determine_mpi_pml_config()` function fails to add `--mca pml ucx` to the mpirun command when `mpi_pml` is set to "ucx" in the config. Instead, it only passes `-x UCX_TLS=auto` (an invalid transport name) and -x UCX_NET_DEVICES= (empty). Without explicit `PML=ucx`, MPI falls back to a non-UCX transport that causes GPU runlist oversubscription and 2-3x bandwidth degradation.

Root Cause
In `cvs/lib/rccl_lib.py`, the `determine_mpi_pml_config()` function:
When `mpi_pml="ucx"`: sets `pml_param = "" `(empty) instead of `"--mca pml ucx"`
Passes `-x UCX_TLS=auto` which is not a valid UCX transport name
Passes `-x UCX_NET_DEVICES=` (empty) which tells UCX to use no devices

The function only ever outputs `--mca pml ob1` or empty string — the code path for `--mca pml ucx` does not exist.
According to [OpenMPI 5.0 documentation](https://docs.open-mpi.org/en/v5.0.x/release-notes/networks.html), UCX PML should auto-select when InfiniBand/RoCE is detected — --mca pml ucx should not be required. However, CVS's invalid UCX environment variables (`-x UCX_TLS=auto` and `-x UCX_NET_DEVICES=`) cause `UCX` to fail initialization before OpenMPI can auto-detect it. With UCX broken, OpenMPI falls back to a non-UCX transport, which causes the GPU queue oversubscription and bandwidth degradation.

The `OMPI_MCA_pml=ucx` workaround forces UCX PML selection regardless of auto-detection, and `UCX_NET_DEVICES=all` fixes the broken device config so UCX can actually initialize. Both are needed because CVS actively passes bad values that override what would otherwise work automatically.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Following params are added in `rccl_config.json` file :
            `"ucx_tls": "rc,self,sm,tcp"`,
            `"_comment_ucx_tls": "When user requested UCX either leave this parameter value blank for auto assignment or assign value tcp"`,
            `"net_dev_list": ""`,
            `"_comment_net_dev_list": "Leave empty for auto-detection from backend NICs, or set explicitly e.g. ens26np0,ens27np0"`

After the fix, in the `rccl_config.json` file user can provide `mpi_pml: ucx` and it correctly passes the `args` to `mpirun`

## Test Plan

Testing was done by Ahsan Kabir and Ryan Lukasik separately, Ryan being the reported. I tested this bugfix first and tried many different combination of providing different type of `pml` like `auto, ob1, ucx` etc. For `ucx`, I built openmpi with `ucx` support. All of these combinations have been tried for for `rccl_perf` test. Same logic was added to `rccl_regression`.

## Test Result

Testing summary is described in the comments section of https://amd-hub.atlassian.net/browse/AIMVT-248 and https://amd.atlassian.net/browse/DCCS-6464

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
