### PR TITLE
Urtiwari/tier2

### DIFF
--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -308,6 +308,25 @@ on branch `dev/preflight-direct-test`.
 - **`ssh_timeout`** (default: `300`)
 - **`extra_args`** (default: `[]`) — additional flags forwarded to primus-cli
 
+#### Tier 2 perf sanity (`node_smoke.tier2_perf`) — optional
+
+When `tier2_perf` is `true`, preflight forwards `--tier2-perf` to Primus `node_smoke`, enabling all three Tier 2 checks on each node (same as `launch_nodesmoke_ssh.sh -- --tier2-perf`):
+
+1. **Large GEMM TFLOPS floor** — 8192³ bf16 `torch.matmul`; FAIL below `gemm_tflops_min` (default 600)
+2. **HBM D2D bandwidth** — 512 MB device-to-device copy; FAIL below `hbm_gbs_min` (default 2000 GB/s)
+3. **Local multi-GPU RCCL all-reduce** — node-local only; FAIL below `rccl_gbs_min` (default 100 GB/s)
+
+Set `NCCL_IB_HCA`, `NCCL_SOCKET_IFNAME`, and `NCCL_IB_GID_INDEX` (via `node_smoke` config or cluster `env_vars`) before enabling Tier 2 — RCCL init enumerates every transport even though the all-reduce is local-only.
+
+- **`tier2_perf`** (default: `false`) — master switch; maps to `--tier2-perf`
+- **`gemm_tflops_min`** (default: `600`) — `--gemm-tflops-min`
+- **`hbm_gbs_min`** (default: `2000`) — `--hbm-gbs-min`
+- **`rccl_gbs_min`** (default: `100`) — `--rccl-gbs-min`
+- **`rccl_size_mb`** (default: `64`) — `--rccl-size-mb`
+- **`rccl_timeout_sec`** (default: `120`) — `--rccl-timeout-sec`
+
+Tier 2 runs need a longer SSH budget; when `tier2_perf` is enabled the effective timeout is at least 600 seconds even if `ssh_timeout` is lower.
+
 ### Reporting Settings (`reporting`)
 
 - **`generate_html_report`** (default: `true`)
@@ -385,6 +404,35 @@ on branch `dev/preflight-direct-test`.
       "rdma": {
         "connectivity_mode": "skip"
       }
+    }
+  }
+}
+```
+
+### Enable Primus Node Smoke with Tier 2 perf
+
+```json
+{
+  "preflight": {
+    "node_check": {
+      "gid_index": "3",
+      "expected_rocm_version": "6.4.2",
+      "rdma_interfaces": ["rdma0", "rdma1", "rdma2", "rdma3", "rdma4", "rdma5", "rdma6", "rdma7"]
+    },
+    "node_smoke": {
+      "connectivity_mode": "run",
+      "auto_setup": true,
+      "shared_install": true,
+      "primus_dir": "/home/{user-id}/INSTALL/Primus",
+      "venv_activate": "/home/{user-id}/envs/preflight/.venv/bin/activate",
+      "gpus_per_node": 8,
+      "tier2_perf": true,
+      "gemm_tflops_min": 700,
+      "hbm_gbs_min": 4500,
+      "rccl_gbs_min": 180,
+      "nccl_ib_hca": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "nccl_ib_gid_index": 3,
+      "ssh_timeout": 600
     }
   }
 }

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -155,7 +155,7 @@
       "venv_activate": "/home/{user-id}/envs/preflight/.venv/bin/activate",
       "_comment_venv_activate": "Path to the Python virtualenv activate script used by primus-cli direct. Required when connectivity_mode is 'run'.",
 
-      "connectivity_mode": "run",
+      "connectivity_mode": "skip",
       "_comment_connectivity_mode": "Options: 'run' (host/GPU/RDMA roll-call via node_smoke) or 'skip' (default).",
 
       "gpus_per_node": 8,

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -155,7 +155,7 @@
       "venv_activate": "/home/{user-id}/envs/preflight/.venv/bin/activate",
       "_comment_venv_activate": "Path to the Python virtualenv activate script used by primus-cli direct. Required when connectivity_mode is 'run'.",
 
-      "connectivity_mode": "skip",
+      "connectivity_mode": "run",
       "_comment_connectivity_mode": "Options: 'run' (host/GPU/RDMA roll-call via node_smoke) or 'skip' (default).",
 
       "gpus_per_node": 8,
@@ -201,7 +201,25 @@
       "_comment_nccl_ib_gid_index": "Optional NCCL_IB_GID_INDEX override. Defaults to node_check.gid_index.",
 
       "ssh_timeout": 300,
-      "_comment_ssh_timeout": "SSH timeout in seconds for each node's node_smoke invocation (~30s; increase for slow nodes).",
+      "_comment_ssh_timeout": "SSH timeout in seconds for each node's node_smoke invocation (~30s Tier 1; use 600+ with tier2_perf).",
+
+      "tier2_perf": false,
+      "_comment_tier2_perf": "Enable Tier 2 perf sanity (--tier2-perf): 8192³ GEMM TFLOPS, HBM D2D copy bandwidth, local multi-GPU RCCL all-reduce. Requires NCCL_IB_HCA / NCCL_SOCKET_IFNAME (see launch_nodesmoke_ssh.sh).",
+
+      "gemm_tflops_min": 600,
+      "_comment_gemm_tflops_min": "Tier 2 FAIL below this large GEMM TFLOPS (--gemm-tflops-min). MI300X healthy nodes typically exceed 600.",
+
+      "hbm_gbs_min": 2000,
+      "_comment_hbm_gbs_min": "Tier 2 FAIL below this HBM device-to-device bandwidth in GB/s (--hbm-gbs-min). MI300X healthy ≈ 4500–5000.",
+
+      "rccl_gbs_min": 100,
+      "_comment_rccl_gbs_min": "Tier 2 FAIL below this local multi-GPU RCCL all-reduce bandwidth in GB/s (--rccl-gbs-min).",
+
+      "rccl_size_mb": 64,
+      "_comment_rccl_size_mb": "Tier 2 local RCCL all-reduce tensor size in MB (--rccl-size-mb).",
+
+      "rccl_timeout_sec": 120,
+      "_comment_rccl_timeout_sec": "Tier 2 local RCCL all-reduce hard timeout in seconds (--rccl-timeout-sec).",
 
       "extra_args": [],
       "_comment_extra_args": "Additional node_smoke CLI flags forwarded to primus-cli. Example: [\"--no-clean-dump-path\"]."

--- a/cvs/lib/preflight/node_smoke.py
+++ b/cvs/lib/preflight/node_smoke.py
@@ -77,6 +77,12 @@ def build_node_smoke_flags(
     allow_foreign_procs: bool = False,
     allowed_procs: Optional[str] = None,
     require_tools: Optional[str] = None,
+    tier2_perf: bool = False,
+    gemm_tflops_min: Optional[float] = None,
+    hbm_gbs_min: Optional[float] = None,
+    rccl_gbs_min: Optional[float] = None,
+    rccl_size_mb: Optional[int] = None,
+    rccl_timeout_sec: Optional[int] = None,
     extra_args: Optional[List[str]] = None,
 ) -> str:
     """Build primus-cli ``node_smoke`` CLI flags."""
@@ -109,6 +115,19 @@ def build_node_smoke_flags(
 
     if require_tools:
         flags.append(f"--require-tools {shlex.quote(str(require_tools))}")
+
+    if tier2_perf:
+        flags.append("--tier2-perf")
+        if gemm_tflops_min is not None:
+            flags.append(f"--gemm-tflops-min {float(gemm_tflops_min)}")
+        if hbm_gbs_min is not None:
+            flags.append(f"--hbm-gbs-min {float(hbm_gbs_min)}")
+        if rccl_gbs_min is not None:
+            flags.append(f"--rccl-gbs-min {float(rccl_gbs_min)}")
+        if rccl_size_mb is not None and int(rccl_size_mb) > 0:
+            flags.append(f"--rccl-size-mb {int(rccl_size_mb)}")
+        if rccl_timeout_sec is not None and int(rccl_timeout_sec) > 0:
+            flags.append(f"--rccl-timeout-sec {int(rccl_timeout_sec)}")
 
     if extra_args:
         for arg in extra_args:
@@ -287,6 +306,13 @@ class NodeSmokeCheck(PreflightCheck):
         self.extra_args = [str(arg) for arg in extra if arg] if isinstance(extra, (list, tuple)) else []
         self.auto_setup = _config_flag_enabled(get_nested_config(cfg, "node_smoke", "auto_setup", True), default=True)
 
+        self.tier2_perf = _config_flag_enabled(get_nested_config(cfg, "node_smoke", "tier2_perf", False))
+        self.gemm_tflops_min = float(get_nested_config(cfg, "node_smoke", "gemm_tflops_min", 600.0))
+        self.hbm_gbs_min = float(get_nested_config(cfg, "node_smoke", "hbm_gbs_min", 2000.0))
+        self.rccl_gbs_min = float(get_nested_config(cfg, "node_smoke", "rccl_gbs_min", 100.0))
+        self.rccl_size_mb = int(get_nested_config(cfg, "node_smoke", "rccl_size_mb", 64))
+        self.rccl_timeout_sec = int(get_nested_config(cfg, "node_smoke", "rccl_timeout_sec", 120))
+
     def _validate_prerequisites(self) -> Optional[str]:
         if not self.primus_dir:
             return "node_smoke.primus_dir is required when connectivity_mode is 'run'"
@@ -308,8 +334,20 @@ class NodeSmokeCheck(PreflightCheck):
             allow_foreign_procs=self.allow_foreign_procs,
             allowed_procs=self.allowed_procs,
             require_tools=self.require_tools,
+            tier2_perf=self.tier2_perf,
+            gemm_tflops_min=self.gemm_tflops_min if self.tier2_perf else None,
+            hbm_gbs_min=self.hbm_gbs_min if self.tier2_perf else None,
+            rccl_gbs_min=self.rccl_gbs_min if self.tier2_perf else None,
+            rccl_size_mb=self.rccl_size_mb if self.tier2_perf else None,
+            rccl_timeout_sec=self.rccl_timeout_sec if self.tier2_perf else None,
             extra_args=self.extra_args,
         )
+
+    def _effective_ssh_timeout(self) -> int:
+        """Tier 2 perf (GEMM + HBM + local RCCL) needs a longer per-node budget."""
+        if self.tier2_perf:
+            return max(self.ssh_timeout, 600)
+        return self.ssh_timeout
 
     def run(self) -> Dict[str, Any]:
         if self.mode in ("skip", "off", "disabled", "false", "0"):
@@ -360,9 +398,15 @@ class NodeSmokeCheck(PreflightCheck):
         hosts_set = set(hosts)
         host_ranks = {host: rank for rank, host in enumerate(hosts)}
 
+        tier2_note = (
+            f", tier2_perf=ON (gemm>={self.gemm_tflops_min} TFLOPS, "
+            f"hbm>={self.hbm_gbs_min} GB/s, rccl>={self.rccl_gbs_min} GB/s)"
+            if self.tier2_perf
+            else ""
+        )
         self.log_info(
             f"Launching Primus node_smoke on {nnodes} node(s) "
-            f"(primus_dir={self.primus_dir}, dump_path={self.dump_path})"
+            f"(primus_dir={self.primus_dir}, dump_path={self.dump_path}{tier2_note})"
         )
 
         commands: List[str] = []
@@ -388,7 +432,7 @@ class NodeSmokeCheck(PreflightCheck):
                     )
                 )
 
-        out_dict = self.phdl.exec_cmd_list(commands, timeout=self.ssh_timeout)
+        out_dict = self.phdl.exec_cmd_list(commands, timeout=self._effective_ssh_timeout())
 
         node_results: Dict[str, Any] = {}
         for host, output in out_dict.items():
@@ -421,6 +465,16 @@ class NodeSmokeCheck(PreflightCheck):
             "node_results": node_results,
             "dump_path": self.dump_path,
             "primus_dir": self.primus_dir,
+            "tier2_perf": self.tier2_perf,
+            "tier2_thresholds": {
+                "gemm_tflops_min": self.gemm_tflops_min,
+                "hbm_gbs_min": self.hbm_gbs_min,
+                "rccl_gbs_min": self.rccl_gbs_min,
+                "rccl_size_mb": self.rccl_size_mb,
+                "rccl_timeout_sec": self.rccl_timeout_sec,
+            }
+            if self.tier2_perf
+            else None,
         }
         if setup_results is not None:
             self.results["setup_results"] = setup_results

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -546,6 +546,13 @@ class PreflightReportGenerator(PreflightCheck):
         passing_nodes = total_nodes - len(failed_nodes) - len(unknown_nodes)
         status = 'FAIL' if failed_nodes or unknown_nodes else 'PASS'
         summary_text = f"{passing_nodes}/{total_nodes} nodes passed Primus node_smoke"
+        if node_smoke_results.get('tier2_perf'):
+            thresholds = node_smoke_results.get('tier2_thresholds') or {}
+            summary_text += (
+                f" (Tier 2: GEMM>={thresholds.get('gemm_tflops_min', '?')} TFLOPS, "
+                f"HBM>={thresholds.get('hbm_gbs_min', '?')} GB/s, "
+                f"RCCL>={thresholds.get('rccl_gbs_min', '?')} GB/s)"
+            )
         if unknown_nodes:
             summary_text += f"; {len(unknown_nodes)} unknown"
         return {
@@ -554,6 +561,7 @@ class PreflightReportGenerator(PreflightCheck):
             'passing_nodes': passing_nodes,
             'failed_nodes': failed_nodes,
             'unknown_nodes': unknown_nodes,
+            'tier2_perf': bool(node_smoke_results.get('tier2_perf')),
             'summary': summary_text,
         }
 
@@ -1227,10 +1235,17 @@ class PreflightReportGenerator(PreflightCheck):
 
         if not failed_nodes:
             passing = len([n for n, r in node_results.items() if r.get('status') == 'PASS'])
+            tier2_html = ""
+            if node_smoke_results.get('tier2_perf'):
+                thresholds = node_smoke_results.get('tier2_thresholds') or {}
+                tier2_html = f"""
+            <p>Tier 2 perf enabled: GEMM &ge; {html.escape(str(thresholds.get('gemm_tflops_min', '?')))} TFLOPS,
+            HBM &ge; {html.escape(str(thresholds.get('hbm_gbs_min', '?')))} GB/s,
+            local RCCL &ge; {html.escape(str(thresholds.get('rccl_gbs_min', '?')))} GB/s.</p>"""
             return f"""
         <section>
             <h2>Primus Node Smoke</h2>
-            <p>All <code>{passing}</code> node(s) passed Primus node_smoke.</p>
+            <p>All <code>{passing}</code> node(s) passed Primus node_smoke.</p>{tier2_html}
         </section>
         """
 

--- a/cvs/lib/preflight/unittests/test_node_smoke.py
+++ b/cvs/lib/preflight/unittests/test_node_smoke.py
@@ -55,6 +55,32 @@ class TestBuildNodeSmokeFlags(unittest.TestCase):
         self.assertIn("--no-clean-dump-path", flags)
         self.assertIn("--allow-foreign-procs", flags)
 
+    def test_tier2_perf_flags(self):
+        flags = build_node_smoke_flags(
+            dump_path="/tmp/smoke",
+            tier2_perf=True,
+            gemm_tflops_min=700,
+            hbm_gbs_min=4500,
+            rccl_gbs_min=180,
+            rccl_size_mb=64,
+            rccl_timeout_sec=120,
+        )
+        self.assertIn("--tier2-perf", flags)
+        self.assertIn("--gemm-tflops-min 700", flags)
+        self.assertIn("--hbm-gbs-min 4500", flags)
+        self.assertIn("--rccl-gbs-min 180", flags)
+        self.assertIn("--rccl-size-mb 64", flags)
+        self.assertIn("--rccl-timeout-sec 120", flags)
+
+    def test_tier2_perf_off_omits_threshold_flags(self):
+        flags = build_node_smoke_flags(
+            dump_path="/tmp/smoke",
+            tier2_perf=False,
+            gemm_tflops_min=700,
+        )
+        self.assertNotIn("--tier2-perf", flags)
+        self.assertNotIn("--gemm-tflops-min", flags)
+
 
 class TestBuildRemoteCommand(unittest.TestCase):
     def test_includes_distributed_env_and_json_markers(self):
@@ -134,6 +160,27 @@ class TestNodeSmokeCheckRun(unittest.TestCase):
         self.assertEqual(set(results["node_results"]), {"node0", "node2"})
         self.assertEqual(results["node_results"]["node0"]["node_rank"], 0)
         self.assertEqual(results["node_results"]["node2"]["node_rank"], 1)
+
+    def test_tier2_perf_extends_ssh_timeout(self):
+        phdl = MagicMock()
+        phdl.reachable_hosts = ["node0"]
+        phdl.exec_cmd_list.return_value = {"node0": "wrote /tmp/smoke/a.json status=PASS\n"}
+
+        cfg = self._config()
+        cfg["node_smoke"]["tier2_perf"] = True
+        cfg["node_smoke"]["ssh_timeout"] = 300
+        checker = NodeSmokeCheck(phdl, ["node0"], cfg)
+        checker.run()
+
+        timeout = phdl.exec_cmd_list.call_args.kwargs.get("timeout") or phdl.exec_cmd_list.call_args[1].get(
+            "timeout"
+        )
+        self.assertEqual(timeout, 600)
+        cmd = phdl.exec_cmd_list.call_args[0][0][0]
+        self.assertIn("--tier2-perf", cmd)
+        self.assertIn("--gemm-tflops-min 600", cmd)
+        self.assertIn("--hbm-gbs-min 2000", cmd)
+        self.assertIn("--rccl-gbs-min 100", cmd)
 
 
 if __name__ == "__main__":

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -1231,6 +1231,38 @@ class PreflightNodeSmokeConfig(BaseModel):
         description="Training NIC allowlist for node_smoke (defaults to node_check.rdma_interfaces)",
     )
     ssh_timeout: int = Field(default=300, ge=30, description="SSH timeout in seconds for each node_smoke run")
+    tier2_perf: bool = Field(
+        default=False,
+        description=(
+            "Enable Primus node_smoke Tier 2 perf sanity (--tier2-perf): "
+            "8192³ GEMM TFLOPS floor, HBM D2D bandwidth, local multi-GPU RCCL all-reduce"
+        ),
+    )
+    gemm_tflops_min: float = Field(
+        default=600.0,
+        ge=0,
+        description="Tier 2 large GEMM TFLOPS floor (--gemm-tflops-min); used when tier2_perf is true",
+    )
+    hbm_gbs_min: float = Field(
+        default=2000.0,
+        ge=0,
+        description="Tier 2 HBM device-to-device bandwidth floor in GB/s (--hbm-gbs-min)",
+    )
+    rccl_gbs_min: float = Field(
+        default=100.0,
+        ge=0,
+        description="Tier 2 local multi-GPU RCCL all-reduce bandwidth floor in GB/s (--rccl-gbs-min)",
+    )
+    rccl_size_mb: int = Field(
+        default=64,
+        ge=1,
+        description="Tier 2 local RCCL all-reduce message size in MB (--rccl-size-mb)",
+    )
+    rccl_timeout_sec: int = Field(
+        default=120,
+        ge=30,
+        description="Tier 2 local RCCL all-reduce hard timeout in seconds (--rccl-timeout-sec)",
+    )
     extra_args: List[str] = Field(
         default_factory=list,
         description="Additional node_smoke CLI flags forwarded to primus-cli",

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -687,6 +687,11 @@ def test_node_smoke(phdl, config_dict):
     Opt-in via ``node_smoke.connectivity_mode`` in the preflight config (default
     ``skip``).  Uses parallel SSH — no Slurm required.
 
+    Optional Tier 2 perf sanity (``node_smoke.tier2_perf``) enables
+    ``--tier2-perf``: large GEMM TFLOPS floor, HBM D2D bandwidth, and local
+    multi-GPU RCCL all-reduce thresholds (``gemm_tflops_min``, ``hbm_gbs_min``,
+    ``rccl_gbs_min``, etc.).
+
     Nodes that fail are reported but are **not** pruned from ``phdl``.
     """
     global preflight_results


### PR DESCRIPTION
Added optional Tier 2 node_smoke support to preflight via config (tier2_perf: true).

When enabled, preflight passes --tier2-perf and thresholds for:

GEMM TFLOPS floor
HBM D2D bandwidth
local multi-GPU RCCL all-reduce
Updated: node_smoke.py, preflight config/schema/docs, report summary, and unit tests.