### PR TITLE
feat(config): add suite config catalog discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,25 @@ cvs copy-config --all --output /tmp/cvs/input/ --force
 
 Alternatively, you can generate the cluster JSON file for N number of hosts using the `cvs generate cluster_json` command. This is useful for automatically creating cluster configurations from a list of host IPs.
 
+### Find a Config for a Test Suite
+
+To see the bundled configs supported by a CVS test suite, pass its name to `cvs copy-config --list`:
+
+```bash
+cvs copy-config --list rccl_perf
+cvs copy-config --list vllm_gpt_oss_120b_single --platform mi355
+```
+
+The command prints config paths relative to `cvs/input/config_file`. Copy a selected config before running the test:
+
+```bash
+cvs copy-config inference/vllm/mi355x_vllm_single.json --output /tmp/vllm_config.json
+```
+
+Supported platform names are `mi300`, `mi300x`, `mi350`, and `mi355`. Without `--platform`, CVS lists every bundled config supported by the suite.
+
+Applications can consume the same mapping from the packaged `cvs/input/config_catalog.json` file.
+
 #### Option 1: Using a hosts file
 
 Create a hosts file with one IP address or hostname per line (supports IP ranges like `192.168.1.10-20` and bracket notation like `hostname[1-10]`, comments with `#`, and blank lines are ignored):

--- a/cvs/cli_plugins/copy_config_plugin.py
+++ b/cvs/cli_plugins/copy_config_plugin.py
@@ -1,5 +1,7 @@
 from .base import SubcommandPlugin
 from cvs.extension import ExtensionConfig
+from cvs.cli_plugins.list_plugin import ListPlugin
+from cvs.lib.config_catalog import ConfigCatalogError, load_config_catalog
 import os
 import shutil
 
@@ -22,6 +24,10 @@ class CopyConfigPlugin(SubcommandPlugin):
             action="store_true",
             help="List available config files at the given path (lists all if no path specified)",
         )
+        parser.add_argument(
+            "--platform",
+            help="Only list configs supported by this platform when a test suite is specified",
+        )
         parser.add_argument("--force", action="store_true", help="Force overwrite of existing files")
         parser.set_defaults(_plugin=self)
         return parser
@@ -34,6 +40,8 @@ Copy-Config Commands:
   cvs copy-config training/jax      List configs in training/jax directory
   cvs copy-config --list            Same as above (list all)
   cvs copy-config training --list   Same as above (list training)
+  cvs copy-config --list rccl_perf  List configs supported by a test suite
+  cvs copy-config --list rccl_perf --platform mi355
 
   Note: --list is optional, same behavior without it
   
@@ -99,9 +107,42 @@ Copy-Config Commands:
                 return candidate
         return None
 
+    @staticmethod
+    def _suite_names():
+        """Return the runnable suite names shown by ``cvs list``."""
+        return {suite for tests in ListPlugin.discover_tests().values() for suite in tests}
+
+    def _list_suite_configs(self, suite, platform, suite_names):
+        """Print catalogued configs for a suite and optional platform."""
+        try:
+            catalog = load_config_catalog()
+            catalog.validate_suites(suite_names)
+            configurations = catalog.configurations_for(suite, platform)
+        except ConfigCatalogError as error:
+            print(f"Error: {error}")
+            return
+
+        if configurations:
+            heading = f"Configs for {suite}"
+            if platform:
+                heading += f" on {platform.lower()}"
+            print(f"{heading}:")
+            for configuration in configurations:
+                print(f"  {configuration.path}")
+            return
+
+        unavailable_reason = catalog.unavailable_reason(suite)
+        if unavailable_reason:
+            print(f"No bundled config is available for {suite}: {unavailable_reason}")
+        elif platform:
+            print(f"No bundled config is available for {suite} on {platform.lower()}.")
+        else:
+            print(f"No bundled config is available for {suite}.")
+
     def run(self, args):
         roots = self._find_config_root()
         path = args.path or ""
+        platform = getattr(args, "platform", None)
 
         if args.all:
             if not args.output:
@@ -134,6 +175,16 @@ Copy-Config Commands:
             return
 
         if args.list or not args.output:
+            suite_names = self._suite_names()
+            if path in suite_names:
+                self._list_suite_configs(path, platform, suite_names)
+                return
+            if platform:
+                if path:
+                    print(f"Error: --platform requires a test suite from 'cvs list', not '{path}'.")
+                else:
+                    print("Error: --platform requires a test suite from 'cvs list'.")
+                return
             found = False
             for root in roots:
                 configs = self._list_configs(root, path)

--- a/cvs/cli_plugins/unittests/test_copy_config_plugin.py
+++ b/cvs/cli_plugins/unittests/test_copy_config_plugin.py
@@ -7,6 +7,7 @@ import io
 from contextlib import redirect_stdout
 
 from cvs.cli_plugins.copy_config_plugin import CopyConfigPlugin
+from cvs.lib.config_catalog import ConfigCatalog
 
 
 class TestCopyConfigPlugin(unittest.TestCase):
@@ -46,6 +47,58 @@ class TestCopyConfigPlugin(unittest.TestCase):
 
         # Should print configs
         mock_print.assert_called()
+
+    def test_list_suite_configs(self):
+        args = argparse.Namespace(path="vllm_gpt_oss_120b_single", output=None, list=True, all=False, force=False)
+
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            self.plugin.run(args)
+
+        output = captured_output.getvalue()
+        self.assertIn("Configs for vllm_gpt_oss_120b_single", output)
+        self.assertIn("inference/vllm/mi355x_vllm_single.json", output)
+
+    def test_list_suite_configs_for_platform(self):
+        args = argparse.Namespace(
+            path="vllm_gpt_oss_120b_single", output=None, list=True, all=False, force=False, platform="mi355"
+        )
+
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            self.plugin.run(args)
+
+        output = captured_output.getvalue()
+        self.assertIn("Configs for vllm_gpt_oss_120b_single on mi355", output)
+        self.assertIn("inference/vllm/mi355x_vllm_single.json", output)
+
+    def test_platform_filter_keeps_shared_config(self):
+        args = argparse.Namespace(path="rccl_perf", output=None, list=True, all=False, force=False, platform="mi355")
+
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            self.plugin.run(args)
+
+        self.assertIn("rccl/rccl_config.json", captured_output.getvalue())
+
+    def test_platform_requires_suite_name(self):
+        args = argparse.Namespace(path="training", output=None, list=True, all=False, force=False, platform="mi355")
+
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            self.plugin.run(args)
+
+        self.assertIn("--platform requires a test suite", captured_output.getvalue())
+
+    @patch("cvs.cli_plugins.copy_config_plugin.load_config_catalog")
+    def test_unavailable_suite_has_a_clear_message(self, mock_load_catalog):
+        mock_load_catalog.return_value = ConfigCatalog([], {"test_aorta": "No default config is bundled."})
+
+        captured_output = io.StringIO()
+        with redirect_stdout(captured_output):
+            self.plugin._list_suite_configs("test_aorta", None, {"test_aorta"})
+
+        self.assertIn("No bundled config is available for test_aorta", captured_output.getvalue())
 
     def test_run_copy_all_success(self):
         """Test successful copy of all configs"""

--- a/cvs/cli_plugins/unittests/test_list_plugin.py
+++ b/cvs/cli_plugins/unittests/test_list_plugin.py
@@ -44,6 +44,10 @@ class TestListPlugin(unittest.TestCase):
         self.assertIsNotNone(plugin.test_map)
         self.assertIsInstance(plugin.test_map, dict)
 
+    def test_conftest_is_not_a_runnable_suite(self):
+        plugin = ListPlugin()
+        self.assertFalse(any("conftest" in tests for tests in plugin.test_map.values()))
+
     def test_find_test_method_exists(self):
         """Test that _find_test helper method exists"""
         plugin = ListPlugin()

--- a/cvs/input/config_catalog.json
+++ b/cvs/input/config_catalog.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": 1,
+  "configurations": [
+    {
+      "path": "aorta/aorta_benchmark.yaml",
+      "platforms": ["mi300"],
+      "suites": ["test_aorta"]
+    },
+    {
+      "path": "anc/anc_config.json",
+      "platforms": ["all"],
+      "suites": ["anc_installation", "anc_test_cpu", "anc_test_gpu"]
+    },
+    {
+      "path": "health/mi300_health_config.json",
+      "platforms": ["mi300", "mi300x"],
+      "suites": [
+        "agfhc_cvs",
+        "csp_qual_agfhc",
+        "rvs_cvs",
+        "transferbench_cvs",
+        "install_agfhc",
+        "install_babelstream",
+        "install_rocblas",
+        "install_rvs",
+        "install_transferbench"
+      ]
+    },
+    {
+      "path": "ibperf/ibperf_config.json",
+      "platforms": ["all"],
+      "suites": ["ib_perf_bw_test", "install_ibperf_tools"]
+    },
+    {
+      "path": "inference/inferencemax/mi300x_inferencemax_gpt_oss_120b_single.json",
+      "platforms": ["mi300x"],
+      "suites": ["inferencemax_gpt_oss_120b_single"]
+    },
+    {
+      "path": "inference/inferencemax/mi355x_inferencemax_gpt_oss_120b_single.json",
+      "platforms": ["mi355"],
+      "suites": ["inferencemax_gpt_oss_120b_single"]
+    },
+    {
+      "path": "inference/pytorch_xdit/mi300x_pytorch_xdit_flux1_dev_single.json",
+      "platforms": ["mi300x", "mi355"],
+      "suites": ["pytorch_xdit_flux1_dev_single"]
+    },
+    {
+      "path": "inference/pytorch_xdit/mi300x_pytorch_xdit_wan22_14b_single.json",
+      "platforms": ["mi300x", "mi355"],
+      "suites": ["pytorch_xdit_wan22_14b_single"]
+    },
+    {
+      "path": "inference/sglang/mi30x_sglang_distributed.json",
+      "platforms": ["mi300x"],
+      "suites": ["sglang_deepseek_r1_671b_distributed", "sglang_llama_70b_distributed"]
+    },
+    {
+      "path": "inference/sglang/mi35x_sglang_distributed.json",
+      "platforms": ["mi350", "mi355"],
+      "suites": ["sglang_deepseek_r1_671b_distributed", "sglang_llama_70b_distributed"]
+    },
+    {
+      "path": "inference/vllm/mi355x_vllm_single.json",
+      "platforms": ["mi355"],
+      "suites": [
+        "vllm_deepseek31_685b_single",
+        "vllm_gpt_oss_120b_single",
+        "vllm_qwen3_235b_single",
+        "vllm_qwen3_80b_single"
+      ]
+    },
+    {
+      "path": "mori/mi35x_mori_config.json",
+      "platforms": ["mi350", "mi355"],
+      "suites": ["mori_benchmark_test"]
+    },
+    {
+      "path": "ompi/ompi_config.json",
+      "platforms": ["all"],
+      "suites": ["install_ompi"]
+    },
+    {
+      "path": "platform/host_config.json",
+      "platforms": ["all"],
+      "suites": ["host_configs_cvs"]
+    },
+    {
+      "path": "preflight/preflight_config.json",
+      "platforms": ["all"],
+      "suites": ["preflight_checks"]
+    },
+    {
+      "path": "rccl/rccl_config.json",
+      "platforms": ["all"],
+      "suites": ["rccl_pairwise", "rccl_perf", "rccl_regression"]
+    },
+    {
+      "path": "training/jax/mi300x_jax_llama3_1_405b_distributed.json",
+      "platforms": ["mi300x"],
+      "suites": ["jax_llama3_1_405b_distributed"]
+    },
+    {
+      "path": "training/jax/mi300x_jax_llama3_1_70b_distributed.json",
+      "platforms": ["mi300x"],
+      "suites": ["jax_llama3_1_70b_distributed"]
+    },
+    {
+      "path": "training/jax/mi300x_jax_llama3_1_70b_single.json",
+      "platforms": ["mi300x"],
+      "suites": ["jax_llama3_1_70b_single"]
+    },
+    {
+      "path": "training/jax/mi35x_jax_llama3_1_70b_single.json",
+      "platforms": ["mi355"],
+      "suites": ["jax_llama3_1_70b_single"]
+    },
+    {
+      "path": "training/megatron/mi35x_megatron_llama_single.json",
+      "platforms": ["mi350", "mi355"],
+      "suites": ["megatron_llama3_1_70b_single", "megatron_llama3_1_8b_single"]
+    },
+    {
+      "path": "training/megatron/mi3xx_megatron_llama_distributed.json",
+      "platforms": ["mi300x"],
+      "suites": ["megatron_llama3_1_70b_distributed", "megatron_llama3_1_8b_distributed"]
+    },
+    {
+      "path": "training/megatron/mi3xx_megatron_llama_single.json",
+      "platforms": ["mi300x"],
+      "suites": ["megatron_llama3_1_70b_single", "megatron_llama3_1_8b_single"]
+    },
+    {
+      "path": "training/torchtitan/mi3xx_torchtitan_deepseek_distributed.json",
+      "platforms": ["mi300x"],
+      "suites": ["torchtitan_deepseek_16b_distributed"]
+    },
+    {
+      "path": "training/torchtitan/mi3xx_torchtitan_deepseek_single.json",
+      "platforms": ["mi300x"],
+      "suites": ["torchtitan_deepseek_16b_single"]
+    },
+    {
+      "path": "training/torchtitan/mi3xx_torchtitan_llama_distributed.json",
+      "platforms": ["mi300x"],
+      "suites": ["torchtitan_llama3_1_70b_distributed", "torchtitan_llama3_1_8b_distributed"]
+    },
+    {
+      "path": "training/torchtitan/mi3xx_torchtitan_llama_single.json",
+      "platforms": ["mi300x"],
+      "suites": ["torchtitan_llama3_1_70b_single", "torchtitan_llama3_1_8b_single"]
+    },
+    {
+      "path": "training/torchtitan/mi3xx_torchtitan_qwen3_distributed.json",
+      "platforms": ["mi300x"],
+      "suites": ["torchtitan_qwen3_32b_distributed"]
+    },
+    {
+      "path": "training/torchtitan/mi3xx_torchtitan_qwen3_single.json",
+      "platforms": ["mi300x"],
+      "suites": ["torchtitan_qwen3_32b_single"]
+    }
+  ],
+  "unavailable_suites": []
+}

--- a/cvs/lib/config_catalog.py
+++ b/cvs/lib/config_catalog.py
@@ -1,0 +1,203 @@
+"""Load and validate the bundled CVS test-suite configuration catalog."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from cvs.extension import ExtensionConfig
+
+
+CATALOG_FILENAME = "config_catalog.json"
+SUPPORTED_PLATFORMS = frozenset({"all", "mi300", "mi300x", "mi350", "mi355"})
+CONFIG_SUFFIXES = frozenset({".json", ".yaml", ".yml"})
+
+
+class ConfigCatalogError(ValueError):
+    """Raised when a configuration catalog is malformed or incomplete."""
+
+
+@dataclass(frozen=True)
+class Configuration:
+    """A bundled config file and the suites/platforms it supports."""
+
+    path: str
+    platforms: Tuple[str, ...]
+    suites: Tuple[str, ...]
+
+
+class ConfigCatalog:
+    """The explicit compatibility mapping used by CVS and consuming applications."""
+
+    def __init__(self, configurations: Sequence[Configuration], unavailable_suites: dict):
+        self.configurations = tuple(configurations)
+        self.unavailable_suites = dict(unavailable_suites)
+
+    @classmethod
+    def from_input_roots(cls, input_roots: Iterable[Path]):
+        """Load catalogs from core and optional extension input roots."""
+        roots = tuple(Path(root) for root in input_roots)
+        configurations = []
+        unavailable_suites = {}
+        known_paths = set()
+
+        for root in roots:
+            catalog_path = root / CATALOG_FILENAME
+            if not catalog_path.is_file():
+                continue
+            try:
+                document = json.loads(catalog_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as error:
+                raise ConfigCatalogError(f"Unable to read {catalog_path}: {error}") from error
+
+            cls._validate_document(document, catalog_path)
+            for raw_configuration in document["configurations"]:
+                configuration = cls._parse_configuration(raw_configuration, catalog_path)
+                if configuration.path in known_paths:
+                    raise ConfigCatalogError(f"Duplicate config path in catalogs: {configuration.path}")
+                known_paths.add(configuration.path)
+                configurations.append(configuration)
+
+            for raw_unavailable in document["unavailable_suites"]:
+                suite, reason = cls._parse_unavailable_suite(raw_unavailable, catalog_path)
+                if suite in unavailable_suites:
+                    raise ConfigCatalogError(f"Duplicate unavailable suite in catalogs: {suite}")
+                unavailable_suites[suite] = reason
+
+        catalog = cls(configurations, unavailable_suites)
+        catalog._validate_config_paths(roots)
+        catalog.validate_config_files(roots)
+        catalog._validate_no_conflicts()
+        return catalog
+
+    @staticmethod
+    def _validate_document(document, catalog_path):
+        if not isinstance(document, dict):
+            raise ConfigCatalogError(f"{catalog_path} must contain a JSON object")
+        if document.get("schema_version") != 1:
+            raise ConfigCatalogError(f"{catalog_path} must use schema_version 1")
+        if not isinstance(document.get("configurations"), list):
+            raise ConfigCatalogError(f"{catalog_path} field 'configurations' must be a list")
+        if not isinstance(document.get("unavailable_suites"), list):
+            raise ConfigCatalogError(f"{catalog_path} field 'unavailable_suites' must be a list")
+
+    @staticmethod
+    def _parse_configuration(raw_configuration, catalog_path):
+        if not isinstance(raw_configuration, dict):
+            raise ConfigCatalogError(f"Invalid configuration entry in {catalog_path}")
+        path = raw_configuration.get("path")
+        platforms = raw_configuration.get("platforms")
+        suites = raw_configuration.get("suites")
+        if not isinstance(path, str) or not path or Path(path).is_absolute() or ".." in Path(path).parts:
+            raise ConfigCatalogError(f"Invalid config path in {catalog_path}: {path!r}")
+        if not isinstance(platforms, list) or not platforms or not all(isinstance(item, str) for item in platforms):
+            raise ConfigCatalogError(f"Config {path} must declare one or more platforms")
+        if not isinstance(suites, list) or not suites or not all(isinstance(item, str) and item for item in suites):
+            raise ConfigCatalogError(f"Config {path} must declare one or more suites")
+
+        normalized_platforms = tuple(platform.lower() for platform in platforms)
+        invalid_platforms = set(normalized_platforms) - SUPPORTED_PLATFORMS
+        if invalid_platforms:
+            raise ConfigCatalogError(f"Config {path} uses unsupported platforms: {sorted(invalid_platforms)}")
+        if len(set(normalized_platforms)) != len(normalized_platforms):
+            raise ConfigCatalogError(f"Config {path} repeats a platform")
+        if "all" in normalized_platforms and len(normalized_platforms) != 1:
+            raise ConfigCatalogError(f"Config {path} cannot combine 'all' with specific platforms")
+        if len(set(suites)) != len(suites):
+            raise ConfigCatalogError(f"Config {path} repeats a suite")
+        return Configuration(path=path, platforms=normalized_platforms, suites=tuple(suites))
+
+    @staticmethod
+    def _parse_unavailable_suite(raw_unavailable, catalog_path):
+        if not isinstance(raw_unavailable, dict):
+            raise ConfigCatalogError(f"Invalid unavailable suite entry in {catalog_path}")
+        suite = raw_unavailable.get("suite")
+        reason = raw_unavailable.get("reason")
+        if not isinstance(suite, str) or not suite or not isinstance(reason, str) or not reason:
+            raise ConfigCatalogError(f"Unavailable suite entries in {catalog_path} require suite and reason")
+        return suite, reason
+
+    def _validate_config_paths(self, input_roots: Iterable[Path]):
+        config_roots = [root / "config_file" for root in input_roots]
+        for configuration in self.configurations:
+            if not any((config_root / configuration.path).is_file() for config_root in config_roots):
+                raise ConfigCatalogError(f"Catalog config file does not exist: {configuration.path}")
+
+    def _validate_no_conflicts(self):
+        configured_suites = {suite for configuration in self.configurations for suite in configuration.suites}
+        conflicting_suites = configured_suites & self.unavailable_suites.keys()
+        if conflicting_suites:
+            raise ConfigCatalogError(f"Suites cannot be both configured and unavailable: {sorted(conflicting_suites)}")
+
+    def validate_config_files(self, input_roots: Iterable[Path]):
+        """Require every bundled JSON/YAML test config to be present in the catalog."""
+        bundled_paths = set()
+        for input_root in input_roots:
+            config_root = Path(input_root) / "config_file"
+            if not config_root.is_dir():
+                continue
+            for config_path in config_root.rglob("*"):
+                if config_path.is_file() and config_path.suffix.lower() in CONFIG_SUFFIXES:
+                    relative_path = config_path.relative_to(config_root).as_posix()
+                    if relative_path in bundled_paths:
+                        raise ConfigCatalogError(f"Duplicate bundled config path: {relative_path}")
+                    bundled_paths.add(relative_path)
+
+        catalog_paths = {configuration.path for configuration in self.configurations}
+        missing_paths = bundled_paths - catalog_paths
+        if missing_paths:
+            raise ConfigCatalogError(f"Catalog is missing config files: {sorted(missing_paths)}")
+
+    def validate_suites(self, suites: Iterable[str]):
+        """Require every runnable suite to be configured or explicitly unavailable."""
+        suite_names = set(suites)
+        catalog_suites = {suite for configuration in self.configurations for suite in configuration.suites}
+        catalog_suites.update(self.unavailable_suites)
+        missing_suites = suite_names - catalog_suites
+        unknown_suites = catalog_suites - suite_names
+        if missing_suites or unknown_suites:
+            messages = []
+            if missing_suites:
+                messages.append(f"missing suites: {sorted(missing_suites)}")
+            if unknown_suites:
+                messages.append(f"unknown suites: {sorted(unknown_suites)}")
+            raise ConfigCatalogError("Catalog suite coverage is invalid: " + "; ".join(messages))
+
+    def configurations_for(self, suite: str, platform: Optional[str] = None) -> List[Configuration]:
+        """Return compatible configurations for a suite, optionally filtered by platform."""
+        normalized_platform = platform.lower() if platform else None
+        if normalized_platform and normalized_platform not in SUPPORTED_PLATFORMS - {"all"}:
+            raise ConfigCatalogError(
+                f"Unknown platform '{platform}'. Supported platforms: {', '.join(self.platforms())}"
+            )
+        return [
+            configuration
+            for configuration in self.configurations
+            if suite in configuration.suites
+            and (
+                not normalized_platform
+                or "all" in configuration.platforms
+                or normalized_platform in configuration.platforms
+            )
+        ]
+
+    def unavailable_reason(self, suite: str) -> Optional[str]:
+        """Return the catalogued reason when no bundled config exists for a suite."""
+        return self.unavailable_suites.get(suite)
+
+    @staticmethod
+    def platforms() -> List[str]:
+        """Return the public platform names accepted by the CLI."""
+        return sorted(SUPPORTED_PLATFORMS - {"all"})
+
+
+def catalog_input_roots() -> Tuple[Path, ...]:
+    """Return the core and configured extension input roots in lookup order."""
+    core_input_root = Path(__file__).resolve().parents[1] / "input"
+    extension_roots = [Path(path) for path in ExtensionConfig().get_input_dirs()]
+    return tuple([core_input_root, *extension_roots])
+
+
+def load_config_catalog() -> ConfigCatalog:
+    """Load the core catalog and any optional extension catalogs."""
+    return ConfigCatalog.from_input_roots(catalog_input_roots())

--- a/cvs/lib/unittests/test_config_catalog.py
+++ b/cvs/lib/unittests/test_config_catalog.py
@@ -1,0 +1,126 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from cvs.cli_plugins.list_plugin import ListPlugin
+from cvs.lib.config_catalog import ConfigCatalog, ConfigCatalogError, load_config_catalog
+
+
+class TestConfigCatalog(unittest.TestCase):
+    @staticmethod
+    def _suite_names():
+        return {suite for tests in ListPlugin.discover_tests().values() for suite in tests}
+
+    def test_bundled_catalog_covers_runnable_suites(self):
+        catalog = load_config_catalog()
+        catalog.validate_suites(self._suite_names())
+
+    def test_bundled_catalog_returns_specific_and_shared_configs(self):
+        catalog = load_config_catalog()
+
+        vllm_configs = catalog.configurations_for("vllm_gpt_oss_120b_single", "mi355")
+        self.assertEqual([config.path for config in vllm_configs], ["inference/vllm/mi355x_vllm_single.json"])
+
+        rccl_configs = catalog.configurations_for("rccl_perf", "mi355")
+        self.assertEqual([config.path for config in rccl_configs], ["rccl/rccl_config.json"])
+
+    def test_unknown_platform_has_a_clear_error(self):
+        catalog = load_config_catalog()
+        with self.assertRaisesRegex(ConfigCatalogError, "Unknown platform 'mi35x'"):
+            catalog.configurations_for("rccl_perf", "mi35x")
+
+    def test_catalog_rejects_missing_config_file(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            input_root = Path(temporary_directory)
+            catalog_path = input_root / "config_catalog.json"
+            catalog_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "configurations": [
+                            {"path": "rccl/missing.json", "platforms": ["all"], "suites": ["rccl_perf"]}
+                        ],
+                        "unavailable_suites": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigCatalogError, "does not exist"):
+                ConfigCatalog.from_input_roots([input_root])
+
+    def test_catalog_rejects_missing_suite_coverage(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            input_root = Path(temporary_directory)
+            config_path = input_root / "config_file" / "rccl" / "rccl_config.json"
+            config_path.parent.mkdir(parents=True)
+            config_path.write_text("{}", encoding="utf-8")
+            (input_root / "config_catalog.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "configurations": [
+                            {"path": "rccl/rccl_config.json", "platforms": ["all"], "suites": ["rccl_perf"]}
+                        ],
+                        "unavailable_suites": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            catalog = ConfigCatalog.from_input_roots([input_root])
+
+            with self.assertRaisesRegex(ConfigCatalogError, "missing suites"):
+                catalog.validate_suites({"rccl_perf", "rccl_regression"})
+
+    def test_catalog_rejects_unlisted_bundled_config(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            input_root = Path(temporary_directory)
+            for relative_path in ("rccl/rccl_config.json", "rccl/extra_config.json"):
+                config_path = input_root / "config_file" / relative_path
+                config_path.parent.mkdir(parents=True, exist_ok=True)
+                config_path.write_text("{}", encoding="utf-8")
+            (input_root / "config_catalog.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "configurations": [
+                            {"path": "rccl/rccl_config.json", "platforms": ["all"], "suites": ["rccl_perf"]}
+                        ],
+                        "unavailable_suites": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ConfigCatalogError, "missing config files"):
+                ConfigCatalog.from_input_roots([input_root])
+
+    def test_catalog_merges_optional_extension_catalog(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            core_input = Path(temporary_directory) / "core" / "input"
+            extension_input = Path(temporary_directory) / "extension" / "input"
+            for input_root, relative_path, suite in (
+                (core_input, "rccl/rccl_config.json", "rccl_perf"),
+                (extension_input, "health/health_config.json", "extension_health"),
+            ):
+                config_path = input_root / "config_file" / relative_path
+                config_path.parent.mkdir(parents=True, exist_ok=True)
+                config_path.write_text("{}", encoding="utf-8")
+                (input_root / "config_catalog.json").write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "configurations": [{"path": relative_path, "platforms": ["all"], "suites": [suite]}],
+                            "unavailable_suites": [],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            catalog = ConfigCatalog.from_input_roots([core_input, extension_input])
+
+        self.assertEqual(
+            [configuration.path for configuration in catalog.configurations],
+            ["rccl/rccl_config.json", "health/health_config.json"],
+        )


### PR DESCRIPTION
## Summary

- Add a versioned suite-to-config catalog covering every bundled config and runnable CVS suite.
- Support `cvs copy-config --list <suite> [--platform <platform>]`.
- Preserve directory-based config listing and exclude `conftest.py` from `cvs list`.

## Validation

- 34 focused catalog, copy-config, and list tests pass.
- Ruff, JSON catalog validation, and diff checks pass.
- The full unit suite is blocked by the existing missing `nodescraper` dependency in this environment.