### PR TITLE
Restore legacy vLLM suites under a 3-month deprecation notice

### DIFF
--- a/cvs/input/config_file/inference/vllm_legacy/mi355x_vllm_single.json
+++ b/cvs/input/config_file/inference/vllm_legacy/mi355x_vllm_single.json
@@ -1,0 +1,371 @@
+{
+    "config": {
+        "container_image": "rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1",
+        "container_name": "vllm_inference_rocm",
+        "nnodes": "1",
+        "benchmark_server_script_path": "/home/{user-id}/benchmark_server_scripts/",
+        "benchmark_script_repo": "https://github.com/kimbochen/bench_serving.git",
+        "hf_token_file": "/home/{user-id}/.hf_token",
+        "shm_size": "16G",
+        "log_dir": "/home/{user-id}/LOGS",
+        "data_cache_dir": "/it-share/models/",
+        "container_config": {
+            "device_list": [
+                "/dev/dri",
+                "/dev/kfd",
+                "/dev/mem"
+            ],
+            "volume_dict": {
+                "/home/{user-id}": "/home/{user-id}",
+                "/it-share/models/": "/models"
+            },
+            "env_dict": {
+                "HF_HUB_CACHE": "/models/huggingface-cache"
+            }
+        }
+    },
+    "benchmark_params": {
+        "gpt-oss-120b": {
+            "container_image": "rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1",
+            "backend": "vllm",
+            "base_url": "http://0.0.0.0",
+            "port_no": "8888",
+            "_example_dataset_name": "sharegpt|hf|random|sonnet|burstgpt",
+            "dataset_name": "random",
+            "concurrency_levels": [
+                16,
+                32,
+                64
+            ],
+            "model": "openai/gpt-oss-120b",
+            "num_prompts": "3200",
+            "sequence_combinations": [
+                {
+                    "isl": "1024",
+                    "osl": "1024",
+                    "name": "balanced"
+                },
+                {
+                    "isl": "1024",
+                    "osl": "8192",
+                    "name": "long_generation"
+                },
+                {
+                    "isl": "8192",
+                    "osl": "1024",
+                    "name": "long_context"
+                }
+            ],
+            "burstiness": "1.0",
+            "seed": "0",
+            "request_rate": "inf",
+            "max_model_length": "9216",
+            "random_range_ratio": "0.8",
+            "random_prefix_len": "0",
+            "tensor_parallelism": "1",
+            "_example_tokenizer_mode": "auto|slow|mistral|custom",
+            "tokenizer_mode": "auto",
+            "percentile_metrics": "ttft,tpot,itl,e2el",
+            "metric_percentiles": "99",
+            "server_script": "gpt-oss-120b_fp4_mi355x_vllm_docker.sh",
+            "bench_serv_script": "benchmark_serving.py",
+            "result_dict": {
+                "ISL=1024,OSL=1024,TP=1,CONC=16": {
+                    "total_throughput_per_sec": "4651",
+                    "mean_ttft_ms": "70",
+                    "mean_tpot_ms": "8"
+                },
+                "ISL=1024,OSL=1024,TP=1,CONC=32": {
+                    "total_throughput_per_sec": "7043",
+                    "mean_ttft_ms": "180",
+                    "mean_tpot_ms": "9"
+                },
+                "ISL=1024,OSL=1024,TP=1,CONC=64": {
+                    "total_throughput_per_sec": "10677",
+                    "mean_ttft_ms": "76",
+                    "mean_tpot_ms": "13"
+                },
+                "ISL=1024,OSL=8192,TP=1,CONC=16": {
+                    "total_throughput_per_sec": "2735",
+                    "mean_ttft_ms": "57",
+                    "mean_tpot_ms": "7"
+                },
+                "ISL=1024,OSL=8192,TP=1,CONC=32": {
+                    "total_throughput_per_sec": "4038",
+                    "mean_ttft_ms": "67",
+                    "mean_tpot_ms": "10"
+                },
+                "ISL=1024,OSL=8192,TP=1,CONC=64": {
+                    "total_throughput_per_sec": "6140",
+                    "mean_ttft_ms": "93",
+                    "mean_tpot_ms": "13"
+                },
+                "ISL=8192,OSL=1024,TP=1,CONC=16": {
+                    "total_throughput_per_sec": "16509",
+                    "mean_ttft_ms": "335",
+                    "mean_tpot_ms": "24"
+                },
+                "ISL=8192,OSL=1024,TP=1,CONC=32": {
+                    "total_throughput_per_sec": "22072",
+                    "mean_ttft_ms": "320",
+                    "mean_tpot_ms": "19"
+                },
+                "ISL=8192,OSL=1024,TP=1,CONC=64": {
+                    "total_throughput_per_sec": "28863",
+                    "mean_ttft_ms": "280",
+                    "mean_tpot_ms": "22"
+                }
+            }
+        },
+        "qwen3-235b": {
+            "container_image": "amdsiloai/vllm:2025111-0.11.1rc2-qwen3",
+            "backend": "vllm",
+            "base_url": "http://0.0.0.0",
+            "port_no": "8888",
+            "dataset_name": "random",
+            "concurrency_levels": [
+                16,
+                32,
+                64
+            ],
+            "model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+            "num_prompts": "3200",
+            "sequence_combinations": [
+                {
+                    "isl": "1024",
+                    "osl": "1024",
+                    "name": "balanced"
+                },
+                {
+                    "isl": "1024",
+                    "osl": "8192",
+                    "name": "long_generation"
+                },
+                {
+                    "isl": "8192",
+                    "osl": "1024",
+                    "name": "long_context"
+                }
+            ],
+            "burstiness": "1.0",
+            "seed": "0",
+            "request_rate": "inf",
+            "max_model_length": "9216",
+            "random_range_ratio": "0.8",
+            "random_prefix_len": "0",
+            "tensor_parallelism": "8",
+            "tokenizer_mode": "auto",
+            "percentile_metrics": "ttft,tpot,itl,e2el",
+            "metric_percentiles": "99",
+            "server_script": "qwen3-235b-bf16_mi355x_vllm_docker.sh",
+            "bench_serv_script": "benchmark_serving.py",
+            "result_dict": {
+                "ISL=1024,OSL=1024,TP=8,CONC=16": {
+                    "total_throughput_per_sec": "2000",
+                    "mean_ttft_ms": "850",
+                    "mean_tpot_ms": "18"
+                },
+                "ISL=1024,OSL=1024,TP=8,CONC=32": {
+                    "total_throughput_per_sec": "3435",
+                    "mean_ttft_ms": "80",
+                    "mean_tpot_ms": "10"
+                },
+                "ISL=1024,OSL=1024,TP=8,CONC=64": {
+                    "total_throughput_per_sec": "5840",
+                    "mean_ttft_ms": "260",
+                    "mean_tpot_ms": "10"
+                },
+                "ISL=1024,OSL=8192,TP=8,CONC=16": {
+                    "total_throughput_per_sec": "1119",
+                    "mean_ttft_ms": "415",
+                    "mean_tpot_ms": "25"
+                },
+                "ISL=1024,OSL=8192,TP=8,CONC=32": {
+                    "total_throughput_per_sec": "1876",
+                    "mean_ttft_ms": "70",
+                    "mean_tpot_ms": "10"
+                },
+                "ISL=1024,OSL=8192,TP=8,CONC=64": {
+                    "total_throughput_per_sec": "3139",
+                    "mean_ttft_ms": "310",
+                    "mean_tpot_ms": "14"
+                },
+                "ISL=8192,OSL=1024,TP=8,CONC=16": {
+                    "total_throughput_per_sec": "7476",
+                    "mean_ttft_ms": "300",
+                    "mean_tpot_ms": "21"
+                },
+                "ISL=8192,OSL=1024,TP=8,CONC=32": {
+                    "total_throughput_per_sec": "11312",
+                    "mean_ttft_ms": "355",
+                    "mean_tpot_ms": "27"
+                },
+                "ISL=8192,OSL=1024,TP=8,CONC=64": {
+                    "total_throughput_per_sec": "16082",
+                    "mean_ttft_ms": "450",
+                    "mean_tpot_ms": "39"
+                }
+            }
+        },
+        "qwen3-80b": {
+            "container_image": "rocm/vllm-dev:nightly",
+            "backend": "vllm",
+            "base_url": "http://0.0.0.0",
+            "port_no": "8888",
+            "dataset_name": "random",
+            "concurrency_levels": [
+                16,
+                32,
+                64
+            ],
+            "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+            "num_prompts": "3200",
+            "sequence_combinations": [
+                {
+                    "isl": "1024",
+                    "osl": "1024",
+                    "name": "balanced"
+                },
+                {
+                    "isl": "1024",
+                    "osl": "8192",
+                    "name": "long_generation"
+                },
+                {
+                    "isl": "8192",
+                    "osl": "1024",
+                    "name": "long_context"
+                }
+            ],
+            "burstiness": "1.0",
+            "seed": "0",
+            "request_rate": "inf",
+            "max_model_length": "9216",
+            "random_range_ratio": "0.8",
+            "random_prefix_len": "0",
+            "tensor_parallelism": "1",
+            "tokenizer_mode": "auto",
+            "percentile_metrics": "ttft,tpot,itl,e2el",
+            "metric_percentiles": "99",
+            "server_script": "qwen3-80b-bf16_mi355x_vllm_docker.sh",
+            "bench_serv_script": "benchmark_serving.py",
+            "result_dict": {
+                "ISL=1024,OSL=1024,TP=1,CONC=16": {
+                    "total_throughput_per_sec": "2003",
+                    "mean_ttft_ms": "69",
+                    "mean_tpot_ms": "9"
+                },
+                "ISL=1024,OSL=1024,TP=1,CONC=32": {
+                    "total_throughput_per_sec": "3155",
+                    "mean_ttft_ms": "69",
+                    "mean_tpot_ms": "12"
+                },
+                "ISL=1024,OSL=1024,TP=1,CONC=64": {
+                    "total_throughput_per_sec": "4570",
+                    "mean_ttft_ms": "375",
+                    "mean_tpot_ms": "23"
+                },
+                "ISL=1024,OSL=8192,TP=1,CONC=16": {
+                    "total_throughput_per_sec": "1200",
+                    "mean_ttft_ms": "84",
+                    "mean_tpot_ms": "12"
+                },
+                "ISL=1024,OSL=8192,TP=1,CONC=32": {
+                    "total_throughput_per_sec": "1800",
+                    "mean_ttft_ms": "200",
+                    "mean_tpot_ms": "12"
+                },
+                "ISL=1024,OSL=8192,TP=1,CONC=64": {
+                    "total_throughput_per_sec": "2600",
+                    "mean_ttft_ms": "768",
+                    "mean_tpot_ms": "21"
+                },
+                "ISL=8192,OSL=1024,TP=1,CONC=16": {
+                    "total_throughput_per_sec": "7500",
+                    "mean_ttft_ms": "495",
+                    "mean_tpot_ms": "16"
+                },
+                "ISL=8192,OSL=1024,TP=1,CONC=32": {
+                    "total_throughput_per_sec": "11300",
+                    "mean_ttft_ms": "280",
+                    "mean_tpot_ms": "17"
+                },
+                "ISL=8192,OSL=1024,TP=1,CONC=64": {
+                    "total_throughput_per_sec": "16000",
+                    "mean_ttft_ms": "91",
+                    "mean_tpot_ms": "18"
+                }
+            }
+        },
+        "deepseek-v31": {
+            "container_image": "rocm/7.x-preview:rocm7.2_preview_ubuntu_22.04_vlm_0.10.1_instinct_20251029",
+            "backend": "vllm",
+            "base_url": "http://0.0.0.0",
+            "port_no": "8888",
+            "dataset_name": "random",
+            "concurrency_levels": [
+                16,
+                32,
+                64
+            ],
+            "model": "deepseek-ai/DeepSeek-V3.1",
+            "num_prompts": "3200",
+            "sequence_combinations": [
+                {
+                    "isl": "1024",
+                    "osl": "1024",
+                    "name": "balanced"
+                },
+                {
+                    "isl": "1024",
+                    "osl": "8192",
+                    "name": "long_generation"
+                }
+            ],
+            "burstiness": "1.0",
+            "seed": "0",
+            "request_rate": "inf",
+            "max_model_length": "9216",
+            "random_range_ratio": "0.8",
+            "random_prefix_len": "0",
+            "tensor_parallelism": "8",
+            "tokenizer_mode": "auto",
+            "percentile_metrics": "ttft,tpot,itl,e2el",
+            "metric_percentiles": "99",
+            "server_script": "dsr1_fp8_mi355x_vllm_docker.sh",
+            "bench_serv_script": "benchmark_serving.py",
+            "result_dict": {
+                "ISL=1024,OSL=1024,TP=8,CONC=16": {
+                    "total_throughput_per_sec": "1944",
+                    "mean_ttft_ms": "84",
+                    "mean_tpot_ms": "12"
+                },
+                "ISL=1024,OSL=1024,TP=8,CONC=32": {
+                    "total_throughput_per_sec": "2939",
+                    "mean_ttft_ms": "302",
+                    "mean_tpot_ms": "21"
+                },
+                "ISL=1024,OSL=1024,TP=8,CONC=64": {
+                    "total_throughput_per_sec": "4834",
+                    "mean_ttft_ms": "250",
+                    "mean_tpot_ms": "11"
+                },
+                "ISL=1024,OSL=8192,TP=8,CONC=16": {
+                    "total_throughput_per_sec": "1109",
+                    "mean_ttft_ms": "253",
+                    "mean_tpot_ms": "19"
+                },
+                "ISL=1024,OSL=8192,TP=8,CONC=32": {
+                    "total_throughput_per_sec": "1676",
+                    "mean_ttft_ms": "305",
+                    "mean_tpot_ms": "21"
+                },
+                "ISL=1024,OSL=8192,TP=8,CONC=64": {
+                    "total_throughput_per_sec": "2716",
+                    "mean_ttft_ms": "280",
+                    "mean_tpot_ms": "13"
+                }
+            }
+        }
+    }
+}

--- a/cvs/lib/inference/base_legacy.py
+++ b/cvs/lib/inference/base_legacy.py
@@ -39,14 +39,6 @@ from cvs.lib import linux_utils
 
 log = globals.log
 
-# The pre-#223 defaults the legacy suites' configs are written against. Named
-# here so the deprecation guard test can assert this copy stayed frozen rather
-# than drifting toward the live base's replacements.
-LEGACY_BENCH_DEFAULTS = {
-    'benchmark_script_repo': 'https://github.com/kimbochen/bench_serving.git',
-    'random_range_ration': '1.0',
-}
-
 inference_err_dict = {
     'NCCL ERROR': 'NCCL ERROR|NCCL timeout|local work queue catastrophic error',
     'GPU HW ERROR': 'HW Exception by GPU|GPU Hang|Uncorrectable error|GPU Reset',

--- a/cvs/lib/inference/base_legacy.py
+++ b/cvs/lib/inference/base_legacy.py
@@ -1,0 +1,742 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+DEPRECATED -- frozen copy, scheduled for removal on 2026-11-11.
+
+This is the pre-#223 ``cvs/lib/inference/base.py``, restored verbatim to serve
+the 3-month OSS deprecation notice for the legacy vLLM suites under
+``cvs/tests/inference/vllm_legacy/``.
+
+It is a FROZEN COPY on purpose. ``cvs.lib.inference.base`` has since changed
+behaviour the legacy suites depend on:
+
+  - the bench client moved from a cloned ``bench_serving`` repo to the
+    ``benchmarks/`` shipped inside the installed ``vllm`` package, and
+    ``benchmark_script_repo`` was dropped;
+  - the ``random_range_ration`` key was respelled ``random_range_ratio``;
+  - server-readiness polling switched from tail+match to a whole-file grep;
+  - parsed result keys were renamed (e.g. ``Total generated tokens:`` ->
+    ``total_generated_tokens``).
+
+Inheriting the live base would mean the "deprecated" path silently behaves
+differently from the code that was removed, which defeats the notice period.
+Do not add features here and do not import it from new code -- new suites use
+``cvs.lib.inference.base``. Delete this file together with the legacy suites
+once the window closes.
+'''
+
+import os
+import re
+import time
+
+from cvs.lib import globals
+from cvs.lib.utils_lib import *
+from cvs.lib.verify_lib import *
+from cvs.lib import linux_utils
+
+log = globals.log
+
+# The pre-#223 defaults the legacy suites' configs are written against. Named
+# here so the deprecation guard test can assert this copy stayed frozen rather
+# than drifting toward the live base's replacements.
+LEGACY_BENCH_DEFAULTS = {
+    'benchmark_script_repo': 'https://github.com/kimbochen/bench_serving.git',
+    'random_range_ration': '1.0',
+}
+
+inference_err_dict = {
+    'NCCL ERROR': 'NCCL ERROR|NCCL timeout|local work queue catastrophic error',
+    'GPU HW ERROR': 'HW Exception by GPU|GPU Hang|Uncorrectable error|GPU Reset',
+    'AssertionError': 'AssertionError|ValueError:|During handling of the above exception|triggered the following exception',
+    'rocm Err': 'FAILED_PRECONDITION: No visible GPU devices|failed call to hipInit: HIP_ERROR_NoDevice|librocm reported version is: NOT_FOUND',
+    'python err': 'ModuleNotFoundError: No module named|Fatal Python error:',
+    'resource': 'RESOURCE_EXHAUSTED: Out of memory|failed: RESOURCE_EXHAUSTED',
+}
+
+err_counters_pattern = 'err|retransmit|drop|discard|naks|invalid|oflow|out_of_buffer|reset|fail'
+
+
+def textwrap_for_yml(msg_string):
+    return '\n'.join([m.lstrip() for m in msg_string.split('\n')])
+
+
+class InferenceBaseJob:
+    """Base class for inference jobs supporting multiple frameworks."""
+
+    def __init__(
+        self,
+        c_phdl,
+        s_phdl,
+        model_name,
+        inference_config_dict,
+        benchmark_params_dict,
+        hf_token,
+        gpu_type='mi300',
+        distributed_inference=False,
+        server_launch_poll_count=20,
+    ):
+        # Client instance phdl
+        self.c_phdl = c_phdl
+        # Server instance phdl
+        self.s_phdl = s_phdl
+
+        self.c_host_list = c_phdl.host_list
+        self.s_host_list = s_phdl.host_list
+
+        self.model_name = model_name
+        self.hf_token = hf_token
+        self.gpu_type = gpu_type
+        self.distributed_inference = distributed_inference
+
+        # Sample inference config and model params dict saved above
+        self.if_dict = inference_config_dict
+        self.benchmark_params_dict = benchmark_params_dict
+
+        self.job_cmd = ''
+        self.job_cmd_list = []
+        log.info("%s", self.gpu_type)
+
+        # Needed only in the case of distributed inference - placeholder for future
+        # Intialize cluster stats dicts ..
+        self.rdma_stats_dict_before = {}
+        self.ethtool_stats_dict_before = {}
+        self.rdma_stats_dict_after = {}
+        self.inference_start_time = s_phdl.exec('date +"%a %b %e %H:%M"')
+        self.inference_end_time = None
+
+        self.home_dir = os.path.expanduser("~")
+        self.if_dict.setdefault('container_image', 'rocm/7.0:rocm7.0_ubuntu_22.04_vllm_0.10.1_instinct_20250927_rc1')
+        self.if_dict.setdefault('container_name', 'inference_max_container')
+        self.if_dict.setdefault('distributed_inference', False)
+        self.if_dict.setdefault('nnodes', 1)
+        self.if_dict.setdefault('nic_type', 'thor2')
+        self.if_dict.setdefault('nccl_ib_hca_list', 'rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7')
+        self.if_dict.setdefault('nccl_ib_hca', 'rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7')
+        self.if_dict.setdefault('nccl_socket_ifname', 'ens51f1np1')
+        self.if_dict.setdefault('gloo_socket_ifname', 'ens51f1np1')
+        self.if_dict.setdefault('nccl_ib_gid_index', '3')
+        self.if_dict.setdefault('nccl_debug', 'ERROR')
+        self.if_dict.setdefault('data_cache_dir', f'{self.home_dir}/cache')
+        self.if_dict.setdefault('log_dir', f'{self.home_dir}/LOG_DIR')
+        self.if_dict.setdefault('benchmark_script_repo', 'https://github.com/kimbochen/bench_serving.git')
+
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info(f'inference_dict = {self.if_dict}')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+
+        # Get model-specific config - check if nested under single_node/multi_node or flat
+        if self.distributed_inference:
+            # Multi-node structure: benchmark_params['multi_node'][model_name] or benchmark_params[model_name]
+            if 'multi_node' in self.benchmark_params_dict:
+                self.bp_dict = self.benchmark_params_dict['multi_node'][self.model_name]
+            else:
+                self.bp_dict = self.benchmark_params_dict[self.model_name]
+        else:
+            # Single-node structure: benchmark_params['single_node'][model_name] or benchmark_params[model_name]
+            if 'single_node' in self.benchmark_params_dict:
+                self.bp_dict = self.benchmark_params_dict['single_node'][self.model_name]
+            else:
+                self.bp_dict = self.benchmark_params_dict[self.model_name]
+
+        # Container image can be model-specific (in bp_dict) or global (in if_dict)
+        self.container_image = self.bp_dict.get('container_image', self.if_dict['container_image'])
+        self.container_name = self.if_dict['container_name']
+
+        self.nnodes = self.if_dict['nnodes']
+        self.nic_type = self.if_dict['nic_type']
+        self.nccl_ib_hca_list = self.if_dict['nccl_ib_hca_list']
+        self.nccl_ib_hca = self.if_dict['nccl_ib_hca']
+        self.nccl_socket_ifname = self.if_dict['nccl_socket_ifname']
+        self.gloo_socket_ifname = self.if_dict['gloo_socket_ifname']
+        self.nccl_ib_gid_index = self.if_dict['nccl_ib_gid_index']
+        self.nccl_debug = self.if_dict['nccl_debug']
+        self.data_cache_dir = self.if_dict['data_cache_dir']
+        self.log_dir = self.if_dict['log_dir']
+
+        # Allow derived classes to override server launch wait duration
+        self.default_server_precheck_wait_time = 30
+        self.default_server_wait_time = 330
+        self.default_server_poll_wait_time = 60
+        self.default_server_poll_count = server_launch_poll_count
+        self.default_server_precheck_error_pattern = re.compile(
+            'no such file or directory|command not found|cannot access|permission denied|error:|exception:|traceback|failed to start',
+            re.I,
+        )
+        self.default_server_error_pattern_poll = re.compile(
+            'failed to start|no such file or directory|command not found|cannot access', re.I
+        )
+        self.default_client_wait_time = 120
+        self.default_client_poll_count = 20
+        self.default_client_poll_wait_time = 60
+
+        # Regex/parse defaults that derived classes may override
+        self.readiness_pattern = re.compile('Application startup complete|Uvicorn running|Started server', re.I)
+
+        # set defaults for benchmark param dict if not passed via JSON file
+        self.bp_dict.setdefault('backend', 'vllm')
+        self.bp_dict.setdefault('base_url', 'http://0.0.0.0')
+        self.bp_dict.setdefault('dataset_name', 'sharegpt')
+        self.bp_dict.setdefault('max_concurrency', '64')
+        self.bp_dict.setdefault('model', 'openai/gpt-oss-120b')
+        self.bp_dict.setdefault('num_prompts', '1000')
+        self.bp_dict.setdefault('input_sequence_length', '8192')
+        self.bp_dict.setdefault('output_sequence_length', '1024')
+        self.bp_dict.setdefault('burstiness', '1.0')
+        self.bp_dict.setdefault('seed', '0')
+        self.bp_dict.setdefault('request_rate', 'inf')
+        self.bp_dict.setdefault('max_model_length', '9216')
+        self.bp_dict.setdefault('random_range_ration', '1.0')
+        self.bp_dict.setdefault('random_prefix_len', '0')
+        self.bp_dict.setdefault('tensor_parallelism', '1')
+        self.bp_dict.setdefault('port_no', '8000')
+        self.bp_dict.setdefault('tokenizer_mode', 'auto')
+        self.bp_dict.setdefault('percentile_metrics', 'ttft,tpot,itl,e2el')
+        self.bp_dict.setdefault('metric_percentiles', '99')
+
+        # Set server and client scripts
+        self.server_script = self.bp_dict['server_script']
+        self.bench_serv_script = self.bp_dict['bench_serv_script']
+
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+        log.info(f'benchmark_params_dict = {self.bp_dict}')
+        log.info('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
+
+    # Framework-specific methods to be implemented by derived classes
+    def get_server_script_directory(self):
+        """Get directory where server scripts are located."""
+        raise NotImplementedError("Derived class must implement get_server_script_directory()")
+
+    def get_result_filename(self):
+        """Get result filename for benchmark output."""
+        raise NotImplementedError("Derived class must implement get_result_filename()")
+
+    def get_completion_pattern(self):
+        """Get regex pattern to detect benchmark completion."""
+        raise NotImplementedError("Derived class must implement get_completion_pattern()")
+
+    def get_log_subdir(self):
+        """Get log subdirectory name for this framework."""
+        raise NotImplementedError("Derived class must implement get_log_subdir()")
+
+    def get_server_script_path(self):
+        """Get directory where server scripts are located."""
+        raise NotImplementedError("Derived class must implement get_server_script_path()")
+
+    def run_preinference_tasks(
+        self,
+    ):
+        if self.distributed_inference is True:
+            self.rdma_stats_dict_before = linux_utils.get_rdma_stats_dict(self.s_phdl)
+            self.ethtool_stats_dict_before = linux_utils.get_nic_ethtool_stats_dict(self.s_phdl)
+
+    def launch_docker_container(self, container_name, image, device_list, volume_dict, env_dict):
+        if self.distributed_inference is True:
+            docker_lib.launch_docker_container(self.s_phdl, container_name, image, device_list, volume_dict, env_dict)
+        else:
+            env_dict['NNODES'] = 1
+            docker_lib.launch_docker_container(self.s_phdl, container_name, image, device_list, volume_dict, env_dict)
+
+    def exec_nic_setup_scripts(
+        self,
+    ):
+        """
+        Execute NIC-related setup steps inside the inference container.
+
+        Behavior:
+        - Only runs for distributed inference.
+        - If NIC type appears to be Broadcom/Thor, applies a temporary workaround:
+          * Copies the bnxt RDMA library from the host-named file to the container?s expected path.
+          * Verifies that ibv_devinfo shows a bnxt_ HCA (to confirm RDMA is wired correctly).
+        - Forces NCCL GID index to 3 for Broadcom/Thor (common requirement).
+
+        Assumptions:
+        - self.s_phdl.exec runs a shell command and returns a dict: {node: stdout}.
+        - sudo is non-interactive within the container.
+        - The bnxt library file paths exist in the container base image.
+        """
+
+        # Run all your backend NIC related bringups for containers here ..
+        if self.distributed_inference is True:
+            # This is a temporary hack needed for broadcom nics to work within containers ..
+            if re.search('broadcom|thor', self.nic_type, re.I):
+                # override the gid_index to 3 for broadcom
+                self.nccl_ib_gid_index = 3
+                out_dict = self.s_phdl.exec(
+                    f'docker exec {self.container_name} /bin/bash -c "sudo \
+                    cp /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host \
+                    /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so; \
+                    sleep 2;ibv_devinfo;sleep 2;"'
+                )
+                for node in out_dict.keys():
+                    if not re.search('hca_id:\s+bnxt_', out_dict[node], re.I):
+                        log.info("%s", out_dict[node])
+                        fail_test(f'Broadcom libbnxt rdma driver is not properly copied on node {node}')
+
+    def build_server_inference_job_cmd(
+        self,
+    ):
+        s_cmd = f'''docker exec {self.container_name} /bin/bash -c "echo '
+                    export MODEL={self.bp_dict['model']}
+                    export ISL={self.bp_dict['input_sequence_length']}
+                    export OSL={self.bp_dict['output_sequence_length']}
+                    export MAX_MODEL_LEN={self.bp_dict['max_model_length']}
+                    export RANDOM_RANGE_RATIO={self.bp_dict['random_range_ratio']}
+                    export TP={self.bp_dict['tensor_parallelism']}
+                    export CONC={self.bp_dict['max_concurrency']}
+                    export HF_TOKEN={self.hf_token}
+                    export VLLM_USE_AITER_UNIFIED_ATTENTION=1
+                    export VLLM_ROCM_USE_AITER_MHA=0
+                    export VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4=1
+                    export RESULT_FILENAME=results
+                    export PORT={self.bp_dict['port_no']}'  > /tmp/server_env_script.sh"
+                    '''
+        time.sleep(3)
+        formatted_cmd = textwrap_for_yml(s_cmd)
+
+        self.s_phdl.exec(formatted_cmd)
+
+        if self.distributed_inference:
+            cmd_list = []
+            for i in range(0, int(self.nnodes)):
+                cmd = f'''docker exec {self.container_name} /bin/bash -c  "echo  '
+                      export NNODES=1
+                      export NODE_RANK=0
+                      export NCCL_DEBUG={self.if_dict['nccl_debug']}
+                      export NCCL_IB_DISABLE=1
+                      export NCCL_SHM_DISABLE=0
+                      export NCCL_P2P_DISABLE=0
+                      export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
+                      export NCCL_DEBUG={self.if_dict['nccl_debug']}
+                      export NCCL_IB_HCA={self.if_dict['nccl_ib_hca']}
+                      export NCCL_IB_GID_INDEX={self.if_dict['nccl_ib_gid_index']}
+                      export HSA_FORCE_FINE_GRAIN_PCIE=1
+                      export NCCL_SOCKET_IFNAME={self.if_dict['nccl_socket_ifname']}
+                      export GLOO_SOCKET_IFNAME={self.if_dict['gloo_socket_ifname']}
+                      export PORT={self.port_no}'  > /tmp/server_env_script.sh"
+                    '''
+                formatted_cmd = textwrap_for_yml(cmd)
+                cmd_list.append(formatted_cmd)
+            log.info("%s", cmd_list)
+            self.s_phdl.exec_cmd_list(cmd_list)
+
+        cmd_list = []
+        for i in range(0, int(self.nnodes)):
+            cmd = f'''docker exec {self.container_name} /bin/bash -c "mkdir -p {self.log_dir}/{self.get_log_subdir()}/out-node{i}" '''
+            cmd_list.append(cmd)
+        self.s_phdl.exec_cmd_list(cmd_list)
+
+    def clone_bench_serving_repo(self, clone_dir):
+        """Clone bench_serving repository for client benchmarks."""
+        cmd = f'''docker exec {self.container_name} /bin/bash -c "cd {clone_dir}; git clone {self.if_dict['benchmark_script_repo']}" '''
+        out_dict = self.c_phdl.exec(cmd)
+        for node in out_dict.keys():
+            # Ignore "already exists" error - repo was cloned in previous test
+            if re.search('error|fail', out_dict[node], re.I) and not re.search('already exists', out_dict[node], re.I):
+                fail_test('Errors or failures seen in pulling bench_serving repo from Github, pls check')
+        time.sleep(3)
+
+    def launch_server(self):
+        """Launch inference server."""
+        script_dir = self.get_server_script_directory()
+        log_file = f'{self.server_script}_server.log'
+        script_path = self.get_server_script_path()
+
+        # Start the server side inference job
+        cmd_list = []
+        for i in range(0, int(self.nnodes)):
+            cmd = f'''docker exec {self.container_name} /bin/bash -c "cd {script_dir}; source /tmp/server_env_script.sh; nohup /bin/bash {script_path} > {self.log_dir}/{self.get_log_subdir()}/out-node{i}/{log_file} 2>&1 &" '''
+            cmd_list.append(cmd)
+        out_dict = self.s_phdl.exec_cmd_list(cmd_list)
+
+        # Check for immediate failures in server launch
+        for node in out_dict.keys():
+            if re.search(
+                'No such file or directory|command not found|cannot access|Permission denied', out_dict[node], re.I
+            ):
+                log.error(f'FAIL - Failed to start server on node {node}: {out_dict[node]}')
+                raise Exception(f'Failed to start server on node {node}: {out_dict[node]}')
+
+    def check_server_status(self, log_file, log_subdir, error_pattern):
+        """Tail recent server logs, detect launch failures, and return the output dict."""
+        cmd_list = []
+        for i in range(0, int(self.nnodes)):
+            cmd = f'tail -30 {self.log_dir}/{log_subdir}/out-node{i}/{log_file}'
+            cmd_list.append(cmd)
+        out_dict = self.s_phdl.exec_cmd_list(cmd_list)
+
+        for node, output in out_dict.items():
+            if error_pattern.search(output or ''):
+                error_msg = f'Failed to start server on node {node}: {output[-500:]}'
+                fail_test(error_msg)
+                raise Exception(error_msg)
+
+        return out_dict
+
+    def is_server_ready(self, out_dict, readiness_pattern):
+        """Return True if all nodes show the readiness marker."""
+        if not out_dict:
+            return False
+
+        node_ready = {node: bool(readiness_pattern.search(output or '')) for node, output in out_dict.items()}
+        return bool(node_ready) and all(node_ready.values())
+
+    def poll_server_startup(self):
+        """Poll for server startup completion."""
+        log_file = f'{self.server_script}_server.log'
+        readiness_pattern = self.readiness_pattern
+
+        # Do an early check for fast failures before the long wait
+        log.info(f'Waiting {self.default_server_precheck_wait_time} secs for server to start writing logs...')
+        time.sleep(self.default_server_precheck_wait_time)
+
+        # Early failure detection
+        cmd_list = []
+        for i in range(0, int(self.nnodes)):
+            cmd = f'tail -30 {self.log_dir}/{self.get_log_subdir()}/out-node{i}/{log_file}'
+            cmd_list.append(cmd)
+        out_dict = self.s_phdl.exec_cmd_list(cmd_list)
+        for node in out_dict.keys():
+            log_content = out_dict[node].lower()
+            if self.default_server_precheck_error_pattern.search(log_content):
+                error_msg = f'Failed to start server on node {node}: {out_dict[node][-500:]}'
+                fail_test(error_msg)
+                raise Exception(error_msg)
+
+        log.info(
+            f'No immediate errors detected. Waiting {self.default_server_wait_time} more secs for server to fully launch...'
+        )
+        time.sleep(self.default_server_wait_time)
+
+        for j in range(0, self.default_server_poll_count):
+            log.info(f'Polling for application startup complete on all nodes, iteration {j}')
+            cmd_list = []
+            for i in range(0, int(self.nnodes)):
+                cmd = f'tail -30 {self.log_dir}/{self.get_log_subdir()}/out-node{i}/{log_file}'
+                cmd_list.append(cmd)
+            out_dict = self.s_phdl.exec_cmd_list(cmd_list)
+
+            for node in out_dict.keys():
+                if self.default_server_error_pattern_poll.search(out_dict[node] or ''):
+                    error_msg = f'Failed to start server on node {node}: {out_dict[node][-500:]}'
+                    fail_test(error_msg)
+                    raise Exception(error_msg)
+
+            if self.is_server_ready(out_dict, readiness_pattern):
+                log.info('Server startup confirmed on all nodes')
+                return
+
+            log.info(f'Waiting {self.default_server_poll_wait_time} secs for next poll')
+            time.sleep(self.default_server_poll_wait_time)
+
+        error_msg = 'Server did not report readiness before timeout; aborting startup'
+        fail_test(error_msg)
+        raise Exception(error_msg)
+
+    def launch_client(self):
+        """Launch client benchmark."""
+        clone_dir = '/app'
+        backend = self.bp_dict['backend']
+        result_filename = self.get_result_filename()
+
+        # Launch client benchmark
+        cmd_list = []
+        for i in range(0, int(self.nnodes)):
+            client_cmd = f'''source /tmp/server_env_script.sh; cd {clone_dir}; \
+                    python3 bench_serving/{self.bench_serv_script} \
+                    --model {self.bp_dict['model']} \
+                    --backend {backend} \
+                    --base-url {self.bp_dict['base_url']}:{self.bp_dict['port_no']} \
+                    --dataset-name {self.bp_dict['dataset_name']} \
+                    --num-prompts {self.bp_dict['num_prompts']} \
+                    --random-input-len {self.bp_dict['input_sequence_length']} \
+                    --random-output-len {self.bp_dict['output_sequence_length']} \
+                    --max-concurrency {self.bp_dict['max_concurrency']} \
+                    --request-rate {self.bp_dict['request_rate']} \
+                    --burstiness {self.bp_dict['burstiness']} \
+                    --tokenizer-mode {self.bp_dict['tokenizer_mode']} \
+                    --seed {self.bp_dict['seed']} \
+                    --random-range-ratio {self.bp_dict['random_range_ratio']} \
+                    --random-prefix-len {self.bp_dict['random_prefix_len']} \
+                    --percentile-metrics {self.bp_dict['percentile_metrics']} \
+                    --ignore-eos \
+                    --save-result \
+                    --result-dir {self.log_dir}/{self.get_log_subdir()}/out-node{i} \
+                    --result-filename {result_filename} \
+                    > {self.log_dir}/{self.get_log_subdir()}/out-node{i}/bench_serv_script.log 2>&1 &'''
+            cmd = f'''docker exec {self.container_name} /bin/bash -c "{client_cmd}" '''
+            cmd_list.append(cmd)
+        self.c_phdl.exec_cmd_list(cmd_list)
+
+    def poll_client_completion(self):
+        """Poll for client benchmark completion."""
+        log.info(f'Waiting for {self.default_client_wait_time} secs for benchmark scripts to start')
+        time.sleep(self.default_client_wait_time)
+        for j in range(0, self.default_client_poll_count):
+            log.info(f'Polling for Benchmark script to complete on all nodes, iteration {j}')
+            cmd_list = []
+            for i in range(0, int(self.nnodes)):
+                cmd = f'tail -30 {self.log_dir}/{self.get_log_subdir()}/out-node{i}/bench_serv_script.log'
+                cmd_list.append(cmd)
+            out_dict = self.c_phdl.exec_cmd_list(cmd_list)
+            for node in out_dict.keys():
+                if re.search('Failed', out_dict[node], re.I):
+                    fail_test(f'Failed to run benchmark script on node {node}')
+                    return
+                if not re.search('End-to-end Latency', out_dict[node], re.I):
+                    log.info(f'Waiting {self.default_client_poll_wait_time} secs for next poll')
+                    time.sleep(self.default_client_poll_wait_time)
+
+    def start_inference_server_job(
+        self,
+    ):
+        """Start inference server - launch and poll for startup."""
+        log.info('Start Server side Inference on all Nodes')
+        self.launch_server()
+        self.poll_server_startup()
+
+    def start_inference_client_job(
+        self,
+    ):
+        log.info('Start Client side benchmark script on all Nodes')
+
+        # Clone bench_serving repo to /app
+        self.clone_bench_serving_repo('/app')
+
+        if self.distributed_inference:
+            log.info('Distributed inference - TBD')
+            return
+
+        # Launch client and poll for completion
+        self.launch_client()
+        self.poll_client_completion()
+
+    def get_inference_results_dict(self, out_dict):
+        log.info('Get the inference results dict using get_inference_results_dict')
+        self.inference_results_dict = {}
+        for node in out_dict.keys():
+            self.inference_results_dict[node] = {}
+            if re.search('Successful requests:', out_dict[node], re.I):
+                match = re.search('Successful requests:\s+([0-9]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['successful_requests'] = match.group(1)
+            if re.search('Benchmark duration\s+\(s\):\s+([0-9]+)', out_dict[node], re.I):
+                match = re.search('Benchmark duration\s+\(s\):\s+([0-9]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['benchmark_duration'] = match.group(1)
+            if re.search('Total input tokens:', out_dict[node], re.I):
+                match = re.search('Total input tokens:\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['total_input_tokens'] = match.group(1)
+            if re.search('Total generated tokens:', out_dict[node], re.I):
+                match = re.search('Total generated tokens:\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['Total generated tokens:'] = match.group(1)
+            if re.search('Request throughput \(req/s\):', out_dict[node], re.I):
+                match = re.search('Request throughput \(req/s\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['request_throughput_per_sec'] = match.group(1)
+            if re.search('Output token throughput \(tok/s\):', out_dict[node], re.I):
+                match = re.search('Output token throughput \(tok/s\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['output_throughput_per_sec'] = match.group(1)
+            if re.search('Total Token throughput \(tok/s\):', out_dict[node], re.I):
+                match = re.search('Total Token throughput \(tok/s\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['total_throughput_per_sec'] = match.group(1)
+            if re.search('Mean TTFT \(ms\):', out_dict[node], re.I):
+                match = re.search('Mean TTFT \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['mean_ttft_ms'] = match.group(1)
+            if re.search('Median TTFT (ms):', out_dict[node], re.I):
+                match = re.search('Median TTFT \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['median_ttft_ms'] = match.group(1)
+            if re.search('P99 TTFT (ms):', out_dict[node], re.I):
+                match = re.search('P99 TTFT \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['p99_ttft_ms'] = match.group(1)
+            if re.search('Mean TPOT \(ms\)', out_dict[node], re.I):
+                match = re.search('Mean TPOT \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['mean_tpot_ms'] = match.group(1)
+            if re.search('Median TPOT \(ms\):', out_dict[node], re.I):
+                match = re.search('Median TPOT \(ms\):\s+([0-9]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['median_tpot_ms'] = match.group(1)
+            if re.search('P99 TPOT (ms):', out_dict[node], re.I):
+                match = re.search('P99 TPOT \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['p99_tpot_ms'] = match.group(1)
+            if re.search('Mean ITL \(ms\):', out_dict[node], re.I):
+                match = re.search('Mean ITL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['mean_itl_ms'] = match.group(1)
+            if re.search('Median ITL \(ms\):', out_dict[node], re.I):
+                match = re.search('Median ITL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['median_itl_ms'] = match.group(1)
+            if re.search('P99 ITL \(ms\):', out_dict[node], re.I):
+                match = re.search('P99 ITL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['p99_itl_ms'] = match.group(1)
+            if re.search('Mean E2EL \(ms\):', out_dict[node], re.I):
+                match = re.search('Mean E2EL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['mean_e2el_ms'] = match.group(1)
+            if re.search('Median E2EL \(ms\):', out_dict[node], re.I):
+                match = re.search('Median E2EL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['median_e2el_ms'] = match.group(1)
+            if re.search('P99 E2EL \(ms\):', out_dict[node], re.I):
+                match = re.search('P99 E2EL \(ms\):\s+([0-9\.]+)', out_dict[node], re.I)
+                self.inference_results_dict[node]['p99_e2el_ms'] = match.group(1)
+
+        log.info("%s", self.inference_results_dict)
+        return self.inference_results_dict
+
+    def scan_for_inference_errors(
+        self,
+    ):
+        log.info('Scan for inference errors')
+        inference_pass = True
+
+        # Build the list of commands to read each node's inference log file
+        cmd_list = []
+
+        # Execute the commands across nodes; returns a mapping of node -> command output
+        for j in range(0, int(self.nnodes)):
+            log_file = f'{self.server_script}_server.log'
+            cmd = f"sudo cat {self.log_dir}/{self.get_log_subdir()}/out-node{j}/{log_file}"
+            cmd_list.append(cmd)
+        out_dict = self.s_phdl.exec_cmd_list(cmd_list)
+
+        # Check the log content against all known inference error patterns
+        for node in out_dict.keys():
+            for err_key in inference_err_dict:
+                if re.search(f"{inference_err_dict[err_key]}", out_dict[node]):
+                    fail_test(f"ERROR {inference_err_dict[err_key]} seen in inference logs ...")
+                    log.error('Aborting inference log polling')
+                    inference_pass = False
+        return inference_pass
+
+    def poll_for_inference_completion(
+        self, waittime_between_iters=120, iterations=15, total_timeout=3600, require_all_nodes=True
+    ):
+        # Initial wait to give inference time to start logging
+        time.sleep(60)
+
+        # Assume 1000 prompts completes in 120 secs ..
+        # iterations = int(float(num_prompts) / 60)
+        self.inference_poll_iterations = iterations
+        completion_pattern = self.get_completion_pattern()
+
+        # Track wall-clock timeout if specified
+        start_time = time.time()
+
+        def timed_out() -> bool:
+            return total_timeout is not None and (time.time() - start_time) >= float(total_timeout)
+
+        for itr in range(1, iterations + 1):
+            log.info(f'Starting iteration {itr}')
+
+            # Early abort on inference errors
+            if not self.scan_for_inference_errors():
+                msg = 'Failures seen in inference logs, Aborting!!!'
+                fail_test(msg)
+                return {"status": "error", "reason": msg}
+
+            # Build commands to tail recent lines from each node's inference log and capture stderr as well
+            cmd_list = []
+            for j in range(0, int(self.nnodes)):
+                cmd = f"sudo tail -2000 {self.log_dir}/{self.get_log_subdir()}/out-node{j}/bench_serv_script.log"
+                cmd_list.append(cmd)
+
+            out_dict = self.c_phdl.exec_cmd_list(cmd_list)
+
+            # Determine completion across nodes
+            node_completion = {}
+            for node, output in out_dict.items():
+                node_completion[node] = bool(completion_pattern.search(output))
+
+            if require_all_nodes:
+                all_complete = all(node_completion.values()) if node_completion else False
+            else:
+                all_complete = any(node_completion.values()) if node_completion else False
+
+            # If not yet complete, wait and continue (subject to timeout)
+            if not all_complete:
+                if timed_out():
+                    msg = f"Timeout while waiting for inference completion after ~{int(time.time() - start_time)}s"
+                    log.warning("%s", msg)
+                    return {"status": "timeout", "reason": msg}
+                log.info('Inference Benchmark is still in progress')
+                # Short progress wait before the longer inter-iteration sleep
+                time.sleep(30)
+                time.sleep(int(waittime_between_iters))
+                continue
+
+            # Parse/store final results and report success
+            res_dict = self.get_inference_results_dict(out_dict)
+            log.info('Completed Inference, returning !!!')
+            return {"status": "success", "results": res_dict}
+
+            # If we reached here, it means poll for inference completion failed
+
+        # If we exhaust the iteration cap without completing, treat as timeout (or in_progress if no wall-clock limit)
+        if timed_out():
+            msg = f"Timeout after maximum iterations ({self.inference_poll_iterations}) and ~{int(time.time() - start_time)}s"
+            log.warning("%s", msg)
+            return {"status": "timeout", "reason": msg}
+        else:
+            # If no wall-clock timeout was set and we hit the iteration cap, report in-progress
+            msg = f"Reached iteration cap ({self.inference_poll_iterations}) without completion; still in progress"
+            log.warning("%s", msg)
+            return {"status": "stuck_in_progress", "reason": msg}
+
+    def verify_inference_results(
+        self,
+    ):
+        """
+        Verify inference results against expected thresholds from result_dict.
+
+        The expected results are keyed by: "ISL=X,OSL=Y,TP=Z,CONC=W"
+        This method builds that key from current test parameters and compares.
+        """
+        log.info('Verify Inference Completion Msg')
+
+        # Build the expected result key from current test parameters
+        isl = self.bp_dict.get('input_sequence_length', '1024')
+        osl = self.bp_dict.get('output_sequence_length', '1024')
+        tp = self.bp_dict.get('tensor_parallelism', '1')
+        conc = self.bp_dict.get('max_concurrency', '64')
+
+        expected_key = f"ISL={isl},OSL={osl},TP={tp},CONC={conc}"
+        log.info(f'Looking for expected results with key: {expected_key}')
+
+        # Get expected results from result_dict
+        result_dict = self.bp_dict.get('result_dict', {})
+        expected_result_dict = result_dict.get(expected_key, {})
+
+        if not expected_result_dict:
+            log.warning(f'Warning: No expected results found for {expected_key}, skipping validation')
+            # Scan Dmesg for errors ..
+            self.inference_end_time = self.s_phdl.exec('date +"%a %b %e %H:%M"')
+            time.sleep(2)
+            verify_dmesg_for_errors(self.s_phdl, self.inference_start_time, self.inference_end_time)
+            log.info("%s", self.inference_results_dict)
+            return
+
+        log.info(f'Expected results: {expected_result_dict}')
+
+        # Compare actual vs expected for each node
+        for node in self.inference_results_dict.keys():
+            for metric_name in expected_result_dict.keys():
+                if metric_name in self.inference_results_dict[node]:
+                    actual_value = float(self.inference_results_dict[node][metric_name])
+                    expected_value = float(expected_result_dict[metric_name])
+
+                    # Latency metrics (ms) - lower is better, fail if actual > expected
+                    if re.search('ms', metric_name, re.I):
+                        if actual_value > expected_value:
+                            fail_test(
+                                f"FAIL - Latency metric {metric_name} higher than expected on node {node}: \
+                                Actual = {actual_value}, Expected = {expected_value}"
+                            )
+                    # Throughput/count metrics - higher is better, fail if actual < expected
+                    else:
+                        if actual_value < expected_value:
+                            fail_test(
+                                f"FAIL - Throughput metric {metric_name} lower than expected on node {node}: \
+                                Actual = {actual_value}, Expected = {expected_value}"
+                            )
+
+        # Scan Dmesg for errors ..
+        self.inference_end_time = self.s_phdl.exec('date +"%a %b %e %H:%M"')
+        time.sleep(2)
+        verify_dmesg_for_errors(self.s_phdl, self.inference_start_time, self.inference_end_time)
+        log.info("%s", self.inference_results_dict)

--- a/cvs/lib/inference/unittests/test_vllm_legacy_deprecation.py
+++ b/cvs/lib/inference/unittests/test_vllm_legacy_deprecation.py
@@ -17,9 +17,12 @@ These tests exist to keep the quarantine intact until the window closes.
 
 import ast
 import datetime
+import hashlib
 import os
+import re
 import unittest
 
+import cvs.lib.inference.base as live_base
 import cvs.lib.inference.base_legacy as base_legacy
 import cvs.lib.inference.vllm as legacy_vllm
 from cvs.lib.inference.base_legacy import InferenceBaseJob as LegacyInferenceBaseJob
@@ -36,6 +39,39 @@ LEGACY_SUITE_STEMS = (
     'vllm_qwen3_235b_single',
     'vllm_deepseek31_685b_single',
 )
+
+
+class _FakePhdl:
+    """Records commands. InferenceBaseJob.__init__ only needs host_list and exec()."""
+
+    host_list = ['node0']
+
+    def __init__(self):
+        self.commands = []
+
+    def exec(self, cmd, *args, **kwargs):
+        self.commands.append(cmd)
+        return {'node0': ''}
+
+    def exec_cmd_list(self, cmd_list, *args, **kwargs):
+        self.commands.extend(cmd_list)
+        return {'node0': ''}
+
+
+def _build_job(base_cls):
+    """Build base_cls against a config that omits random_range_ratio.
+
+    Both bases take the same __init__ signature, so one builder serves the
+    frozen and the live class and the assertions can contrast them directly.
+    """
+    return base_cls(
+        c_phdl=_FakePhdl(),
+        s_phdl=_FakePhdl(),
+        model_name='m',
+        inference_config_dict={'container_image': 'img:tag', 'benchmark_server_script_path': '/scripts'},
+        benchmark_params_dict={'m': {'server_script': 'srv.sh', 'bench_serv_script': 'bench.py'}},
+        hf_token='tok',
+    )
 
 
 class TestLegacyVllmJobRestored(unittest.TestCase):
@@ -74,17 +110,30 @@ class TestFrozenLegacyBase(unittest.TestCase):
         self.assertIsNot(base_legacy, live_base)
         self.assertIsNot(base_legacy.InferenceBaseJob, live_base.InferenceBaseJob)
 
-    def test_retains_pre_dtni_bench_clone_behaviour(self):
+    def test_frozen_base_clones_bench_serving_and_live_base_does_not(self):
         # dtni turned clone_bench_serving_repo into a no-op and dropped the
-        # benchmark_script_repo default. The frozen copy must still do neither,
-        # or restored configs silently stop working the way they used to.
-        self.assertIn('benchmark_script_repo', base_legacy.LEGACY_BENCH_DEFAULTS)
+        # benchmark_script_repo default; the frozen copy must still clone.
+        legacy_job = _build_job(base_legacy.InferenceBaseJob)
+        legacy_job.clone_bench_serving_repo('/app')
+        self.assertIn(
+            'git clone https://github.com/kimbochen/bench_serving.git',
+            legacy_job.c_phdl.commands[-1],
+        )
 
-    def test_retains_legacy_random_range_ratio_key_spelling(self):
-        # The deleted code spelled it 'random_range_ration'; dtni fixed the
-        # typo. Legacy configs still carry the misspelling, so the frozen base
-        # must keep honouring it.
-        self.assertIn('random_range_ration', base_legacy.LEGACY_BENCH_DEFAULTS)
+        live_job = _build_job(live_base.InferenceBaseJob)
+        live_job.clone_bench_serving_repo('/app')
+        self.assertEqual(live_job.c_phdl.commands, [])
+
+    def test_frozen_base_requires_random_range_ratio_in_config(self):
+        # base_legacy setdefaults the misspelled 'random_range_ration', so the
+        # reads of 'random_range_ratio' have no fallback and a config omitting
+        # the key raises. dtni fixed the spelling. Legacy configs must set it.
+        legacy_job = _build_job(base_legacy.InferenceBaseJob)
+        with self.assertRaises(KeyError):
+            legacy_job.bp_dict['random_range_ratio']
+
+        live_job = _build_job(live_base.InferenceBaseJob)
+        self.assertEqual(live_job.bp_dict['random_range_ratio'], '1.0')
 
 
 class TestLegacySuiteQuarantine(unittest.TestCase):
@@ -119,6 +168,48 @@ class TestLegacySuiteQuarantine(unittest.TestCase):
     def test_unified_suite_still_present(self):
         # Restoration must not disturb the replacement suite.
         self.assertTrue(os.path.isfile(os.path.join(_UNIFIED_SUITE_DIR, 'vllm.py')))
+
+
+class TestFrozenContentPins(unittest.TestCase):
+    """The restored files still hash to their pre-#223 content on main.
+
+    Pinned by hash rather than compared against ``git show origin/main:...``:
+    CI checks out at depth 1 with no ``origin/main`` ref, these tests also run
+    from the sdist copy which has no ``.git`` at all, and ``origin/main`` is not
+    an ancestor of ``dev/dtni``. Hashes are of the file with the added
+    deprecation header stripped, taken against main at commit d8da9a43.
+    """
+
+    # sha256 of each file minus its inserted deprecation block.
+    FROZEN_SHA256 = {
+        'lib/inference/base_legacy.py': '7744e396a547ba22820a2d55be8f8ef742b3ab65b64fd9fa62211f1361fc0a47',
+        'tests/inference/vllm_legacy/vllm_gpt_oss_120b_single.py': (
+            'f3ad2f1cf58691401745fa5ef08ab89cac52a29579596a7486a08dffd97c0b99'
+        ),
+        'tests/inference/vllm_legacy/vllm_qwen3_80b_single.py': (
+            '25edc96e9b7fff58b69414f99bb07d5551de5388b0d2b64c1c051885a08a9135'
+        ),
+        'tests/inference/vllm_legacy/vllm_qwen3_235b_single.py': (
+            '84ce576cbcc477f967d01ef63cb687d92330ac66cb7d0d0c7415b2822adae52b'
+        ),
+        'tests/inference/vllm_legacy/vllm_deepseek31_685b_single.py': (
+            'efa1593fb0e4fb0e604b4d0f9fc190af71e3332549e1e0241f363dd0ddcde1ce'
+        ),
+    }
+
+    # The header is inserted inside the module docstring, not prepended, so
+    # neither a byte- nor a suffix-compare identifies the frozen content.
+    _SUITE_HEADER = re.compile(r'\n\nDEPRECATED -- scheduled.*?There is deliberately no conftest\.py here\.\n', re.S)
+    _BASE_HEADER = re.compile(r'\n\nDEPRECATED -- frozen copy.*?once the window closes\.\n', re.S)
+
+    def test_restored_files_match_their_pre_deletion_content(self):
+        for relpath, expected in self.FROZEN_SHA256.items():
+            with self.subTest(path=relpath):
+                with open(os.path.join(_CVS_ROOT, relpath)) as fp:
+                    body = fp.read()
+                stripped = self._BASE_HEADER.sub('\n', self._SUITE_HEADER.sub('\n', body))
+                self.assertNotEqual(stripped, body, 'deprecation header missing from ' + relpath)
+                self.assertEqual(hashlib.sha256(stripped.encode()).hexdigest(), expected)
 
 
 class TestDeprecationNotice(unittest.TestCase):

--- a/cvs/lib/inference/unittests/test_vllm_legacy_deprecation.py
+++ b/cvs/lib/inference/unittests/test_vllm_legacy_deprecation.py
@@ -1,0 +1,155 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Guards the deprecated-but-restored legacy vLLM suites (OSS 3-month notice
+window, 2026-08-11 -> 2026-11-11).
+
+The legacy suites were hard-deleted in #223 without serving a notice period.
+They are restored under ``cvs/tests/inference/vllm_legacy/`` -- deliberately
+NOT under ``cvs/tests/inference/vllm/``, whose conftest sorts collected items
+by a rank table keyed on the unified suite's test names. Legacy names are
+absent from that table, so they would all tie at the default rank and get
+reordered into an unrunnable sequence (inference before container launch).
+
+These tests exist to keep the quarantine intact until the window closes.
+'''
+
+import ast
+import datetime
+import os
+import unittest
+
+import cvs.lib.inference.base_legacy as base_legacy
+import cvs.lib.inference.vllm as legacy_vllm
+from cvs.lib.inference.base_legacy import InferenceBaseJob as LegacyInferenceBaseJob
+from cvs.lib.inference.vllm import DEPRECATION_REMOVAL_DATE, VllmJob as LegacyVllmJob
+
+_CVS_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+_TESTS_ROOT = os.path.join(_CVS_ROOT, 'tests')
+_LEGACY_SUITE_DIR = os.path.join(_TESTS_ROOT, 'inference', 'vllm_legacy')
+_UNIFIED_SUITE_DIR = os.path.join(_TESTS_ROOT, 'inference', 'vllm')
+
+LEGACY_SUITE_STEMS = (
+    'vllm_gpt_oss_120b_single',
+    'vllm_qwen3_80b_single',
+    'vllm_qwen3_235b_single',
+    'vllm_deepseek31_685b_single',
+)
+
+
+class TestLegacyVllmJobRestored(unittest.TestCase):
+    """The deleted lib module is importable again and still its own type."""
+
+    def test_vllm_job_subclasses_frozen_legacy_base(self):
+        # Not the live base: dtni's base.py changed the bench driver, readiness
+        # polling, and result-key names. Inheriting it would mean the
+        # "deprecated" path behaves differently from what was deleted.
+        self.assertTrue(issubclass(LegacyVllmJob, LegacyInferenceBaseJob))
+
+    def test_vllm_job_does_not_subclass_live_base(self):
+        from cvs.lib.inference.base import InferenceBaseJob as LiveInferenceBaseJob
+
+        self.assertFalse(issubclass(LegacyVllmJob, LiveInferenceBaseJob))
+
+    def test_legacy_hooks_preserved(self):
+        for name, expected in (
+            ('get_result_filename', 'vllm_test_result.json'),
+            ('get_log_subdir', 'vllm'),
+        ):
+            with self.subTest(hook=name):
+                self.assertEqual(getattr(LegacyVllmJob, name)(LegacyVllmJob), expected)
+
+    def test_completion_pattern_matches_legacy_marker(self):
+        pattern = LegacyVllmJob.get_completion_pattern(LegacyVllmJob)
+        self.assertTrue(pattern.search('End-to-end Latency (ms): 12.5'))
+
+
+class TestFrozenLegacyBase(unittest.TestCase):
+    """base_legacy is a frozen copy, not a re-export of the evolving base."""
+
+    def test_is_a_distinct_module_from_live_base(self):
+        import cvs.lib.inference.base as live_base
+
+        self.assertIsNot(base_legacy, live_base)
+        self.assertIsNot(base_legacy.InferenceBaseJob, live_base.InferenceBaseJob)
+
+    def test_retains_pre_dtni_bench_clone_behaviour(self):
+        # dtni turned clone_bench_serving_repo into a no-op and dropped the
+        # benchmark_script_repo default. The frozen copy must still do neither,
+        # or restored configs silently stop working the way they used to.
+        self.assertIn('benchmark_script_repo', base_legacy.LEGACY_BENCH_DEFAULTS)
+
+    def test_retains_legacy_random_range_ratio_key_spelling(self):
+        # The deleted code spelled it 'random_range_ration'; dtni fixed the
+        # typo. Legacy configs still carry the misspelling, so the frozen base
+        # must keep honouring it.
+        self.assertIn('random_range_ration', base_legacy.LEGACY_BENCH_DEFAULTS)
+
+
+class TestLegacySuiteQuarantine(unittest.TestCase):
+    """Restored suites live outside the unified suite's conftest scope."""
+
+    def test_legacy_suites_present_in_quarantine_dir(self):
+        for stem in LEGACY_SUITE_STEMS:
+            with self.subTest(suite=stem):
+                self.assertTrue(os.path.isfile(os.path.join(_LEGACY_SUITE_DIR, stem + '.py')))
+
+    def test_quarantine_dir_has_no_conftest(self):
+        # A conftest here would reintroduce exactly the reordering hazard the
+        # quarantine exists to avoid.
+        self.assertFalse(os.path.isfile(os.path.join(_LEGACY_SUITE_DIR, 'conftest.py')))
+
+    def test_legacy_suites_not_restored_into_unified_suite_dir(self):
+        for stem in LEGACY_SUITE_STEMS:
+            with self.subTest(suite=stem):
+                self.assertFalse(os.path.isfile(os.path.join(_UNIFIED_SUITE_DIR, stem + '.py')))
+
+    def test_legacy_suites_do_not_import_the_unified_job(self):
+        # Each restored suite must bind to the legacy VllmJob, not vllm_job.
+        for stem in LEGACY_SUITE_STEMS:
+            with self.subTest(suite=stem):
+                path = os.path.join(_LEGACY_SUITE_DIR, stem + '.py')
+                with open(path) as fp:
+                    tree = ast.parse(fp.read())
+                modules = {n.module for n in ast.walk(tree) if isinstance(n, ast.ImportFrom) and n.module}
+                self.assertIn('cvs.lib.inference.vllm', modules)
+                self.assertNotIn('cvs.lib.inference.vllm_job', modules)
+
+    def test_unified_suite_still_present(self):
+        # Restoration must not disturb the replacement suite.
+        self.assertTrue(os.path.isfile(os.path.join(_UNIFIED_SUITE_DIR, 'vllm.py')))
+
+
+class TestDeprecationNotice(unittest.TestCase):
+    """The notice window is explicit and machine-checkable."""
+
+    def test_removal_date_is_three_months_after_notice_start(self):
+        self.assertEqual(DEPRECATION_REMOVAL_DATE, datetime.date(2026, 11, 11))
+
+    def test_importing_legacy_module_warns(self):
+        import importlib
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            importlib.reload(legacy_vllm)
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning) for w in caught),
+            'importing cvs.lib.inference.vllm must raise a DeprecationWarning',
+        )
+
+    def test_warning_names_the_replacement_and_the_date(self):
+        import importlib
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            importlib.reload(legacy_vllm)
+        messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertTrue(any('2026-11-11' in m for m in messages))
+        self.assertTrue(any('cvs.tests.inference.vllm' in m for m in messages))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/lib/inference/vllm.py
+++ b/cvs/lib/inference/vllm.py
@@ -1,0 +1,84 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+DEPRECATED -- scheduled for removal on 2026-11-11.
+
+Host+docker vLLM job used by the legacy single-node suites under
+``cvs/tests/inference/vllm_legacy/``. Removed in #223 without a notice period
+and restored here to serve the 3-month OSS deprecation window (notice given
+2026-08-11).
+
+Replacement: ``cvs.lib.inference.vllm_job.VllmJob``, driven by the unified
+topology-parametrized suite ``cvs.tests.inference.vllm``, which covers both
+single-node and PP-distributed runs from one ``schema_version: 1`` config.
+
+Bound to the frozen ``base_legacy`` rather than the live ``base`` -- see that
+module's header for the behaviour differences that make the distinction load
+bearing.
+'''
+
+import datetime
+import re
+import time
+import warnings
+
+from cvs.lib import globals
+from cvs.lib.inference.base_legacy import InferenceBaseJob
+
+# Notice served 2026-08-11; 3-month OSS deprecation window.
+DEPRECATION_REMOVAL_DATE = datetime.date(2026, 11, 11)
+
+warnings.warn(
+    "cvs.lib.inference.vllm and the cvs/tests/inference/vllm_legacy suites are "
+    "deprecated and will be removed on 2026-11-11. Migrate to the unified suite "
+    "cvs.tests.inference.vllm (cvs.lib.inference.vllm_job.VllmJob), which covers "
+    "single-node and distributed runs from one schema_version: 1 config.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class VllmJob(InferenceBaseJob):
+    """vLLM-specific implementation."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.if_dict.setdefault('benchmark_server_script_path', '/host_scripts')
+
+    def get_server_script_path(self):
+        """vLLM scripts are mounted from host."""
+        return self.server_script
+
+    def get_server_script_directory(self):
+        """vLLM scripts are mounted from host."""
+        return self.if_dict['benchmark_server_script_path']
+
+    def get_result_filename(self):
+        """vLLM result filename."""
+        return 'vllm_test_result.json'
+
+    def get_completion_pattern(self):
+        """vLLM completion pattern."""
+        return re.compile('End-to-end Latency', re.I)
+
+    def get_log_subdir(self):
+        """vLLM uses 'vllm' log subdirectory."""
+        return 'vllm'
+
+    def stop_server(self):
+        """Stop the vLLM server process."""
+        log = globals.log
+        log.info("Stopping vLLM server")
+        self.s_phdl.exec(f'docker exec {self.container_name} pkill -f "vllm serve"')
+        time.sleep(5)  # Wait for graceful shutdown
+
+    def restart_server(self):
+        """Restart the vLLM server with updated parameters."""
+        log = globals.log
+        log.info("Restarting vLLM server with updated parameters")
+        self.stop_server()
+        self.build_server_inference_job_cmd()
+        self.start_inference_server_job()

--- a/cvs/lib/inference_lib.py
+++ b/cvs/lib/inference_lib.py
@@ -16,7 +16,7 @@ class _LegacyVllmInferenceJobPlaceholder:
     def __init__(self, *args, **kwargs):
         raise NotImplementedError(
             "InferenceJobFactory no longer builds a host+docker vLLM InferenceBaseJob. "
-            "Use ``cvs.lib.inference.vllm_single.VllmJob`` with ``ContainerOrchestrator`` "
+            "Use ``cvs.lib.inference.vllm_job.VllmJob`` with ``ContainerOrchestrator`` "
             "from the tests under ``cvs.tests.inference.vllm``."
         )
 

--- a/cvs/tests/inference/vllm_legacy/README.md
+++ b/cvs/tests/inference/vllm_legacy/README.md
@@ -44,6 +44,33 @@ cvs run vllm_gpt_oss_120b_single \
 Importing `cvs.lib.inference.vllm` raises a `DeprecationWarning` naming the
 removal date and the replacement.
 
+## Known limitations of the frozen path
+
+These are preserved pre-#223 behaviour, not new defects. They are not fixed
+here because doing so would break the freeze that makes this a faithful
+deprecation notice; the replacement suite addresses all of them.
+
+1. **The server launch scripts are not distributed with CVS.** The config's
+   `server_script` values (`gpt-oss-120b_fp4_mi355x_vllm_docker.sh`,
+   `qwen3-235b-bf16_mi355x_vllm_docker.sh`,
+   `qwen3-80b-bf16_mi355x_vllm_docker.sh`, `dsr1_fp8_mi355x_vllm_docker.sh`)
+   live in no repository. Pre-stage them at `benchmark_server_script_path` on
+   every node or the command above cannot run.
+2. **Every model block must spell `random_range_ratio`.** The frozen base
+   setdefaults the misspelled `random_range_ration`, so the correctly-spelled
+   key it later reads has no fallback and a config omitting it raises
+   `KeyError` while building the server command.
+3. **Server-readiness budget is tight.** 30s precheck + 330s wait + 20 polls x
+   60s = 1560s (2160s for `vllm_qwen3_80b_single`, which polls 30 times). A
+   first run that downloads weights from HF can exhaust it and fail on a
+   readiness timeout rather than on a real fault. Pre-stage the weights. There
+   is no config knob for this -- `server_launch_poll_count` is a constructor
+   argument, so the only in-tree override is the `VllmJob(...)` call site in
+   the suite file.
+4. **The bench client is cloned at run time** from
+   `https://github.com/kimbochen/bench_serving.git`, a third-party repository
+   that is not pinned or mirrored.
+
 ## Why this directory, and why no conftest.py
 
 `cvs/tests/inference/vllm/conftest.py` defines `pytest_collection_modifyitems`,

--- a/cvs/tests/inference/vllm_legacy/README.md
+++ b/cvs/tests/inference/vllm_legacy/README.md
@@ -1,0 +1,73 @@
+# Legacy vLLM suites (deprecated)
+
+**Notice given 2026-08-11 · scheduled for removal 2026-11-11.**
+
+These are the pre-#223 single-node vLLM suites. They were hard-deleted by
+"vLLM single node refactor (#223)" without a deprecation period; they are
+restored here so the 3-month OSS notice window is actually served.
+
+Nothing new should be built on them.
+
+## Replacement
+
+| Deprecated | Replacement |
+|---|---|
+| `cvs run vllm_gpt_oss_120b_single` | `cvs run vllm` |
+| `cvs run vllm_qwen3_80b_single` | `cvs run vllm` |
+| `cvs run vllm_qwen3_235b_single` | `cvs run vllm` |
+| `cvs run vllm_deepseek31_685b_single` | `cvs run vllm` |
+| `cvs/lib/inference/vllm.py` (`VllmJob`) | `cvs/lib/inference/vllm_job.py` (`VllmJob`) |
+| `cvs/lib/inference/base_legacy.py` | `cvs/lib/inference/base.py` |
+| `input/config_file/inference/vllm_legacy/mi355x_vllm_single.json` | `input/config_file/inference/vllm/*.json` (`schema_version: 1`) |
+
+The unified `vllm` suite covers single-node **and** PP-distributed runs from one
+config (topology follows `params.nnodes` / `params.pipeline_parallel_size`), and
+adds GPU metrics, vLLM `/metrics` scraping, threshold enforcement against a
+sibling threshold file, and the run-deck HTML report.
+
+Migrating means rewriting the config: the legacy shape is `config` +
+`benchmark_params` with thresholds inline under `result_dict`, whereas the
+unified suite takes a pydantic-validated `schema_version: 1` config with
+`paths` / `model` / `container` / `roles` / `params` / `sweep` blocks and a
+separate threshold file.
+
+## Running them meanwhile
+
+```
+cvs run vllm_gpt_oss_120b_single \
+  --cluster_file input/cluster_file/cluster.json \
+  --config_file input/config_file/inference/vllm_legacy/mi355x_vllm_single.json \
+  --html=/var/www/html/cvs/gpt.html --self-contained-html \
+  --capture=tee-sys --log-file=/tmp/gpt.log -vvv -s
+```
+
+Importing `cvs.lib.inference.vllm` raises a `DeprecationWarning` naming the
+removal date and the replacement.
+
+## Why this directory, and why no conftest.py
+
+`cvs/tests/inference/vllm/conftest.py` defines `pytest_collection_modifyitems`,
+which sorts collected items by a rank table keyed on the *unified* suite's test
+names (`test_launch_container`, `test_discover_topology`, ...). These suites'
+test names are absent from that table, so they would all tie at the default
+rank and be reordered into an unrunnable sequence — `test_vllm_inference` would
+run before `test_launch_inference_containers`.
+
+Keeping them in a sibling directory with **no conftest.py** avoids that
+entirely. These suites carry their own fixtures inline (`cluster_dict`,
+`hf_token`, `s_phdl`, `c_phdl`), so they need nothing from a conftest. The
+ancestor `cvs/tests/conftest.py` only defines a lazily-evaluated `orch` fixture
+that these suites never request, and `cvs/conftest.py`'s report auto-registration
+no-ops for these stems (there is no `cvs.lib.report.presets.<stem>` module).
+
+`cvs list` / `cvs run` discover suites by filename stem, so all four remain
+selectable exactly as before.
+
+## Removal checklist (on or after 2026-11-11)
+
+1. Delete `cvs/tests/inference/vllm_legacy/`.
+2. Delete `cvs/lib/inference/vllm.py` and `cvs/lib/inference/base_legacy.py`.
+3. Delete `cvs/input/config_file/inference/vllm_legacy/`.
+4. Delete `cvs/lib/inference/unittests/test_vllm_legacy_deprecation.py`.
+5. Drop the `'vllm'` entry from `InferenceJobFactory._FRAMEWORK_CLASSES`
+   (`cvs/lib/inference_lib.py`) if nothing else references it.

--- a/cvs/tests/inference/vllm_legacy/vllm_deepseek31_685b_single.py
+++ b/cvs/tests/inference/vllm_legacy/vllm_deepseek31_685b_single.py
@@ -1,0 +1,467 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+DEPRECATED -- scheduled for removal on 2026-11-11.
+
+Legacy single-node vLLM suite, removed in #223 and restored to serve the
+3-month OSS deprecation notice (given 2026-08-11).
+
+Replacement: ``cvs run vllm`` (cvs/tests/inference/vllm/vllm.py), which covers
+single-node and PP-distributed runs from one schema_version: 1 config.
+
+Kept in this directory, NOT cvs/tests/inference/vllm/: that directory's
+conftest sorts collected items by a rank table keyed on the unified suite's
+test names. These test names are absent from it, so they would all tie at the
+default rank and be reordered into an unrunnable sequence (inference before
+container launch). There is deliberately no conftest.py here.
+'''
+
+import pytest
+
+import re
+import os
+import time
+import json
+from pprint import pprint
+from tabulate import tabulate
+
+
+from cvs.lib.parallel_ssh_lib import *
+from cvs.lib.utils_lib import *
+from cvs.lib import docker_lib
+from cvs.lib.inference.vllm import VllmJob
+from cvs.lib import globals
+
+log = globals.log
+
+# Model name for this test suite
+MODEL_NAME = "deepseek-v31"
+
+inf_res_dict = {}
+
+
+# Importing additional cmd line args to script ..
+@pytest.fixture(scope="module")
+def cluster_file(pytestconfig):
+    """
+    Retrieve the --cluster_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the cluster JSON file specified via --cluster_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --cluster_file=/path/to/cluster.json
+      - Use module scope so the value is resolved once per test module.
+    """
+    return pytestconfig.getoption("cluster_file")
+
+
+@pytest.fixture(scope="module")
+def training_config_file(pytestconfig):
+    """
+    Retrieve the --config_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the training config JSON file specified via --config_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --config_file=/path/to/training_config.json
+      - Module scope avoids re-fetching the option across tests in this module.
+    """
+    return pytestconfig.getoption("config_file")
+
+
+# Importing the cluster and cofig files to script to access node, switch, test config params
+@pytest.fixture(scope="module")
+def cluster_dict(cluster_file):
+    """
+    Load the entire cluster configuration from the provided JSON file.
+
+    Args:
+      cluster_file (str): Path to the cluster JSON file.
+
+    Returns:
+      dict: Parsed JSON representing the cluster (nodes, credentials, etc.).
+
+    Notes:
+      - Logs the loaded structure for visibility; consider using log.debug if verbose.
+    """
+    with open(cluster_file) as json_file:
+        cluster_dict = json.load(json_file)
+
+    # Resolve path placeholders like {user-id} in cluster config
+    cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
+    log.info("%s", cluster_dict)
+    return cluster_dict
+
+
+@pytest.fixture(scope="module")
+def inference_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    inference_dict = inference_dict_t['config']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    inference_dict = resolve_test_config_placeholders(inference_dict, cluster_dict)
+    return inference_dict
+
+
+@pytest.fixture(scope="module")
+def benchmark_params_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    benchmark_params_dict = inference_dict_t['benchmark_params']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
+
+    log.info("%s", benchmark_params_dict)
+    return benchmark_params_dict
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Dynamically parametrize inference tests based on sequence combinations and concurrency levels
+    for the DeepSeek-V3.1 model.
+
+    Behavior:
+      - Reads the config file path from pytest's --config_file option.
+      - Loads the JSON and extracts deepseek-v31 model configuration.
+      - Extracts sequence_combinations (ISL/OSL pairs) and concurrency_levels.
+      - Creates test cases for each sequence combination × concurrency level.
+
+    Test Matrix:
+      - Test IDs: "combination_name-concX" (e.g., "balanced-conc16")
+
+    Notes:
+      - If no config_file is provided, the hook returns without parametrizing.
+      - Each combination gets a separate test case with clear ID.
+    """
+    config_file = metafunc.config.getoption("config_file")
+    if not config_file or not os.path.exists(config_file):
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
+        return
+
+    with open(config_file) as fp:
+        cfg = json.load(fp)
+
+    # Extract deepseek-v31 model config (now directly under benchmark_params, no single_node nesting)
+    benchmark_params = cfg.get("benchmark_params", {})
+    model_config = benchmark_params.get(MODEL_NAME, {})
+
+    if not model_config:
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
+        return
+
+    # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
+    test_params = []
+
+    # Check if model uses sequence_combinations or legacy ISL/OSL
+    seq_combos = model_config.get("sequence_combinations", [])
+
+    if seq_combos:
+        # New format: multiple combinations per model
+        for combo in seq_combos:
+            combo_name = combo.get("name", f"isl{combo['isl']}_osl{combo['osl']}")
+
+            # Check if model has concurrency_levels array or single max_concurrency
+            conc_levels = model_config.get("concurrency_levels", [])
+            if conc_levels:
+                # Parametrize across concurrency levels
+                for conc in conc_levels:
+                    test_id = f"{combo_name}-conc{conc}"
+                    test_params.append((combo, conc, test_id))
+            else:
+                # Backward compatibility: use max_concurrency as single value
+                max_conc = int(model_config.get("max_concurrency", "64"))
+                test_id = f"{combo_name}"
+                test_params.append((combo, max_conc, test_id))
+    else:
+        # Legacy format: single ISL/OSL values
+        isl = model_config.get("input_sequence_length", "1024")
+        osl = model_config.get("output_sequence_length", "1024")
+        combo = {"isl": isl, "osl": osl, "name": "default"}
+
+        conc_levels = model_config.get("concurrency_levels", [])
+        if conc_levels:
+            for conc in conc_levels:
+                test_id = f"conc{conc}"
+                test_params.append((combo, conc, test_id))
+        else:
+            max_conc = int(model_config.get("max_concurrency", "64"))
+            test_params.append((combo, max_conc, "default"))
+
+    # Parametrize if test uses these fixtures
+    if "seq_combo" in metafunc.fixturenames and "concurrency" in metafunc.fixturenames:
+        if test_params:
+            combos, concs, ids = zip(*test_params)
+            metafunc.parametrize("seq_combo,concurrency", list(zip(combos, concs)), ids=ids)
+
+
+@pytest.fixture(scope="module")
+def hf_token(inference_dict):
+    """
+    Load the Hugging Face access token from the file path specified in the training config.
+
+    Args:
+      inference_dict (dict): Training configuration dict that includes:
+        - 'hf_token_file': Path to the file containing the HF token.
+
+    Returns:
+      str: The HF token string read from the file.
+
+    Behavior:
+      - Reads the token from inference_dict['hf_token_file'] (already resolved for placeholders).
+      - Strips the trailing newline from the token.
+    """
+    hf_token_file = inference_dict['hf_token_file']
+    try:
+        with open(hf_token_file, 'r') as fp:
+            hf_token = fp.read().rstrip("\n")
+    except FileNotFoundError:
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
+        raise
+    except Exception as e:
+        log.error(f"An error occurred: {e}")
+        raise
+    return hf_token
+
+
+@pytest.fixture(scope="module")
+def s_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (server).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return s_phdl
+
+
+@pytest.fixture(scope="module")
+def c_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (client).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return c_phdl
+
+
+def test_cleanup_stale_containers(s_phdl, inference_dict):
+    """
+    Pytest: Clean up potentially stale Docker containers and volumes before tests.
+
+    Args:
+      s_phdl: Parallel SSH/process handle used by docker_lib to run commands on nodes.
+      inference_dict (dict): Training configuration dict that includes:
+        - 'container_name': Name of the container to be killed if running.
+
+    Behavior:
+      - Kills the specific container identified by inference_dict['container_name'].
+      - Deletes all containers and volumes on the target nodes (broad cleanup).
+
+    Notes:
+      - This performs a broad cleanup via delete_all_containers_and_volumes; ensure the
+        test environment is isolated so this doesn't remove unrelated containers/volumes.
+      - Consider narrowing cleanup scope if other workloads may be present on the hosts.
+    """
+
+    container_name = inference_dict['container_name']
+    docker_lib.kill_docker_container(s_phdl, container_name)
+    docker_lib.delete_all_containers_and_volumes(s_phdl)
+
+
+def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_dict):
+    """
+    Launch vLLM inference containers on all nodes.
+
+    Note: Container image can be model-specific or use global default.
+    """
+
+    log.info(f'Testcase launch vLLM containers for {MODEL_NAME}')
+    globals.error_list = []
+    container_name = inference_dict['container_name']
+
+    # Get model-specific container image or use global default
+    container_image = benchmark_params_dict.get(MODEL_NAME, {}).get(
+        'container_image', inference_dict['container_image']
+    )
+
+    # Launch the containers ..
+    docker_lib.launch_docker_container(
+        s_phdl,
+        container_name,
+        container_image,
+        inference_dict['container_config']['device_list'],
+        inference_dict['container_config']['volume_dict'],
+        inference_dict['container_config']['env_dict'],
+        shm_size='16G',
+        timeout=60 * 20,
+    )
+    # ADD verifications ..
+    time.sleep(30)
+    log.info('Verify if the containers have been launched properly')
+    out_dict = s_phdl.exec('docker ps')
+    for node in out_dict.keys():
+        if not re.search(f'{container_name}', out_dict[node], re.I):
+            fail_test(f'Failed to launch container on node {node}')
+    update_test_result()
+
+
+def test_vllm_inference(c_phdl, s_phdl, inference_dict, benchmark_params_dict, hf_token, seq_combo, concurrency):
+    """
+    Test vLLM inference for DeepSeek-V3.1 with specific sequence combination and concurrency level.
+
+    This test is parametrized via pytest_generate_tests to run once per:
+      - Sequence combination (ISL/OSL pair) defined in model's sequence_combinations
+      - Concurrency level defined in model's concurrency_levels
+
+    The factory will automatically create the correct VllmJob instance with
+    the model-specific container image and parameters.
+
+    Args:
+        seq_combo: Dict with 'isl', 'osl', 'name' keys for this test iteration
+        concurrency: Integer concurrency level for this test iteration
+    """
+    # Since this is a per-GPU-type config file (mi355x), gpu_type is implicit
+    gpu_type = "mi355x"
+
+    log.info(
+        f"Starting inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']} (ISL={seq_combo['isl']}, OSL={seq_combo['osl']}), concurrency: {concurrency}"
+    )
+    globals.error_list = []
+
+    # Override ISL/OSL and concurrency in benchmark_params for this specific test iteration
+    # Config is now fully flattened, so access directly under benchmark_params
+    model_params = benchmark_params_dict[MODEL_NAME]
+    model_params['input_sequence_length'] = seq_combo['isl']
+    model_params['output_sequence_length'] = seq_combo['osl']
+    model_params['max_concurrency'] = str(concurrency)
+
+    # Calculate num_prompts based on OSL (matching recipe logic)
+    osl = int(seq_combo['osl'])
+    if osl == 8192:
+        model_params['num_prompts'] = str(concurrency * 20)
+    else:
+        model_params['num_prompts'] = str(concurrency * 50)
+
+    # Create VllmJob instance
+    vllm_job = VllmJob(
+        c_phdl=c_phdl,
+        s_phdl=s_phdl,
+        model_name=MODEL_NAME,
+        inference_config_dict=inference_dict,
+        benchmark_params_dict=benchmark_params_dict,
+        hf_token=hf_token,
+        gpu_type=gpu_type,
+        distributed_inference=False,
+    )
+
+    # Stop any existing server process for clean state
+    vllm_job.stop_server()
+
+    # Build and start server with current test parameters
+    vllm_job.build_server_inference_job_cmd()
+    vllm_job.start_inference_server_job()
+
+    # Run benchmark client
+    vllm_job.start_inference_client_job()
+    # res_dict will have status, results from base inference class
+    # - {"status": "success", "results": self.inference_result_dict}
+    res_dict = vllm_job.poll_for_inference_completion()
+    res_index = (MODEL_NAME, gpu_type, seq_combo['isl'], seq_combo['osl'], seq_combo['name'], concurrency)
+    inf_res_dict[res_index] = res_dict
+    vllm_job.verify_inference_results()
+    update_test_result()
+
+    log.info(
+        f"Completed inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']}, concurrency: {concurrency}"
+    )
+
+
+def test_print_results_table():
+    globals.error_list = []
+    log.info("%s", inf_res_dict)
+    pprint(inf_res_dict, depth=3)
+    rows = []
+    headers = [
+        "Model",
+        "GPU",
+        "ISL",
+        "OSL",
+        "Policy",
+        "Concurrency",
+        "Host",
+        "Req/s",
+        "Total tok/s",
+        "Mean TTFT (ms)",
+        "Mean TPOT (ms)",
+        "P99 ITL (ms)",
+    ]
+
+    for (model, gpu, isl, osl, policy, concurrency), entry in inf_res_dict.items():
+        for host, m in entry["results"].items():
+            rows.append(
+                [
+                    model,
+                    gpu,
+                    isl,
+                    osl,
+                    policy,
+                    concurrency,
+                    host,
+                    m["successful_requests"],
+                    m["total_throughput_per_sec"],
+                    m["mean_ttft_ms"],
+                    m["mean_tpot_ms"],
+                    m["p99_itl_ms"],
+                ]
+            )
+
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
+    update_test_result()

--- a/cvs/tests/inference/vllm_legacy/vllm_gpt_oss_120b_single.py
+++ b/cvs/tests/inference/vllm_legacy/vllm_gpt_oss_120b_single.py
@@ -1,0 +1,465 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+DEPRECATED -- scheduled for removal on 2026-11-11.
+
+Legacy single-node vLLM suite, removed in #223 and restored to serve the
+3-month OSS deprecation notice (given 2026-08-11).
+
+Replacement: ``cvs run vllm`` (cvs/tests/inference/vllm/vllm.py), which covers
+single-node and PP-distributed runs from one schema_version: 1 config.
+
+Kept in this directory, NOT cvs/tests/inference/vllm/: that directory's
+conftest sorts collected items by a rank table keyed on the unified suite's
+test names. These test names are absent from it, so they would all tie at the
+default rank and be reordered into an unrunnable sequence (inference before
+container launch). There is deliberately no conftest.py here.
+'''
+
+import pytest
+
+import re
+import os
+import time
+import json
+from pprint import pprint
+from tabulate import tabulate
+
+from cvs.lib.parallel_ssh_lib import *
+from cvs.lib.utils_lib import *
+from cvs.lib import docker_lib
+from cvs.lib.inference.vllm import VllmJob
+from cvs.lib import globals
+
+log = globals.log
+
+# Model name for this test suite
+MODEL_NAME = "gpt-oss-120b"
+
+inf_res_dict = {}
+
+
+# Importing additional cmd line args to script ..
+@pytest.fixture(scope="module")
+def cluster_file(pytestconfig):
+    """
+    Retrieve the --cluster_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the cluster JSON file specified via --cluster_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --cluster_file=/path/to/cluster.json
+      - Use module scope so the value is resolved once per test module.
+    """
+    return pytestconfig.getoption("cluster_file")
+
+
+@pytest.fixture(scope="module")
+def training_config_file(pytestconfig):
+    """
+    Retrieve the --config_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the training config JSON file specified via --config_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --config_file=/path/to/training_config.json
+      - Module scope avoids re-fetching the option across tests in this module.
+    """
+    return pytestconfig.getoption("config_file")
+
+
+# Importing the cluster and cofig files to script to access node, switch, test config params
+@pytest.fixture(scope="module")
+def cluster_dict(cluster_file):
+    """
+    Load the entire cluster configuration from the provided JSON file.
+
+    Args:
+      cluster_file (str): Path to the cluster JSON file.
+
+    Returns:
+      dict: Parsed JSON representing the cluster (nodes, credentials, etc.).
+
+    Notes:
+      - Logs the loaded structure for visibility; consider using log.debug if verbose.
+    """
+    with open(cluster_file) as json_file:
+        cluster_dict = json.load(json_file)
+
+    # Resolve path placeholders like {user-id} in cluster config
+    cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
+    log.info("%s", cluster_dict)
+    return cluster_dict
+
+
+@pytest.fixture(scope="module")
+def inference_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    inference_dict = inference_dict_t['config']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    inference_dict = resolve_test_config_placeholders(inference_dict, cluster_dict)
+    return inference_dict
+
+
+@pytest.fixture(scope="module")
+def benchmark_params_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    benchmark_params_dict = inference_dict_t['benchmark_params']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
+
+    log.info("%s", benchmark_params_dict)
+    return benchmark_params_dict
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Dynamically parametrize inference tests based on sequence combinations and concurrency levels
+    for the GPT-OSS-120B model.
+
+    Behavior:
+      - Reads the config file path from pytest's --config_file option.
+      - Loads the JSON and extracts gpt-oss-120b model configuration.
+      - Extracts sequence_combinations (ISL/OSL pairs) and concurrency_levels.
+      - Creates test cases for each sequence combination × concurrency level.
+
+    Test Matrix:
+      - Test IDs: "combination_name-concX" (e.g., "balanced-conc16")
+
+    Notes:
+      - If no config_file is provided, the hook returns without parametrizing.
+      - Each combination gets a separate test case with clear ID.
+    """
+    config_file = metafunc.config.getoption("config_file")
+    if not config_file or not os.path.exists(config_file):
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
+        return
+
+    with open(config_file) as fp:
+        cfg = json.load(fp)
+
+    # Extract gpt-oss-120b model config (now directly under benchmark_params, no single_node nesting)
+    benchmark_params = cfg.get("benchmark_params", {})
+    model_config = benchmark_params.get(MODEL_NAME, {})
+
+    if not model_config:
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
+        return
+
+    # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
+    test_params = []
+
+    # Check if model uses sequence_combinations or legacy ISL/OSL
+    seq_combos = model_config.get("sequence_combinations", [])
+
+    if seq_combos:
+        # New format: multiple combinations per model
+        for combo in seq_combos:
+            combo_name = combo.get("name", f"isl{combo['isl']}_osl{combo['osl']}")
+
+            # Check if model has concurrency_levels array or single max_concurrency
+            conc_levels = model_config.get("concurrency_levels", [])
+            if conc_levels:
+                # Parametrize across concurrency levels
+                for conc in conc_levels:
+                    test_id = f"{combo_name}-conc{conc}"
+                    test_params.append((combo, conc, test_id))
+            else:
+                # Backward compatibility: use max_concurrency as single value
+                max_conc = int(model_config.get("max_concurrency", "64"))
+                test_id = f"{combo_name}"
+                test_params.append((combo, max_conc, test_id))
+    else:
+        # Legacy format: single ISL/OSL values
+        isl = model_config.get("input_sequence_length", "1024")
+        osl = model_config.get("output_sequence_length", "1024")
+        combo = {"isl": isl, "osl": osl, "name": "default"}
+
+        conc_levels = model_config.get("concurrency_levels", [])
+        if conc_levels:
+            for conc in conc_levels:
+                test_id = f"conc{conc}"
+                test_params.append((combo, conc, test_id))
+        else:
+            max_conc = int(model_config.get("max_concurrency", "64"))
+            test_params.append((combo, max_conc, "default"))
+
+    # Parametrize if test uses these fixtures
+    if "seq_combo" in metafunc.fixturenames and "concurrency" in metafunc.fixturenames:
+        if test_params:
+            combos, concs, ids = zip(*test_params)
+            metafunc.parametrize("seq_combo,concurrency", list(zip(combos, concs)), ids=ids)
+
+
+@pytest.fixture(scope="module")
+def hf_token(inference_dict):
+    """
+    Load the Hugging Face access token from the file path specified in the training config.
+
+    Args:
+      inference_dict (dict): Training configuration dict that includes:
+        - 'hf_token_file': Path to the file containing the HF token.
+
+    Returns:
+      str: The HF token string read from the file.
+
+    Behavior:
+      - Reads the token from inference_dict['hf_token_file'] (already resolved for placeholders).
+      - Strips the trailing newline from the token.
+    """
+    hf_token_file = inference_dict['hf_token_file']
+    try:
+        with open(hf_token_file, 'r') as fp:
+            hf_token = fp.read().rstrip("\n")
+    except FileNotFoundError:
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
+        raise
+    except Exception as e:
+        log.error(f"An error occurred: {e}")
+        raise
+    return hf_token
+
+
+@pytest.fixture(scope="module")
+def s_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (server).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return s_phdl
+
+
+@pytest.fixture(scope="module")
+def c_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (client).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return c_phdl
+
+
+def test_cleanup_stale_containers(s_phdl, inference_dict):
+    """
+    Pytest: Clean up potentially stale Docker containers and volumes before tests.
+
+    Args:
+      s_phdl: Parallel SSH/process handle used by docker_lib to run commands on nodes.
+      inference_dict (dict): Training configuration dict that includes:
+        - 'container_name': Name of the container to be killed if running.
+
+    Behavior:
+      - Kills the specific container identified by inference_dict['container_name'].
+      - Deletes all containers and volumes on the target nodes (broad cleanup).
+
+    Notes:
+      - This performs a broad cleanup via delete_all_containers_and_volumes; ensure the
+        test environment is isolated so this doesn't remove unrelated containers/volumes.
+      - Consider narrowing cleanup scope if other workloads may be present on the hosts.
+    """
+
+    container_name = inference_dict['container_name']
+    docker_lib.kill_docker_container(s_phdl, container_name)
+    docker_lib.delete_all_containers_and_volumes(s_phdl)
+
+
+def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_dict):
+    """
+    Launch vLLM inference containers on all nodes.
+
+    Note: Container image can be model-specific or use global default.
+    """
+
+    log.info(f'Testcase launch vLLM containers for {MODEL_NAME}')
+    globals.error_list = []
+    container_name = inference_dict['container_name']
+
+    # Get model-specific container image or use global default
+    container_image = benchmark_params_dict.get(MODEL_NAME, {}).get(
+        'container_image', inference_dict['container_image']
+    )
+
+    # Launch the containers ..
+    docker_lib.launch_docker_container(
+        s_phdl,
+        container_name,
+        container_image,
+        inference_dict['container_config']['device_list'],
+        inference_dict['container_config']['volume_dict'],
+        inference_dict['container_config']['env_dict'],
+        shm_size='16G',
+        timeout=60 * 20,
+    )
+    # ADD verifications ..
+    time.sleep(30)
+    log.info('Verify if the containers have been launched properly')
+    out_dict = s_phdl.exec('docker ps')
+    for node in out_dict.keys():
+        if not re.search(f'{container_name}', out_dict[node], re.I):
+            fail_test(f'Failed to launch container on node {node}')
+    update_test_result()
+
+
+def test_vllm_inference(c_phdl, s_phdl, inference_dict, benchmark_params_dict, hf_token, seq_combo, concurrency):
+    """
+    Test vLLM inference for GPT-OSS-120B with specific sequence combination and concurrency level.
+
+    This test is parametrized via pytest_generate_tests to run once per:
+      - Sequence combination (ISL/OSL pair) defined in model's sequence_combinations
+      - Concurrency level defined in model's concurrency_levels
+
+    The factory will automatically create the correct VllmJob instance with
+    the model-specific container image and parameters.
+
+    Args:
+        seq_combo: Dict with 'isl', 'osl', 'name' keys for this test iteration
+        concurrency: Integer concurrency level for this test iteration
+    """
+    # Since this is a per-GPU-type config file (mi355x), gpu_type is implicit
+    gpu_type = "mi355x"
+
+    log.info(
+        f"Starting inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']} (ISL={seq_combo['isl']}, OSL={seq_combo['osl']}), concurrency: {concurrency}"
+    )
+    globals.error_list = []
+
+    # Override ISL/OSL and concurrency in benchmark_params for this specific test iteration
+    # Config is now fully flattened, so access directly under benchmark_params
+    model_params = benchmark_params_dict[MODEL_NAME]
+    model_params['input_sequence_length'] = seq_combo['isl']
+    model_params['output_sequence_length'] = seq_combo['osl']
+    model_params['max_concurrency'] = str(concurrency)
+
+    # Calculate num_prompts based on OSL (matching recipe logic)
+    osl = int(seq_combo['osl'])
+    if osl == 8192:
+        model_params['num_prompts'] = str(concurrency * 20)
+    else:
+        model_params['num_prompts'] = str(concurrency * 50)
+
+    # Create VllmJob instance
+    vllm_job = VllmJob(
+        c_phdl=c_phdl,
+        s_phdl=s_phdl,
+        model_name=MODEL_NAME,
+        inference_config_dict=inference_dict,
+        benchmark_params_dict=benchmark_params_dict,
+        hf_token=hf_token,
+        gpu_type=gpu_type,
+        distributed_inference=False,
+    )
+
+    # Stop any existing server process for clean state
+    vllm_job.stop_server()
+
+    # Build and start server with current test parameters
+    vllm_job.build_server_inference_job_cmd()
+    vllm_job.start_inference_server_job()
+
+    # Run benchmark client
+    vllm_job.start_inference_client_job()
+    # res_dict will have status, results from base inference class
+    # - {"status": "success", "results": self.inference_result_dict}
+    res_dict = vllm_job.poll_for_inference_completion()
+    res_index = (MODEL_NAME, gpu_type, seq_combo['isl'], seq_combo['osl'], seq_combo['name'], concurrency)
+    inf_res_dict[res_index] = res_dict
+    vllm_job.verify_inference_results()
+    update_test_result()
+
+    log.info(
+        f"Completed inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']}, concurrency: {concurrency}"
+    )
+
+
+def test_print_results_table():
+    globals.error_list = []
+    pprint(inf_res_dict, depth=3)
+    rows = []
+    headers = [
+        "Model",
+        "GPU",
+        "ISL",
+        "OSL",
+        "Policy",
+        "Concurrency",
+        "Host",
+        "Req/s",
+        "Total tok/s",
+        "Mean TTFT (ms)",
+        "Mean TPOT (ms)",
+        "P99 ITL (ms)",
+    ]
+
+    for (model, gpu, isl, osl, policy, concurrency), entry in inf_res_dict.items():
+        for host, m in entry["results"].items():
+            rows.append(
+                [
+                    model,
+                    gpu,
+                    isl,
+                    osl,
+                    policy,
+                    concurrency,
+                    host,
+                    m["successful_requests"],
+                    m["total_throughput_per_sec"],
+                    m["mean_ttft_ms"],
+                    m["mean_tpot_ms"],
+                    m["p99_itl_ms"],
+                ]
+            )
+
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
+    update_test_result()

--- a/cvs/tests/inference/vllm_legacy/vllm_qwen3_235b_single.py
+++ b/cvs/tests/inference/vllm_legacy/vllm_qwen3_235b_single.py
@@ -1,0 +1,463 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+DEPRECATED -- scheduled for removal on 2026-11-11.
+
+Legacy single-node vLLM suite, removed in #223 and restored to serve the
+3-month OSS deprecation notice (given 2026-08-11).
+
+Replacement: ``cvs run vllm`` (cvs/tests/inference/vllm/vllm.py), which covers
+single-node and PP-distributed runs from one schema_version: 1 config.
+
+Kept in this directory, NOT cvs/tests/inference/vllm/: that directory's
+conftest sorts collected items by a rank table keyed on the unified suite's
+test names. These test names are absent from it, so they would all tie at the
+default rank and be reordered into an unrunnable sequence (inference before
+container launch). There is deliberately no conftest.py here.
+'''
+
+import pytest
+
+import re
+import os
+import time
+import json
+from pprint import pprint
+from tabulate import tabulate
+
+from cvs.lib.parallel_ssh_lib import *
+from cvs.lib.utils_lib import *
+from cvs.lib import docker_lib
+from cvs.lib.inference.vllm import VllmJob
+from cvs.lib import globals
+
+log = globals.log
+
+# Model name for this test suite
+MODEL_NAME = "qwen3-235b"
+
+inf_res_dict = {}
+
+
+# Importing additional cmd line args to script ..
+@pytest.fixture(scope="module")
+def cluster_file(pytestconfig):
+    """
+    Retrieve the --cluster_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the cluster JSON file specified via --cluster_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --cluster_file=/path/to/cluster.json
+      - Use module scope so the value is resolved once per test module.
+    """
+    return pytestconfig.getoption("cluster_file")
+
+
+@pytest.fixture(scope="module")
+def training_config_file(pytestconfig):
+    """
+    Retrieve the --config_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the training config JSON file specified via --config_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --config_file=/path/to/training_config.json
+      - Module scope avoids re-fetching the option across tests in this module.
+    """
+    return pytestconfig.getoption("config_file")
+
+
+# Importing the cluster and cofig files to script to access node, switch, test config params
+@pytest.fixture(scope="module")
+def cluster_dict(cluster_file):
+    """
+    Load the entire cluster configuration from the provided JSON file.
+
+    Args:
+      cluster_file (str): Path to the cluster JSON file.
+
+    Returns:
+      dict: Parsed JSON representing the cluster (nodes, credentials, etc.).
+
+    Notes:
+      - Logs the loaded structure for visibility; consider using log.debug if verbose.
+    """
+    with open(cluster_file) as json_file:
+        cluster_dict = json.load(json_file)
+
+    # Resolve path placeholders like {user-id} in cluster config
+    cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
+    log.info("%s", cluster_dict)
+    return cluster_dict
+
+
+@pytest.fixture(scope="module")
+def inference_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    inference_dict = inference_dict_t['config']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    inference_dict = resolve_test_config_placeholders(inference_dict, cluster_dict)
+    return inference_dict
+
+
+@pytest.fixture(scope="module")
+def benchmark_params_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    benchmark_params_dict = inference_dict_t['benchmark_params']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
+
+    log.info("%s", benchmark_params_dict)
+    return benchmark_params_dict
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Dynamically parametrize inference tests based on sequence combinations and concurrency levels
+    for the Qwen3-235B model.
+
+    Behavior:
+      - Reads the config file path from pytest's --config_file option.
+      - Loads the JSON and extracts qwen3-235b model configuration.
+      - Extracts sequence_combinations (ISL/OSL pairs) and concurrency_levels.
+      - Creates test cases for each sequence combination × concurrency level.
+
+    Test Matrix:
+      - Test IDs: "combination_name-concX" (e.g., "balanced-conc16")
+
+    Notes:
+      - If no config_file is provided, the hook returns without parametrizing.
+      - Each combination gets a separate test case with clear ID.
+    """
+    config_file = metafunc.config.getoption("config_file")
+    if not config_file or not os.path.exists(config_file):
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
+        return
+
+    with open(config_file) as fp:
+        cfg = json.load(fp)
+
+    # Extract qwen3-235b model config (now directly under benchmark_params, no single_node nesting)
+    benchmark_params = cfg.get("benchmark_params", {})
+    model_config = benchmark_params.get(MODEL_NAME, {})
+
+    if not model_config:
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
+        return
+
+    # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
+    test_params = []
+
+    # Check if model uses sequence_combinations or legacy ISL/OSL
+    seq_combos = model_config.get("sequence_combinations", [])
+
+    if seq_combos:
+        # New format: multiple combinations per model
+        for combo in seq_combos:
+            combo_name = combo.get("name", f"isl{combo['isl']}_osl{combo['osl']}")
+
+            # Check if model has concurrency_levels array or single max_concurrency
+            conc_levels = model_config.get("concurrency_levels", [])
+            if conc_levels:
+                # Parametrize across concurrency levels
+                for conc in conc_levels:
+                    test_id = f"{combo_name}-conc{conc}"
+                    test_params.append((combo, conc, test_id))
+            else:
+                # Backward compatibility: use max_concurrency as single value
+                max_conc = int(model_config.get("max_concurrency", "64"))
+                test_id = f"{combo_name}"
+                test_params.append((combo, max_conc, test_id))
+    else:
+        # Legacy format: single ISL/OSL values
+        isl = model_config.get("input_sequence_length", "1024")
+        osl = model_config.get("output_sequence_length", "1024")
+        combo = {"isl": isl, "osl": osl, "name": "default"}
+
+        conc_levels = model_config.get("concurrency_levels", [])
+        if conc_levels:
+            for conc in conc_levels:
+                test_id = f"conc{conc}"
+                test_params.append((combo, conc, test_id))
+        else:
+            max_conc = int(model_config.get("max_concurrency", "64"))
+            test_params.append((combo, max_conc, "default"))
+
+    # Parametrize if test uses these fixtures
+    if "seq_combo" in metafunc.fixturenames and "concurrency" in metafunc.fixturenames:
+        if test_params:
+            combos, concs, ids = zip(*test_params)
+            metafunc.parametrize("seq_combo,concurrency", list(zip(combos, concs)), ids=ids)
+
+
+@pytest.fixture(scope="module")
+def hf_token(inference_dict):
+    """
+    Load the Hugging Face access token from the file path specified in the training config.
+
+    Args:
+      inference_dict (dict): Training configuration dict that includes:
+        - 'hf_token_file': Path to the file containing the HF token.
+
+    Returns:
+      str: The HF token string read from the file.
+
+    Behavior:
+      - Reads the token from inference_dict['hf_token_file'] (already resolved for placeholders).
+      - Strips the trailing newline from the token.
+    """
+    hf_token_file = inference_dict['hf_token_file']
+    try:
+        with open(hf_token_file, 'r') as fp:
+            hf_token = fp.read().rstrip("\n")
+    except FileNotFoundError:
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
+        raise
+    except Exception as e:
+        log.error(f"An error occurred: {e}")
+        raise
+    return hf_token
+
+
+@pytest.fixture(scope="module")
+def s_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (server).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return s_phdl
+
+
+@pytest.fixture(scope="module")
+def c_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (client).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return c_phdl
+
+
+def test_cleanup_stale_containers(s_phdl, inference_dict):
+    """
+    Pytest: Clean up potentially stale Docker containers and volumes before tests.
+
+    Args:
+      s_phdl: Parallel SSH/process handle used by docker_lib to run commands on nodes.
+      inference_dict (dict): Training configuration dict that includes:
+        - 'container_name': Name of the container to be killed if running.
+
+    Behavior:
+      - Kills the specific container identified by inference_dict['container_name'].
+      - Deletes all containers and volumes on the target nodes (broad cleanup).
+
+    Notes:
+      - This performs a broad cleanup via delete_all_containers_and_volumes; ensure the
+        test environment is isolated so this doesn't remove unrelated containers/volumes.
+      - Consider narrowing cleanup scope if other workloads may be present on the hosts.
+    """
+
+    container_name = inference_dict['container_name']
+    docker_lib.kill_docker_container(s_phdl, container_name)
+    docker_lib.delete_all_containers_and_volumes(s_phdl)
+
+
+def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_dict):
+    """
+    Launch vLLM inference containers on all nodes.
+
+    Note: Container image can be model-specific or use global default.
+    """
+
+    log.info(f'Testcase launch vLLM containers for {MODEL_NAME}')
+    globals.error_list = []
+    container_name = inference_dict['container_name']
+
+    # Get model-specific container image or use global default
+    container_image = benchmark_params_dict.get(MODEL_NAME, {}).get(
+        'container_image', inference_dict['container_image']
+    )
+
+    # Launch the containers ..
+    docker_lib.launch_docker_container(
+        s_phdl,
+        container_name,
+        container_image,
+        inference_dict['container_config']['device_list'],
+        inference_dict['container_config']['volume_dict'],
+        inference_dict['container_config']['env_dict'],
+        shm_size='16G',
+        timeout=60 * 20,
+    )
+    # ADD verifications ..
+    time.sleep(30)
+    log.info('Verify if the containers have been launched properly')
+    out_dict = s_phdl.exec('docker ps')
+    for node in out_dict.keys():
+        if not re.search(f'{container_name}', out_dict[node], re.I):
+            fail_test(f'Failed to launch container on node {node}')
+    update_test_result()
+
+
+def test_vllm_inference(c_phdl, s_phdl, inference_dict, benchmark_params_dict, hf_token, seq_combo, concurrency):
+    """
+    Test vLLM inference for Qwen3-235B with specific sequence combination and concurrency level.
+
+    This test is parametrized via pytest_generate_tests to run once per:
+      - Sequence combination (ISL/OSL pair) defined in model's sequence_combinations
+      - Concurrency level defined in model's concurrency_levels
+
+    The factory will automatically create the correct VllmJob instance with
+    the model-specific container image and parameters.
+
+    Args:
+        seq_combo: Dict with 'isl', 'osl', 'name' keys for this test iteration
+        concurrency: Integer concurrency level for this test iteration
+    """
+    # Since this is a per-GPU-type config file (mi355x), gpu_type is implicit
+    gpu_type = "mi355x"
+
+    log.info(
+        f"Starting inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']} (ISL={seq_combo['isl']}, OSL={seq_combo['osl']}), concurrency: {concurrency}"
+    )
+    globals.error_list = []
+
+    # Override ISL/OSL and concurrency in benchmark_params for this specific test iteration
+    # Config is now fully flattened, so access directly under benchmark_params
+    model_params = benchmark_params_dict[MODEL_NAME]
+    model_params['input_sequence_length'] = seq_combo['isl']
+    model_params['output_sequence_length'] = seq_combo['osl']
+    model_params['max_concurrency'] = str(concurrency)
+
+    # Calculate num_prompts based on OSL (matching recipe logic)
+    osl = int(seq_combo['osl'])
+    if osl == 8192:
+        model_params['num_prompts'] = str(concurrency * 20)
+    else:
+        model_params['num_prompts'] = str(concurrency * 50)
+
+    # Create VllmJob instance
+    vllm_job = VllmJob(
+        c_phdl=c_phdl,
+        s_phdl=s_phdl,
+        model_name=MODEL_NAME,
+        inference_config_dict=inference_dict,
+        benchmark_params_dict=benchmark_params_dict,
+        hf_token=hf_token,
+        gpu_type=gpu_type,
+        distributed_inference=False,
+    )
+
+    # Stop any existing server process for clean state
+    vllm_job.stop_server()
+
+    # Build and start server with current test parameters
+    vllm_job.build_server_inference_job_cmd()
+    vllm_job.start_inference_server_job()
+
+    # Run benchmark client
+    vllm_job.start_inference_client_job()
+    res_dict = vllm_job.poll_for_inference_completion()
+    res_index = (MODEL_NAME, gpu_type, seq_combo['isl'], seq_combo['osl'], seq_combo['name'], concurrency)
+    inf_res_dict[res_index] = res_dict
+    vllm_job.verify_inference_results()
+    update_test_result()
+
+    log.info(
+        f"Completed inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']}, concurrency: {concurrency}"
+    )
+
+
+def test_print_results_table():
+    globals.error_list = []
+    pprint(inf_res_dict, depth=3)
+    rows = []
+    headers = [
+        "Model",
+        "GPU",
+        "ISL",
+        "OSL",
+        "Policy",
+        "Concurrency",
+        "Host",
+        "Req/s",
+        "Total tok/s",
+        "Mean TTFT (ms)",
+        "Mean TPOT (ms)",
+        "P99 ITL (ms)",
+    ]
+
+    for (model, gpu, isl, osl, policy, concurrency), entry in inf_res_dict.items():
+        for host, m in entry["results"].items():
+            rows.append(
+                [
+                    model,
+                    gpu,
+                    isl,
+                    osl,
+                    policy,
+                    concurrency,
+                    host,
+                    m["successful_requests"],
+                    m["total_throughput_per_sec"],
+                    m["mean_ttft_ms"],
+                    m["mean_tpot_ms"],
+                    m["p99_itl_ms"],
+                ]
+            )
+
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
+    update_test_result()

--- a/cvs/tests/inference/vllm_legacy/vllm_qwen3_80b_single.py
+++ b/cvs/tests/inference/vllm_legacy/vllm_qwen3_80b_single.py
@@ -1,0 +1,494 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+DEPRECATED -- scheduled for removal on 2026-11-11.
+
+Legacy single-node vLLM suite, removed in #223 and restored to serve the
+3-month OSS deprecation notice (given 2026-08-11).
+
+Replacement: ``cvs run vllm`` (cvs/tests/inference/vllm/vllm.py), which covers
+single-node and PP-distributed runs from one schema_version: 1 config.
+
+Kept in this directory, NOT cvs/tests/inference/vllm/: that directory's
+conftest sorts collected items by a rank table keyed on the unified suite's
+test names. These test names are absent from it, so they would all tie at the
+default rank and be reordered into an unrunnable sequence (inference before
+container launch). There is deliberately no conftest.py here.
+'''
+
+import pytest
+
+import re
+import os
+import time
+import json
+from pprint import pprint
+from tabulate import tabulate
+
+from cvs.lib.parallel_ssh_lib import *
+from cvs.lib.utils_lib import *
+from cvs.lib import docker_lib
+from cvs.lib.inference.vllm import VllmJob
+from cvs.lib import globals
+
+log = globals.log
+
+# Model name for this test suite
+MODEL_NAME = "qwen3-80b"
+
+inf_res_dict = {}
+
+
+# Importing additional cmd line args to script ..
+@pytest.fixture(scope="module")
+def cluster_file(pytestconfig):
+    """
+    Retrieve the --cluster_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the cluster JSON file specified via --cluster_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --cluster_file=/path/to/cluster.json
+      - Use module scope so the value is resolved once per test module.
+    """
+    return pytestconfig.getoption("cluster_file")
+
+
+@pytest.fixture(scope="module")
+def training_config_file(pytestconfig):
+    """
+    Retrieve the --config_file CLI option provided to pytest.
+
+    Args:
+      pytestconfig: Built-in pytest fixture exposing command-line options.
+
+    Returns:
+      str: Path to the training config JSON file specified via --config_file.
+
+    Notes:
+      - Ensure your pytest.ini or CLI includes: --config_file=/path/to/training_config.json
+      - Module scope avoids re-fetching the option across tests in this module.
+    """
+    return pytestconfig.getoption("config_file")
+
+
+# Importing the cluster and cofig files to script to access node, switch, test config params
+@pytest.fixture(scope="module")
+def cluster_dict(cluster_file):
+    """
+    Load the entire cluster configuration from the provided JSON file.
+
+    Args:
+      cluster_file (str): Path to the cluster JSON file.
+
+    Returns:
+      dict: Parsed JSON representing the cluster (nodes, credentials, etc.).
+
+    Notes:
+      - Logs the loaded structure for visibility; consider using log.debug if verbose.
+    """
+    with open(cluster_file) as json_file:
+        cluster_dict = json.load(json_file)
+
+    # Resolve path placeholders like {user-id} in cluster config
+    cluster_dict = resolve_cluster_config_placeholders(cluster_dict)
+    log.info("%s", cluster_dict)
+    return cluster_dict
+
+
+@pytest.fixture(scope="module")
+def inference_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    inference_dict = inference_dict_t['config']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    inference_dict = resolve_test_config_placeholders(inference_dict, cluster_dict)
+    return inference_dict
+
+
+@pytest.fixture(scope="module")
+def benchmark_params_dict(training_config_file, cluster_dict):
+    with open(training_config_file) as json_file:
+        inference_dict_t = json.load(json_file)
+    benchmark_params_dict = inference_dict_t['benchmark_params']
+
+    # Resolve path placeholders like {user-id}, {home-mount-dir}, etc.
+    benchmark_params_dict = resolve_test_config_placeholders(benchmark_params_dict, cluster_dict)
+
+    log.info("%s", benchmark_params_dict)
+    return benchmark_params_dict
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Dynamically parametrize inference tests based on sequence combinations and concurrency levels
+    for the Qwen3-80B model.
+
+    Behavior:
+      - Reads the config file path from pytest's --config_file option.
+      - Loads the JSON and extracts qwen3-80b model configuration.
+      - Extracts sequence_combinations (ISL/OSL pairs) and concurrency_levels.
+      - Creates test cases for each sequence combination × concurrency level.
+
+    Test Matrix:
+      - Test IDs: "combination_name-concX" (e.g., "balanced-conc16")
+
+    Notes:
+      - If no config_file is provided, the hook returns without parametrizing.
+      - Each combination gets a separate test case with clear ID.
+    """
+    config_file = metafunc.config.getoption("config_file")
+    if not config_file or not os.path.exists(config_file):
+        log.warning(f'Warning: Missing or invalid config file {config_file}')
+        return
+
+    with open(config_file) as fp:
+        cfg = json.load(fp)
+
+    # Extract qwen3-80b model config (now directly under benchmark_params, no single_node nesting)
+    benchmark_params = cfg.get("benchmark_params", {})
+    model_config = benchmark_params.get(MODEL_NAME, {})
+
+    if not model_config:
+        log.warning(f'Warning: Model {MODEL_NAME} not found in config')
+        return
+
+    # Build test parameters: list of (seq_combo_dict, concurrency, test_id)
+    test_params = []
+
+    # Check if model uses sequence_combinations or legacy ISL/OSL
+    seq_combos = model_config.get("sequence_combinations", [])
+
+    if seq_combos:
+        # New format: multiple combinations per model
+        for combo in seq_combos:
+            combo_name = combo.get("name", f"isl{combo['isl']}_osl{combo['osl']}")
+
+            # Check if model has concurrency_levels array or single max_concurrency
+            conc_levels = model_config.get("concurrency_levels", [])
+            if conc_levels:
+                # Parametrize across concurrency levels
+                for conc in conc_levels:
+                    test_id = f"{combo_name}-conc{conc}"
+                    test_params.append((combo, conc, test_id))
+            else:
+                # Backward compatibility: use max_concurrency as single value
+                max_conc = int(model_config.get("max_concurrency", "64"))
+                test_id = f"{combo_name}"
+                test_params.append((combo, max_conc, test_id))
+    else:
+        # Legacy format: single ISL/OSL values
+        isl = model_config.get("input_sequence_length", "1024")
+        osl = model_config.get("output_sequence_length", "1024")
+        combo = {"isl": isl, "osl": osl, "name": "default"}
+
+        conc_levels = model_config.get("concurrency_levels", [])
+        if conc_levels:
+            for conc in conc_levels:
+                test_id = f"conc{conc}"
+                test_params.append((combo, conc, test_id))
+        else:
+            max_conc = int(model_config.get("max_concurrency", "64"))
+            test_params.append((combo, max_conc, "default"))
+
+    # Parametrize if test uses these fixtures
+    if "seq_combo" in metafunc.fixturenames and "concurrency" in metafunc.fixturenames:
+        if test_params:
+            combos, concs, ids = zip(*test_params)
+            metafunc.parametrize("seq_combo,concurrency", list(zip(combos, concs)), ids=ids)
+
+
+@pytest.fixture(scope="module")
+def hf_token(inference_dict):
+    """
+    Load the Hugging Face access token from the file path specified in the training config.
+
+    Args:
+      inference_dict (dict): Training configuration dict that includes:
+        - 'hf_token_file': Path to the file containing the HF token.
+
+    Returns:
+      str: The HF token string read from the file.
+
+    Behavior:
+      - Reads the token from inference_dict['hf_token_file'] (already resolved for placeholders).
+      - Strips the trailing newline from the token.
+    """
+    hf_token_file = inference_dict['hf_token_file']
+    try:
+        with open(hf_token_file, 'r') as fp:
+            hf_token = fp.read().rstrip("\n")
+    except FileNotFoundError:
+        log.error(f"Error: The file '{hf_token_file}' was not found.")
+        raise
+    except Exception as e:
+        log.error(f"An error occurred: {e}")
+        raise
+    return hf_token
+
+
+@pytest.fixture(scope="module")
+def s_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (server).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    s_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return s_phdl
+
+
+@pytest.fixture(scope="module")
+def c_phdl(cluster_dict):
+    """
+    Create and return a parallel SSH handle for all cluster nodes (client).
+
+    Args:
+      cluster_dict (dict): Cluster configuration loaded by another fixture. Expected keys:
+        - 'node_dict': dict of node_name -> node_details (used to derive the node list)
+        - 'username': SSH username for connecting to nodes
+        - 'priv_key_file': path to the SSH private key file
+
+    Returns:
+      Pssh: An initialized Pssh handle for issuing commands across all nodes.
+
+    Behavior:
+      - Prints the full cluster_dict for quick debugging (consider switching to log.debug to reduce noise).
+      - Collects all node names from cluster_dict['node_dict'] and constructs a Pssh handle.
+
+    Notes:
+      - This fixture has module scope, so a single connection handle is reused for all tests in the module.
+    """
+    log.info("%s", cluster_dict)
+    env_vars = cluster_dict.get("env_vars")
+    node_list = list(cluster_dict['node_dict'].keys())
+    c_phdl = Pssh(log, node_list, user=cluster_dict['username'], pkey=cluster_dict['priv_key_file'], env_vars=env_vars)
+    return c_phdl
+
+
+@pytest.fixture(scope="module", autouse=True)
+def cleanup_on_exit(s_phdl, inference_dict):
+    """
+    Automatically clean up containers after all tests in the module complete.
+
+    This fixture runs automatically (autouse=True) and ensures cleanup happens
+    even if tests fail, providing proper test isolation.
+
+    Args:
+      s_phdl: Parallel SSH handle for server nodes
+      inference_dict: Inference configuration containing container_name
+
+    Yields:
+      None (all tests run between yield statement and cleanup)
+
+    Behavior:
+      - Runs setup code before yield (currently none)
+      - Yields control to run all module tests
+      - After all tests complete (success or failure), kills container and cleans up volumes
+    """
+    # Setup (before tests) - nothing needed currently
+    yield
+    # Teardown (after all tests, even on failure)
+    try:
+        container_name = inference_dict['container_name']
+        log.info(f"Cleaning up container {container_name} after test module completion")
+        docker_lib.kill_docker_container(s_phdl, container_name)
+        docker_lib.delete_all_containers_and_volumes(s_phdl)
+    except Exception as e:
+        log.warning(f"Cleanup failed (non-critical): {e}")
+
+
+def test_cleanup_stale_containers(s_phdl, inference_dict):
+    """
+    Pytest: Clean up potentially stale Docker containers and volumes before tests.
+
+    Args:
+      s_phdl: Parallel SSH/process handle used by docker_lib to run commands on nodes.
+      inference_dict (dict): Training configuration dict that includes:
+        - 'container_name': Name of the container to be killed if running.
+
+    Behavior:
+      - Kills the specific container identified by inference_dict['container_name'].
+      - Deletes all containers and volumes on the target nodes (broad cleanup).
+
+    Notes:
+      - This performs a broad cleanup via delete_all_containers_and_volumes; ensure the
+        test environment is isolated so this doesn't remove unrelated containers/volumes.
+      - Consider narrowing cleanup scope if other workloads may be present on the hosts.
+    """
+
+    container_name = inference_dict['container_name']
+    docker_lib.kill_docker_container(s_phdl, container_name)
+    docker_lib.delete_all_containers_and_volumes(s_phdl)
+
+
+def test_launch_inference_containers(s_phdl, inference_dict, benchmark_params_dict):
+    """
+    Launch vLLM inference containers on all nodes.
+
+    Note: Container image can be model-specific or use global default.
+    """
+
+    log.info(f'Testcase launch vLLM containers for {MODEL_NAME}')
+    globals.error_list = []
+    container_name = inference_dict['container_name']
+
+    # Get model-specific container image or use global default
+    container_image = benchmark_params_dict.get(MODEL_NAME, {}).get(
+        'container_image', inference_dict['container_image']
+    )
+
+    # Launch the containers ..
+    docker_lib.launch_docker_container(
+        s_phdl,
+        container_name,
+        container_image,
+        inference_dict['container_config']['device_list'],
+        inference_dict['container_config']['volume_dict'],
+        inference_dict['container_config']['env_dict'],
+        shm_size='16G',
+        timeout=60 * 20,
+    )
+    # ADD verifications ..
+    time.sleep(30)
+    log.info('Verify if the containers have been launched properly')
+    out_dict = s_phdl.exec('docker ps')
+    for node in out_dict.keys():
+        if not re.search(f'{container_name}', out_dict[node], re.I):
+            fail_test(f'Failed to launch container on node {node}')
+    update_test_result()
+
+
+def test_vllm_inference(c_phdl, s_phdl, inference_dict, benchmark_params_dict, hf_token, seq_combo, concurrency):
+    """
+    Test vLLM inference for Qwen3-80B with specific sequence combination and concurrency level.
+
+    This test is parametrized via pytest_generate_tests to run once per:
+      - Sequence combination (ISL/OSL pair) defined in model's sequence_combinations
+      - Concurrency level defined in model's concurrency_levels
+
+    The vllm_server fixture provides a running server that is reused across all iterations.
+
+    Args:
+        vllm_server: VllmJob instance with running server (from fixture)
+        seq_combo: Dict with 'isl', 'osl', 'name' keys for this test iteration
+        concurrency: Integer concurrency level for this test iteration
+    """
+    gpu_type = "mi355x"
+
+    log.info(
+        f"Starting inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']} (ISL={seq_combo['isl']}, OSL={seq_combo['osl']}), concurrency: {concurrency}"
+    )
+    globals.error_list = []
+
+    # Override ISL/OSL and concurrency in benchmark_params for this specific test iteration
+    model_params = benchmark_params_dict[MODEL_NAME]
+    model_params['input_sequence_length'] = seq_combo['isl']
+    model_params['output_sequence_length'] = seq_combo['osl']
+    model_params['max_concurrency'] = str(concurrency)
+
+    # Calculate num_prompts based on OSL (matching recipe logic)
+    osl = int(seq_combo['osl'])
+    if osl == 8192:
+        model_params['num_prompts'] = str(concurrency * 20)
+    else:
+        model_params['num_prompts'] = str(concurrency * 50)
+
+    # Create VllmJob instance
+    vllm_job = VllmJob(
+        c_phdl=c_phdl,
+        s_phdl=s_phdl,
+        model_name=MODEL_NAME,
+        inference_config_dict=inference_dict,
+        benchmark_params_dict=benchmark_params_dict,
+        hf_token=hf_token,
+        gpu_type=gpu_type,
+        distributed_inference=False,
+        server_launch_poll_count=30,
+    )
+
+    # Stop any existing server process for clean state
+    vllm_job.stop_server()
+
+    # Build and start server with current test parameters
+    vllm_job.build_server_inference_job_cmd()
+    vllm_job.start_inference_server_job()
+
+    # Run benchmark client
+    vllm_job.start_inference_client_job()
+    res_dict = vllm_job.poll_for_inference_completion()
+    res_index = (MODEL_NAME, gpu_type, seq_combo['isl'], seq_combo['osl'], seq_combo['name'], concurrency)
+    inf_res_dict[res_index] = res_dict
+    vllm_job.verify_inference_results()
+    update_test_result()
+
+    log.info(
+        f"Completed inference test for model: {MODEL_NAME}, GPU: {gpu_type}, combination: {seq_combo['name']}, concurrency: {concurrency}"
+    )
+
+
+def test_print_results_table():
+    globals.error_list = []
+    pprint(inf_res_dict, depth=3)
+    rows = []
+    headers = [
+        "Model",
+        "GPU",
+        "ISL",
+        "OSL",
+        "Policy",
+        "Concurrency",
+        "Host",
+        "Req/s",
+        "Total tok/s",
+        "Mean TTFT (ms)",
+        "Mean TPOT (ms)",
+        "P99 ITL (ms)",
+    ]
+
+    for (model, gpu, isl, osl, policy, concurrency), entry in inf_res_dict.items():
+        for host, m in entry["results"].items():
+            rows.append(
+                [
+                    model,
+                    gpu,
+                    isl,
+                    osl,
+                    policy,
+                    concurrency,
+                    host,
+                    m["successful_requests"],
+                    m["total_throughput_per_sec"],
+                    m["mean_ttft_ms"],
+                    m["mean_tpot_ms"],
+                    m["p99_itl_ms"],
+                ]
+            )
+
+    log.info(tabulate(rows, headers=headers, tablefmt="github"))
+    update_test_result()


### PR DESCRIPTION
## Summary

`dev/dtni` replaced the per-model vLLM suites with the unified `vllm` suite, deleting the old
entry points outright. AMD's OSS policy requires a deprecated interface to stay available for
three months before removal, so this restores them behind a dated notice rather than leaving
the merge as a silent breaking change.

Notice served 2026-08-11; removal 2026-11-11.

## Change

- Legacy suites live in `cvs/tests/inference/vllm_legacy/`, not alongside the new ones. The new
  suite's `conftest.py` reorders collection from a rank table that has no entries for the legacy
  test names — sharing a directory ties them all at rank 99 and runs inference before the
  container launches. A separate directory keeps that conftest out of scope.
- `base_legacy.py` is a frozen copy of `main`'s `base.py`. The legacy suites pin to it so the
  unified suite's base can keep evolving without dragging them along.
- Importing `cvs.lib.inference.vllm` raises a `DeprecationWarning` naming the replacement.
- Out of scope: sglang and inferencemax, which were deleted the same way and need the same
  treatment separately.

## Tests

- `test_vllm_legacy_deprecation.py` (new, 15 tests) — pins the quarantine boundary, the frozen
  base, and the removal date, so re-merging the suites or re-pointing them at the live base fails.
- Hardware smoke on splinter-126-016d (1x MI300X, ROCm 7.14 GA, gpt-oss-120b): container
  lifecycle, server env contract, launch, readiness polling, and report generation all exercised
  on the restored path. `test_vllm_inference` did not complete — the GPU dropped off the PCIe bus
  (`amdgpu: device lost from bus!`) four seconds after vLLM finished warmup, and the harness
  failed cleanly on its readiness timeout. The client benchmark step remains unvalidated.
- Gates: 15/15 new unit tests pass; `ruff format --check` and `ruff check` clean on all 8 changed
  files. Full `make ut` is not runnable here — `dev/dtni` already fails `fmt-check` (23 files) and
  `lint` (14 errors) before this branch, verified against an extracted pristine baseline.
