### PR TITLE
test(atom): align multinode unit tests with session key and fabric discovery

### DIFF
--- a/cvs/lib/inference/unittests/test_atom_config_loader.py
+++ b/cvs/lib/inference/unittests/test_atom_config_loader.py
@@ -279,7 +279,14 @@ class TestATOMAtomConfigLoader(unittest.TestCase):
         self.assertFalse(reuse_server_flag(SimpleNamespace()))
         variant = SimpleNamespace(
             model=SimpleNamespace(id="m"),
-            params=SimpleNamespace(driver="atom", tensor_parallelism="8"),
+            params=SimpleNamespace(
+                driver="atom",
+                tensor_parallelism="8",
+                nnodes="1",
+                pipeline_parallel_size="1",
+                master_addr="",
+                master_port="29501",
+            ),
             roles=SimpleNamespace(server=SimpleNamespace(atom_args=("-tp", "8"))),
         )
         self.assertNotEqual(server_session_key(variant, "1", "2"), server_session_key(variant, "3", "4"))

--- a/cvs/lib/inference/unittests/test_atom_orch_parse.py
+++ b/cvs/lib/inference/unittests/test_atom_orch_parse.py
@@ -10,6 +10,7 @@ import json
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import patch
 
 from cvs.lib.inference.atom.atom_orch import AtomJob
@@ -554,7 +555,7 @@ class TestATOMAtomBuildServerCmd(unittest.TestCase):
 
 
 class _RecordingOrch:
-    hosts = ["10.0.0.1", "10.0.0.2"]
+    hosts: ClassVar[list[str]] = ["10.0.0.1", "10.0.0.2"]
 
     def __init__(self, responder=None, hosts=None):
         self.calls = []

--- a/cvs/lib/inference/unittests/test_atom_orch_parse.py
+++ b/cvs/lib/inference/unittests/test_atom_orch_parse.py
@@ -20,6 +20,8 @@ _FIXTURES = _HERE / "fixtures"
 _ISL = 7168
 _OSL = 1024
 _TP = 8
+# Prefill fabric so build_server_cmd skips lazy IB discovery in FakeOrch tests.
+_PREFILLED_FABRIC = {"ib_hcas": ["mlx5_0"], "ib_netdev": "eth0"}
 
 
 def _fake_variant(
@@ -278,6 +280,7 @@ class TestATOMAtomOrchParse(unittest.TestCase):
             osl="1024",
             concurrency=128,
             num_prompts=100,
+            **_PREFILLED_FABRIC,
         )
         job.build_server_cmd(clear_atom_cache=False)
         job.start_server()
@@ -451,7 +454,8 @@ class TestATOMAtomBuildServerCmd(unittest.TestCase):
     def _env_script(orch):
         return orch.commands[0][0]
 
-    def test_nccl_ib_hca_line_present_only_when_ib_hcas_supplied(self):
+    @patch("cvs.lib.utils.ib_discovery.resolve_multinode_fabric", return_value=([], "eth0"))
+    def test_nccl_ib_hca_line_present_only_when_ib_hcas_supplied(self, _mock_resolve):
         cases = [
             (["mlx5_0", "mlx5_1"], True),
             ([], False),
@@ -499,6 +503,7 @@ class TestATOMAtomBuildServerCmd(unittest.TestCase):
             osl="1024",
             concurrency=128,
             num_prompts=100,
+            **_PREFILLED_FABRIC,
         )
         job.build_server_cmd()
         script = self._env_script(orch)

--- a/cvs/lib/inference/unittests/test_atom_server_reuse.py
+++ b/cvs/lib/inference/unittests/test_atom_server_reuse.py
@@ -16,6 +16,23 @@ from cvs.lib.inference.atom.atom_config_loader import (
 from cvs.lib.inference.atom.atom_parsing import METRIC_TIER_ORDER
 
 
+def _session_key_variant(*, model_id="model-a", **params_kw):
+    params = {
+        "driver": "atom",
+        "tensor_parallelism": "8",
+        "nnodes": "1",
+        "pipeline_parallel_size": "1",
+        "master_addr": "",
+        "master_port": "29501",
+    }
+    params.update(params_kw)
+    return SimpleNamespace(
+        model=SimpleNamespace(id=model_id),
+        params=SimpleNamespace(**params),
+        roles=SimpleNamespace(server=SimpleNamespace(atom_args=("-tp", "8"))),
+    )
+
+
 class TestServerReuseHelpers(unittest.TestCase):
     def test_reuse_server_flag_truthy_values(self):
         for raw in ("true", "1", "yes", "TRUE", " Yes "):
@@ -31,26 +48,14 @@ class TestServerReuseHelpers(unittest.TestCase):
         self.assertFalse(reuse_server_flag(SimpleNamespace()))
 
     def test_server_session_key_differs_for_model(self):
-        base = SimpleNamespace(
-            model=SimpleNamespace(id="model-a"),
-            params=SimpleNamespace(driver="atom", tensor_parallelism="8"),
-            roles=SimpleNamespace(server=SimpleNamespace(atom_args=("-tp", "8"))),
-        )
-        other = SimpleNamespace(
-            model=SimpleNamespace(id="model-b"),
-            params=SimpleNamespace(driver="atom", tensor_parallelism="8"),
-            roles=SimpleNamespace(server=SimpleNamespace(atom_args=("-tp", "8"))),
-        )
+        base = _session_key_variant(model_id="model-a")
+        other = _session_key_variant(model_id="model-b")
         k1 = server_session_key(base, "1024", "1024")
         k2 = server_session_key(other, "1024", "1024")
         self.assertNotEqual(k1, k2)
 
     def test_server_session_key_differs_for_shape(self):
-        variant = SimpleNamespace(
-            model=SimpleNamespace(id="model-a"),
-            params=SimpleNamespace(driver="atom", tensor_parallelism="8"),
-            roles=SimpleNamespace(server=SimpleNamespace(atom_args=("-tp", "8"))),
-        )
+        variant = _session_key_variant()
         self.assertNotEqual(
             server_session_key(variant, "1024", "1024"),
             server_session_key(variant, "2048", "2048"),


### PR DESCRIPTION
# Fix atom multinode unit test failures

**Branch:** `hnimrama/fix-atom-multinode-unit-tests`  
**Base:** `dev/dtni`

## Summary

Fixes seven pre-existing unit test errors in the atom inference test suite that appeared after multinode support landed on `dev/dtni`. These were stale test fixtures and missing topology mocks — not runtime bugs in the atom multinode driver.

- Align `server_session_key` test fixtures with the multinode-aware session key (add `nnodes`, `pipeline_parallel_size`, `master_addr`, `master_port`)
- Prefill IB fabric on multinode `build_server_cmd` unit tests so `FakeOrch` runs match the lab lifecycle path (`test_discover_topology` → `AtomJob.from_variant`)
- Mock lazy `resolve_multinode_fabric` for tests that intentionally exercise empty HCA lists
- Fix RUF012 lint on `_RecordingOrch.hosts` (`ClassVar` annotation)

## Problem

After atom multinode (#296), `server_session_key()` and `AtomJob.build_server_cmd()` gained multinode fields and lazy IB topology resolution. Several unit tests still used minimal `SimpleNamespace` fixtures and bare `FakeOrch` instances, causing:

| Error | Count | Root cause |
|---|---|---|
| `AttributeError: ... has no attribute 'nnodes'` | 3 | `server_session_key` fixtures missing multinode params |
| `StopIteration` in `resolve_multinode_fabric` | 4 | `build_server_cmd` triggered lazy discovery on empty `FakeOrch` |

These failures did **not** affect hardware pytest runs (`tests/inference/atom/atom.py`), which load real variant configs and run `test_discover_topology` before benchmarks.

## Changes

### `test_atom_server_reuse.py`

- Add `_session_key_variant()` helper with full default params
- Use it in `test_server_session_key_differs_for_model` and `test_server_session_key_differs_for_shape`

### `test_atom_config_loader.py`

- Extend `test_reuse_server_flag_and_session_key_helpers` variant fixture with multinode params

### `test_atom_orch_parse.py`

- Add `_PREFILLED_FABRIC` constant (`ib_hcas` + `ib_netdev`) for multinode jobs that call `build_server_cmd`
- Patch `resolve_multinode_fabric` in `test_nccl_ib_hca_line_present_only_when_ib_hcas_supplied` for empty-HCA subtests
- Annotate `_RecordingOrch.hosts` as `ClassVar[list[str]]` (RUF012)

## Test plan

- [x] `python -m unittest discover -s cvs/lib/inference/unittests -p "test_atom*.py" -v` — 61/61 pass
- [x] `ruff format --check` on changed files
- [x] `ruff check` on changed files

## Notes

No production code changes. Runtime multinode behavior is unchanged; this PR only brings unit test mocks in line with the integration test lifecycle.
