### PR TITLE
Close SSH sessions left open by temporary subset Pssh handles

### DIFF
--- a/cvs/core/orchestrators/baremetal.py
+++ b/cvs/core/orchestrators/baremetal.py
@@ -108,7 +108,10 @@ class BaremetalOrchestrator(Orchestrator):
                 host_key_check=False,
                 stop_on_errors=self.stop_on_errors,
             )
-            return pssh.exec(cmd, timeout=timeout, detailed=detailed, print_console=print_console)
+            try:
+                return pssh.exec(cmd, timeout=timeout, detailed=detailed, print_console=print_console)
+            finally:
+                pssh.destroy_clients()
 
     def sudo_prefix(self):
         """
@@ -170,7 +173,10 @@ class BaremetalOrchestrator(Orchestrator):
                 host_key_check=False,
                 stop_on_errors=self.stop_on_errors,
             )
-            result = pssh.exec(f"bash {env_script}", timeout=60, detailed=True)
+            try:
+                result = pssh.exec(f"bash {env_script}", timeout=60, detailed=True)
+            finally:
+                pssh.destroy_clients()
 
         # Check if all hosts succeeded
         success = all(output['exit_code'] == 0 for output in result.values())

--- a/cvs/core/orchestrators/unittests/test_baremetal.py
+++ b/cvs/core/orchestrators/unittests/test_baremetal.py
@@ -279,5 +279,64 @@ class TestBaremetalOrchestratorSudoPrefix(unittest.TestCase):
         pssh_instance.exec.assert_called_once_with("sudo -n true >/dev/null 2>&1; echo $?")
 
 
+class TestBaremetalOrchestratorSubsetHandleCleanup(unittest.TestCase):
+    """The subset branch builds a throwaway Pssh; it must be destroyed.
+
+    Left to refcounting, a call whose exec timed out keeps its SSH session
+    open on the target host, so a polling suite accumulates sessions until
+    sshd's limit is hit.
+    """
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_exec_destroys_subset_handle(self, mock_pssh):
+        # The timeout path is the one that leaks, so cleanup must not depend
+        # on a clean return.
+        for label, side_effect in (("returns", None), ("raises", RuntimeError("timed out"))):
+            with self.subTest(label):
+                orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+                orch.all = MagicMock()
+                mock_pssh.reset_mock()
+                mock_pssh.return_value.exec.side_effect = side_effect
+
+                if side_effect is None:
+                    orch.exec("hostname", hosts=["10.0.0.2"])
+                else:
+                    with self.assertRaises(RuntimeError):
+                        orch.exec("sleep 300", hosts=["10.0.0.2"], timeout=1)
+
+                mock_pssh.return_value.destroy_clients.assert_called_once_with()
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_setup_env_destroys_subset_handle(self, mock_pssh):
+        # Same subset branch as exec(); it has no callers today, but it is an
+        # abstractmethod on the base class, so an implementation could reach it.
+        for label, side_effect in (("returns", None), ("raises", RuntimeError("timed out"))):
+            with self.subTest(label):
+                orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+                orch.all = MagicMock()
+                mock_pssh.reset_mock()
+                if side_effect is None:
+                    mock_pssh.return_value.exec.return_value = {"10.0.0.2": {"exit_code": 0}}
+                    mock_pssh.return_value.exec.side_effect = None
+                    orch.setup_env(["10.0.0.2"], env_script="/tmp/env.sh")
+                else:
+                    mock_pssh.return_value.exec.side_effect = side_effect
+                    with self.assertRaises(RuntimeError):
+                        orch.setup_env(["10.0.0.2"], env_script="/tmp/env.sh")
+
+                mock_pssh.return_value.destroy_clients.assert_called_once_with()
+
+    @patch("cvs.core.orchestrators.baremetal.Pssh")
+    def test_exec_does_not_destroy_shared_all_handle(self, _mock_pssh):
+        # self.all is long-lived and reused; tearing it down would break
+        # every later call.
+        orch = BaremetalOrchestrator(MagicMock(), _make_orch_config())
+        orch.all = MagicMock()
+
+        orch.exec("hostname")
+
+        orch.all.destroy_clients.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -260,7 +260,10 @@ class DockerRuntime:
                 host_key_check=False,
                 stop_on_errors=self.orchestrator.stop_on_errors,
             )
-            return pssh.exec(exec_cmd, timeout=timeout, detailed=detailed, print_console=print_console)
+            try:
+                return pssh.exec(exec_cmd, timeout=timeout, detailed=detailed, print_console=print_console)
+            finally:
+                pssh.destroy_clients()
 
         return self.orchestrator.all.exec(exec_cmd, timeout=timeout, detailed=detailed, print_console=print_console)
 

--- a/cvs/core/runtimes/unittests/test_docker.py
+++ b/cvs/core/runtimes/unittests/test_docker.py
@@ -488,5 +488,43 @@ class TestDockerRuntimeSudoProbeCachedAcrossCalls(unittest.TestCase):
         self.assertEqual(len(probe_calls), 1, f"probe must fire once total, calls: {pssh_instance.exec.call_args_list}")
 
 
+class TestDockerRuntimeExecSubsetHandleCleanup(unittest.TestCase):
+    """The host-subset branch builds a throwaway Pssh; it must be destroyed.
+
+    Mirrors BaremetalOrchestrator.exec: without an explicit teardown a
+    timed-out exec leaves its sshd session open on the target host.
+    """
+
+    def _make_runtime(self):
+        orchestrator = MagicMock()
+        orchestrator.hosts = ["host1"]
+        orchestrator.log = MagicMock()
+        orchestrator.user = "u"
+        orchestrator.password = None
+        orchestrator.pkey = None
+        orchestrator.stop_on_errors = False
+        orchestrator.sudo_prefix.return_value = ""
+        return DockerRuntime(MagicMock(), orchestrator), orchestrator
+
+    def test_exec_destroys_subset_handle(self):
+        # The timeout path is the one that leaks, so cleanup must not depend
+        # on a clean return.
+        for label, side_effect in (("returns", None), ("raises", RuntimeError("timed out"))):
+            with self.subTest(label):
+                rt, _ = self._make_runtime()
+
+                with patch("cvs.lib.parallel_ssh_lib.Pssh") as mock_pssh_cls:
+                    mock_pssh_cls.return_value.exec.side_effect = side_effect
+                    mock_pssh_cls.return_value.exec.return_value = {"host1": {"output": "", "exit_code": 0}}
+
+                    if side_effect is None:
+                        rt.exec("cvs_iter_test", "echo hi", hosts=["host1"])
+                    else:
+                        with self.assertRaises(RuntimeError):
+                            rt.exec("cvs_iter_test", "sleep 300", hosts=["host1"], timeout=1)
+
+                    mock_pssh_cls.return_value.destroy_clients.assert_called_once_with()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/lib/parallel/pssh.py
+++ b/cvs/lib/parallel/pssh.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 import warnings
 from gevent import Timeout as GTimeout
+from gevent import killall
 from pssh.clients import ParallelSSHClient
 from pssh.exceptions import Timeout, ConnectionError, SessionError
 
@@ -545,5 +546,34 @@ class Pssh:
         self.client.run_command('reboot -f', stop_on_errors=self.stop_on_errors)
 
     def destroy_clients(self):
+        """Close the SSH transport for every host and drop the client.
+
+        Dropping the reference alone is not sufficient. A timed-out exec leaves
+        its per-host greenlet in client.cmds unfinished, and that greenlet's
+        callable is a bound method of the ParallelSSHClient, so the client stays
+        reachable, SSHClient.__del__ never runs and the sshd session outlives
+        this object. Kill the pending greenlets, then disconnect each host
+        client explicitly.
+        """
         self.log.info('Destroying Current phdl connections ..')
+        client = getattr(self, 'client', None)
+        if client is None:
+            return
+
+        pending = getattr(client, 'cmds', None)
+        if pending:
+            try:
+                killall(pending, block=True, timeout=5)
+            except Exception as exc:
+                self.log.debug(f"Error killing pending SSH greenlets: {exc}")
+            client.cmds = None
+
+        host_clients = getattr(client, '_host_clients', None) or {}
+        for key, host_client in list(host_clients.items()):
+            try:
+                host_client._disconnect()
+            except Exception as exc:
+                self.log.debug(f"Error disconnecting SSH client {key}: {exc}")
+        host_clients.clear()
+
         del self.client

--- a/cvs/lib/parallel/unittests/test_pssh.py
+++ b/cvs/lib/parallel/unittests/test_pssh.py
@@ -1227,5 +1227,58 @@ class TestPsshInactivityTimeout(unittest.TestCase):
             self.pssh.exec("run", inactivity_timeout=0.3)
 
 
+class TestPsshDestroyClients(unittest.TestCase):
+    """destroy_clients must actually tear the SSH transport down.
+
+    A timed-out exec leaves the per-host greenlet in client.cmds unfinished.
+    That greenlet's callable is a bound method of the ParallelSSHClient, so the
+    client stays reachable, SSHClient.__del__ never runs, and the sshd session
+    survives the Pssh object -- verified against a live sshd. Dropping the
+    reference is therefore not enough; the teardown has to be explicit.
+    """
+
+    @patch("cvs.lib.parallel.pssh.ParallelSSHClient")
+    def _make_pssh(self, mock_pssh_client, host_clients=None, cmds=None):
+        mock_client = MagicMock()
+        mock_client.cmds = cmds
+        mock_client._host_clients = host_clients if host_clients is not None else {}
+        mock_pssh_client.return_value = mock_client
+        pssh = Pssh(MagicMock(), ["host1"], user="user", password="pass")
+        return pssh, mock_client
+
+    def test_destroy_clients_disconnects_each_host_client(self):
+        # The per-host SSHClient owns the socket; without an explicit
+        # _disconnect() the session is left open on the server.
+        host_client = MagicMock()
+        pssh, client = self._make_pssh(host_clients={(0, "host1"): host_client})
+
+        pssh.destroy_clients()
+
+        host_client._disconnect.assert_called_once_with()
+
+    def test_destroy_clients_kills_pending_command_greenlets(self):
+        # Unfinished greenlets from a timed-out exec are what pin the client;
+        # they must be killed or the disconnect above is unreachable.
+        greenlet = MagicMock()
+        pssh, client = self._make_pssh(cmds=[greenlet])
+
+        with patch("cvs.lib.parallel.pssh.killall") as mock_killall:
+            pssh.destroy_clients()
+
+        mock_killall.assert_called_once()
+        self.assertEqual(list(mock_killall.call_args.args[0]), [greenlet])
+
+    def test_destroy_clients_survives_disconnect_errors(self):
+        # A host that is already gone must not abort teardown of the others.
+        dead = MagicMock()
+        dead._disconnect.side_effect = OSError("connection already gone")
+        alive = MagicMock()
+        pssh, client = self._make_pssh(host_clients={(0, "h1"): dead, (1, "h2"): alive})
+
+        pssh.destroy_clients()
+
+        alive._disconnect.assert_called_once_with()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`BaremetalOrchestrator.exec`, `BaremetalOrchestrator.setup_env` and
`DockerRuntime.exec` build a throwaway `Pssh` for a host subset and drop it on
return. On timeout the per-host greenlet in `ParallelSSHClient.cmds` never
finishes; it holds a bound method of the client, so `SSHClient.__del__` never
runs and the sshd session survives. vLLM readiness polling does this per rank up
to 60 times a run, until sshd's per-user limit starts rejecting unrelated logins.

Ticket: AIMVT-283

## Change

- `Pssh.destroy_clients()` was `del self.client`, a no-op here. It now kills
  pending greenlets and `_disconnect()`s each host client, tolerating errors so
  one dead host can't abort the rest.
- All three subset call sites tear down in `try/finally`. `DockerRuntime.exec`
  builds its own `Pssh` instead of delegating, so container mode needs its own
  fix. `setup_env` has no callers today but is an `abstractmethod` on the base
  orchestrator, so it gets the same treatment.
- Shared `orch.head`/`orch.all` are reused, not rebuilt, and measure flat across
  repeated timeouts; left alone, with a guard test.
- Uses parallel-ssh internals (`_host_clients`, `_disconnect()`) — the public
  `disconnect()` is a documented no-op. Re-verify on any parallel-ssh bump.
- Out of scope: caching subset handles; sshd-side session limits.

## Tests

7 unit tests; reverting the fix turns them red. Against a live sshd, 8
timing-out subset execs grew sessions 1..8 before and hold flat at 1 after.
Clean execs never leaked.

Gate: 1110 tests, 4 failures, all 4 identical to the `dev/dtni` baseline
(1103/same 4). `fmt-check` and `lint` clean on every file touched here.