### PR TITLE
[Documentation]: cli usage message/help Run Commands incorrect, check and update all

### DIFF
--- a/cvs/cli_plugins/run_plugin.py
+++ b/cvs/cli_plugins/run_plugin.py
@@ -43,10 +43,10 @@ class RunPlugin(ListPlugin):
     def get_epilog(self):
         return """
 Run Commands:
-  cvs run agfhc                      Run all tests in agfhc
-  cvs run agfhc test1                Run specific test function
-  cvs run agfhc test1 test2 test3    Run multiple specific test functions
-  cvs run agfhc --html report.html   Run test and generate HTML report"""
+  cvs run agfhc_cvs                      Run all tests in agfhc_cvs
+  cvs run agfhc_cvs test1                Run specific test function
+  cvs run agfhc_cvs test1 test2 test3    Run multiple specific test functions
+  cvs run agfhc_cvs --html report.html   Run test and generate HTML report"""
 
     def run(self, args):
         self.run_test(

--- a/cvs/cli_plugins/unittests/test_run_plugin.py
+++ b/cvs/cli_plugins/unittests/test_run_plugin.py
@@ -15,6 +15,12 @@ class TestRunPlugin(unittest.TestCase):
     def setUp(self):
         self.plugin = RunPlugin()
 
+    def test_epilog_uses_valid_agfhc_suite(self):
+        """Keep help examples synchronized with the real test-suite name."""
+        epilog = self.plugin.get_epilog()
+        self.assertEqual(epilog.count("cvs run agfhc_cvs"), 4)
+        self.assertNotIn("cvs run agfhc ", epilog)
+
     @patch("cvs.cli_plugins.run_plugin.pytest.main")
     @patch("cvs.cli_plugins.run_plugin.sys.exit")
     def test_run_test_single_function(self, mock_exit, mock_pytest_main):


### PR DESCRIPTION
## Summary

Closes #262. Applies the user-supplied structured edits to `cvs/cli_plugins/run_plugin.py` and updates its unit tests in `cvs/cli_plugins/unittests/test_run_plugin.py` to match.

## Changed files

- `cvs/cli_plugins/run_plugin.py`
- `cvs/cli_plugins/unittests/test_run_plugin.py`

## Validation

- Target architecture `gfx1100`: `True`
- Baseline failed: `True`
- Fixed run passed: `True`
- Tests passed: `True`
- Fix confirmed: `True`

## Disclosure

This change was prepared with assistance from the radeon-issue automation and independently checked by a separately configured validation model. Maintainer review is still required.
