### PR TITLE
 ANC installations relocatable

### DIFF
--- a/cvs/input/config_file/anc/anc_config.json
+++ b/cvs/input/config_file/anc/anc_config.json
@@ -16,6 +16,9 @@
         "_comment_anc_release_url": "URL of the ANC release archive to download and install. Flavour (deb/rpm/tar) is auto-detected from the filename.",
         "anc_release_url": "REPLACE_ME",
 
+        "_comment_ANC_INSTALL_PATH": "TAR installs ONLY: relocatable install prefix ANC is extracted into (its anc/ dir, tool folders, and content live under here). A leading '{home}' expands to the runner user's home directory (e.g. '/home/{id}/my/anc/install/path'); a leading '~' is also expanded. Applies exclusively to tar releases -- deb/rpm packages carry predefined absolute locations baked into their archive and IGNORE this key entirely. Leave blank or omit to keep the legacy default (/opt/amdtools).",
+        "ANC_INSTALL_PATH": "",
+
         "_comment_print_all_to_console": "'True' echoes ANC group output to the console; 'False' suppresses it (install/ldconfig/version diagnostics still print).",
         "print_all_to_console": "True",
 

--- a/cvs/input/config_file/anc/anc_config.json
+++ b/cvs/input/config_file/anc/anc_config.json
@@ -13,17 +13,17 @@
         "_comment_anc_version": "Expected ANC version. The install pre-task skips (re)installation when this version is already present on the node, and post-verifies the install matches.",
         "anc_version": "1.4.9",
 
-        "_comment_anc_release_url": "URL of the ANC release archive to download and install. Both packaging generations are supported and auto-detected from the filename: LEGACY (<=1.4.x) outer tarballs carry a '-deb-'/'-rpm-'/'-tar-' token (e.g. anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz); DIRECT (1.5.0+) URLs point straight at a '.deb'/'.rpm'/'.tar.gz' with no flavour token (e.g. anc-release-helios-nda-1.5.5-x86_64.tar.gz). When anc_version is set it must match the version in this URL or the run aborts before contacting any node.",
-        "anc_release_url": "REPLACE_ME",
+        "_comment_anc_release_url": "URL of the ANC release archive to download and install. Replace the placeholder changeme with the real URL before running. Both packaging generations are supported and auto-detected from the filename: LEGACY (<=1.4.x) outer tarballs carry a '-deb-'/'-rpm-'/'-tar-' token (e.g. anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz); DIRECT (1.5.0+) URLs point straight at a '.deb'/'.rpm'/'.tar.gz' with no flavour token (e.g. anc-release-helios-nda-1.5.5-x86_64.tar.gz). When anc_version is set it must match the version in this URL or the run aborts before contacting any node.",
+        "anc_release_url": "<changeme>",
 
-        "_comment_ANC_INSTALL_PATH": "TAR installs ONLY: relocatable install prefix ANC is extracted into (its anc/ dir, tool folders, and content live under here). A leading '{home}' expands to the runner user's home directory (e.g. '/home/{id}/my/anc/install/path'); a leading '~' is also expanded. Applies exclusively to tar releases -- deb/rpm packages carry predefined absolute locations baked into their archive and IGNORE this key entirely. Leave blank or omit to keep the legacy default (/opt/amdtools).",
+        "_comment_ANC_INSTALL_PATH": "TAR installs ONLY: relocatable install prefix ANC is extracted into (its anc/ dir, tool folders, and content live under here). A leading '{home}' expands to the runner user's home directory (e.g. '/home/{user-id}/my/anc/install/path'); a leading '~' is also expanded. Applies exclusively to tar releases -- deb/rpm packages carry predefined absolute locations baked into their archive and IGNORE this key entirely. Leave blank or omit to keep the legacy default (/opt/amdtools).",
         "ANC_INSTALL_PATH": "",
 
         "_comment_print_all_to_console": "'True' echoes ANC group output to the console; 'False' suppresses it (install/ldconfig/version diagnostics still print).",
         "print_all_to_console": "True",
 
-        "_comment_log_folder_path": "Controller-side destination PREFIX for ALL ANC artifacts (collected logs AND the auto-collected HTML report). Set it to a plain directory path (a leading '~' is expanded to your home directory) under which CVS lays down its own per-node/per-test/per-run folder structure. Required: replace 'REPLACE_ME' before running. To send the HTML report elsewhere, pass --html on the command line.",
-        "log_folder_path": "REPLACE_ME",
+        "_comment_log_folder_path": "Controller-side destination PREFIX for ALL ANC artifacts (collected logs AND the auto-collected HTML report). Set it to a plain directory path (a leading '~' is expanded to your home directory; '{home}'/'{user-id}' tokens are also resolved) under which CVS lays down its own per-node/per-test/per-run folder structure. Required: replace the placeholder changeme before running. To send the HTML report elsewhere, pass --html on the command line.",
+        "log_folder_path": "<changeme>",
 
         "_comment_ADD_ANC_LOGS_TO_HTML_REPORTS": "'True' always bundles the collected ANC log tree into the pytest-html report zip. 'False' (default) bundles it only when the test fails, so passing runs stay lean while failures always carry their logs.",
         "ADD_ANC_LOGS_TO_HTML_REPORTS": "False",

--- a/cvs/input/config_file/anc/anc_config.json
+++ b/cvs/input/config_file/anc/anc_config.json
@@ -13,7 +13,7 @@
         "_comment_anc_version": "Expected ANC version. The install pre-task skips (re)installation when this version is already present on the node, and post-verifies the install matches.",
         "anc_version": "1.4.9",
 
-        "_comment_anc_release_url": "URL of the ANC release archive to download and install. Flavour (deb/rpm/tar) is auto-detected from the filename.",
+        "_comment_anc_release_url": "URL of the ANC release archive to download and install. Both packaging generations are supported and auto-detected from the filename: LEGACY (<=1.4.x) outer tarballs carry a '-deb-'/'-rpm-'/'-tar-' token (e.g. anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz); DIRECT (1.5.0+) URLs point straight at a '.deb'/'.rpm'/'.tar.gz' with no flavour token (e.g. anc-release-helios-nda-1.5.5-x86_64.tar.gz). When anc_version is set it must match the version in this URL or the run aborts before contacting any node.",
         "anc_release_url": "REPLACE_ME",
 
         "_comment_ANC_INSTALL_PATH": "TAR installs ONLY: relocatable install prefix ANC is extracted into (its anc/ dir, tool folders, and content live under here). A leading '{home}' expands to the runner user's home directory (e.g. '/home/{id}/my/anc/install/path'); a leading '~' is also expanded. Applies exclusively to tar releases -- deb/rpm packages carry predefined absolute locations baked into their archive and IGNORE this key entirely. Leave blank or omit to keep the legacy default (/opt/amdtools).",

--- a/cvs/lib/anc_lib.py
+++ b/cvs/lib/anc_lib.py
@@ -44,10 +44,20 @@ from cvs.lib.run_config_paths import resolve_runner_results_base
 log = globals.log
 
 # --- Install locations ---------------------------------------------------
+# Default install prefix laid down by the deb/rpm packages and by a legacy tar
+# install. TAR installs may relocate elsewhere via config anc.ANC_INSTALL_PATH
+# (see resolve_anc_install_prefix); deb/rpm always use this fixed prefix because
+# their archives bake in absolute locations.
 ANC_TOOLS_PREFIX = "/opt/amdtools"
-# ANC directory and entrypoint laid down by the deb/rpm packages.
+# ANC directory and entrypoint at the DEFAULT prefix. Per-install paths (which
+# honour a relocated tar prefix) come from resolve_anc_paths, not these; these
+# remain the deb/rpm layout and the fallback when no relocation is configured.
 ANC_DIR = f"{ANC_TOOLS_PREFIX}/anc"
 ANC_BIN = f"{ANC_DIR}/anc.py"
+
+# config anc.ANC_INSTALL_PATH: TAR-ONLY relocatable install prefix. Blank/absent
+# -> ANC_TOOLS_PREFIX. deb/rpm ignore it entirely (fixed archive locations).
+ANC_INSTALL_PATH_KEY = "ANC_INSTALL_PATH"
 
 # validate_exe_paths.py ships beside the anc test suites.
 RESOURCES_DIR = os.path.join(
@@ -500,9 +510,69 @@ def detect_package_type(anc_release_url):
     )
 
 
-def node_version_matches(phdl, expected_version):
+# Install paths for one run: the prefix ANC is extracted under, plus the derived
+# anc/ dir and anc.py entrypoint. For deb/rpm these are always the fixed default
+# layout; for tar they honour a relocated config anc.ANC_INSTALL_PATH.
+AncPaths = namedtuple("AncPaths", ["prefix", "anc_dir", "anc_bin"])
+
+
+def resolve_anc_install_prefix(config_dict, pkg_type):
     '''
-    Query ``ANC_BIN --version`` on every node and report version matches.
+    Resolve the install PREFIX ANC is laid down under for this run.
+
+    Only tar installs are relocatable: when pkg_type == "tar" and config
+    anc.ANC_INSTALL_PATH is set to a non-blank value, that value (leading "~"
+    expanded; "{home}"/other tokens are already substituted by the config
+    placeholder pass in the ANC conftest) is the prefix. A blank/absent value,
+    or ANY deb/rpm install, resolves to the fixed ANC_TOOLS_PREFIX because those
+    packages carry predefined absolute locations baked into their archive.
+
+    The returned prefix is normalised to an absolute path with no trailing slash
+    so it composes cleanly into "<prefix>/anc/anc.py".
+    '''
+    prefix = ANC_TOOLS_PREFIX
+    if pkg_type == "tar":
+        raw = config_dict.get("anc", {}).get(ANC_INSTALL_PATH_KEY)
+        if raw and str(raw).strip():
+            prefix = os.path.expanduser(str(raw).strip())
+    return os.path.abspath(prefix)
+
+
+def resolve_anc_paths(config_dict, pkg_type):
+    '''
+    Build the AncPaths (prefix, anc_dir, anc_bin) for this install flavour.
+
+    anc_dir is "<prefix>/anc" and anc_bin is "<prefix>/anc/anc.py", mirroring the
+    layout the release archives lay down under any prefix.
+    '''
+    prefix = resolve_anc_install_prefix(config_dict, pkg_type)
+    anc_dir = f"{prefix}/anc"
+    return AncPaths(prefix=prefix, anc_dir=anc_dir, anc_bin=f"{anc_dir}/anc.py")
+
+
+def resolve_anc_paths_from_config(config_dict):
+    '''
+    Resolve AncPaths from config alone, detecting the package flavour from
+    anc.anc_release_url. Used by run-time consumers (version check, group run,
+    ldconfig-independent path lookups) that need the live install location
+    without re-passing pkg_type. Falls back to the default prefix if the URL is
+    missing or its flavour cannot be determined.
+    '''
+    url = config_dict.get("anc", {}).get("anc_release_url") or ""
+    try:
+        pkg_type = detect_package_type(url) if url and str(url).strip() else ""
+    except ValueError:
+        pkg_type = ""
+    return resolve_anc_paths(config_dict, pkg_type)
+
+
+def node_version_matches(phdl, expected_version, anc_bin=ANC_BIN):
+    '''
+    Query ``<anc_bin> --version`` on every node and report version matches.
+
+    ``anc_bin`` is the anc.py entrypoint path; it defaults to the fixed-prefix
+    ANC_BIN but callers pass the per-install path (which may be a relocated tar
+    prefix) so a version check hits the location ANC was actually installed to.
 
     The version is matched as a whole token (bounded by non-version characters),
     not a substring, so expecting "1.4.7" does NOT match "1.4.70" or "1.4.7-rc".
@@ -512,7 +582,7 @@ def node_version_matches(phdl, expected_version):
       standalone version token in the node's ``anc.py --version`` output (False
       if ANC is absent or reports a different version).
     '''
-    out_dict = phdl.exec(f"{ANC_BIN} --version 2>&1 || true", timeout=60)
+    out_dict = phdl.exec(f"{anc_bin} --version 2>&1 || true", timeout=60)
     print_test_output(log, out_dict)
     # Boundaries are any char that isn't part of a version token (digits, dots,
     # hyphens, alphanumerics) so "1.4.7" won't match inside "1.4.70"/"1.4.7-rc".
@@ -548,6 +618,13 @@ def install_anc(phdl, cluster_dict, config_dict):
     pkg_type = detect_package_type(anc_release_url)
     log.info("ANC package type detected from archive: %s", pkg_type)
 
+    # Per-install paths: tar honours a relocated anc.ANC_INSTALL_PATH; deb/rpm
+    # always resolve to the fixed default prefix. The version prechecks and
+    # post-verify below query anc.py at this resolved location so a relocated
+    # tar install is detected/verified where it actually lives.
+    paths = resolve_anc_paths(config_dict, pkg_type)
+    log.info("ANC install prefix for this run: %s (anc.py -> %s)", paths.prefix, paths.anc_bin)
+
     expected = _expected_nodes(cluster_dict)
 
     # Precheck: skip install only when EVERY expected node already runs the
@@ -555,7 +632,7 @@ def install_anc(phdl, cluster_dict, config_dict):
     # == None -> falsy, so we never skip on incomplete coverage.
     if anc_version:
         log.info("ANC precheck: expecting version %s", anc_version)
-        matches = node_version_matches(phdl, anc_version)
+        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin)
         if expected and all(matches.get(host) for host in expected):
             log.info(
                 "ANC %s already installed on all nodes; skipping install",
@@ -585,7 +662,7 @@ def install_anc(phdl, cluster_dict, config_dict):
     # detail focused).
     if anc_version and not globals.error_list:
         log.info("ANC final verification: expecting version %s", anc_version)
-        matches = node_version_matches(phdl, anc_version)
+        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin)
         for host in expected:
             if host not in matches:
                 fail_test(
@@ -595,7 +672,7 @@ def install_anc(phdl, cluster_dict, config_dict):
                 log.info("Node %s: ANC version %s confirmed", host, anc_version)
             else:
                 fail_test(
-                    f"ANC version verification failed on {host}: expected {anc_version} from '{ANC_BIN} --version'"
+                    f"ANC version verification failed on {host}: expected {anc_version} from '{paths.anc_bin} --version'"
                 )
 
     update_test_result()
@@ -723,6 +800,26 @@ def _install_anc_deb(phdl, cluster_dict, config_dict):
     _fail_unreachable_nodes(cluster_dict, out_dict, ".deb install")
 
 
+def _sudo_prefix_snippet(prefix):
+    '''
+    Build a shell snippet that sets ``SUDO`` to "sudo" or "" for writing under
+    ``prefix``, honouring the "auto: sudo only if not writable" policy.
+
+    We cannot test the (not-yet-existing) prefix directly, so walk up to its
+    deepest EXISTING ancestor and test whether THAT is writable by the current
+    user. A user-writable ancestor (e.g. the home dir for a relocated install)
+    means we can mkdir/extract without sudo, so files land user-owned and can be
+    cleaned up later without root. A non-writable ancestor (e.g. /opt) selects
+    sudo. The result is exported as ``$SUDO`` for the extract/rewrite commands.
+    '''
+    return (
+        f"probe='{prefix}'; "
+        f"while [ ! -e \"$probe\" ] && [ \"$probe\" != '/' ]; do probe=$(dirname \"$probe\"); done; "
+        f"if [ -w \"$probe\" ]; then SUDO=''; else SUDO='sudo'; fi; "
+        f"echo \"ANC install: prefix '{prefix}' -> $( [ -n \"$SUDO\" ] && echo 'sudo' || echo 'no-sudo (user-writable)' )\""
+    )
+
+
 def _install_anc_tar(phdl, cluster_dict, config_dict):
     '''
     Install ANC from the tar release on remote nodes (fresh install each run).
@@ -733,10 +830,24 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
         ccx_tests, computerocker, difect, firexs2, maxcorestim, maxiostim,
         memrocker, miidct, mithac, rvs, transferbench)
 
-    Extracting BOTH into ``ANC_TOOLS_PREFIX`` (/opt/amdtools) reproduces exactly
-    the layout the deb/rpm packages install, so ANC ends up at ``ANC_BIN``
-    (/opt/amdtools/anc/anc.py) and the content YAMLs' hard-coded
-    ``exe_path: /opt/amdtools/...`` entries resolve.
+    Install PREFIX is relocatable (config anc.ANC_INSTALL_PATH): tar releases are
+    the ONLY relocatable flavour, because deb/rpm packages bake absolute paths
+    into their archive. A blank/absent ANC_INSTALL_PATH keeps the legacy default
+    (/opt/amdtools). Extracting BOTH inner tarballs into ``<prefix>`` reproduces
+    the deb/rpm layout under that prefix, so ANC ends up at ``<prefix>/anc/anc.py``.
+
+    The content YAMLs ship absolute ``exe_path: /opt/amdtools/<tool>`` entries.
+    When the prefix is relocated, those entries would point at the old location,
+    so after extraction every ``exe_path`` under ``<prefix>/anc/content`` is
+    rewritten from ``/opt/amdtools`` to ``<prefix>`` (relative entries like
+    ``./exe`` and system entries like ``/usr/bin`` are untouched because the
+    substitution only rewrites strings containing ``/opt/amdtools``).
+
+    sudo policy (auto): extraction and the exe_path rewrite use sudo ONLY when
+    the prefix's deepest existing ancestor is not user-writable (e.g. /opt). A
+    user-writable prefix (a home-dir install) is extracted WITHOUT sudo so the
+    tree is user-owned. Running ANC itself always uses sudo regardless (hardware
+    access), so passwordless sudo is still required to run the groups.
 
     Algorithm (per node):
       1. Download the outer archive into a private ``mktemp -d`` staging dir. A
@@ -744,28 +855,40 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
          the ~1.3 GB of archives never linger.
       2. Extract the outer archive to expose the two inner tarballs, derive the
          set of TOP-LEVEL folders they provide, and ``rm -rf`` each of those
-         under /opt/amdtools so the install is clean (a stale file removed in a
+         under ``<prefix>`` so the install is clean (a stale file removed in a
          new release does not survive as an overlaid leftover). Only the folders
-         the release actually ships are touched; unrelated /opt/amdtools content
-         is left alone.
-      3. Extract both inner tarballs into /opt/amdtools. The top-level folders
-         are thus replaced wholesale; the files inside arrange themselves from
-         the archive. ``content/base`` (a no_op placeholder) is kept, matching
-         the deb/rpm install.
-
-    Extraction into /opt/amdtools needs sudo, so the runner must have
-    passwordless sudo (already required to run ANC).
+         the release actually ships are touched; unrelated content is left alone.
+      3. Extract both inner tarballs into ``<prefix>``, then rewrite exe_path
+         entries if relocated.
 
     Records failures via fail_test; the caller (install_anc) owns the single
     update_test_result reporting call.
     '''
     anc_cfg = config_dict["anc"]
     anc_release_url = anc_cfg["anc_release_url"]
+    paths = resolve_anc_paths(config_dict, "tar")
+    prefix = paths.prefix
+    anc_bin = paths.anc_bin
+    content_dir = f"{paths.anc_dir}/content"
+    relocated = prefix != ANC_TOOLS_PREFIX
 
-    log.info("ANC: install tar release on remote nodes (staging=mktemp temp dir, install prefix=%s)", ANC_TOOLS_PREFIX)
+    log.info("ANC: install tar release on remote nodes (staging=mktemp temp dir, install prefix=%s)", prefix)
+
+    # Rewrite exe_path entries only when relocated (a default-prefix install
+    # keeps the archive's own /opt/amdtools entries). The substitution targets
+    # content YAMLs and only rewrites the /opt/amdtools token, leaving relative
+    # (./exe) and system (/usr/bin) exe_path values intact.
+    rewrite_snippet = ""
+    if relocated:
+        rewrite_snippet = (
+            f"echo 'Rewriting exe_path entries {ANC_TOOLS_PREFIX} -> {prefix}...'; "
+            f"$SUDO find '{content_dir}' -type f \\( -name '*.yml' -o -name '*.yaml' \\) "
+            f"-exec sed -i 's#{ANC_TOOLS_PREFIX}#{prefix}#g' {{}} +; "
+        )
 
     install_cmd = (
         f"set -e; "
+        f"{_sudo_prefix_snippet(prefix)}; "
         # Private staging dir; trap removes it on success AND failure so the
         # large download/unpack never leaks onto the node.
         f"STAGE=$(mktemp -d); "
@@ -780,17 +903,18 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
         f"echo 'Determining top-level tool folders...'; "
         f"tops=$( {{ tar -tzf anc-tool*.tar.gz; tar -tzf anc-content*.tar.gz; }} "
         f"| sed 's#^\\./##' | awk -F/ '{{print $1}}' | grep -vE '^[.]?$' | sort -u ); "
-        f"sudo mkdir -p '{ANC_TOOLS_PREFIX}'; "
-        f"echo 'Replacing top-level folders under {ANC_TOOLS_PREFIX}...'; "
-        f"for name in $tops; do echo \"  {ANC_TOOLS_PREFIX}/$name\"; sudo rm -rf \"{ANC_TOOLS_PREFIX}/$name\"; done; "
-        f"echo 'Extracting anc-tool archive to {ANC_TOOLS_PREFIX}...'; "
-        f"sudo tar -xzf anc-tool*.tar.gz -C '{ANC_TOOLS_PREFIX}'; "
-        f"echo 'Extracting anc-content archive to {ANC_TOOLS_PREFIX}...'; "
-        f"sudo tar -xzf anc-content*.tar.gz -C '{ANC_TOOLS_PREFIX}'; "
+        f"$SUDO mkdir -p '{prefix}'; "
+        f"echo 'Replacing top-level folders under {prefix}...'; "
+        f"for name in $tops; do echo \"  {prefix}/$name\"; $SUDO rm -rf \"{prefix}/$name\"; done; "
+        f"echo 'Extracting anc-tool archive to {prefix}...'; "
+        f"$SUDO tar -xzf anc-tool*.tar.gz -C '{prefix}'; "
+        f"echo 'Extracting anc-content archive to {prefix}...'; "
+        f"$SUDO tar -xzf anc-content*.tar.gz -C '{prefix}'; "
+        f"{rewrite_snippet}"
         f"echo '--- Installed top-level tools ---'; "
-        f"ls '{ANC_TOOLS_PREFIX}' | sort; "
+        f"ls '{prefix}' | sort; "
         f"echo '--- Verification ---'; "
-        f"test -f '{ANC_BIN}' && echo 'ANC_INSTALL_SUCCESS'"
+        f"test -f '{anc_bin}' && echo 'ANC_INSTALL_SUCCESS'"
     )
 
     out_dict = phdl.exec(install_cmd, timeout=_install_timeout(anc_cfg))
@@ -798,9 +922,7 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
 
     for host, output in out_dict.items():
         if "ANC_INSTALL_SUCCESS" not in output:
-            fail_test(
-                f"ANC installation failed on {host}: '{ANC_BIN}' not found after extracting into {ANC_TOOLS_PREFIX}"
-            )
+            fail_test(f"ANC installation failed on {host}: '{anc_bin}' not found after extracting into {prefix}")
         else:
             log.info("Node %s: ANC directory installed successfully", host)
 
@@ -812,7 +934,6 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
         return
 
     # Validate exe_path entries with the bundled script.
-    content_dir = f"{ANC_DIR}/content"
     local_script = os.path.join(RESOURCES_DIR, "validate_exe_paths.py")
     remote_script = "/tmp/validate_exe_paths.py"
 
@@ -934,20 +1055,24 @@ def _anc_installed(phdl, cluster_dict, config_dict):
     '''
     Report whether ANC is already installed on every expected node.
 
+    "Installed" is judged at the per-install anc.py location (a relocated tar
+    prefix when configured, else the default), so a run configured for a new
+    prefix does not treat a leftover install at the old location as present.
     When ``anc.anc_version`` is set, "installed" means every node reports that
-    version (reuses ``node_version_matches``). Otherwise "installed" means
-    ``ANC_BIN`` is present on every node.
+    version there; otherwise it means that anc.py is present on every node.
     '''
     expected = _expected_nodes(cluster_dict)
     if not expected:
         return False
 
+    paths = resolve_anc_paths_from_config(config_dict)
+
     anc_version = config_dict.get("anc", {}).get("anc_version")
     if anc_version:
-        matches = node_version_matches(phdl, anc_version)
+        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin)
         return all(matches.get(host) for host in expected)
 
-    out_dict = phdl.exec(f"test -f '{ANC_BIN}' && echo ANC_PRESENT || true", timeout=60)
+    out_dict = phdl.exec(f"test -f '{paths.anc_bin}' && echo ANC_PRESENT || true", timeout=60)
     return all("ANC_PRESENT" in (out_dict.get(host) or "") for host in expected)
 
 
@@ -1391,6 +1516,10 @@ def run_anc_groups(phdl, cluster_dict, config_dict, groups, test_name, request=N
     globals.error_list = []
 
     anc_cfg = config_dict["anc"]
+    # anc.py lives under the per-install prefix (a relocated tar prefix when
+    # configured, else the default), so the group run cd's to where ANC actually
+    # installed rather than the fixed default dir.
+    anc_dir = resolve_anc_paths_from_config(config_dict).anc_dir
     inactivity_timeout = anc_cfg.get(INACTIVITY_TIMEOUT_KEY, DEFAULT_ANC_INACTIVITY_TIMEOUT)
     print_all = _as_bool(anc_cfg.get(PRINT_ALL_TO_CONSOLE_KEY), default=True)
     timestamp = new_run_timestamp()
@@ -1411,7 +1540,7 @@ def run_anc_groups(phdl, cluster_dict, config_dict, groups, test_name, request=N
         # Run ANC normally so its full output streams back, and print it. ANC's
         # own progress lines keep the SSH channel active, which continually
         # resets the inactivity timer (only a genuine stall trips it).
-        cmd = f"cd '{ANC_DIR}' && sudo ./anc.py -g {groups_arg}"
+        cmd = f"cd '{anc_dir}' && sudo ./anc.py -g {groups_arg}"
     else:
         # Suppress the (potentially huge) ANC output: redirect stdout/stderr to
         # a per-run file on the node and echo ONLY the "Log directory:" line.
@@ -1428,7 +1557,7 @@ def run_anc_groups(phdl, cluster_dict, config_dict, groups, test_name, request=N
         # first output, which would otherwise look like silence).
         remote_stdout = "/tmp/anc_run_$$.out"
         cmd = (
-            f"cd '{ANC_DIR}' && "
+            f"cd '{anc_dir}' && "
             f"( sudo ./anc.py -g {groups_arg} > '{remote_stdout}' 2>&1 ) & "
             f"anc_pid=$! && "
             f"last=-1; "

--- a/cvs/lib/anc_lib.py
+++ b/cvs/lib/anc_lib.py
@@ -664,22 +664,78 @@ def resolve_anc_paths_from_config(config_dict):
     return resolve_anc_paths(config_dict, pkg_type)
 
 
-def node_version_matches(phdl, expected_version, anc_bin=ANC_BIN):
+# The release-content plugin line in ``anc.py --content-list`` output (DIRECT
+# 1.5.0+ packaging only), e.g.
+#   "  anc-release-helios-nda    1.5.5   Helios NDA Release"
+# The plugin name starts with ``anc-release-`` and its MIDDLE column is the
+# release version, which tracks the archive version. Legacy (<=1.4.x)
+# --content-list has no version column and no anc-release-* plugin at all, so
+# this pattern deliberately never matches there (legacy uses --version instead).
+ANC_RELEASE_PLUGIN_RE = re.compile(
+    r"^\s*anc-release-\S+\s+(\d+\.\d+(?:\.\d+)*)\b",
+    re.MULTILINE,
+)
+
+
+def parse_release_version_from_content_list(output):
     '''
-    Query ``<anc_bin> --version`` on every node and report version matches.
+    Extract the release version from ``anc.py --content-list`` output (DIRECT
+    1.5.0+ packaging), or None.
+
+    The 1.5.0+ content list is a three-column "Name Version Description" table
+    with a dedicated ``anc-release-<product>`` plugin whose MIDDLE column is the
+    release version (it tracks the installed archive version). This reads that
+    version because ``anc.py --version`` is unreliable on 1.5.0+ (reports the
+    tool version, not the release). Returns None when no ``anc-release-*`` line
+    is present (e.g. legacy <=1.4.x output, which has neither the column nor the
+    plugin).
+    '''
+    match = ANC_RELEASE_PLUGIN_RE.search(output or "")
+    return match.group(1) if match else None
+
+
+def node_release_versions(phdl, anc_bin=ANC_BIN):
+    '''
+    Query ``<anc_bin> --content-list`` on every node and return the parsed
+    release version per host (DIRECT 1.5.0+ packaging).
+
+    Returns:
+      dict[str, str | None]: host -> release version parsed from the
+      ``anc-release-*`` plugin line, or None when ANC is absent, the node is
+      unreachable to the parse, or the output carries no such line.
+    '''
+    out_dict = phdl.exec(f"{anc_bin} --content-list 2>&1 || true", timeout=120)
+    print_test_output(log, out_dict)
+    return {host: parse_release_version_from_content_list(output) for host, output in out_dict.items()}
+
+
+def node_version_matches(phdl, expected_version, anc_bin=ANC_BIN, is_direct=False):
+    '''
+    Query ANC on every node and report which nodes report ``expected_version``.
+
+    Mechanism depends on packaging generation:
+      - DIRECT (1.5.0+, ``is_direct=True``): parse ``<anc_bin> --content-list``
+        and compare the ``anc-release-*`` plugin's version column, because
+        ``anc.py --version`` on 1.5.0+ reports the tool version, not the release.
+      - LEGACY (<=1.4.x, ``is_direct=False``): match ``<anc_bin> --version``
+        output, whose version IS the release version there.
 
     ``anc_bin`` is the anc.py entrypoint path; it defaults to the fixed-prefix
     ANC_BIN but callers pass the per-install path (which may be a relocated tar
-    prefix) so a version check hits the location ANC was actually installed to.
+    prefix) so the check hits the location ANC was actually installed to.
 
-    The version is matched as a whole token (bounded by non-version characters),
+    DIRECT compares the parsed version by exact equality. LEGACY matches
+    ``--version`` output as a whole token (bounded by non-version characters),
     not a substring, so expecting "1.4.7" does NOT match "1.4.70" or "1.4.7-rc".
 
     Returns:
-      dict[str, bool]: host -> True when ``expected_version`` appears as a
-      standalone version token in the node's ``anc.py --version`` output (False
-      if ANC is absent or reports a different version).
+      dict[str, bool]: host -> True when the node reports ``expected_version``
+      (False if ANC is absent or reports a different version).
     '''
+    if is_direct:
+        parsed = node_release_versions(phdl, anc_bin=anc_bin)
+        return {host: version == expected_version for host, version in parsed.items()}
+
     out_dict = phdl.exec(f"{anc_bin} --version 2>&1 || true", timeout=60)
     print_test_output(log, out_dict)
     # Boundaries are any char that isn't part of a version token (digits, dots,
@@ -695,9 +751,12 @@ def install_anc(phdl, cluster_dict, config_dict):
     The packaging kind is inferred from the ``anc_release_url`` archive name
     (``-deb-`` / ``-rpm-`` / ``-tar-``) and the matching installer is invoked.
     When ``anc_version`` is set in config, a precheck runs first: install is
-    skipped ONLY if every expected node already reports that version via
-    ``anc.py --version``. After installing, the same version check runs as the
-    final step to confirm the target version is present on all nodes.
+    skipped ONLY if every expected node already reports that version. After
+    installing, the same version check runs as the final step to confirm the
+    target version is present on all nodes. The version is read via
+    ``anc.py --content-list`` (the ``anc-release-*`` plugin's version column) for
+    DIRECT 1.5.0+ packaging, and via ``anc.py --version`` for legacy <=1.4.x
+    (whose ``--version`` reports the release version; 1.5.0+ does not).
 
     Node coverage: ``phdl.exec`` returns only reachable hosts, so any expected
     node (from ``cluster_dict["node_dict"]``) that is unreachable is treated as
@@ -735,7 +794,7 @@ def install_anc(phdl, cluster_dict, config_dict):
     # == None -> falsy, so we never skip on incomplete coverage.
     if anc_version:
         log.info("ANC precheck: expecting version %s", anc_version)
-        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin)
+        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin, is_direct=flavour.is_direct)
         if expected and all(matches.get(host) for host in expected):
             log.info(
                 "ANC %s already installed on all nodes; skipping install",
@@ -774,7 +833,8 @@ def install_anc(phdl, cluster_dict, config_dict):
     # detail focused).
     if anc_version and not globals.error_list:
         log.info("ANC final verification: expecting version %s", anc_version)
-        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin)
+        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin, is_direct=flavour.is_direct)
+        verify_source = "--content-list" if flavour.is_direct else "--version"
         for host in expected:
             if host not in matches:
                 fail_test(
@@ -784,7 +844,7 @@ def install_anc(phdl, cluster_dict, config_dict):
                 log.info("Node %s: ANC version %s confirmed", host, anc_version)
             else:
                 fail_test(
-                    f"ANC version verification failed on {host}: expected {anc_version} from '{paths.anc_bin} --version'"
+                    f"ANC version verification failed on {host}: expected {anc_version} from '{paths.anc_bin} {verify_source}'"
                 )
 
     update_test_result()
@@ -1421,7 +1481,8 @@ def _anc_installed(phdl, cluster_dict, config_dict):
     prefix when configured, else the default), so a run configured for a new
     prefix does not treat a leftover install at the old location as present.
     When ``anc.anc_version`` is set, "installed" means every node reports that
-    version there; otherwise it means that anc.py is present on every node.
+    version there (via --content-list for DIRECT 1.5.0+, --version for legacy);
+    otherwise it means that anc.py is present on every node.
     '''
     expected = _expected_nodes(cluster_dict)
     if not expected:
@@ -1431,7 +1492,12 @@ def _anc_installed(phdl, cluster_dict, config_dict):
 
     anc_version = config_dict.get("anc", {}).get("anc_version")
     if anc_version:
-        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin)
+        url = config_dict.get("anc", {}).get("anc_release_url") or ""
+        try:
+            is_direct = detect_package_flavour(url).is_direct if url and str(url).strip() else False
+        except ValueError:
+            is_direct = False
+        matches = node_version_matches(phdl, anc_version, anc_bin=paths.anc_bin, is_direct=is_direct)
         return all(matches.get(host) for host in expected)
 
     out_dict = phdl.exec(f"test -f '{paths.anc_bin}' && echo ANC_PRESENT || true", timeout=60)

--- a/cvs/lib/anc_lib.py
+++ b/cvs/lib/anc_lib.py
@@ -138,10 +138,6 @@ ERRORS_JSON = "errors.json"
 # diagnostics always print. Default: print everything.
 PRINT_ALL_TO_CONSOLE_KEY = "print_all_to_console"
 
-# Sentinel a user must overwrite in the config before running. Values left at
-# this literal are treated as "unset" and fail the run with a clear message.
-REPLACE_ME_SENTINEL = "REPLACE_ME"
-
 # config anc.log_folder_path is the single user-supplied PREFIX directory for all
 # ANC artifacts (collected logs AND the HTML report). The fixed layout appended
 # under it is owned by the code (below), not the config: the config just says
@@ -223,47 +219,18 @@ def cluster_node_label_from_file(cluster_dict):
 def _prefix_problem(config_dict, key):
     '''
     Return a human-readable problem string if config anc.<key> is not a usable
-    path prefix (missing, blank, or still the REPLACE_ME sentinel), else None.
+    path prefix (missing or blank), else None.
 
-    Used both by the fail-fast fixture check (validate_anc_path_prefixes) and by
-    _resolve_prefix so the two agree on what "unset" means.
+    The ``<changeme>`` placeholder is caught earlier and globally by the standard
+    config resolver (_resolve_placeholders_in_dict hard-exits on it), so it does
+    not need handling here. Used both by the fail-fast fixture check
+    (validate_anc_path_prefixes) and by _resolve_prefix so the two agree on what
+    "unset" means.
     '''
     prefix = config_dict.get("anc", {}).get(key)
-    if not prefix or not str(prefix).strip() or str(prefix).strip() == REPLACE_ME_SENTINEL:
-        return (
-            f'config anc.{key} is unset (still "{REPLACE_ME_SENTINEL}"); set it to the '
-            f"directory prefix where ANC artifacts should be written"
-        )
+    if not prefix or not str(prefix).strip():
+        return f"config anc.{key} is unset; set it to the directory prefix where ANC artifacts should be written"
     return None
-
-
-def find_replace_me_placeholders(config, _path=""):
-    '''
-    Recursively scan a loaded config for any value still left at the REPLACE_ME
-    sentinel and return a sorted list of dotted paths to them (empty when none).
-
-    Documentation keys (those whose name starts with "_comment") are skipped:
-    the shipped config's own "_comment_*" strings literally say
-    'replace "REPLACE_ME" before running', which are instructions, not unset
-    values. Only an exact value match (after stripping) counts, so a longer
-    string that merely mentions REPLACE_ME is not flagged.
-
-    Used by the ANC conftest to abort the whole run up front when ANY required
-    field is still a placeholder, instead of failing partway through.
-    '''
-    found = []
-    if isinstance(config, dict):
-        for key, value in config.items():
-            if isinstance(key, str) and key.startswith("_comment"):
-                continue
-            child_path = f"{_path}.{key}" if _path else str(key)
-            found.extend(find_replace_me_placeholders(value, child_path))
-    elif isinstance(config, list):
-        for idx, value in enumerate(config):
-            found.extend(find_replace_me_placeholders(value, f"{_path}[{idx}]"))
-    elif isinstance(config, str) and config.strip() == REPLACE_ME_SENTINEL:
-        found.append(_path)
-    return sorted(found)
 
 
 def validate_anc_path_prefixes(config_dict):
@@ -271,30 +238,23 @@ def validate_anc_path_prefixes(config_dict):
     Validate the ANC path prefix up front, before any ANC command runs. Returns a
     list of problem strings (empty when set).
 
-    Only anc.log_folder_path is checked here, and only for the MISSING/BLANK case:
-    it is the single prefix for all ANC artifacts (collected logs and the derived
-    HTML report). The REPLACE_ME sentinel is caught separately and more broadly by
-    find_replace_me_placeholders, so it is deliberately excluded here to avoid
-    reporting the same field twice.
+    Only anc.log_folder_path is checked here, for the MISSING/BLANK case: it is
+    the single prefix for all ANC artifacts (collected logs and the derived HTML
+    report). The ``<changeme>`` placeholder is caught earlier by the standard
+    config resolver, so only the empty/unset case remains for this check.
     '''
-    prefix = config_dict.get("anc", {}).get(LOG_FOLDER_PATH_KEY)
-    if not prefix or not str(prefix).strip():
-        return [
-            f"config anc.{LOG_FOLDER_PATH_KEY} is not set; set it to the directory "
-            f"prefix where ANC artifacts should be written"
-        ]
-    return []
+    return [p for p in (_prefix_problem(config_dict, LOG_FOLDER_PATH_KEY),) if p]
 
 
 def _resolve_prefix(config_dict, key):
     '''
     Read a user-supplied prefix directory from config anc.<key> and normalise it.
 
-    The prefix is a plain filesystem path (leading "~" expanded); it does NOT
-    accept "{home}"/"{runner_log_folder}" tokens -- only the fixed suffix the
-    code owns carries "<node>"/"<test_name>"/"<timestamp>". A missing prefix or
-    one still left at the REPLACE_ME sentinel RAISES ValueError so a bad config
-    can never silently resolve to a path containing the literal sentinel. The
+    The prefix is a plain filesystem path (leading "~" expanded); "{home}"/
+    "{user-id}" tokens are already substituted by the config placeholder pass in
+    the ANC conftest, and only the fixed suffix the code owns carries
+    "<node>"/"<test_name>"/"<timestamp>". A missing or blank prefix RAISES
+    ValueError so a bad config can never silently resolve to a garbage path. The
     fail-fast fixture (validate_anc_path_prefixes) normally catches this first;
     this raise is the last-line guard for any direct caller.
     '''
@@ -446,24 +406,92 @@ LDCONFIG_TARGET_LIB = "librocblas"
 # =========================================================================
 # Package installation
 # =========================================================================
+# Characters that make a config value unsafe to interpolate into the remote
+# shell strings the installers build. A single quote breaks single-quoted
+# interpolations; a double quote, backtick, ``$`` or backslash can be expanded
+# or command-substituted inside a DOUBLE-quoted interpolation (e.g. the
+# ``"<prefix>/$name"`` rm target); a newline splits the command. Config is
+# trusted, so rather than shell-escape everywhere we reject these at the
+# boundary and fail fast with a clear message.
+SHELL_UNSAFE_CHARS = ("'", '"', "`", "$", "\\", "\n")
+
+
 def _assert_shell_safe(anc_cfg, keys):
     '''
-    Reject config values that would break the single-quoted remote shell strings.
+    Reject config values that would break or subvert the remote shell strings.
 
-    The install commands wrap config values (anc_release_url, ...) in single
-    quotes when interpolating them into the remote command. A value that itself
-    contains a single quote would break that quoting. Config is trusted, so
-    rather than shell-escape everywhere we validate at this boundary and fail
-    fast with a clear message.
+    The install commands interpolate config values (anc_release_url,
+    ANC_INSTALL_PATH, ...) into the remote command, both inside single quotes
+    (which only a ``'`` breaks) and inside double quotes (where ``$``/backtick/
+    ``\\`` still expand). A value containing any SHELL_UNSAFE_CHARS is rejected
+    here so it can never reach the shell verbatim.
     '''
     for key in keys:
         value = anc_cfg.get(key)
-        if value is not None and "'" in str(value):
+        if value is None:
+            continue
+        text = str(value)
+        bad = [c for c in SHELL_UNSAFE_CHARS if c in text]
+        if bad:
+            shown = ", ".join(repr(c) for c in bad)
             raise ValueError(
-                f"ANC config value {key}={value!r} contains a single quote, "
-                f"which is not supported (it would break the remote shell "
-                f"command quoting). Remove the quote from the value."
+                f"ANC config value {key}={value!r} contains unsafe shell "
+                f"character(s) {shown}, which are not supported (they would break "
+                f"or subvert the remote shell command). Remove them from the value."
             )
+
+
+def validate_cluster_username(cluster_dict):
+    '''
+    Return a problem string if the cluster file's ``username`` is unsafe to
+    interpolate into remote shell commands, else None.
+
+    The username comes from the cluster file (not the anc config), so it never
+    passes through _assert_shell_safe, yet it is interpolated into remote
+    commands (e.g. the ``sudo chown <user>`` in _pull_log_dir). A value with a
+    space would split into two chown args; one with shell metacharacters could
+    inject a command under sudo. Validate it at the fixture boundary. An
+    empty/missing username is left to the connection layer to report.
+    '''
+    username = cluster_dict.get("username")
+    if username is None or not str(username).strip():
+        return None
+    text = str(username)
+    bad = [c for c in SHELL_UNSAFE_CHARS + (" ", "\t") if c in text]
+    if bad:
+        shown = ", ".join(repr(c) for c in bad)
+        return (
+            f"cluster file username={username!r} contains unsafe character(s) {shown}; "
+            f"ANC interpolates the username into remote shell commands (e.g. chown), "
+            f"so it must be a plain user name"
+        )
+    return None
+
+
+def _remote_user_tmp(user):
+    '''
+    Return a per-user remote temp DIRECTORY (``/tmp/<user>``) for ANC scratch
+    files, so concurrent users running ANC on the same node do not collide on a
+    shared, fixed-name path they cannot overwrite (another user's root/other
+    ownership under /tmp/<file> would raise a permission error). Callers are
+    responsible for ``mkdir -p`` before writing. The user is sanitised to a
+    single safe path component.
+    '''
+    return f"/tmp/{_sanitize_path_component(str(user))}"
+
+
+def _sed_replacement_safe(value):
+    '''
+    Escape a string for safe use as the REPLACEMENT half of ``sed 's#...#REPL#g'``.
+
+    ``#`` is our sed delimiter and ``&`` means "the whole match" in a sed
+    replacement, so an unescaped one in the install prefix would break the
+    expression or silently corrupt the rewritten exe_path. Backslash is escaped
+    first so we do not double-escape the escapes we add. (Shell-unsafe
+    characters are rejected earlier by _assert_shell_safe; this guards the
+    sed-specific metacharacters that are legal in a filesystem path.)
+    '''
+    return value.replace("\\", "\\\\").replace("&", "\\&").replace("#", "\\#")
 
 
 def _expected_nodes(cluster_dict):
@@ -608,6 +636,55 @@ def check_version_matches_url(config_dict):
     return None
 
 
+def validate_anc_config(config_dict, cluster_dict, require_log_folder):
+    '''
+    Collect all fail-fast ANC config problems, before any node is contacted.
+
+    Returns a list of human-readable problem strings (empty when the config is
+    usable). The caller (the ANC conftest fixture) aborts the run if non-empty,
+    so a bad config costs seconds instead of a partial run on the cluster. The
+    ``<changeme>`` placeholder is caught even earlier by the standard resolver;
+    this covers the checks that resolver does not:
+
+      - anc.anc_release_url present and non-blank (an empty URL would otherwise
+        crash install_anc with an uncaught error);
+      - anc.anc_version, when set, matches the version in the URL;
+      - anc.ANC_INSTALL_PATH resolves to a safe, non-root prefix (the shell-safe
+        + non-root guards in resolve_anc_install_prefix are surfaced here as a
+        clean message rather than a mid-run traceback);
+      - the cluster username is safe to interpolate into remote commands;
+      - anc.log_folder_path is set for the group suites (require_log_folder).
+    '''
+    problems = []
+
+    anc_cfg = config_dict.get("anc", {}) or {}
+    url = anc_cfg.get("anc_release_url")
+    if not url or not str(url).strip():
+        problems.append("config anc.anc_release_url is not set; set it to the ANC release archive URL")
+
+    version_problem = check_version_matches_url(config_dict)
+    if version_problem:
+        problems.append(version_problem)
+
+    # Pre-resolve the install prefix so a shell-unsafe or root-resolving
+    # ANC_INSTALL_PATH aborts here with a clear message instead of raising a raw
+    # traceback deep in install / group-run. Only meaningful for tar URLs, but
+    # resolving unconditionally is harmless (deb/rpm ignore the key).
+    try:
+        resolve_anc_paths_from_config(config_dict)
+    except ValueError as exc:
+        problems.append(str(exc))
+
+    username_problem = validate_cluster_username(cluster_dict)
+    if username_problem:
+        problems.append(username_problem)
+
+    if require_log_folder:
+        problems += validate_anc_path_prefixes(config_dict)
+
+    return problems
+
+
 # Install paths for one run: the prefix ANC is extracted under, plus the derived
 # anc/ dir and anc.py entrypoint. For deb/rpm these are always the fixed default
 # layout; for tar they honour a relocated config anc.ANC_INSTALL_PATH.
@@ -627,13 +704,31 @@ def resolve_anc_install_prefix(config_dict, pkg_type):
 
     The returned prefix is normalised to an absolute path with no trailing slash
     so it composes cleanly into "<prefix>/anc/anc.py".
+
+    The user-supplied value is validated here (the single chokepoint every
+    consumer -- install, group run, version check -- reaches): shell-unsafe
+    characters are rejected (expanduser/abspath normalise but do NOT sanitise),
+    and a resolved prefix of "/" is rejected because the installer's cleanup
+    loop would then ``rm -rf`` top-level system directories. Raises ValueError
+    on either.
     '''
     prefix = ANC_TOOLS_PREFIX
     if pkg_type == "tar":
         raw = config_dict.get("anc", {}).get(ANC_INSTALL_PATH_KEY)
         if raw and str(raw).strip():
+            _assert_shell_safe(config_dict.get("anc", {}), (ANC_INSTALL_PATH_KEY,))
             prefix = os.path.expanduser(str(raw).strip())
-    return os.path.abspath(prefix)
+    resolved = os.path.abspath(prefix)
+    # abspath preserves a leading "//" (POSIX-special), so an exact "== '/'"
+    # check misses "//" / "//x/.." which are ALSO filesystem root. Test the
+    # slash-stripped form so every all-slash resolution (/, //, ///) is rejected;
+    # otherwise the installer's cleanup loop would rm -rf top-level system dirs.
+    if not resolved.strip("/"):
+        raise ValueError(
+            f"config anc.{ANC_INSTALL_PATH_KEY} resolves to filesystem root ({resolved!r}), which is not a "
+            f"valid ANC install prefix (the installer would rm -rf top-level system directories)"
+        )
+    return resolved
 
 
 def resolve_anc_paths(config_dict, pkg_type):
@@ -767,9 +862,11 @@ def install_anc(phdl, cluster_dict, config_dict):
     globals.error_list = []
 
     anc_cfg = config_dict["anc"]
-    # Values interpolated into single-quoted remote shell strings by the
-    # sub-installers; reject quotes up front (config is trusted, boundary check).
-    _assert_shell_safe(anc_cfg, ("anc_release_url",))
+    # Values interpolated into remote shell strings by the sub-installers; reject
+    # unsafe characters up front (config is trusted, boundary check). Both the
+    # release URL and the relocatable install prefix reach the shell, so both are
+    # guarded here (the prefix is re-checked at its resolve chokepoint too).
+    _assert_shell_safe(anc_cfg, ("anc_release_url", ANC_INSTALL_PATH_KEY))
     anc_version = anc_cfg.get("anc_version")
     anc_release_url = anc_cfg["anc_release_url"]
     flavour = detect_package_flavour(anc_release_url)
@@ -1149,7 +1246,7 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
         rewrite_snippet = (
             f"echo 'Rewriting exe_path entries {ANC_TOOLS_PREFIX} -> {prefix}...'; "
             f"$SUDO find '{content_dir}' -type f \\( -name '*.yml' -o -name '*.yaml' \\) "
-            f"-exec sed -i 's#{ANC_TOOLS_PREFIX}#{prefix}#g' {{}} +; "
+            f"-exec sed -i 's#{ANC_TOOLS_PREFIX}#{_sed_replacement_safe(prefix)}#g' {{}} +; "
         )
 
     install_cmd = (
@@ -1165,13 +1262,17 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
         f"echo 'Extracting outer archive...'; "
         f"tar -xzf 'outer.tar.gz'; "
         # Top-level folders shipped by either payload; strip the content
-        # tarball's './' prefix and drop the '.' root entry.
+        # tarball's './' prefix and drop the '.'/'..' entries so a malicious or
+        # corrupt archive name cannot make the cleanup rm -rf outside the prefix.
         f"echo 'Determining top-level tool folders...'; "
         f"tops=$( {{ tar -tzf anc-tool*.tar.gz; tar -tzf anc-content*.tar.gz; }} "
-        f"| sed 's#^\\./##' | awk -F/ '{{print $1}}' | grep -vE '^[.]?$' | sort -u ); "
+        f"| sed 's#^\\./##' | awk -F/ '{{print $1}}' | grep -vE '^([.]{{1,2}})?$' | sort -u ); "
         f"$SUDO mkdir -p '{prefix}'; "
         f"echo 'Replacing top-level folders under {prefix}...'; "
-        f"for name in $tops; do echo \"  {prefix}/$name\"; $SUDO rm -rf \"{prefix}/$name\"; done; "
+        # Defensive: skip any name that is not a single plain path component
+        # (belt-and-braces alongside the tops filter above).
+        f"for name in $tops; do case \"$name\" in */*|.|..) continue;; esac; "
+        f"echo \"  {prefix}/$name\"; $SUDO rm -rf '{prefix}'/\"$name\"; done; "
         f"echo 'Extracting anc-tool archive to {prefix}...'; "
         f"$SUDO tar -xzf anc-tool*.tar.gz -C '{prefix}'; "
         f"echo 'Extracting anc-content archive to {prefix}...'; "
@@ -1213,17 +1314,21 @@ def _validate_exe_paths(phdl, cluster_dict, content_dir):
         return
 
     local_script = os.path.join(RESOURCES_DIR, "validate_exe_paths.py")
-    remote_script = "/tmp/validate_exe_paths.py"
+    # Per-user remote path so concurrent users on the same node do not collide on
+    # a shared /tmp/validate_exe_paths.py they cannot overwrite.
+    user_tmp = _remote_user_tmp(cluster_dict.get("username", ""))
+    remote_script = f"{user_tmp}/validate_exe_paths.py"
 
     log.info("Uploading validation script to remote nodes...")
+    phdl.exec(f"mkdir -p '{user_tmp}'", timeout=30)
     phdl.upload_file(local_script, remote_script)
 
     log.info("Validating exe_path entries from %s", content_dir)
-    validate_dict = phdl.exec(f"python3 {remote_script} '{content_dir}'", timeout=60)
+    validate_dict = phdl.exec(f"python3 '{remote_script}' '{content_dir}'", timeout=60)
     print_test_output(log, validate_dict)
 
     log.info("Removing validation script from remote nodes...")
-    phdl.exec(f"rm -f {remote_script}", timeout=10)
+    phdl.exec(f"rm -f '{remote_script}'", timeout=10)
 
     for host, output in validate_dict.items():
         if "VALIDATION_FAILED" in output:
@@ -1288,7 +1393,7 @@ def _install_anc_tar_direct(phdl, cluster_dict, config_dict):
         rewrite_snippet = (
             f"echo 'Rewriting exe_path entries {ANC_TOOLS_PREFIX} -> {prefix}...'; "
             f"$SUDO find '{content_dir}' -type f \\( -name '*.yml' -o -name '*.yaml' \\) "
-            f"-exec sed -i 's#{ANC_TOOLS_PREFIX}#{prefix}#g' {{}} +; "
+            f"-exec sed -i 's#{ANC_TOOLS_PREFIX}#{_sed_replacement_safe(prefix)}#g' {{}} +; "
         )
 
     install_cmd = (
@@ -1300,12 +1405,16 @@ def _install_anc_tar_direct(phdl, cluster_dict, config_dict):
         f"echo 'Downloading ANC release...'; "
         f"{_download_with_progress_snippet(anc_release_url, 'anc.tar.gz')}; "
         # Top-level folders shipped by the archive; strip a leading './' and drop
-        # the '.' root entry so only real folder names remain.
+        # the '.'/'..' entries so a malicious or corrupt archive name cannot make
+        # the cleanup rm -rf outside the prefix.
         f"echo 'Determining top-level tool folders...'; "
-        f"tops=$( tar -tzf anc.tar.gz | sed 's#^\\./##' | awk -F/ '{{print $1}}' | grep -vE '^[.]?$' | sort -u ); "
+        f"tops=$( tar -tzf anc.tar.gz | sed 's#^\\./##' | awk -F/ '{{print $1}}' | grep -vE '^([.]{{1,2}})?$' | sort -u ); "
         f"$SUDO mkdir -p '{prefix}'; "
         f"echo 'Replacing top-level folders under {prefix}...'; "
-        f"for name in $tops; do echo \"  {prefix}/$name\"; $SUDO rm -rf \"{prefix}/$name\"; done; "
+        # Defensive: skip any name that is not a single plain path component
+        # (belt-and-braces alongside the tops filter above).
+        f"for name in $tops; do case \"$name\" in */*|.|..) continue;; esac; "
+        f"echo \"  {prefix}/$name\"; $SUDO rm -rf '{prefix}'/\"$name\"; done; "
         f"echo 'Extracting archive to {prefix}...'; "
         f"$SUDO tar -xzf anc.tar.gz -C '{prefix}'; "
         f"{rewrite_snippet}"
@@ -1603,13 +1712,19 @@ def _pull_log_dir(single, host, user, log_dir, dest_dir):
     log_dir = log_dir.rstrip("/")
     base = os.path.basename(log_dir)
     parent = os.path.dirname(log_dir)
-    remote_tar = f"/tmp/anc_{base}.tar.gz"
+    # Per-user remote path so concurrent users on the same node do not collide on
+    # a shared /tmp/anc_<base>.tar.gz owned by another user.
+    user_tmp = _remote_user_tmp(user)
+    remote_tar = f"{user_tmp}/anc_{base}.tar.gz"
 
     # ANC ran under sudo, so log_dir (and its parents, e.g. /root/logs) are
     # root-owned and unreadable by the plain SSH user. Build the archive under
     # sudo, then chown it back so SFTP can pull it. `&&` so a tar failure aborts
     # before the (silent-on-nonzero) exec proceeds to download a missing file.
-    archive_cmd = f"sudo tar -czf '{remote_tar}' -C '{parent}' '{base}' && sudo chown {user} '{remote_tar}'"
+    archive_cmd = (
+        f"mkdir -p '{user_tmp}' && sudo tar -czf '{remote_tar}' -C '{parent}' '{base}' "
+        f"&& sudo chown '{user}' '{remote_tar}'"
+    )
     try:
         single.exec(archive_cmd, timeout=600)
     except Exception as exc:
@@ -2000,9 +2115,12 @@ def run_anc_groups(phdl, cluster_dict, config_dict, groups, test_name, request=N
         # print_all_to_console=true mode. ``last=-1`` seeds the loop so the first
         # tick always emits once (arming the timer through ANC's startup / time to
         # first output, which would otherwise look like silence).
-        remote_stdout = "/tmp/anc_run_$$.out"
+        # Per-user remote scratch ($$ keeps it per-run) so concurrent users on
+        # the same node never collide on ownership of a shared /tmp path.
+        user_tmp = _remote_user_tmp(cluster_dict.get("username", ""))
+        remote_stdout = f"{user_tmp}/anc_run_$$.out"
         cmd = (
-            f"cd '{anc_dir}' && "
+            f"mkdir -p '{user_tmp}' && cd '{anc_dir}' && "
             f"( sudo ./anc.py -g {groups_arg} > '{remote_stdout}' 2>&1 ) & "
             f"anc_pid=$! && "
             f"last=-1; "

--- a/cvs/lib/anc_lib.py
+++ b/cvs/lib/anc_lib.py
@@ -11,8 +11,11 @@ This module holds the logic reused across the ANC suites so each suite file
 stays thin:
 
   - Package install (``install_anc``) dispatched by release-archive flavour
-    (``-deb-`` / ``-rpm-`` / ``-tar-``), with an optional version precheck /
-    post-verify driven by ``config["anc"]["anc_version"]``.
+    (deb / rpm / tar) AND packaging generation: LEGACY (<=1.4.x) outer tarballs
+    whose name carries a ``-deb-`` / ``-rpm-`` / ``-tar-`` token, and DIRECT
+    (1.5.0+) URLs that point straight at a ``.deb`` / ``.rpm`` / ``.tar.gz``.
+    An optional version precheck / post-verify is driven by
+    ``config["anc"]["anc_version"]``.
   - Group execution (``run_anc_groups``): run one or more ANC groups in a
     single ``anc.py -g <groups...>`` invocation on all nodes, collect the
     per-run artifacts, and judge pass/fail from the final ANC return code.
@@ -488,26 +491,121 @@ def _fail_unreachable_nodes(cluster_dict, out_dict, action):
     return missing
 
 
-def detect_package_type(anc_release_url):
+# ANC changed its release packaging in the 1.5.0 series:
+#   - LEGACY (<= 1.4.x): every flavour ships as an OUTER ``.tar.gz`` whose name
+#     carries a ``-deb-`` / ``-rpm-`` / ``-tar-`` token, e.g.
+#     ``anc-release-helios-nda-1.4.9-deb-linux-x64.tar.gz``. Inside are the real
+#     deb/rpm packages (deb/rpm flavours) or two inner tarballs (tar flavour).
+#   - DIRECT (1.5.0+): the URL points straight at the artifact -- a ``.deb``, a
+#     ``.rpm``, or a ``.tar.gz`` that IS the tree (no inner archives) -- with NO
+#     ``-<flavour>-`` token, e.g. ``anc-release-helios-nda_1.5.5_amd64.deb`` /
+#     ``anc-release-helios-nda-1.5.5-x86_64.tar.gz``.
+# The two are told apart by the presence of the legacy ``-<flavour>-`` token
+# (see detect_package_flavour); a legacy tar's name also ends in ``.tar.gz``, so
+# the token MUST be checked before the extension.
+PackageFlavour = namedtuple("PackageFlavour", ["pkg_type", "is_direct"])
+
+# Extract the semantic version (``1.4.9`` / ``1.5.5``) from a release URL. The
+# first dotted-numeric run in the filename is the version in every ANC naming
+# scheme, legacy and direct alike ("x86_64"/"x64" have no dot-separated triple,
+# so they never match first).
+_URL_VERSION_RE = re.compile(r"\d+\.\d+(?:\.\d+)*")
+
+
+def detect_package_flavour(anc_release_url):
     '''
-    Infer the ANC package flavour from the release archive name.
+    Infer the ANC package flavour AND packaging generation from the release name.
 
-    Archive names embed the packaging kind as a ``-<type>-`` token, e.g.
-    ``anc-release-helios-nda-1.4.7-deb-linux-x64.tar.gz`` -> ``deb``.
+    Returns a PackageFlavour(pkg_type, is_direct):
+      - pkg_type: one of ``"deb"``, ``"rpm"``, ``"tar"``.
+      - is_direct: False for the LEGACY outer-tarball layout (name carries a
+        ``-<flavour>-`` token, or a trailing ``-<flavour>.`` before the
+        extension); True for the DIRECT 1.5.0+ layout (the URL is the artifact
+        itself, flavour taken from the extension).
 
-    Returns:
-      str: one of ``"deb"``, ``"rpm"``, ``"tar"``.
+    The legacy token is checked FIRST because a legacy tar release also ends in
+    ``.tar.gz`` -- extension alone cannot distinguish it from a direct tar.
 
     Raises:
-      ValueError: if no known package token is present in the name.
+      ValueError: if neither a legacy token nor a known direct extension is
+      present in the name.
     '''
     name = anc_release_url.rsplit("/", 1)[-1].lower()
+    # Legacy outer-tarball names carry the flavour as a `-<flavour>-` token, or a
+    # trailing `-<flavour>.` before the extension (e.g. `...-1.4.9-deb.tar.gz`).
+    # Match BOTH forms here, before the direct-extension fallback, so a legacy
+    # `...-tar.tar.gz` is not mistaken for a DIRECT tar by its `.tar.gz` suffix.
     for pkg_type in ("deb", "rpm", "tar"):
         if f"-{pkg_type}-" in name or f"-{pkg_type}." in name:
-            return pkg_type
+            return PackageFlavour(pkg_type, False)
+    if name.endswith(".deb"):
+        return PackageFlavour("deb", True)
+    if name.endswith(".rpm"):
+        return PackageFlavour("rpm", True)
+    if name.endswith(".tar.gz") or name.endswith(".tgz"):
+        return PackageFlavour("tar", True)
     raise ValueError(
-        f"Cannot determine ANC package type from archive name '{name}'; expected a '-deb-', '-rpm-', or '-tar-' token"
+        f"Cannot determine ANC package flavour from archive name '{name}'; expected a legacy "
+        f"'-deb-'/'-rpm-'/'-tar-' token or a direct '.deb'/'.rpm'/'.tar.gz' extension"
     )
+
+
+def detect_package_type(anc_release_url):
+    '''
+    Infer just the ANC package flavour (deb/rpm/tar) from the release name.
+
+    Thin wrapper over detect_package_flavour for callers that only need the
+    flavour (path resolution, pkg-type dispatch) and not the generation.
+
+    Raises:
+      ValueError: if the flavour cannot be determined.
+    '''
+    return detect_package_flavour(anc_release_url).pkg_type
+
+
+def parse_version_from_url(anc_release_url):
+    '''
+    Extract the semantic version embedded in an ANC release URL, or None.
+
+    Matches the first dotted-numeric run in the filename (e.g. ``1.4.9`` from
+    ``...-1.4.9-deb-linux-x64.tar.gz``, ``1.5.5`` from
+    ``...-1.5.5-x86_64.tar.gz`` and ``..._1.5.5_amd64.deb``). Returns None when
+    the URL is empty or carries no version token.
+
+    Used by the fail-fast config guard to abort (before contacting any node)
+    when the user-supplied ``anc.anc_version`` disagrees with the archive.
+    '''
+    if not anc_release_url:
+        return None
+    name = anc_release_url.rsplit("/", 1)[-1]
+    match = _URL_VERSION_RE.search(name)
+    return match.group(0) if match else None
+
+
+def check_version_matches_url(config_dict):
+    '''
+    Return a problem string if config ``anc.anc_version`` disagrees with the
+    version parsed from ``anc.anc_release_url``, else None.
+
+    Only enforced when BOTH a version is configured and one can be parsed from
+    the URL; a blank version or an unparseable URL yields None (no opinion).
+    Applies to legacy and direct packaging alike so a user cannot point a run at
+    the wrong archive for the version they asked for.
+    '''
+    anc_cfg = config_dict.get("anc", {}) or {}
+    configured = anc_cfg.get("anc_version")
+    url = anc_cfg.get("anc_release_url")
+    if not configured or not str(configured).strip():
+        return None
+    url_version = parse_version_from_url(url)
+    if not url_version:
+        return None
+    if str(configured).strip() != url_version:
+        return (
+            f"config anc.anc_version ({configured}) does not match the version in "
+            f"anc.anc_release_url ({url_version}); fix one so they agree before running"
+        )
+    return None
 
 
 # Install paths for one run: the prefix ANC is extracted under, plus the derived
@@ -615,8 +713,13 @@ def install_anc(phdl, cluster_dict, config_dict):
     _assert_shell_safe(anc_cfg, ("anc_release_url",))
     anc_version = anc_cfg.get("anc_version")
     anc_release_url = anc_cfg["anc_release_url"]
-    pkg_type = detect_package_type(anc_release_url)
-    log.info("ANC package type detected from archive: %s", pkg_type)
+    flavour = detect_package_flavour(anc_release_url)
+    pkg_type = flavour.pkg_type
+    log.info(
+        "ANC package detected from archive: type=%s, layout=%s",
+        pkg_type,
+        "direct (1.5.0+)" if flavour.is_direct else "legacy (<=1.4.x)",
+    )
 
     # Per-install paths: tar honours a relocated anc.ANC_INSTALL_PATH; deb/rpm
     # always resolve to the fixed default prefix. The version prechecks and
@@ -646,11 +749,20 @@ def install_anc(phdl, cluster_dict, config_dict):
     # update_test_result so the whole install is reported exactly once. Each
     # sub-installer also flags any expected node missing from its output.
     if pkg_type == "deb":
-        _install_anc_deb(phdl, cluster_dict, config_dict)
+        if flavour.is_direct:
+            _install_anc_deb_direct(phdl, cluster_dict, config_dict)
+        else:
+            _install_anc_deb(phdl, cluster_dict, config_dict)
     elif pkg_type == "rpm":
-        _install_anc_rpm(phdl, cluster_dict, config_dict)
+        if flavour.is_direct:
+            _install_anc_rpm_direct(phdl, cluster_dict, config_dict)
+        else:
+            _install_anc_rpm(phdl, cluster_dict, config_dict)
     elif pkg_type == "tar":
-        _install_anc_tar(phdl, cluster_dict, config_dict)
+        if flavour.is_direct:
+            _install_anc_tar_direct(phdl, cluster_dict, config_dict)
+        else:
+            _install_anc_tar(phdl, cluster_dict, config_dict)
     else:
         fail_test(f"ANC '{pkg_type}' package installation is not yet supported")
         update_test_result()
@@ -800,6 +912,100 @@ def _install_anc_deb(phdl, cluster_dict, config_dict):
     _fail_unreachable_nodes(cluster_dict, out_dict, ".deb install")
 
 
+def _install_anc_rpm_direct(phdl, cluster_dict, config_dict):
+    '''
+    Install ANC from a DIRECT .rpm URL (1.5.0+ packaging) on remote nodes.
+
+    Unlike the legacy layout, the URL points straight at a single ``.rpm`` (no
+    outer tarball to extract). Download it into a private staging dir, install
+    with ``dnf install`` (deps resolved from configured repos), then smoke-test
+    with ``ANC_BIN --help``.
+
+    Records failures via fail_test; the caller (install_anc) owns the single
+    update_test_result reporting call.
+    '''
+    anc_cfg = config_dict["anc"]
+    anc_release_url = anc_cfg["anc_release_url"]
+
+    log.info("ANC: install direct .rpm package on remote nodes (staging=mktemp temp dir)")
+
+    install_cmd = (
+        f"set -e; "
+        f"STAGE=$(mktemp -d); "
+        f"trap 'rm -rf \"$STAGE\"' EXIT; "
+        f"cd \"$STAGE\"; "
+        f"echo 'Downloading ANC .rpm package...'; "
+        f"{_download_with_progress_snippet(anc_release_url, 'anc.rpm')}; "
+        f"echo 'Installing ANC .rpm package...'; "
+        f"sudo dnf install -y ./anc.rpm; "
+        f"echo '--- Verification ---'; "
+        f"{ANC_BIN} --help && echo 'ANC_INSTALL_SUCCESS'"
+    )
+
+    out_dict = phdl.exec(install_cmd, timeout=_install_timeout(anc_cfg))
+    print_test_output(log, out_dict)
+
+    for host, output in out_dict.items():
+        if "ANC_INSTALL_SUCCESS" not in output:
+            fail_test(f"ANC .rpm installation failed on {host}: '{ANC_BIN} --help' did not succeed")
+        else:
+            log.info("Node %s: ANC .rpm installed and verified", host)
+
+    _fail_unreachable_nodes(cluster_dict, out_dict, ".rpm install")
+
+
+def _install_anc_deb_direct(phdl, cluster_dict, config_dict):
+    '''
+    Install ANC from a DIRECT .deb URL (1.5.0+ packaging) on remote nodes.
+
+    Unlike the legacy layout, the URL points straight at a single ``.deb`` (no
+    outer tarball to extract). Download it into a private staging dir, install
+    with ``dpkg -i --force-depends`` (python3 is present but not tracked in
+    dpkg's DB on these nodes, so a plain install aborts on the depends check),
+    configure any package left half-configured, then smoke-test with
+    ``ANC_BIN --help``.
+
+    Records failures via fail_test; the caller (install_anc) owns the single
+    update_test_result reporting call.
+    '''
+    anc_cfg = config_dict["anc"]
+    anc_release_url = anc_cfg["anc_release_url"]
+
+    log.info("ANC: install direct .deb package on remote nodes (staging=mktemp temp dir)")
+
+    install_cmd = (
+        f"set -e; "
+        f"STAGE=$(mktemp -d); "
+        f"trap 'rm -rf \"$STAGE\"' EXIT; "
+        f"cd \"$STAGE\"; "
+        f"echo 'Downloading ANC .deb package...'; "
+        f"{_download_with_progress_snippet(anc_release_url, 'anc.deb')}; "
+        f"echo 'Installing ANC .deb package...'; "
+        f"sudo dpkg -i --force-depends ./anc.deb; "
+        # Configure ONLY the ANC package (by name), not `-a`. dpkg -i above
+        # already configures it (force-depends lets its configure pass); this is
+        # a fallback for the rare case it was left half-configured. Skip the
+        # configure when already "install ok installed" (re-configuring prints a
+        # noisy stderr + non-zero exit); the --help check below is the real gate.
+        f"pkg=$(dpkg-deb -f ./anc.deb Package); "
+        f"if ! dpkg-query -W -f='${{Status}}' \"$pkg\" 2>/dev/null | grep -q 'install ok installed'; then "
+        f"sudo dpkg --configure --force-depends \"$pkg\"; fi; "
+        f"echo '--- Verification ---'; "
+        f"{ANC_BIN} --help && echo 'ANC_INSTALL_SUCCESS'"
+    )
+
+    out_dict = phdl.exec(install_cmd, timeout=_install_timeout(anc_cfg))
+    print_test_output(log, out_dict)
+
+    for host, output in out_dict.items():
+        if "ANC_INSTALL_SUCCESS" not in output:
+            fail_test(f"ANC .deb installation failed on {host}: '{ANC_BIN} --help' did not succeed")
+        else:
+            log.info("Node %s: ANC .deb installed and verified", host)
+
+    _fail_unreachable_nodes(cluster_dict, out_dict, ".deb install")
+
+
 def _sudo_prefix_snippet(prefix):
     '''
     Build a shell snippet that sets ``SUDO`` to "sudo" or "" for writing under
@@ -928,12 +1134,24 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
 
     _fail_unreachable_nodes(cluster_dict, out_dict, "tar install")
 
+    _validate_exe_paths(phdl, cluster_dict, content_dir)
+
+
+def _validate_exe_paths(phdl, cluster_dict, content_dir):
+    '''
+    Validate the exe_path entries under a tar install's content dir with the
+    bundled validate_exe_paths.py script (shared by legacy and direct tar).
+
+    Skips silently when a prior install/reachability step already recorded a
+    failure (nothing to validate). Uploads the script, runs it against
+    content_dir on every node, records per-node pass/fail via fail_test, and
+    flags any unreachable node.
+    '''
     # Skip exe_path validation if the extraction/reachability already failed
     # (nothing to validate); the caller reports the recorded failure.
     if globals.error_list:
         return
 
-    # Validate exe_path entries with the bundled script.
     local_script = os.path.join(RESOURCES_DIR, "validate_exe_paths.py")
     remote_script = "/tmp/validate_exe_paths.py"
 
@@ -958,6 +1176,97 @@ def _install_anc_tar(phdl, cluster_dict, config_dict):
             fail_test(f"Unexpected validation output on {host}: {output.strip()}")
 
     _fail_unreachable_nodes(cluster_dict, validate_dict, "exe_path validation")
+
+
+def _install_anc_tar_direct(phdl, cluster_dict, config_dict):
+    '''
+    Install ANC from a DIRECT tar release (1.5.0+ packaging) on remote nodes.
+
+    Unlike the legacy tar (an outer archive holding two inner ``anc-tool*`` /
+    ``anc-content*`` tarballs), the 1.5.0+ ``.tar.gz`` IS the tree: extracting it
+    lays down the top-level folders (``anc/`` plus the tool dirs) directly, so
+    the install is a single-stage untar into ``<prefix>``.
+
+    Everything else mirrors the legacy tar install:
+      - Install PREFIX is relocatable via config anc.ANC_INSTALL_PATH; blank/
+        absent keeps the legacy default (/opt/amdtools). tar is the ONLY
+        relocatable flavour (deb/rpm bake absolute paths into their package).
+      - The shipped content YAMLs carry absolute ``exe_path: /opt/amdtools/...``
+        entries; when relocated, every exe_path under ``<prefix>/anc/content`` is
+        rewritten from /opt/amdtools to <prefix> (relative/system paths intact).
+      - sudo policy (auto): extract + rewrite use sudo ONLY when the prefix's
+        deepest existing ancestor is not user-writable.
+
+    Algorithm (per node):
+      1. Download the archive into a private ``mktemp -d`` staging dir; a
+         ``trap ... EXIT`` removes it on ANY exit so the large archive never
+         lingers.
+      2. Derive the set of TOP-LEVEL folders the archive ships and ``rm -rf``
+         each under ``<prefix>`` so a stale file removed in a new release does
+         not survive as an overlaid leftover; unrelated content is left alone.
+      3. Extract the archive into ``<prefix>``, then rewrite exe_path if
+         relocated.
+
+    Records failures via fail_test; the caller (install_anc) owns the single
+    update_test_result reporting call.
+    '''
+    anc_cfg = config_dict["anc"]
+    anc_release_url = anc_cfg["anc_release_url"]
+    paths = resolve_anc_paths(config_dict, "tar")
+    prefix = paths.prefix
+    anc_bin = paths.anc_bin
+    content_dir = f"{paths.anc_dir}/content"
+    relocated = prefix != ANC_TOOLS_PREFIX
+
+    log.info(
+        "ANC: install direct tar release on remote nodes (staging=mktemp temp dir, install prefix=%s)",
+        prefix,
+    )
+
+    rewrite_snippet = ""
+    if relocated:
+        rewrite_snippet = (
+            f"echo 'Rewriting exe_path entries {ANC_TOOLS_PREFIX} -> {prefix}...'; "
+            f"$SUDO find '{content_dir}' -type f \\( -name '*.yml' -o -name '*.yaml' \\) "
+            f"-exec sed -i 's#{ANC_TOOLS_PREFIX}#{prefix}#g' {{}} +; "
+        )
+
+    install_cmd = (
+        f"set -e; "
+        f"{_sudo_prefix_snippet(prefix)}; "
+        f"STAGE=$(mktemp -d); "
+        f"trap 'rm -rf \"$STAGE\"' EXIT; "
+        f"cd \"$STAGE\"; "
+        f"echo 'Downloading ANC release...'; "
+        f"{_download_with_progress_snippet(anc_release_url, 'anc.tar.gz')}; "
+        # Top-level folders shipped by the archive; strip a leading './' and drop
+        # the '.' root entry so only real folder names remain.
+        f"echo 'Determining top-level tool folders...'; "
+        f"tops=$( tar -tzf anc.tar.gz | sed 's#^\\./##' | awk -F/ '{{print $1}}' | grep -vE '^[.]?$' | sort -u ); "
+        f"$SUDO mkdir -p '{prefix}'; "
+        f"echo 'Replacing top-level folders under {prefix}...'; "
+        f"for name in $tops; do echo \"  {prefix}/$name\"; $SUDO rm -rf \"{prefix}/$name\"; done; "
+        f"echo 'Extracting archive to {prefix}...'; "
+        f"$SUDO tar -xzf anc.tar.gz -C '{prefix}'; "
+        f"{rewrite_snippet}"
+        f"echo '--- Installed top-level tools ---'; "
+        f"ls '{prefix}' | sort; "
+        f"echo '--- Verification ---'; "
+        f"test -f '{anc_bin}' && echo 'ANC_INSTALL_SUCCESS'"
+    )
+
+    out_dict = phdl.exec(install_cmd, timeout=_install_timeout(anc_cfg))
+    print_test_output(log, out_dict)
+
+    for host, output in out_dict.items():
+        if "ANC_INSTALL_SUCCESS" not in output:
+            fail_test(f"ANC installation failed on {host}: '{anc_bin}' not found after extracting into {prefix}")
+        else:
+            log.info("Node %s: ANC directory installed successfully", host)
+
+    _fail_unreachable_nodes(cluster_dict, out_dict, "tar install")
+
+    _validate_exe_paths(phdl, cluster_dict, content_dir)
 
 
 # =========================================================================
@@ -1050,6 +1359,59 @@ def ensure_rocm_ldconfig(phdl, cluster_dict):
 # attempt is retried by the next group rather than silently skipped.
 _ANC_READY = False
 
+# Session-scoped cache of the AncPaths (prefix, anc_dir, anc_bin) that group runs
+# construct their ``anc.py -g`` command from. Populated by
+# resolve_anc_install_location once ANC is confirmed on the nodes, so every group
+# in the session reuses the SAME node-verified install path instead of each
+# re-deriving it from config. Reset to None whenever the derivation fails so a
+# later group re-probes rather than reusing a stale/None value.
+_ANC_INSTALL_PATHS = None
+
+
+def resolve_anc_install_location(phdl, cluster_dict, config_dict):
+    '''
+    Resolve the on-node ANC install location group commands run from, verifying
+    it actually exists on every node, and cache it for the session.
+
+    Algorithm (driven by the release-URL flavour):
+      - deb / rpm: the packages bake in absolute locations, so the install is
+        always at the fixed default prefix -> check ``/opt/amdtools/anc/anc.py``.
+      - tar: the install honours config anc.ANC_INSTALL_PATH (a relocated prefix,
+        or the default when blank) -> check ``<prefix>/anc/anc.py``.
+    In every case the resolved anc.py is probed on all expected nodes. When it is
+    present everywhere, log "Using ANC installation at <path>" and cache the
+    AncPaths; when it is missing on any node, log "ANC installation not found in
+    the path <path>" for that node and fail_test (the caller's
+    update_test_result turns the recorded failure into a pytest failure).
+
+    Returns:
+      AncPaths on success; None when the location could not be verified (a
+      failure has been recorded via fail_test).
+    '''
+    global _ANC_INSTALL_PATHS
+
+    paths = resolve_anc_paths_from_config(config_dict)
+    expected = _expected_nodes(cluster_dict)
+
+    out_dict = phdl.exec(f"test -f '{paths.anc_bin}' && echo ANC_PRESENT || true", timeout=60)
+    print_test_output(log, out_dict)
+
+    all_present = True
+    for host in expected:
+        if "ANC_PRESENT" in (out_dict.get(host) or ""):
+            log.info("Node %s: Using ANC installation at %s", host, paths.anc_bin)
+        else:
+            all_present = False
+            log.error("Node %s: ANC installation not found in the path %s", host, paths.anc_bin)
+            fail_test(f"ANC installation not found in the path {paths.anc_bin} on {host}")
+
+    if not all_present:
+        _ANC_INSTALL_PATHS = None
+        return None
+
+    _ANC_INSTALL_PATHS = paths
+    return paths
+
 
 def _anc_installed(phdl, cluster_dict, config_dict):
     '''
@@ -1088,6 +1450,10 @@ def ensure_anc_ready(phdl, cluster_dict, config_dict):
 
     Install / ldconfig failures propagate as pytest failures (via their own
     ``update_test_result``), which aborts the calling group test.
+
+    After install + ldconfig succeed, the on-node install location is resolved
+    and cached (resolve_anc_install_location) so every group in the session runs
+    ``anc.py -g`` from the SAME node-verified path.
     '''
     global _ANC_READY
     if _ANC_READY:
@@ -1101,6 +1467,16 @@ def ensure_anc_ready(phdl, cluster_dict, config_dict):
         install_anc(phdl, cluster_dict, config_dict)
 
     ensure_rocm_ldconfig(phdl, cluster_dict)
+
+    # Resolve + verify the on-node install location now that ANC is present, and
+    # cache it for the session's group runs. A missing location records a failure
+    # here; surface it as a pytest failure so we never proceed to run groups
+    # against a path that does not exist.
+    globals.error_list = []
+    if resolve_anc_install_location(phdl, cluster_dict, config_dict) is None:
+        update_test_result()
+        return
+
     _ANC_READY = True
 
 
@@ -1518,8 +1894,11 @@ def run_anc_groups(phdl, cluster_dict, config_dict, groups, test_name, request=N
     anc_cfg = config_dict["anc"]
     # anc.py lives under the per-install prefix (a relocated tar prefix when
     # configured, else the default), so the group run cd's to where ANC actually
-    # installed rather than the fixed default dir.
-    anc_dir = resolve_anc_paths_from_config(config_dict).anc_dir
+    # installed rather than the fixed default dir. Prefer the session-cached
+    # location resolved + node-verified by resolve_anc_install_location (via
+    # ensure_anc_ready); fall back to a fresh config resolve for direct callers
+    # that ran a group without going through the readiness guard.
+    anc_dir = (_ANC_INSTALL_PATHS or resolve_anc_paths_from_config(config_dict)).anc_dir
     inactivity_timeout = anc_cfg.get(INACTIVITY_TIMEOUT_KEY, DEFAULT_ANC_INACTIVITY_TIMEOUT)
     print_all = _as_bool(anc_cfg.get(PRINT_ALL_TO_CONSOLE_KEY), default=True)
     timestamp = new_run_timestamp()

--- a/cvs/lib/unittests/test_anc_lib.py
+++ b/cvs/lib/unittests/test_anc_lib.py
@@ -125,6 +125,77 @@ class TestNodeVersionMatchesUsesAncBin(unittest.TestCase):
         self.assertIn("/home/u/my/anc/anc/anc.py --version", phdl.cmd)
         self.assertTrue(result["node1"])
 
+    def test_direct_uses_content_list(self):
+        content_out = (
+            "Available content plugins (2):\n"
+            "  Name                      Version Description\n"
+            "  anc-release-helios-nda    1.5.5   Helios NDA Release\n"
+            "  base                      1.0.0   Base ANC items\n"
+        )
+
+        class FakePhdl:
+            def __init__(self):
+                self.cmd = None
+
+            def exec(self, cmd, timeout=None):
+                self.cmd = cmd
+                return {"node1": content_out}
+
+        phdl = FakePhdl()
+        with patch.object(anc_lib, "print_test_output"):
+            result = anc_lib.node_version_matches(phdl, "1.5.5", anc_bin="/opt/amdtools/anc/anc.py", is_direct=True)
+        self.assertIn("/opt/amdtools/anc/anc.py --content-list", phdl.cmd)
+        self.assertTrue(result["node1"])
+
+    def test_direct_mismatch_is_false(self):
+        content_out = "  anc-release-helios-nda    1.5.4   Helios NDA Release\n"
+
+        class FakePhdl:
+            def exec(self, cmd, timeout=None):
+                return {"node1": content_out}
+
+        with patch.object(anc_lib, "print_test_output"):
+            result = anc_lib.node_version_matches(
+                FakePhdl(), "1.5.5", anc_bin="/opt/amdtools/anc/anc.py", is_direct=True
+            )
+        self.assertFalse(result["node1"])
+
+
+class TestParseReleaseVersionFromContentList(unittest.TestCase):
+    '''parse_release_version_from_content_list: read the anc-release-* version column.'''
+
+    def test_direct_155_output(self):
+        out = (
+            "Start Time: 2026-08-07 12:08:45\n"
+            "Available content plugins (5):\n"
+            "  Name                      Version Description\n"
+            "  anc-release-helios-nda    1.5.5   Helios NDA Release\n"
+            "  base                      1.0.0   Base ANC items\n"
+            "Program exiting with return code ANC_SUCCESS [0]\n"
+        )
+        self.assertEqual(anc_lib.parse_release_version_from_content_list(out), "1.5.5")
+
+    def test_legacy_two_column_returns_none(self):
+        # Legacy <=1.4.x has no version column and no anc-release-* plugin.
+        out = (
+            "Available content plugins (4):\n"
+            "  base - Base ANC items and utilities...\n"
+            "  helios_nda - Helios NDA Test Content\n"
+        )
+        self.assertIsNone(anc_lib.parse_release_version_from_content_list(out))
+
+    def test_hardware_discovery_failure_returns_none(self):
+        out = "FATAL: Error occurred during hardware discovery\n"
+        self.assertIsNone(anc_lib.parse_release_version_from_content_list(out))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(anc_lib.parse_release_version_from_content_list(""))
+        self.assertIsNone(anc_lib.parse_release_version_from_content_list(None))
+
+    def test_two_part_version(self):
+        out = "  anc-release-venice-nda    2.0   Venice NDA Release\n"
+        self.assertEqual(anc_lib.parse_release_version_from_content_list(out), "2.0")
+
 
 class TestDetectPackageFlavour(unittest.TestCase):
     '''detect_package_flavour: flavour + legacy/direct generation from the name.'''

--- a/cvs/lib/unittests/test_anc_lib.py
+++ b/cvs/lib/unittests/test_anc_lib.py
@@ -126,5 +126,260 @@ class TestNodeVersionMatchesUsesAncBin(unittest.TestCase):
         self.assertTrue(result["node1"])
 
 
+class TestDetectPackageFlavour(unittest.TestCase):
+    '''detect_package_flavour: flavour + legacy/direct generation from the name.'''
+
+    def test_legacy_tar_token(self):
+        url = "http://x/anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("tar", False))
+
+    def test_legacy_deb_token(self):
+        url = "http://x/anc-release-helios-nda-1.4.9-deb-linux-x64.tar.gz"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("deb", False))
+
+    def test_legacy_rpm_token(self):
+        url = "http://x/anc-release-helios-nda-1.4.9-rpm-linux-x64.tar.gz"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("rpm", False))
+
+    def test_legacy_dot_token_tar(self):
+        # Trailing "-tar." before the extension is legacy, NOT a direct tar.
+        url = "http://x/anc-release-helios-nda-1.4.9-tar.tar.gz"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("tar", False))
+
+    def test_legacy_dot_token_deb(self):
+        url = "http://x/anc-release-helios-nda-1.4.9-deb.tar.gz"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("deb", False))
+
+    def test_direct_deb(self):
+        url = "http://x/anc-release-helios-nda_1.5.5_amd64.deb"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("deb", True))
+
+    def test_direct_rpm(self):
+        url = "http://x/anc-release-helios-nda-1.5.5-1.x86_64.rpm"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("rpm", True))
+
+    def test_direct_tar(self):
+        url = "http://x/anc-release-helios-nda-1.5.5-x86_64.tar.gz"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("tar", True))
+
+    def test_direct_tgz(self):
+        url = "http://x/anc-release-helios-nda-1.5.5-x86_64.tgz"
+        self.assertEqual(anc_lib.detect_package_flavour(url), anc_lib.PackageFlavour("tar", True))
+
+    def test_unrecognised_raises(self):
+        with self.assertRaises(ValueError):
+            anc_lib.detect_package_flavour("http://x/mystery.bin")
+
+    def test_detect_package_type_wrapper_direct_tar(self):
+        self.assertEqual(anc_lib.detect_package_type("http://x/anc-1.5.5-x86_64.tar.gz"), "tar")
+
+    def test_detect_package_type_wrapper_legacy_deb(self):
+        self.assertEqual(anc_lib.detect_package_type("http://x/anc-1.4.9-deb-linux-x64.tar.gz"), "deb")
+
+
+class TestParseVersionFromUrl(unittest.TestCase):
+    '''parse_version_from_url: first dotted-numeric run in the filename.'''
+
+    def test_legacy_url(self):
+        self.assertEqual(
+            anc_lib.parse_version_from_url("http://x/anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz"),
+            "1.4.9",
+        )
+
+    def test_direct_tar_url(self):
+        self.assertEqual(
+            anc_lib.parse_version_from_url("http://x/anc-release-helios-nda-1.5.5-x86_64.tar.gz"),
+            "1.5.5",
+        )
+
+    def test_direct_deb_url(self):
+        self.assertEqual(
+            anc_lib.parse_version_from_url("http://x/anc-release-helios-nda_1.5.5_amd64.deb"),
+            "1.5.5",
+        )
+
+    def test_no_version_returns_none(self):
+        self.assertIsNone(anc_lib.parse_version_from_url("http://x/anc-release.tar.gz"))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(anc_lib.parse_version_from_url(""))
+
+
+class TestCheckVersionMatchesUrl(unittest.TestCase):
+    '''check_version_matches_url: abort when configured version != URL version.'''
+
+    def test_match_returns_none(self):
+        cfg = {"anc": {"anc_version": "1.5.5", "anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz"}}
+        self.assertIsNone(anc_lib.check_version_matches_url(cfg))
+
+    def test_mismatch_returns_problem(self):
+        cfg = {"anc": {"anc_version": "1.5.4", "anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz"}}
+        problem = anc_lib.check_version_matches_url(cfg)
+        self.assertIsNotNone(problem)
+        self.assertIn("1.5.4", problem)
+        self.assertIn("1.5.5", problem)
+
+    def test_blank_version_skips(self):
+        cfg = {"anc": {"anc_version": "", "anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz"}}
+        self.assertIsNone(anc_lib.check_version_matches_url(cfg))
+
+    def test_unparseable_url_skips(self):
+        cfg = {"anc": {"anc_version": "1.5.5", "anc_release_url": "http://x/anc-release.tar.gz"}}
+        self.assertIsNone(anc_lib.check_version_matches_url(cfg))
+
+    def test_legacy_url_match(self):
+        cfg = {"anc": {"anc_version": "1.4.9", "anc_release_url": "http://x/anc-1.4.9-tar-linux-x64.tar.gz"}}
+        self.assertIsNone(anc_lib.check_version_matches_url(cfg))
+
+
+class _RecordingPhdl:
+    '''Minimal phdl stand-in: records the install command, returns a success line.'''
+
+    def __init__(self, response):
+        self.cmd = None
+        self._response = response
+
+    def exec(self, cmd, timeout=None):  # noqa: ARG002
+        self.cmd = cmd
+        return dict(self._response)
+
+
+class TestDirectInstallers(unittest.TestCase):
+    '''Direct 1.5.0+ installers issue single-artifact download + install commands.'''
+
+    CLUSTER = {"node_dict": {"node1": {}}, "username": "u", "priv_key_file": "k"}
+
+    def _cfg(self, url, install_path=""):
+        return {"anc": {"anc_release_url": url, "ANC_INSTALL_PATH": install_path}}
+
+    def test_deb_direct_command_shape(self):
+        cfg = self._cfg("http://x/anc-release-helios-nda_1.5.5_amd64.deb")
+        phdl = _RecordingPhdl({"node1": "ANC_INSTALL_SUCCESS"})
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "update_test_result"):
+            anc_lib._install_anc_deb_direct(phdl, self.CLUSTER, cfg)
+        self.assertIn("dpkg -i --force-depends ./anc.deb", phdl.cmd)
+        self.assertIn("anc-release-helios-nda_1.5.5_amd64.deb", phdl.cmd)
+        # No outer-tarball extraction for a direct package.
+        self.assertNotIn("outer.tar.gz", phdl.cmd)
+
+    def test_rpm_direct_command_shape(self):
+        cfg = self._cfg("http://x/anc-release-helios-nda-1.5.5-1.x86_64.rpm")
+        phdl = _RecordingPhdl({"node1": "ANC_INSTALL_SUCCESS"})
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "update_test_result"):
+            anc_lib._install_anc_rpm_direct(phdl, self.CLUSTER, cfg)
+        self.assertIn("dnf install -y ./anc.rpm", phdl.cmd)
+        self.assertNotIn("outer.tar.gz", phdl.cmd)
+
+    def test_tar_direct_default_prefix_no_rewrite(self):
+        cfg = self._cfg("http://x/anc-release-helios-nda-1.5.5-x86_64.tar.gz")
+        phdl = _RecordingPhdl({"node1": "ANC_INSTALL_SUCCESS"})
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "_validate_exe_paths"):
+            anc_lib._install_anc_tar_direct(phdl, self.CLUSTER, cfg)
+        self.assertIn(f"tar -xzf anc.tar.gz -C '{anc_lib.ANC_TOOLS_PREFIX}'", phdl.cmd)
+        # Single archive, no inner anc-tool/anc-content tarballs.
+        self.assertNotIn("anc-tool", phdl.cmd)
+        self.assertNotIn("anc-content", phdl.cmd)
+        # Default prefix -> no exe_path rewrite.
+        self.assertNotIn("Rewriting exe_path", phdl.cmd)
+
+    def test_tar_direct_relocated_rewrites_exe_path(self):
+        cfg = self._cfg("http://x/anc-release-helios-nda-1.5.5-x86_64.tar.gz", install_path="/home/u/anc")
+        phdl = _RecordingPhdl({"node1": "ANC_INSTALL_SUCCESS"})
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "_validate_exe_paths"):
+            anc_lib._install_anc_tar_direct(phdl, self.CLUSTER, cfg)
+        self.assertIn("tar -xzf anc.tar.gz -C '/home/u/anc'", phdl.cmd)
+        self.assertIn("Rewriting exe_path", phdl.cmd)
+        self.assertIn(f"s#{anc_lib.ANC_TOOLS_PREFIX}#/home/u/anc#g", phdl.cmd)
+
+
+class _ProbePhdl:
+    '''phdl stand-in for resolve_anc_install_location: records the probe command
+    and returns a canned per-host response.'''
+
+    def __init__(self, response):
+        self.cmd = None
+        self._response = response
+
+    def exec(self, cmd, timeout=None):  # noqa: ARG002
+        self.cmd = cmd
+        return dict(self._response)
+
+
+class TestResolveAncInstallLocation(unittest.TestCase):
+    '''resolve_anc_install_location: probe by URL flavour, verify, cache.'''
+
+    def setUp(self):
+        anc_lib._ANC_INSTALL_PATHS = None
+        globals_patcher = patch.object(anc_lib.globals, "error_list", [])
+        globals_patcher.start()
+        self.addCleanup(globals_patcher.stop)
+        self.addCleanup(setattr, anc_lib, "_ANC_INSTALL_PATHS", None)
+
+    def _cluster(self):
+        return {"node_dict": {"node1": {}}, "username": "u", "priv_key_file": "k"}
+
+    def test_deb_probes_default_prefix(self):
+        cfg = {"anc": {"anc_release_url": "http://x/anc_1.5.5_amd64.deb", "ANC_INSTALL_PATH": "/home/u/anc"}}
+        phdl = _ProbePhdl({"node1": "ANC_PRESENT"})
+        with patch.object(anc_lib, "print_test_output"):
+            paths = anc_lib.resolve_anc_install_location(phdl, self._cluster(), cfg)
+        self.assertEqual(paths.anc_bin, anc_lib.ANC_BIN)
+        self.assertIn(anc_lib.ANC_BIN, phdl.cmd)
+        self.assertIs(anc_lib._ANC_INSTALL_PATHS, paths)
+
+    def test_tar_probes_relocated_prefix(self):
+        cfg = {"anc": {"anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz", "ANC_INSTALL_PATH": "/home/u/anc"}}
+        phdl = _ProbePhdl({"node1": "ANC_PRESENT"})
+        with patch.object(anc_lib, "print_test_output"):
+            paths = anc_lib.resolve_anc_install_location(phdl, self._cluster(), cfg)
+        self.assertEqual(paths.anc_bin, "/home/u/anc/anc/anc.py")
+        self.assertIn("/home/u/anc/anc/anc.py", phdl.cmd)
+
+    def test_missing_fails_and_clears_cache(self):
+        cfg = {"anc": {"anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz", "ANC_INSTALL_PATH": "/home/u/anc"}}
+        phdl = _ProbePhdl({"node1": ""})
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "fail_test") as ft:
+            result = anc_lib.resolve_anc_install_location(phdl, self._cluster(), cfg)
+        self.assertIsNone(result)
+        self.assertIsNone(anc_lib._ANC_INSTALL_PATHS)
+        ft.assert_called_once()
+        self.assertIn("/home/u/anc/anc/anc.py", ft.call_args[0][0])
+
+    def test_partial_coverage_fails(self):
+        cluster = {"node_dict": {"node1": {}, "node2": {}}, "username": "u", "priv_key_file": "k"}
+        cfg = {"anc": {"anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz", "ANC_INSTALL_PATH": "/home/u/anc"}}
+        phdl = _ProbePhdl({"node1": "ANC_PRESENT"})  # node2 unreachable / absent
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "fail_test") as ft:
+            result = anc_lib.resolve_anc_install_location(phdl, cluster, cfg)
+        self.assertIsNone(result)
+        ft.assert_called_once()
+        self.assertIn("node2", ft.call_args[0][0])
+
+
+class TestRunAncGroupsUsesCachedPath(unittest.TestCase):
+    '''run_anc_groups builds the command from the session-cached install path.'''
+
+    def setUp(self):
+        self.addCleanup(setattr, anc_lib, "_ANC_INSTALL_PATHS", None)
+
+    def test_cached_path_used_in_command(self):
+        cached = anc_lib.AncPaths(prefix="/home/u/anc", anc_dir="/home/u/anc/anc", anc_bin="/home/u/anc/anc/anc.py")
+        anc_lib._ANC_INSTALL_PATHS = cached
+        cluster = {"node_dict": {"node1": {}}, "username": "u", "priv_key_file": "k"}
+        cfg = {"anc": {"print_all_to_console": "True", "log_folder_path": "/tmp/logs"}}
+
+        captured = {}
+
+        class FakePhdl:
+            def exec(self, cmd, inactivity_timeout=None):  # noqa: ARG002
+                captured["cmd"] = cmd
+                return {}
+
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "update_test_result"):
+            anc_lib.run_anc_groups(FakePhdl(), cluster, cfg, ["cpu_sanity"], "test_cpu_sanity")
+
+        self.assertIn("cd '/home/u/anc/anc' && sudo ./anc.py -g cpu_sanity", captured["cmd"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/lib/unittests/test_anc_lib.py
+++ b/cvs/lib/unittests/test_anc_lib.py
@@ -1,0 +1,130 @@
+# cvs/lib/unittests/test_anc_lib.py
+import os
+import unittest
+from unittest.mock import patch
+
+import cvs.lib.anc_lib as anc_lib
+
+
+class TestResolveAncInstallPrefix(unittest.TestCase):
+    '''resolve_anc_install_prefix: tar honours ANC_INSTALL_PATH; deb/rpm ignore it.'''
+
+    def test_tar_with_custom_path(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/my/anc"}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "tar"), "/home/u/my/anc")
+
+    def test_tar_blank_falls_back_to_default(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": ""}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "tar"), anc_lib.ANC_TOOLS_PREFIX)
+
+    def test_tar_whitespace_only_falls_back(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "   "}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "tar"), anc_lib.ANC_TOOLS_PREFIX)
+
+    def test_tar_missing_key_falls_back(self):
+        cfg = {"anc": {}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "tar"), anc_lib.ANC_TOOLS_PREFIX)
+
+    def test_deb_ignores_custom_path(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/my/anc"}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "deb"), anc_lib.ANC_TOOLS_PREFIX)
+
+    def test_rpm_ignores_custom_path(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/my/anc"}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "rpm"), anc_lib.ANC_TOOLS_PREFIX)
+
+    def test_tilde_is_expanded(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "~/my/anc"}}
+        expected = os.path.abspath(os.path.expanduser("~/my/anc"))
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "tar"), expected)
+
+    def test_trailing_slash_normalised(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/my/anc/"}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "tar"), "/home/u/my/anc")
+
+
+class TestResolveAncPaths(unittest.TestCase):
+    '''resolve_anc_paths: derives anc_dir/anc_bin under the resolved prefix.'''
+
+    def test_relocated_tar_paths(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/my/anc"}}
+        paths = anc_lib.resolve_anc_paths(cfg, "tar")
+        self.assertEqual(paths.prefix, "/home/u/my/anc")
+        self.assertEqual(paths.anc_dir, "/home/u/my/anc/anc")
+        self.assertEqual(paths.anc_bin, "/home/u/my/anc/anc/anc.py")
+
+    def test_default_tar_paths_match_module_constants(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": ""}}
+        paths = anc_lib.resolve_anc_paths(cfg, "tar")
+        self.assertEqual(paths.prefix, anc_lib.ANC_TOOLS_PREFIX)
+        self.assertEqual(paths.anc_dir, anc_lib.ANC_DIR)
+        self.assertEqual(paths.anc_bin, anc_lib.ANC_BIN)
+
+    def test_deb_paths_are_default(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/my/anc"}}
+        paths = anc_lib.resolve_anc_paths(cfg, "deb")
+        self.assertEqual(paths.anc_bin, anc_lib.ANC_BIN)
+
+
+class TestResolveAncPathsFromConfig(unittest.TestCase):
+    '''resolve_anc_paths_from_config: pkg flavour inferred from the release URL.'''
+
+    def test_tar_url_relocated(self):
+        cfg = {
+            "anc": {
+                "anc_release_url": "http://x/anc-release-1.4.9-tar-linux-x64.tar.gz",
+                "ANC_INSTALL_PATH": "/home/u/my/anc",
+            }
+        }
+        self.assertEqual(anc_lib.resolve_anc_paths_from_config(cfg).anc_bin, "/home/u/my/anc/anc/anc.py")
+
+    def test_deb_url_ignores_install_path(self):
+        cfg = {
+            "anc": {
+                "anc_release_url": "http://x/anc-release-1.4.9-deb-linux-x64.tar.gz",
+                "ANC_INSTALL_PATH": "/home/u/my/anc",
+            }
+        }
+        self.assertEqual(anc_lib.resolve_anc_paths_from_config(cfg).anc_bin, anc_lib.ANC_BIN)
+
+    def test_missing_url_falls_back_to_default(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/my/anc"}}
+        self.assertEqual(anc_lib.resolve_anc_paths_from_config(cfg).anc_bin, anc_lib.ANC_BIN)
+
+    def test_unrecognised_url_falls_back_to_default(self):
+        cfg = {"anc": {"anc_release_url": "http://x/mystery.bin", "ANC_INSTALL_PATH": "/home/u/my/anc"}}
+        self.assertEqual(anc_lib.resolve_anc_paths_from_config(cfg).anc_bin, anc_lib.ANC_BIN)
+
+
+class TestSudoPrefixSnippet(unittest.TestCase):
+    '''_sudo_prefix_snippet: emits a shell probe that selects sudo by writability.'''
+
+    def test_snippet_mentions_prefix_and_writability_branch(self):
+        snippet = anc_lib._sudo_prefix_snippet("/home/u/my/anc")
+        self.assertIn("/home/u/my/anc", snippet)
+        self.assertIn("SUDO=''", snippet)
+        self.assertIn("SUDO='sudo'", snippet)
+        self.assertIn("-w", snippet)
+
+
+class TestNodeVersionMatchesUsesAncBin(unittest.TestCase):
+    '''node_version_matches queries the passed anc_bin path.'''
+
+    def test_custom_anc_bin_in_command(self):
+        class FakePhdl:
+            def __init__(self):
+                self.cmd = None
+
+            def exec(self, cmd, timeout=None):
+                self.cmd = cmd
+                return {"node1": "version 1.4.9"}
+
+        phdl = FakePhdl()
+        with patch.object(anc_lib, "print_test_output"):
+            result = anc_lib.node_version_matches(phdl, "1.4.9", anc_bin="/home/u/my/anc/anc/anc.py")
+        self.assertIn("/home/u/my/anc/anc/anc.py --version", phdl.cmd)
+        self.assertTrue(result["node1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/unittests/test_anc_lib.py
+++ b/cvs/lib/unittests/test_anc_lib.py
@@ -452,5 +452,255 @@ class TestRunAncGroupsUsesCachedPath(unittest.TestCase):
         self.assertIn("cd '/home/u/anc/anc' && sudo ./anc.py -g cpu_sanity", captured["cmd"])
 
 
+class TestAssertShellSafe(unittest.TestCase):
+    '''_assert_shell_safe rejects every shell-metacharacter that can subvert the
+    remote command, not just a single quote.'''
+
+    def test_accepts_clean_value(self):
+        anc_lib._assert_shell_safe({"k": "/home/u/my/anc"}, ("k",))  # no raise
+
+    def test_accepts_missing_key(self):
+        anc_lib._assert_shell_safe({}, ("k",))  # None value is skipped, no raise
+
+    def test_rejects_each_unsafe_char(self):
+        for ch in ("'", '"', "`", "$", "\\", "\n"):
+            with self.subTest(ch=ch):
+                with self.assertRaises(ValueError):
+                    anc_lib._assert_shell_safe({"k": f"/home/u{ch}anc"}, ("k",))
+
+    def test_rejects_command_substitution(self):
+        with self.assertRaises(ValueError):
+            anc_lib._assert_shell_safe({"ANC_INSTALL_PATH": "/home/$(whoami)/anc"}, ("ANC_INSTALL_PATH",))
+
+
+class TestResolveAncInstallPrefixValidation(unittest.TestCase):
+    '''resolve_anc_install_prefix rejects unsafe/degenerate prefixes.'''
+
+    def test_rejects_shell_unsafe_prefix(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/a$b"}}
+        with self.assertRaises(ValueError):
+            anc_lib.resolve_anc_install_prefix(cfg, "tar")
+
+    def test_rejects_quote_prefix(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/o'brien/anc"}}
+        with self.assertRaises(ValueError):
+            anc_lib.resolve_anc_install_prefix(cfg, "tar")
+
+    def test_rejects_root_prefix(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/"}}
+        with self.assertRaises(ValueError):
+            anc_lib.resolve_anc_install_prefix(cfg, "tar")
+
+    def test_rejects_double_slash_root(self):
+        # abspath preserves a leading "//" (POSIX-special); it is still root.
+        for value in ("//", "///", "//x/.."):
+            with self.subTest(value=value):
+                cfg = {"anc": {"ANC_INSTALL_PATH": value}}
+                with self.assertRaises(ValueError):
+                    anc_lib.resolve_anc_install_prefix(cfg, "tar")
+
+    def test_rejects_root_after_normalisation(self):
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/.."}}  # abspath -> "/home" not "/"
+        # "/home/u/.." normalises to "/home", which is allowed; a value that
+        # normalises to "/" (e.g. "/..") is rejected.
+        cfg_root = {"anc": {"ANC_INSTALL_PATH": "/.."}}
+        with self.assertRaises(ValueError):
+            anc_lib.resolve_anc_install_prefix(cfg_root, "tar")
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "tar"), "/home")
+
+    def test_deb_ignores_unsafe_install_path(self):
+        # deb/rpm never read ANC_INSTALL_PATH, so an unsafe value there is moot.
+        cfg = {"anc": {"ANC_INSTALL_PATH": "/home/u/a$b"}}
+        self.assertEqual(anc_lib.resolve_anc_install_prefix(cfg, "deb"), anc_lib.ANC_TOOLS_PREFIX)
+
+
+class TestSedReplacementSafe(unittest.TestCase):
+    '''_sed_replacement_safe escapes sed-replacement metacharacters (# & \\).'''
+
+    def test_escapes_delimiter_and_ampersand(self):
+        self.assertEqual(anc_lib._sed_replacement_safe("/home/a#b&c"), "/home/a\\#b\\&c")
+
+    def test_escapes_backslash_first(self):
+        self.assertEqual(anc_lib._sed_replacement_safe("a\\b"), "a\\\\b")
+
+    def test_plain_value_unchanged(self):
+        self.assertEqual(anc_lib._sed_replacement_safe("/home/u/anc"), "/home/u/anc")
+
+
+class TestRmRfSinkIsSingleQuoted(unittest.TestCase):
+    '''The top-level cleanup loop single-quotes the (untrusted) prefix so a
+    double-quoted expansion can never command-substitute or mis-target.'''
+
+    CLUSTER = {"node_dict": {"node1": {}}, "username": "u", "priv_key_file": "k"}
+
+    def _run_direct_tar(self, install_path):
+        cfg = {"anc": {"anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz", "ANC_INSTALL_PATH": install_path}}
+        phdl = _RecordingPhdl({"node1": "ANC_INSTALL_SUCCESS"})
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "_validate_exe_paths"):
+            anc_lib._install_anc_tar_direct(phdl, self.CLUSTER, cfg)
+        return phdl.cmd
+
+    def test_prefix_single_quoted_name_double_quoted(self):
+        cmd = self._run_direct_tar("/home/u/anc")
+        # prefix single-quoted, archive-derived $name double-quoted.
+        self.assertIn("rm -rf '/home/u/anc'/\"$name\"", cmd)
+        # The old double-quoted "{prefix}/$name" form must be gone.
+        self.assertNotIn('rm -rf "/home/u/anc/$name"', cmd)
+
+
+class TestPerUserTmpNamespacing(unittest.TestCase):
+    '''Remote temp paths are namespaced under /tmp/<user> to avoid cross-user
+    ownership collisions on shared nodes.'''
+
+    def test_remote_user_tmp(self):
+        self.assertEqual(anc_lib._remote_user_tmp("alice"), "/tmp/alice")
+
+    def test_remote_user_tmp_sanitizes(self):
+        # A user value with a path separator collapses to one safe component.
+        self.assertEqual(anc_lib._remote_user_tmp("a/b"), "/tmp/a_b")
+
+    def test_validate_exe_paths_uses_per_user_tmp(self):
+        cluster = {"node_dict": {"node1": {}}, "username": "alice", "priv_key_file": "k"}
+        cmds = []
+
+        class FakePhdl:
+            def exec(self, cmd, timeout=None):  # noqa: ARG002
+                cmds.append(cmd)
+                return {"node1": "VALIDATION_SUCCESS"}
+
+            def upload_file(self, local, remote):
+                cmds.append(f"UPLOAD {remote}")
+
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib.globals, "error_list", []):
+            anc_lib._validate_exe_paths(FakePhdl(), cluster, "/opt/amdtools/anc/content")
+
+        joined = "\n".join(cmds)
+        self.assertIn("mkdir -p '/tmp/alice'", joined)
+        self.assertIn("/tmp/alice/validate_exe_paths.py", joined)
+
+    def test_run_anc_groups_quiet_uses_per_user_tmp(self):
+        anc_lib._ANC_INSTALL_PATHS = anc_lib.AncPaths("/opt/amdtools", "/opt/amdtools/anc", "/opt/amdtools/anc/anc.py")
+        self.addCleanup(setattr, anc_lib, "_ANC_INSTALL_PATHS", None)
+        cluster = {"node_dict": {"node1": {}}, "username": "bob", "priv_key_file": "k"}
+        cfg = {"anc": {"print_all_to_console": "False", "log_folder_path": "/tmp/logs"}}
+        captured = {}
+
+        class FakePhdl:
+            def exec(self, cmd, inactivity_timeout=None):  # noqa: ARG002
+                captured["cmd"] = cmd
+                return {}
+
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "update_test_result"):
+            anc_lib.run_anc_groups(FakePhdl(), cluster, cfg, ["cpu_sanity"], "test_cpu_sanity")
+
+        self.assertIn("/tmp/bob/anc_run_$$.out", captured["cmd"])
+        self.assertIn("mkdir -p '/tmp/bob'", captured["cmd"])
+
+
+class TestValidateClusterUsername(unittest.TestCase):
+    '''validate_cluster_username rejects usernames unsafe for shell interpolation.'''
+
+    def test_clean_username_ok(self):
+        self.assertIsNone(anc_lib.validate_cluster_username({"username": "ashmishr"}))
+
+    def test_missing_or_blank_is_deferred(self):
+        self.assertIsNone(anc_lib.validate_cluster_username({}))
+        self.assertIsNone(anc_lib.validate_cluster_username({"username": "  "}))
+
+    def test_rejects_space(self):
+        self.assertIsNotNone(anc_lib.validate_cluster_username({"username": "a b"}))
+
+    def test_rejects_command_injection(self):
+        problem = anc_lib.validate_cluster_username({"username": "x; rm -rf /root"})
+        self.assertIsNotNone(problem)
+
+
+class TestValidateAncConfig(unittest.TestCase):
+    '''validate_anc_config aggregates the fail-fast config problems.'''
+
+    def _cfg(self, **anc):
+        base = {"anc_release_url": "http://x/anc-1.5.5-x86_64.tar.gz", "ANC_INSTALL_PATH": ""}
+        base.update(anc)
+        return {"anc": base}
+
+    def _cluster(self, username="ashmishr"):
+        return {"username": username}
+
+    def test_clean_config_no_problems(self):
+        problems = anc_lib.validate_anc_config(self._cfg(), self._cluster(), require_log_folder=False)
+        self.assertEqual(problems, [])
+
+    def test_blank_url_flagged(self):
+        problems = anc_lib.validate_anc_config(self._cfg(anc_release_url=""), self._cluster(), require_log_folder=False)
+        self.assertTrue(any("anc_release_url" in p for p in problems))
+
+    def test_version_mismatch_flagged(self):
+        cfg = self._cfg(anc_version="1.5.4")  # url is 1.5.5
+        problems = anc_lib.validate_anc_config(cfg, self._cluster(), require_log_folder=False)
+        self.assertTrue(any("does not match" in p for p in problems))
+
+    def test_unsafe_prefix_flagged_cleanly(self):
+        cfg = self._cfg(ANC_INSTALL_PATH="//")
+        problems = anc_lib.validate_anc_config(cfg, self._cluster(), require_log_folder=False)
+        # The resolve_anc_paths_from_config ValueError is surfaced, not raised.
+        self.assertTrue(any("root" in p.lower() for p in problems))
+
+    def test_bad_username_flagged(self):
+        problems = anc_lib.validate_anc_config(self._cfg(), self._cluster(username="a b"), require_log_folder=False)
+        self.assertTrue(any("username" in p for p in problems))
+
+    def test_log_folder_required_for_group_suites(self):
+        cfg = self._cfg(log_folder_path="")
+        without = anc_lib.validate_anc_config(cfg, self._cluster(), require_log_folder=False)
+        with_req = anc_lib.validate_anc_config(cfg, self._cluster(), require_log_folder=True)
+        self.assertFalse(any("log_folder_path" in p for p in without))
+        self.assertTrue(any("log_folder_path" in p for p in with_req))
+
+
+class TestTarCleanupFiltersDotDot(unittest.TestCase):
+    '''Both tar installers filter '.'/'..' from the top-level cleanup list.'''
+
+    CLUSTER = {"node_dict": {"node1": {}}, "username": "u", "priv_key_file": "k"}
+
+    def _cmd(self, installer, url):
+        cfg = {"anc": {"anc_release_url": url, "ANC_INSTALL_PATH": ""}}
+        phdl = _RecordingPhdl({"node1": "ANC_INSTALL_SUCCESS"})
+        with patch.object(anc_lib, "print_test_output"), patch.object(anc_lib, "_validate_exe_paths"):
+            installer(phdl, self.CLUSTER, cfg)
+        return phdl.cmd
+
+    def test_direct_tar_filters_and_guards(self):
+        cmd = self._cmd(anc_lib._install_anc_tar_direct, "http://x/anc-1.5.5-x86_64.tar.gz")
+        # tops filter drops '.' and '..'
+        self.assertIn("grep -vE '^([.]{1,2})?$'", cmd)
+        # per-name defensive guard against a path-separator/dot component
+        self.assertIn('case "$name" in */*|.|..) continue;; esac', cmd)
+
+    def test_legacy_tar_filters_and_guards(self):
+        cmd = self._cmd(anc_lib._install_anc_tar, "http://x/anc-1.4.9-tar-linux-x64.tar.gz")
+        self.assertIn("grep -vE '^([.]{1,2})?$'", cmd)
+        self.assertIn('case "$name" in */*|.|..) continue;; esac', cmd)
+
+
+class TestChownArgumentQuoted(unittest.TestCase):
+    '''_pull_log_dir single-quotes the chown user argument (defense in depth).'''
+
+    def test_chown_user_single_quoted(self):
+        captured = {}
+
+        class FakeSingle:
+            def exec(self, cmd, timeout=None):  # noqa: ARG002
+                captured.setdefault("first", cmd)
+                return {}
+
+            def download_file(self, remote, local):  # noqa: ARG002
+                return {}
+
+        # download_file returns {} so _pull_log_dir bails after the archive_cmd;
+        # we only care that the archive command quotes the user.
+        anc_lib._pull_log_dir(FakeSingle(), "node1", "alice", "/root/logs/run1", "/tmp/dest")
+        self.assertIn("sudo chown 'alice'", captured["first"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/tests/anc/README.md
+++ b/cvs/tests/anc/README.md
@@ -132,18 +132,20 @@ The ANC config lives at `cvs/input/config_file/anc/anc_config.json`:
         "inactivity_timeout": 900,
         "install_timeout": 1800,
         "anc_version": "1.4.9",
-        "anc_release_url": "REPLACE_ME",
+        "anc_release_url": "<changeme>",
         "ANC_INSTALL_PATH": "",
         "print_all_to_console": "True",
-        "log_folder_path": "REPLACE_ME",
+        "log_folder_path": "<changeme>",
         "ADD_ANC_LOGS_TO_HTML_REPORTS": "False",
         "COLLECT_HTML_REPORTS": "True"
     }
 }
 ```
 
-`anc_release_url` and `log_folder_path` ship as the `REPLACE_ME` sentinel and
-**must** be replaced before running; an unresolved sentinel aborts the run.
+`anc_release_url` and `log_folder_path` ship as the `<changeme>` placeholder and
+**must** be replaced before running; an unresolved `<changeme>` aborts the run
+up front (the standard config resolver hard-exits on it, before any node is
+contacted).
 
 Each key is documented inline in the shipped config via a matching
 `_comment_<key>` sibling (keys prefixed with `_comment` are ignored at runtime).
@@ -154,15 +156,17 @@ Each key is documented inline in the shipped config via a matching
 | `install_timeout` | Package download+install **inactivity** timeout in seconds (default 1800 = 30 min), used only by `anc_installation` / the install pre-task. It is a per-read (no-output) timeout, not a total budget: the download emits a periodic progress heartbeat so a slow link never trips it, while a genuine stall still fails. Independent of `inactivity_timeout`. |
 | `anc_version` | Expected ANC version; install pre-task skips (re)install when already present and post-verifies the match. When set, it must equal the version in `anc_release_url` or the run aborts before contacting any node. The version is read per node via `anc.py --content-list` (the `anc-release-*` plugin's version column) for **direct 1.5.0+** packaging, and via `anc.py --version` for **legacy ≤1.4.x** (whose `--version` reports the release version; 1.5.0+ does not). |
 | `anc_release_url` | ANC release archive URL (used by `anc_installation`). Both packaging generations are auto-detected from the filename: **legacy (≤1.4.x)** outer tarballs carry a `-deb-`/`-rpm-`/`-tar-` token (e.g. `anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz`); **direct (1.5.0+)** URLs point straight at a `.deb`/`.rpm`/`.tar.gz` with no flavour token (e.g. `anc-release-helios-nda-1.5.5-x86_64.tar.gz`). The download/unpack is staged in a private temp dir on each node and removed after install (success or failure). deb/rpm install to `/opt/amdtools/anc`; tar installs to `ANC_INSTALL_PATH` (default `/opt/amdtools`). |
-| `ANC_INSTALL_PATH` | **Tar installs only:** relocatable prefix ANC is extracted into (its `anc/` dir, tool folders, and content live under here), giving `<prefix>/anc/anc.py`. A leading `~` is expanded. deb/rpm packages carry absolute locations baked into their archive and **ignore** this key. Leave blank or omit to keep the default `/opt/amdtools`. |
+| `ANC_INSTALL_PATH` | **Tar installs only:** relocatable prefix ANC is extracted into (its `anc/` dir, tool folders, and content live under here), giving `<prefix>/anc/anc.py`. A leading `~` is expanded and the `{home}`/`{user-id}` placeholders are resolved during config load. The value is validated up front: shell-metacharacters (`'`, `"`, `` ` ``, `$`, `\`, newline) and a prefix that resolves to filesystem root (`/`, `//`) are rejected before any node is contacted. deb/rpm packages carry absolute locations baked into their archive and **ignore** this key. Leave blank or omit to keep the default `/opt/amdtools`. |
 | `print_all_to_console` | `True` echoes ANC group output to console; `False` suppresses it (diagnostics still print). |
-| `log_folder_path` | Controller-side destination **prefix** for **all** ANC artifacts — collected logs and the auto-collected HTML report. A plain directory path (leading `~` expanded); **required** — replace the shipped `REPLACE_ME`. CVS appends its own fixed structure under it: logs at `anc_logs/<node>/<test_name>/<timestamp>` and the report at `html_reports/<node>/<test_name>/<timestamp>/<test_name>.html` (`<node>` → the node's `<ip>_<hostname>` label, `<test_name>` → the group's test name, `<timestamp>` → per-run stamp). |
+| `log_folder_path` | Controller-side destination **prefix** for **all** ANC artifacts — collected logs and the auto-collected HTML report. A plain directory path (leading `~` expanded); **required** — replace the shipped `<changeme>`. CVS appends its own fixed structure under it: logs at `anc_logs/<node>/<test_name>/<timestamp>` and the report at `html_reports/<node>/<test_name>/<timestamp>/<test_name>.html` (`<node>` → the node's `<ip>_<hostname>` label, `<test_name>` → the group's test name, `<timestamp>` → per-run stamp). |
 | `ADD_ANC_LOGS_TO_HTML_REPORTS` | Governs the per-node **ANC logs** tarball links. `True` always bundles each node's collected log tree (one `.tar.gz` + link per node) into the pytest-html report zip. `False` (default) bundles them **only when the test fails**. The per-node `errors.json` links appear regardless of this flag. |
 | `COLLECT_HTML_REPORTS` | `True` (default) auto-generates a pytest-html report even when no `--html` is passed, written under `log_folder_path`. `False` disables auto-collection. An explicit `--html` on the command line always overrides the auto-collected path. |
 
-`log_folder_path` is a plain directory prefix (it does **not** accept
-`{home}`/`{runner_log_folder}` tokens). With a `log_folder_path` of
-`/home/user/cvs_logs`, logs land at
+`log_folder_path` is a directory prefix. Leading `~` is expanded, and the
+standard config placeholders `{home}`/`{user-id}` are resolved during config
+load (it does **not** accept the CVS-owned `<node>`/`<test_name>`/`<timestamp>`
+tokens — those name the fixed structure CVS appends under the prefix). With a
+`log_folder_path` of `/home/user/cvs_logs`, logs land at
 `/home/user/cvs_logs/anc_logs/<node>/<test_name>/<timestamp>` and the HTML report
 at `/home/user/cvs_logs/html_reports/<node>/<test_name>/<timestamp>/<test_name>.html`,
 where `<node>` is that node's `<ip>_<hostname>` label. To send the report

--- a/cvs/tests/anc/README.md
+++ b/cvs/tests/anc/README.md
@@ -51,7 +51,9 @@ the session-cached setup guard `ensure_anc_ready`, ldconfig fix, group
 execution, and artifact collection — lives in `cvs/lib/anc_lib.py` (group sets
 are `CPU_GROUPS` / `GPU_GROUPS`). Shared pytest fixtures live in this directory's
 `conftest.py` and apply to the `cpu/` and `gpu/` subfolders too. ANC is invoked
-from its installed location `/opt/amdtools/anc/anc.py`.
+from its installed location `<prefix>/anc/anc.py` — `<prefix>` is `/opt/amdtools`
+by default, or, for **tar** installs only, the relocated `ANC_INSTALL_PATH`
+(deb/rpm always use `/opt/amdtools`).
 
 **Logs & console:** each group's ANC log directory is copied under the
 `log_folder_path` prefix, where CVS lays down the fixed
@@ -129,15 +131,19 @@ The ANC config lives at `cvs/input/config_file/anc/anc_config.json`:
         "description": "AMD Node Check",
         "inactivity_timeout": 900,
         "install_timeout": 1800,
-        "anc_version": "1.4.7",
-        "anc_release_url": "https://.../anc-release-helios-nda-1.4.7-rpm-linux-x64.tar.gz",
+        "anc_version": "1.4.9",
+        "anc_release_url": "REPLACE_ME",
+        "ANC_INSTALL_PATH": "",
         "print_all_to_console": "True",
-        "log_folder_path": "/home/user/cvs_logs",
+        "log_folder_path": "REPLACE_ME",
         "ADD_ANC_LOGS_TO_HTML_REPORTS": "False",
         "COLLECT_HTML_REPORTS": "True"
     }
 }
 ```
+
+`anc_release_url` and `log_folder_path` ship as the `REPLACE_ME` sentinel and
+**must** be replaced before running; an unresolved sentinel aborts the run.
 
 Each key is documented inline in the shipped config via a matching
 `_comment_<key>` sibling (keys prefixed with `_comment` are ignored at runtime).
@@ -146,8 +152,9 @@ Each key is documented inline in the shipped config via a matching
 | --- | --- |
 | `inactivity_timeout` | Per-group **inactivity** timeout in seconds (default 900 = 15 min). Applies to ANC group runs only, not install. A group is aborted only after this many seconds with **no new ANC output**; there is no total wall-clock cap, so a group that keeps producing progress runs as long as it needs. (Replaces the old `test_timeout` total-budget cap, which killed healthy, actively-running groups.) |
 | `install_timeout` | Package download+install **inactivity** timeout in seconds (default 1800 = 30 min), used only by `anc_installation` / the install pre-task. It is a per-read (no-output) timeout, not a total budget: the download emits a periodic progress heartbeat so a slow link never trips it, while a genuine stall still fails. Independent of `inactivity_timeout`. |
-| `anc_version` | Expected ANC version; install pre-task skips (re)install when already present and post-verifies the match. |
-| `anc_release_url` | ANC release archive URL (used by `anc_installation`). Flavour (deb/rpm/tar) is auto-detected from the filename. The download/unpack is staged in a private temp dir on each node and removed after install (success or failure); ANC itself always installs to `/opt/amdtools/anc`. |
+| `anc_version` | Expected ANC version; install pre-task skips (re)install when already present and post-verifies the match. When set, it must equal the version in `anc_release_url` or the run aborts before contacting any node. The version is read per node via `anc.py --content-list` (the `anc-release-*` plugin's version column) for **direct 1.5.0+** packaging, and via `anc.py --version` for **legacy ≤1.4.x** (whose `--version` reports the release version; 1.5.0+ does not). |
+| `anc_release_url` | ANC release archive URL (used by `anc_installation`). Both packaging generations are auto-detected from the filename: **legacy (≤1.4.x)** outer tarballs carry a `-deb-`/`-rpm-`/`-tar-` token (e.g. `anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz`); **direct (1.5.0+)** URLs point straight at a `.deb`/`.rpm`/`.tar.gz` with no flavour token (e.g. `anc-release-helios-nda-1.5.5-x86_64.tar.gz`). The download/unpack is staged in a private temp dir on each node and removed after install (success or failure). deb/rpm install to `/opt/amdtools/anc`; tar installs to `ANC_INSTALL_PATH` (default `/opt/amdtools`). |
+| `ANC_INSTALL_PATH` | **Tar installs only:** relocatable prefix ANC is extracted into (its `anc/` dir, tool folders, and content live under here), giving `<prefix>/anc/anc.py`. A leading `~` is expanded. deb/rpm packages carry absolute locations baked into their archive and **ignore** this key. Leave blank or omit to keep the default `/opt/amdtools`. |
 | `print_all_to_console` | `True` echoes ANC group output to console; `False` suppresses it (diagnostics still print). |
 | `log_folder_path` | Controller-side destination **prefix** for **all** ANC artifacts — collected logs and the auto-collected HTML report. A plain directory path (leading `~` expanded); **required** — replace the shipped `REPLACE_ME`. CVS appends its own fixed structure under it: logs at `anc_logs/<node>/<test_name>/<timestamp>` and the report at `html_reports/<node>/<test_name>/<timestamp>/<test_name>.html` (`<node>` → the node's `<ip>_<hostname>` label, `<test_name>` → the group's test name, `<timestamp>` → per-run stamp). |
 | `ADD_ANC_LOGS_TO_HTML_REPORTS` | Governs the per-node **ANC logs** tarball links. `True` always bundles each node's collected log tree (one `.tar.gz` + link per node) into the pytest-html report zip. `False` (default) bundles them **only when the test fails**. The per-node `errors.json` links appear regardless of this flag. |
@@ -167,10 +174,10 @@ elsewhere, pass `--html` on the command line.
 
 Every ANC validation suite installs ANC as a pre-task, so a separate install
 step is **optional**. Run `anc_installation` on its own when you want to
-install/refresh ANC without running a validation group. ANC always installs to
-`/opt/amdtools/anc` (for all three flavours — deb, rpm, and tar), with the
-entrypoint at `/opt/amdtools/anc/anc.py`. You can install it in either of the
-ways below.
+install/refresh ANC without running a validation group. deb/rpm always install to
+`/opt/amdtools/anc`; **tar** installs to `ANC_INSTALL_PATH` (default
+`/opt/amdtools`), giving the entrypoint `<prefix>/anc/anc.py`. You can install it
+in either of the ways below.
 
 ### Option A - from the head node (recommended)
 
@@ -184,17 +191,20 @@ cvs run anc_installation \
   --config_file cvs/input/config_file/anc/anc_config.json
 ```
 
-This downloads the `anc_release_url` archive, installs ANC to `/opt/amdtools/anc`
-on every target node (the flavour — deb/rpm/tar — is auto-detected from the
-filename), and validates the install.
+This downloads the `anc_release_url` archive, installs ANC on every target node
+(the flavour — deb/rpm/tar — and generation — legacy/direct — are auto-detected
+from the filename; deb/rpm land in `/opt/amdtools/anc`, tar in
+`ANC_INSTALL_PATH`), and validates the install.
 
 ### Option B - manually on a target node
 
 If you do not want to run `anc_installation`, install ANC directly on the target
-node. The example below is for the **tar** flavour: download and extract the
-release archive in a staging dir, then extract the two `anc-tool` and
-`anc-content` archives into `/opt/amdtools` so the layout matches the deb/rpm
-packages:
+node. The examples below use `/opt/amdtools` as the prefix; substitute your
+`ANC_INSTALL_PATH` for a relocated tar install.
+
+**Legacy (≤1.4.x) tar** — the outer archive holds two inner `anc-tool` and
+`anc-content` tarballs; extract both into the prefix so the layout matches the
+deb/rpm packages:
 
 ```bash
 STAGE=$(mktemp -d)              # private staging dir, only for the download/unpack
@@ -202,7 +212,7 @@ trap 'rm -rf "$STAGE"' EXIT     # auto-remove it on exit (success or failure)
 cd "$STAGE"
 
 # Download and extract the ANC release
-wget -q "https://atlartifactory.amd.com:8443/artifactory/HW-ANCRelease-REL-LOCAL/anc-release/helios_nda/1.4.7/anc-release-helios-nda-1.4.7-tar-linux-x64.tar.gz" \
+wget -q "https://atlartifactory.amd.com:8443/artifactory/HW-ANCRelease-REL-LOCAL/anc-release/helios_nda/1.4.9/anc-release-helios-nda-1.4.9-tar-linux-x64.tar.gz" \
   -O outer.tar.gz
 tar -xzf outer.tar.gz
 
@@ -213,11 +223,29 @@ sudo tar -xzf anc-tool*.tar.gz    -C /opt/amdtools
 sudo tar -xzf anc-content*.tar.gz -C /opt/amdtools
 ```
 
-For the **deb**/**rpm** flavours, install the extracted `anc*.deb` / `anc*.rpm`
-packages instead (`sudo dpkg -i` / `sudo dnf install`); they lay ANC down under
-`/opt/amdtools/anc` directly. This is the sequence performed by
-[`anc_installation.py`](anc_installation.py) (which delegates to
-`cvs/lib/anc_lib.py`).
+**Direct (1.5.0+) tar** — the `.tar.gz` *is* the tree (no inner archives); a
+single untar into the prefix lays down `anc/` and the tool folders:
+
+```bash
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+cd "$STAGE"
+
+wget -q "https://atlartifactory.amd.com:8443/artifactory/HW-ANCRelease-REL-LOCAL/anc-release/helios_nda/1.5.5/anc-release-helios-nda-1.5.5-x86_64.tar.gz" \
+  -O anc.tar.gz
+sudo mkdir -p /opt/amdtools
+sudo tar -xzf anc.tar.gz -C /opt/amdtools
+```
+
+> For a relocated tar prefix, `anc_installation` also rewrites the content
+> YAMLs' absolute `exe_path` entries from `/opt/amdtools` to the new prefix — do
+> the same if you relocate a manual install.
+
+For the **deb**/**rpm** flavours, install the extracted (legacy) or downloaded
+(direct) `anc*.deb` / `anc*.rpm` packages instead (`sudo dpkg -i` /
+`sudo dnf install`); they lay ANC down under `/opt/amdtools/anc` directly. This
+is the sequence performed by [`anc_installation.py`](anc_installation.py) (which
+delegates to `cvs/lib/anc_lib.py`).
 
 ---
 

--- a/cvs/tests/anc/conftest.py
+++ b/cvs/tests/anc/conftest.py
@@ -97,6 +97,11 @@ def config_dict(config_file, cluster_dict, pytestconfig):
         # Broad: any leftover REPLACE_ME placeholder anywhere in the config.
         placeholders = anc_lib.find_replace_me_placeholders(config_dict)
         problems += [f'{p} is still "{anc_lib.REPLACE_ME_SENTINEL}"' for p in placeholders]
+        # Abort before contacting any node when the configured anc_version and
+        # the version in anc_release_url disagree (only when a version is set).
+        version_problem = anc_lib.check_version_matches_url(config_dict)
+        if version_problem:
+            problems.append(version_problem)
         # Group suites additionally require a usable log_folder_path prefix.
         if suite_name.startswith("anc_test"):
             problems += anc_lib.validate_anc_path_prefixes(config_dict)

--- a/cvs/tests/anc/conftest.py
+++ b/cvs/tests/anc/conftest.py
@@ -74,13 +74,16 @@ def config_dict(config_file, cluster_dict, pytestconfig):
     Placeholders such as {home} are resolved using cluster_dict
     (e.g. a "{home}/logs" value -> "/home/<user>/logs").
 
-    Fails the run up front (before any ANC command runs) on config problems:
+    Any field still left at the ``<changeme>`` placeholder is caught up front by
+    resolve_test_config_placeholders (which hard-exits with a clear message), so
+    it is not re-checked here. This fixture additionally fails the run before any
+    ANC command runs on:
 
-      - ANY field still left at the REPLACE_ME sentinel (e.g. anc_release_url,
-        log_folder_path) aborts every ANC suite, including install-only runs.
-      - anc.log_folder_path additionally must be present and non-blank for the
-        group suites (anc_test_*), which write logs + the HTML report under it;
-        the install-only suite does not need it.
+      - a configured anc_version that disagrees with the version parsed from
+        anc_release_url (aborts before any node is contacted); and
+      - a missing/blank anc.log_folder_path for the group suites (anc_test_*),
+        which write logs + the HTML report under it (the install-only suite does
+        not need it).
 
     Failing here (fixture setup) means a bad config costs seconds, not a full
     suite run on the nodes.
@@ -93,18 +96,11 @@ def config_dict(config_file, cluster_dict, pytestconfig):
 
     suite_name = getattr(pytestconfig, "_suite_name", "") or ""
     if suite_name.startswith("anc") and "anc" in config_dict:
-        problems = []
-        # Broad: any leftover REPLACE_ME placeholder anywhere in the config.
-        placeholders = anc_lib.find_replace_me_placeholders(config_dict)
-        problems += [f'{p} is still "{anc_lib.REPLACE_ME_SENTINEL}"' for p in placeholders]
-        # Abort before contacting any node when the configured anc_version and
-        # the version in anc_release_url disagree (only when a version is set).
-        version_problem = anc_lib.check_version_matches_url(config_dict)
-        if version_problem:
-            problems.append(version_problem)
-        # Group suites additionally require a usable log_folder_path prefix.
-        if suite_name.startswith("anc_test"):
-            problems += anc_lib.validate_anc_path_prefixes(config_dict)
+        # Group suites (anc_test_*) additionally require a usable log_folder_path
+        # prefix; the install-only suite does not.
+        problems = anc_lib.validate_anc_config(
+            config_dict, cluster_dict, require_log_folder=suite_name.startswith("anc_test")
+        )
         if problems:
             pytest.fail(
                 "ANC config error (fix before running): " + "; ".join(problems),


### PR DESCRIPTION
This PR resolves the issue #283. 
This PR Make ANC installations relocatable and add support for ANC's new 1.5.0+ packaging layout

Technical Details :

1) Relocatable tar installs (ANC_INSTALL_PATH)
  - New optional ANC_INSTALL_PATH config tag lets tar releases extract to a user-chosen prefix; blank/absent falls back to the legacy /opt/amdtools. Supports {home}/~ expansion to the runner user's home.
  - Applies to tar releases only — deb/rpm packages carry predefined absolute locations in their archives and ignore the key.
  - resolve_anc_install_prefix / resolve_anc_paths thread the per-install prefix through version check, install verification, group run, and readiness.
  - Relocated tar installs rewrite content YAML exe_path entries from /opt/amdtools to the chosen prefix, leaving relative/system paths intact.
  - Auto-sudo: extraction skips sudo when the target prefix is user-writable.

2) 1.5.0+ direct packaging support
  - detect_package_flavour now returns (pkg_type, is_direct). Legacy token forms (-<flavour>- / -<flavour>.) are matched before the direct extension fallback so a legacy tar is never mistaken for a direct
  one.
  - Direct installers: deb (dpkg -i) / rpm (dnf install) download-and-install; tar untars straight into the relocatable prefix and rewrites exe_path.
  - exe_path validation is shared between legacy and direct tar installers.

3) Centralized install-path resolution
  - resolve_anc_install_location probes the node for anc.py by URL flavour, logs and caches the resolved path for the session, and fails clearly when absent. ensure_anc_ready populates it; run_anc_groups
  builds its anc.py -g command from the cached, node-verified path.

4) Fail-fast config guard
  - check_version_matches_url aborts the run before contacting any node when anc_version disagrees with the version parsed from anc_release_url (both packaging generations). Wired into
  cvs/tests/anc/conftest.py config validation.

All the UTs are passing with this change.