### PR TITLE
Fix misleading 'unreachable' log message

### DIFF
--- a/cvs/lib/parallel/multiprocess_pssh.py
+++ b/cvs/lib/parallel/multiprocess_pssh.py
@@ -448,9 +448,14 @@ class MultiProcessPssh(ShardableSshInterface):
 
         return merged_results
 
-    def prune_nodes(self, nodes_to_remove):
+    def prune_nodes(self, nodes_to_remove, reason="Unreachable", log_pruning=True):
         """
         Explicitly prune nodes from future operations.
+
+        Args:
+            nodes_to_remove: Iterable of hostnames/IPs to remove.
+            reason: Optional reason for pruning passed to underlying Pssh instance.
+            log_pruning: If True (default), log each pruned host in underlying Pssh.
 
         Works in both modes:
         - sharded mode: updates wrapper host state
@@ -466,7 +471,7 @@ class MultiProcessPssh(ShardableSshInterface):
 
         if self.pssh is not None:
             # Non-sharded mode: let single-process Pssh own prune + client rebuild.
-            removed = self.pssh.prune_nodes(removed)
+            removed = self.pssh.prune_nodes(removed, reason=reason, log_pruning=log_pruning)
             self._sync_pssh_state()
             return removed
 

--- a/cvs/lib/parallel/pssh.py
+++ b/cvs/lib/parallel/pssh.py
@@ -112,12 +112,15 @@ class Pssh:
         unreachable = [item.host for item in output if item.exception]
         return unreachable
 
-    def prune_nodes(self, nodes_to_remove):
+    def prune_nodes(self, nodes_to_remove, reason="Unreachable", log_pruning=True):
         """
         Explicitly prune hosts from this Pssh instance and rebuild client.
 
         Args:
             nodes_to_remove: Iterable of hostnames/IPs to remove.
+            reason: Reason for pruning. Defaults to "Unreachable".
+            log_pruning: If True (default), log each pruned host. Set False to suppress logging
+                        when caller handles summary logging.
 
         Returns:
             list: Hosts actually removed from reachable_hosts.
@@ -130,8 +133,9 @@ class Pssh:
         if not removed:
             return []
 
-        for host in removed:
-            self.log.warning(f"Host {host} is unreachable, pruning from reachable hosts list.")
+        if log_pruning:
+            for host in removed:
+                self.log.warning(f"Host {host} pruned from reachable hosts list: {reason}")
 
         self.reachable_hosts = [h for h in self.reachable_hosts if h not in remove_set]
         for host in removed:

--- a/cvs/lib/parallel/unittests/test_multiprocess_pssh.py
+++ b/cvs/lib/parallel/unittests/test_multiprocess_pssh.py
@@ -432,7 +432,7 @@ class TestMultiProcessPsshHelperMethods(unittest.TestCase):
 
         removed = pssh.prune_nodes(["host2"])
 
-        pssh.pssh.prune_nodes.assert_called_once_with(["host2"])
+        pssh.pssh.prune_nodes.assert_called_once_with(["host2"], reason="Unreachable", log_pruning=True)
         self.assertEqual(removed, ["host2"])
         self.assertEqual(pssh.reachable_hosts, ["host1"])
         self.assertEqual(pssh.host_list, ["host1", "host2"])

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -186,10 +186,10 @@ def _prune_nodes_from_phdl(phdl, failed_nodes, reason):
     on_host = [h for h in phdl.reachable_hosts if h in remove]
     if not on_host:
         return
-    pruned = phdl.prune_nodes(on_host)
+    pruned = phdl.prune_nodes(on_host, reason=reason.rstrip(":"), log_pruning=False)
     if not pruned:
         return
-    log.info(f"{reason} Pruned {len(pruned)} node(s) from further preflight tests: {', '.join(sorted(pruned))}")
+    log.warning(f"{reason} Pruned {len(pruned)} node(s) from further preflight tests: {', '.join(sorted(pruned))}")
 
 
 # Override update_test_result for preflight tests to be reporting-only


### PR DESCRIPTION
in pssh.prune_nodes()

The prune_nodes() method was logging all host removals as 'unreachable' even when hosts were pruned for other reasons
(e.g., GID consistency failures, interface validation failures). This was misleading since these hosts were actually reachable over SSH but failed other checks.

Changes:
- Add optional 'reason' parameter to prune_nodes() (defaults to 'Unreachable')
- Add optional 'log_pruning' parameter to avoid duplicate logging
- Update preflight checks to pass specific failure reasons
- Change preflight summary log level from INFO to WARNING
- Apply fixes to both single-process and multiprocess Pssh classes

Addresses AIMVT-275: Generic prune_nodes() API should not assume unreachability.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
