### PR TITLE
fix(accuracy): install lm-eval math extra and probe it by capability

### DIFF
--- a/cvs/lib/inference/unittests/test_lm_eval_job.py
+++ b/cvs/lib/inference/unittests/test_lm_eval_job.py
@@ -158,6 +158,29 @@ class TestBuildLmEvalCmd(unittest.TestCase):
         self.assertIsInstance(cmd, str)
 
 
+class TestInstallGuard(unittest.TestCase):
+    '''The install guard must cover the `math` extra and detect it by capability.
+
+    leaderboard_math_hard imports math_verify at task-build time; the `api`
+    extra alone omits it, so the task dies with ModuleNotFoundError after the
+    server is already up (observed on GLM-5.2, 2026-07-31).
+    '''
+
+    def test_installs_math_extra(self):
+        self.assertIn("lm-eval[api,math]", LM_EVAL_INSTALL_CHECK_CMD)
+
+    def test_guard_probes_math_verify_import_not_just_lm_eval_presence(self):
+        # A `pip list | grep lm_eval` guard short-circuits on an image that
+        # preinstalls bare lm-eval, silently skipping the math extra. Probing
+        # the import instead fails closed.
+        self.assertIn("import lm_eval, math_verify", LM_EVAL_INSTALL_CHECK_CMD)
+        self.assertNotIn("pip list", LM_EVAL_INSTALL_CHECK_CMD)
+
+    def test_install_still_runs_only_when_probe_fails(self):
+        self.assertIn("||", LM_EVAL_INSTALL_CHECK_CMD)
+        self.assertIn("pip install", LM_EVAL_INSTALL_CHECK_CMD)
+
+
 class FakeOrch:
     """Head-only orch test double: records commands, returns queued responses.
 

--- a/cvs/lib/inference/utils/lm_eval_job.py
+++ b/cvs/lib/inference/utils/lm_eval_job.py
@@ -19,7 +19,9 @@ from typing import Any, Dict, List
 from cvs.lib.inference.utils.accuracy_config import AccuracyTask
 from cvs.lib.inference.utils.lm_eval_parsing import project
 
-LM_EVAL_INSTALL_CHECK_CMD = "pip list 2>/dev/null | grep -q '^lm[_-]eval ' || pip install -q 'lm-eval[api]>=0.4.4'"
+LM_EVAL_INSTALL_CHECK_CMD = (
+    "python -c 'import lm_eval, math_verify' 2>/dev/null || pip install -q 'lm-eval[api,math]>=0.4.4'"
+)
 PER_TASK_TIMEOUT_S = 4 * 60 * 60
 
 


### PR DESCRIPTION
## Problem

`leaderboard_math_hard` imports `math_verify` while building its prompt
templates. The lm-eval install guard requested only the `api` extra, so the
task aborted with `ModuleNotFoundError: No module named 'math_verify'` —
after the vLLM server was up and hours of evaluation had been spent.

Observed on GLM-5.2-FP8 (TP8 × PP2, 2 nodes, ROCm 7.14, no chat template),
2026-07-31: 8 of 10 accuracy tasks scored, math_hard died on the missing
dependency. (`leaderboard_gpqa` also failed, unrelated — gated HF dataset.)

## Change

```diff
-LM_EVAL_INSTALL_CHECK_CMD = "pip list 2>/dev/null | grep -q '^lm[_-]eval ' || pip install -q 'lm-eval[api]>=0.4.4'"
+LM_EVAL_INSTALL_CHECK_CMD = (
+    "python -c 'import lm_eval, math_verify' 2>/dev/null || pip install -q 'lm-eval[api,math]>=0.4.4'"
+)
```

1. **`[api]` → `[api,math]`** — the `math` extra supplies `math-verify`,
   `sympy>=1.12`, and the pinned `antlr4-python3-runtime`. This is the fix.

2. **Presence check → capability probe.** `pip list | grep lm_eval` tests
   only that *some* lm-eval exists, not that it carries the extras we need;
   on an image preinstalling bare lm-eval it short-circuits and reproduces
   this failure while the install line still reads correctly. Importing both
   modules fails closed. Latent fail-open mode, not the cause here — on the
   image actually used, lm-eval is not preinstalled and the install did run.

## Tests

New `TestInstallGuard` (3 cases): requests the `math` extra, probes by import
rather than `pip list`, still installs only when the probe fails.

Red proven against unchanged source with genuine assertion failures, not
import errors. Green after: module 30/30. Full suite 953 → 956 tests, same 4
pre-existing `dev/dtni` failures. `ruff format --check` and `ruff check`
clean on both changed files.

## Hardware validation

Rerun on GLM-5.2-FP8 (TP8 x PP2, nodes .122/.123, ROCm 7.14, no chat template)
2026-07-31, run `glm52_mathgpqa_20260731_175056`: `leaderboard_math_hard`
**passes** -- aggregate `exact_match` 0.5869 +/- 0.0120 over 7 subtasks, zero
`ModuleNotFoundError` in the log. Both the `math_verify` metric
(`exact_match`) and lm-eval's legacy matcher (`exact_match_original`) are
populated, confirming `math_verify` imported and ran.

| subtask | exact_match | original |
|---|---|---|
| algebra_hard | 0.8469 | 0.7980 |
| prealgebra_hard | 0.8135 | 0.7720 |
| num_theory_hard | 0.6623 | 0.5779 |
| counting_and_prob_hard | 0.6179 | 0.5447 |
| geometry_hard | 0.4015 | 0.3636 |
| precalculus_hard | 0.3333 | 0.2222 |
| intermediate_algebra_hard | 0.3000 | 0.2357 |

The same run's `leaderboard_gpqa` still fails, unrelated and not addressed
here: `Idavidrein/gpqa` is a gated Hub dataset and the configured token's
account is not on its authorized list. HF auth plumbing itself is intact --
`conftest.py` reads `paths.hf_token_file`, `vllm_job.py` exports `HF_TOKEN`
into `/tmp/server_env_script.sh`, and lm-eval sources that script on every
task.
