### PR TITLE
report: comment out Value/Unit columns in inference suite HTML reports

### DIFF
--- a/cvs/lib/inference/utils/inference_suite_lifecycle.py
+++ b/cvs/lib/inference/utils/inference_suite_lifecycle.py
@@ -256,23 +256,23 @@ def attach_lifecycle_html_table(item, report):
     report.extras = extras
 
 
-def html_metric_table_header(cells):
-    cells.insert(-1, "<th>Value</th>")
-    cells.insert(-1, "<th>Unit</th>")
-
-
-def html_metric_table_row(report, cells):
-    props = dict(report.user_properties)
-    has = "metric_value" in props
-    val = props.get("metric_value")
-    unit = props.get("metric_unit", "") if has else ""
-    if not has:
-        shown = ""
-    elif val is None:
-        shown = "-"
-    elif isinstance(val, float):
-        shown = f"{val:.3f}"
-    else:
-        shown = str(val)
-    cells.insert(-1, f"<td>{shown}</td>")
-    cells.insert(-1, f"<td>{unit}</td>")
+# def html_metric_table_header(cells):
+#     cells.insert(-1, "<th>Value</th>")
+#     cells.insert(-1, "<th>Unit</th>")
+#
+#
+# def html_metric_table_row(report, cells):
+#     props = dict(report.user_properties)
+#     has = "metric_value" in props
+#     val = props.get("metric_value")
+#     unit = props.get("metric_unit", "") if has else ""
+#     if not has:
+#         shown = ""
+#     elif val is None:
+#         shown = "-"
+#     elif isinstance(val, float):
+#         shown = f"{val:.3f}"
+#     else:
+#         shown = str(val)
+#     cells.insert(-1, f"<td>{shown}</td>")
+#     cells.insert(-1, f"<td>{unit}</td>")

--- a/cvs/tests/inference/inferencex_atom/conftest.py
+++ b/cvs/tests/inference/inferencex_atom/conftest.py
@@ -12,8 +12,8 @@ from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFacto
 from cvs.lib import globals
 from cvs.lib.inference.utils.inference_suite_lifecycle import (
     InferenceLifecycle,
-    html_metric_table_header,
-    html_metric_table_row,
+    # html_metric_table_header,
+    # html_metric_table_row,
     sort_lifecycle_items,
 )
 from cvs.lib.inference.inferencex_atom.inferencex_atom_config_loader import (
@@ -137,9 +137,9 @@ def pytest_collection_modifyitems(items):
     sort_lifecycle_items(items, LIFECYCLE_RANK)
 
 
-def pytest_html_results_table_header(cells):
-    html_metric_table_header(cells)
-
-
-def pytest_html_results_table_row(report, cells):
-    html_metric_table_row(report, cells)
+# def pytest_html_results_table_header(cells):
+#     html_metric_table_header(cells)
+#
+#
+# def pytest_html_results_table_row(report, cells):
+#     html_metric_table_row(report, cells)

--- a/cvs/tests/inference/sglang/conftest.py
+++ b/cvs/tests/inference/sglang/conftest.py
@@ -514,23 +514,23 @@ def pytest_runtest_makereport(item, call):
     report.extras = extras
 
 
-def pytest_html_results_table_header(cells):
-    cells.insert(-1, "<th>Value</th>")
-    cells.insert(-1, "<th>Unit</th>")
-
-
-def pytest_html_results_table_row(report, cells):
-    props = dict(report.user_properties)
-    has = "metric_value" in props
-    val = props.get("metric_value")
-    unit = props.get("metric_unit", "") if has else ""
-    if not has:
-        shown = ""
-    elif val is None:
-        shown = "-"
-    elif isinstance(val, float):
-        shown = f"{val:.3f}"
-    else:
-        shown = str(val)
-    cells.insert(-1, f"<td>{shown}</td>")
-    cells.insert(-1, f"<td>{unit}</td>")
+# def pytest_html_results_table_header(cells):
+#     cells.insert(-1, "<th>Value</th>")
+#     cells.insert(-1, "<th>Unit</th>")
+#
+#
+# def pytest_html_results_table_row(report, cells):
+#     props = dict(report.user_properties)
+#     has = "metric_value" in props
+#     val = props.get("metric_value")
+#     unit = props.get("metric_unit", "") if has else ""
+#     if not has:
+#         shown = ""
+#     elif val is None:
+#         shown = "-"
+#     elif isinstance(val, float):
+#         shown = f"{val:.3f}"
+#     else:
+#         shown = str(val)
+#     cells.insert(-1, f"<td>{shown}</td>")
+#     cells.insert(-1, f"<td>{unit}</td>")

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -152,29 +152,29 @@ def pytest_collection_modifyitems(items):
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
 
 
-def pytest_html_results_table_header(cells):
-    """Add Value + Unit columns just before the trailing Links column.
-
-    Populated for test_metric rows; blank for lifecycle/inference rows (they
-    record no metric_value user-property). Scoped to this suite's conftest, so
-    other suites' result tables are unaffected.
-    """
-    cells.insert(-1, "<th>Value</th>")
-    cells.insert(-1, "<th>Unit</th>")
-
-
-def pytest_html_results_table_row(report, cells):
-    props = dict(report.user_properties)
-    has = "metric_value" in props
-    val = props.get("metric_value")
-    unit = props.get("metric_unit", "") if has else ""
-    if not has:
-        shown = ""
-    elif val is None:
-        shown = "-"
-    elif isinstance(val, float):
-        shown = f"{val:.3f}"
-    else:
-        shown = str(val)
-    cells.insert(-1, f"<td>{shown}</td>")
-    cells.insert(-1, f"<td>{unit}</td>")
+# def pytest_html_results_table_header(cells):
+#     """Add Value + Unit columns just before the trailing Links column.
+#
+#     Populated for test_metric rows; blank for lifecycle/inference rows (they
+#     record no metric_value user-property). Scoped to this suite's conftest, so
+#     other suites' result tables are unaffected.
+#     """
+#     cells.insert(-1, "<th>Value</th>")
+#     cells.insert(-1, "<th>Unit</th>")
+#
+#
+# def pytest_html_results_table_row(report, cells):
+#     props = dict(report.user_properties)
+#     has = "metric_value" in props
+#     val = props.get("metric_value")
+#     unit = props.get("metric_unit", "") if has else ""
+#     if not has:
+#         shown = ""
+#     elif val is None:
+#         shown = "-"
+#     elif isinstance(val, float):
+#         shown = f"{val:.3f}"
+#     else:
+#         shown = str(val)
+#     cells.insert(-1, f"<td>{shown}</td>")
+#     cells.insert(-1, f"<td>{unit}</td>")


### PR DESCRIPTION
Ticket: AIMVT-284

## Summary
Removes the Value/Unit columns from the pytest-html results table across
the vllm, sglang, and inferencex_atom inference suites.

## Change
- Commented out `pytest_html_results_table_header`/`_row` in each suite's
  `conftest.py`, plus the shared `html_metric_table_header`/`_row` helper
  in `inference_suite_lifecycle.py` (and ATOM's now-unused import of it)
- vllm and inferencex_atom previously populated real per-metric values;
  sglang's columns were already always blank (no sglang test sets
  metric_value/metric_unit)
- Out of scope: sglang's separate per-stage lifecycle mini-table
  (stage/value/unit), which is a different, smaller HTML extra untouched
  by this change

## Tests
- `.test_venv/bin/python run_all_unittests.py`: 1110 tests, same 4
  pre-existing failures as on `dev/dtni` baseline, no new failures
- `dev/dtni` baseline fmt-check/lint are already red (unrelated,
  pre-existing); diffed before/after and confirmed this change adds no
  new fmt-check/lint violations
