### PR TITLE
Hnimrama/atom test readme

### DIFF
--- a/cvs/input/config_file/inference/atom/README.md
+++ b/cvs/input/config_file/inference/atom/README.md
@@ -24,23 +24,16 @@ In the CVS repo, variants are flat sibling pairs in **this directory**:
 | `mi300x_atom_deepseek-r1_fp8_baseline_sweep` | `…_baseline_sweep_threshold.json` | MI300X | `atom` | DTNI baseline: 1K/1K + 8K/1K × C=4–256 (14 cells) |
 | `mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed` | `…_baseline_sweep_distributed_threshold.json` | MI300X | `vllm_atom` | 2-node DTNI baseline (14 cells); PP=2, scaling gates |
 | `mi300x_atom_deepseek-r1_fp8_distributed` | `…_distributed_threshold.json` | MI300X | `vllm_atom` | W1 2-node PP=2; lab-calibrated thresholds |
-| `mi300x_atom_deepseek-r1_fp8_sglang_distributed` | `…_sglang_distributed_threshold.json` | MI300X | `sglang` | W1 2-node PP=2 SGLang path; record-only until lab confirm |
 | `mi300x_atom_deepseek-r1_fp8_mtp3` | `…_mtp3_threshold.json` | MI300X | `atom` | W1 FP8 + MTP3 |
 | `mi355x_atom_deepseek-r1_fp8_single` | `…_single_threshold.json` | MI355X | `atom` | W1 single-node; CI seeds, `enforce_thresholds: false` |
 | `mi355x_atom_deepseek-r1_fp8_baseline_sweep` | `…_baseline_sweep_threshold.json` | MI355X | `atom` | DTNI baseline matrix; record-only |
 | `mi355x_atom_deepseek-r1_fp8_distributed` | `…_distributed_threshold.json` | MI355X | `vllm_atom` | W1 2-node PP=2; record-only until lab confirm |
 | `mi355x_atom_deepseek-r1_fp8_mtp3` | `…_mtp3_threshold.json` | MI355X | `atom` | W1 FP8 + MTP3 |
-| `mi300x_atom_gpt-oss-120b_bf16` | `…_threshold.json` | MI300X | `vllm` | GPT-OSS uplift placeholder |
-| `mi355x_atom_gpt-oss-120b_bf16` | `…_threshold.json` | MI355X | `vllm` | GPT-OSS uplift placeholder |
 
 Add analogous config + threshold pairs for other archs or models as needed.
 
 Keys prefixed with `_` (e.g. `_comment`) are inline comments and are ignored by
 the loader.
-
-**Removed:** `*_smoke` variants — use `-k` on a full variant for a one-cell smoke.
-**Removed:** bare `driver=atom` multinode PP — use `vllm_atom` or `sglang`
-distributed stems above.
 
 ## What you MUST change for your cluster / setup
 
@@ -49,7 +42,7 @@ these:
 
 | Where | Variable | Change to |
 |---|---|---|
-| `container.image` | container image | Your ATOM / vLLM+ATOM / SGLang ROCm image on the nodes |
+| `container.image` | container image | Your ATOM ROCm image on the nodes |
 | `container.name` | container name | Any unique name (optional) |
 | `paths.shared_fs` | base path | A path reachable from all nodes; `{user-id}` resolves to the cluster/OS user |
 | `paths.models_dir` | model cache | Host path to the staged model (shipped configs use `/home/models`) |
@@ -57,18 +50,17 @@ these:
 | `paths.hf_token_file` | HF token path | Location of your Hugging Face token file |
 | `model.id` | model repo id | The model under test (W1: `deepseek-ai/DeepSeek-R1-0528`) |
 | `model.remote` | fetch mode | `0` = already cached on nodes; `1` = not implemented |
-| `params.driver` | execution stack | `atom`, `vllm_atom`, `sglang`, or interim `vllm` (see below) |
+| `params.driver` | execution stack | `atom` (single-node) or `vllm_atom` (multinode PP); see below |
 | `params.nnodes` | node count | `1` single-node; `2` for shipped multinode PP variants |
 | `params.master_addr` | PP coordinator | Head node VPC IP (replace `{head-node-ip}` on multinode stems) |
 | `params.master_port` | PP coordinator port | Usually `29501` |
 | `params.pipeline_parallel_size` | PP size | `2` on shipped multinode stems |
 | `params.scaling_baseline_output_throughput` | 1-node baseline | Measured single-node output tok/s for `scaling.efficiency_pct` (multinode) |
 | `roles.server.atom_args` | ATOM server CLI | Tokens after `--model` / `--server-port` when `driver=atom` |
-| `roles.server.serve_args` | vLLM serve flags | Dict of `vllm serve` flags when `driver=vllm_atom` or `vllm` |
-| `roles.server.sglang_args` | SGLang server CLI | Args for `sglang.launch_server` when `driver=sglang` |
+| `roles.server.serve_args` | multinode serve flags | Dict merged into the multinode server argv when `driver=vllm_atom` |
 | `roles.server.ib_hca_devices` | RDMA HCAs | `"auto"` (default) or explicit list; probed in `test_discover_topology` |
 | `roles.server.ib_netdev` | socket netdev | `"auto"` (default on distributed) or explicit name; **not** `mlx5_*` |
-| `roles.server.env` | server env | Driver-specific env (ATOM mmap, vLLM AITER flags, …) |
+| `roles.server.env` | server env | ATOM / multinode env (e.g. mmap, AITER flags) |
 | `.json` gated values | thresholds | Calibrated PASS/FAIL bounds for your hardware |
 | cluster file `node_dict` | node IPs | Your node IPs; **host count must equal `params.nnodes`** |
 | cluster template | `atom_cluster.json` | Copy from `cvs/input/cluster_file/atom_cluster.json` |
@@ -83,8 +75,7 @@ into its **own subdirectory** so threshold discovery is unambiguous:
 
 ```text
 ~/input/.../atom/single/              # single-node config + threshold only
-~/input/.../atom/distributed/         # vllm_atom PP=2
-~/input/.../atom/sglang_distributed/  # sglang PP=2
+~/input/.../atom/distributed/         # multinode PP=2 (driver=vllm_atom)
 ~/input/.../atom/baseline_sweep/      # DTNI single-node matrix
 ```
 
@@ -126,11 +117,11 @@ Top-level (framework-agnostic) fields:
 
 | Field | Meaning |
 |---|---|
-| `driver` | `atom`, `vllm_atom`, `sglang`, or interim `vllm` |
+| `driver` | `atom` (single-node) or `vllm_atom` (multinode PP) |
 | `tensor_parallelism` | TP size (W1: `8`) |
 | `pipeline_parallel_size` | PP size (`1` single-node; `2` on multinode stems) |
 | `nnodes` | Node count (`1` or `2` on shipped variants) |
-| `master_addr` / `master_port` | Multinode coordinator (vLLM / SGLang) |
+| `master_addr` / `master_port` | Multinode PP coordinator address/port |
 | `port_no` | Server HTTP port (default `8000`) |
 | `num_prompts` | Benchmark prompt count per cell |
 | `max_model_length` | Server MML; must cover `(ISL+OSL) × (1+random_range_ratio)` |
@@ -146,23 +137,21 @@ Top-level (framework-agnostic) fields:
 | Field | Meaning |
 |---|---|
 | `atom_args` | Extra CLI tokens for `python -m atom.entrypoints.openai_server` (`driver=atom`) |
-| `serve_args` | Dict merged into `vllm serve` argv (`driver=vllm_atom` / `vllm`) |
-| `sglang_args` | Args for `sglang.launch_server` (`driver=sglang`) |
+| `serve_args` | Multinode server flags when `driver=vllm_atom` |
 | `env` | Exported in `/tmp/server_env_script.sh` (orchestrator-managed NCCL keys are stripped) |
 | `ib_hca_devices` | `"auto"` or explicit HCA list for `NCCL_IB_HCA` |
 | `ib_netdev` | `"auto"` or explicit socket interface for `NCCL/GLOO/TP_SOCKET_IFNAME` |
 
 ### Execution drivers (`params.driver`)
 
-Standalone ATOM has **no native pipeline parallel**. Multinode PP requires a
-framework coordinator:
+Standalone ATOM has **no native pipeline parallel**. Single-node variants use
+the native ATOM server; shipped multinode PP stems use `vllm_atom` (same ATOM
+bench client and ROCm env, with a PP coordinator for 2-node runs):
 
-| Driver | When to use | Server | Multinode PP |
+| Driver | When to use | Server entrypoint | Multinode PP |
 |---|---|---|---|
 | `atom` | Single-node W1, baseline sweep, MTP3 | `atom.entrypoints.openai_server` | No |
-| `vllm_atom` | Shipped 2-node PP stems | `vllm serve` + ATOM ROCm env | Yes |
-| `sglang` | Shipped SGLang multinode stem | `sglang.launch_server` | Yes |
-| `vllm` | GPT-OSS placeholder | `vllm serve` | When PP flags configured |
+| `vllm_atom` | Shipped 2-node PP stems | Multinode serve path + ATOM ROCm env | Yes |
 
 Multinode fabric is probed once per run in `test_discover_topology` (on the
 **cluster host OS**, not inside the container). Probes can be skipped on
@@ -242,7 +231,7 @@ Template: `cvs/input/cluster_file/atom_cluster.json`. Copy to
 | Variant type | `params.nnodes` | `node_dict` |
 |---|---|---|
 | Single-node (`*_single`, baseline sweep, MTP3) | `1` | Head node only |
-| Multinode PP (`*_distributed`, `*_baseline_sweep_distributed`, `*_sglang_distributed`) | `2` | Head + worker |
+| Multinode PP (`*_distributed`, `*_baseline_sweep_distributed`) | `2` | Head + worker |
 
 `test_setup_sshd` runs when `len(node_dict) > 1`.
 
@@ -291,20 +280,12 @@ cvs run atom \
 ```
 
 For multinode PP variants, use a two-host cluster file, copy the matching
-`*_distributed*` (or `*_sglang_distributed*`) config pair into its own
-subdirectory, set `container.image`, `params.master_addr`, and verify fabric
-discovery (or set `roles.server.ib_netdev` explicitly).
+`*_distributed*` config pair into its own subdirectory, set `container.image`,
+`params.master_addr`, and verify fabric discovery (or set `roles.server.ib_netdev`
+explicitly).
 
 Smoke a single cell with `-k`, for example `-k "w1_1k_1k-conc128"`.
 
 When `--html` is set, the **ATOM Run Deck** is generated at session end and
 bundled into the pytest zip (render-only; does not affect gates). See
 `cvs/lib/report/README.md`.
-
-## Related docs
-
-| Doc | Purpose |
-|---|---|
-| `cvs/tests/inference/atom/README.md` | Suite lifecycle, sweeps, metric tiers, quick start |
-| `cvs/lib/inference/utils/docs/atom-parsing.md` | `client.*` metric vocabulary and tiers |
-| `docs/reference/configuration-files/atom.rst` | Published config reference (Sphinx) |

--- a/cvs/input/config_file/inference/atom/README.md
+++ b/cvs/input/config_file/inference/atom/README.md
@@ -1,142 +1,272 @@
-# ATOM variants
+# ATOM Inference — Config and Threshold Files
 
-W1 **DeepSeek R1 FP8** on 8× GPU, ISL=OSL=1024, TP8.
+This folder holds the input files for the `atom` suite (see
+`cvs/tests/inference/atom/README.md` for how to run it). Each **config** file
+has a sibling **threshold** file (referenced by its `threshold_json` field).
+One config = one GPU arch + topology + driver mode (single-node, multinode PP,
+baseline matrix, …).
 
-## Layout
+W1 workloads target **DeepSeek R1 FP8** on 8× GPU per node (ISL/OSL sweeps,
+TP8 unless noted).
 
-**In the CVS repo**, all variants live as flat sibling pairs in **this directory**:
+## File inventory
+
+In the CVS repo, variants are flat sibling pairs in **this directory**:
 
 ```text
 {gpu}_atom_{model}_{precision}[_{mode}].json
 {gpu}_atom_{model}_{precision}[_{mode}]_threshold.json
 ```
 
-Same convention as ``inference/vllm/`` (for example ``mi300x_vllm_llama31-70b_fp8_single.json`` / ``…_distributed.json``): flat sibling pairs, no ``_config`` suffix on the main JSON.
+| Config | Threshold | GPU | Driver | Notes |
+|---|---|---|---|---|
+| `mi300x_atom_deepseek-r1_fp8_single` | `…_single_threshold.json` | MI300X | `atom` | W1 single-node; portable min-SLO thresholds; server reuse |
+| `mi300x_atom_deepseek-r1_fp8_baseline_sweep` | `…_baseline_sweep_threshold.json` | MI300X | `atom` | DTNI baseline: 1K/1K + 8K/1K × C=4–256 (14 cells) |
+| `mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed` | `…_baseline_sweep_distributed_threshold.json` | MI300X | `vllm_atom` | 2-node DTNI baseline (14 cells); PP=2, scaling gates |
+| `mi300x_atom_deepseek-r1_fp8_distributed` | `…_distributed_threshold.json` | MI300X | `vllm_atom` | W1 2-node PP=2; lab-calibrated thresholds |
+| `mi300x_atom_deepseek-r1_fp8_sglang_distributed` | `…_sglang_distributed_threshold.json` | MI300X | `sglang` | W1 2-node PP=2 SGLang path; record-only until lab confirm |
+| `mi300x_atom_deepseek-r1_fp8_mtp3` | `…_mtp3_threshold.json` | MI300X | `atom` | W1 FP8 + MTP3 |
+| `mi355x_atom_deepseek-r1_fp8_single` | `…_single_threshold.json` | MI355X | `atom` | W1 single-node; CI seeds, `enforce_thresholds: false` |
+| `mi355x_atom_deepseek-r1_fp8_baseline_sweep` | `…_baseline_sweep_threshold.json` | MI355X | `atom` | DTNI baseline matrix; record-only |
+| `mi355x_atom_deepseek-r1_fp8_distributed` | `…_distributed_threshold.json` | MI355X | `vllm_atom` | W1 2-node PP=2; record-only until lab confirm |
+| `mi355x_atom_deepseek-r1_fp8_mtp3` | `…_mtp3_threshold.json` | MI355X | `atom` | W1 FP8 + MTP3 |
+| `mi300x_atom_gpt-oss-120b_bf16` | `…_threshold.json` | MI300X | `vllm` | GPT-OSS uplift placeholder |
+| `mi355x_atom_gpt-oss-120b_bf16` | `…_threshold.json` | MI355X | `vllm` | GPT-OSS uplift placeholder |
 
-**On your lab machine** (`~/input/config_file/inference/atom/`), copy each variant into its **own subdirectory** so only one `*threshold.json` sits next to the config you pass to `--config_file`. `substitute_config` globs the config's parent directory; multiple `*threshold.json` files there raises `ValueError: multiple *threshold.json files … (ambiguous)`.
+Add analogous config + threshold pairs for other archs or models as needed.
+
+Keys prefixed with `_` (e.g. `_comment`) are inline comments and are ignored by
+the loader.
+
+**Removed:** `*_smoke` variants — use `-k` on a full variant for a one-cell smoke.
+**Removed:** bare `driver=atom` multinode PP — use `vllm_atom` or `sglang`
+distributed stems above.
+
+## What you MUST change for your cluster / setup
+
+Start from the config closest to your target GPU / topology / driver and edit
+these:
+
+| Where | Variable | Change to |
+|---|---|---|
+| `container.image` | container image | Your ATOM / vLLM+ATOM / SGLang ROCm image on the nodes |
+| `container.name` | container name | Any unique name (optional) |
+| `paths.shared_fs` | base path | A path reachable from all nodes; `{user-id}` resolves to the cluster/OS user |
+| `paths.models_dir` | model cache | Host path to the staged model (shipped configs use `/home/models`) |
+| `paths.log_dir` | benchmark logs | Usually `{shared_fs}/LOGS` |
+| `paths.hf_token_file` | HF token path | Location of your Hugging Face token file |
+| `model.id` | model repo id | The model under test (W1: `deepseek-ai/DeepSeek-R1-0528`) |
+| `model.remote` | fetch mode | `0` = already cached on nodes; `1` = not implemented |
+| `params.driver` | execution stack | `atom`, `vllm_atom`, `sglang`, or interim `vllm` (see below) |
+| `params.nnodes` | node count | `1` single-node; `2` for shipped multinode PP variants |
+| `params.master_addr` | PP coordinator | Head node VPC IP (replace `{head-node-ip}` on multinode stems) |
+| `params.master_port` | PP coordinator port | Usually `29501` |
+| `params.pipeline_parallel_size` | PP size | `2` on shipped multinode stems |
+| `params.scaling_baseline_output_throughput` | 1-node baseline | Measured single-node output tok/s for `scaling.efficiency_pct` (multinode) |
+| `roles.server.atom_args` | ATOM server CLI | Tokens after `--model` / `--server-port` when `driver=atom` |
+| `roles.server.serve_args` | vLLM serve flags | Dict of `vllm serve` flags when `driver=vllm_atom` or `vllm` |
+| `roles.server.sglang_args` | SGLang server CLI | Args for `sglang.launch_server` when `driver=sglang` |
+| `roles.server.ib_hca_devices` | RDMA HCAs | `"auto"` (default) or explicit list; probed in `test_discover_topology` |
+| `roles.server.ib_netdev` | socket netdev | `"auto"` (default on distributed) or explicit name; **not** `mlx5_*` |
+| `roles.server.env` | server env | Driver-specific env (ATOM mmap, vLLM AITER flags, …) |
+| `.json` gated values | thresholds | Calibrated PASS/FAIL bounds for your hardware |
+| cluster file `node_dict` | node IPs | Your node IPs; **host count must equal `params.nnodes`** |
+| cluster template | `atom_cluster.json` | Copy from `cvs/input/cluster_file/atom_cluster.json` |
+
+Also set `enforce_thresholds` to `true` for real PASS/FAIL or `false` for
+record-only (MI355X stems ship record-only until lab calibration).
+
+### Lab directory layout
+
+On your lab machine (`~/input/config_file/inference/atom/`), copy each variant
+into its **own subdirectory** so threshold discovery is unambiguous:
 
 ```text
-~/input/.../atom/single/   # single-node config + threshold only
-~/input/.../atom/distributed/  # vllm_atom PP=2 config + threshold only
-~/input/.../atom/sglang_distributed/  # sglang PP=2 config + threshold only
+~/input/.../atom/single/              # single-node config + threshold only
+~/input/.../atom/distributed/         # vllm_atom PP=2
+~/input/.../atom/sglang_distributed/  # sglang PP=2
+~/input/.../atom/baseline_sweep/      # DTNI single-node matrix
 ```
 
-Each shipped config sets `"threshold_json"` to the sibling threshold filename (resolved relative to the config directory). You may also use an absolute path (vLLM-style).
+`substitute_config` globs the config's parent directory; multiple `*threshold.json`
+files in one folder raises `ValueError: multiple *threshold.json files … (ambiguous)`.
 
-Legacy nested layouts (`deepseek_r1_fp8_mi300x_atom_perf/`, `inferencemax/`, etc.) are **removed** from the repo tree. Use only the flat stems below.
+Each shipped config sets `"threshold_json"` to the sibling threshold filename
+(relative to the config directory). You may also use an absolute path.
 
-**Config filename example:** `mi300x_atom_deepseek-r1_fp8_single.json`
+## Placeholder substitution
 
-| Variant | GPU | Driver | Notes |
-|---------|-----|--------|-------|
-| `mi300x_atom_deepseek-r1_fp8_single` | MI300X | `atom` | W1 single-node, portable min-SLO thresholds, server reuse across sweep |
-| `mi300x_atom_deepseek-r1_fp8_baseline_sweep` | MI300X | `atom` | **DTNI baseline matrix:** 1K/1K + 8K/1K × C=4–256 (14 cells); `max_model_length=10240` |
-| `mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed` | MI300X | `vllm_atom` | **2-node** DTNI baseline (14 cells); `PP=2`, scaling gates |
-| `mi300x_atom_deepseek-r1_fp8_distributed` | MI300X | `vllm_atom` | W1 **2-node** PP=2; `enforce_thresholds: true` after lab recalibration |
-| `mi300x_atom_deepseek-r1_fp8_sglang_distributed` | MI300X | `sglang` | W1 **2-node** PP=2; `enforce_thresholds: false` until lab confirm |
-| `mi300x_atom_deepseek-r1_fp8_mtp3` | MI300X | `atom` | W1 FP8+MTP3 |
-| `mi355x_atom_deepseek-r1_fp8_single` | MI355X | `atom` | W1 single-node (CI seeds, `enforce_thresholds: false`) |
-| `mi355x_atom_deepseek-r1_fp8_baseline_sweep` | MI355X | `atom` | **DTNI baseline matrix:** 1K/1K + 8K/1K × C=4–256 (14 cells); threshold seeds, `enforce_thresholds: false` |
-| `mi355x_atom_deepseek-r1_fp8_distributed` | MI355X | `vllm_atom` | W1 **2-node** PP=2; `enforce_thresholds: false` until lab confirm |
-| `mi355x_atom_deepseek-r1_fp8_mtp3` | MI355X | `atom` | W1 FP8+MTP3 |
-| `mi300x_atom_gpt-oss-120b_bf16` | MI300X | `vllm` | GPT-OSS uplift placeholder |
-| `mi355x_atom_gpt-oss-120b_bf16` | MI355X | `vllm` | GPT-OSS uplift placeholder |
+Configs use placeholders resolved at load time:
 
-**Removed:** `*_smoke` variant (use `-k` on `single`, `distributed`, or `sglang_distributed` for a one-cell smoke). **Removed:** bare `driver=atom` multinode PP — use `vllm_atom` or `sglang` distributed stems above.
+- `{user-id}` — the cluster username (or the local OS user as fallback).
+- `{shared_fs}` — self-reference within the `paths` block.
+- `{paths.models_dir}` (and other `{paths.*}`) — cross-referenced anywhere.
+- `{head-node-ip}` — replace manually in copied multinode configs (not auto-resolved).
 
-ATOM server CLI for **`driver=atom`** lives in `roles.server.atom_args`. Multinode **PP=2** variants use **`driver=vllm_atom`** (`roles.server.serve_args`) or **`driver=sglang`** (`roles.server.sglang_args`). MTP3 variants also set `params.bench_extra_args`.
+`threshold_json` is a literal filename resolved next to the config; no
+placeholder substitution is applied to it.
 
-## Execution drivers (`params.driver`)
+## Config structure
 
-Standalone ATOM has **no native pipeline parallel**. Multinode PP validation requires a framework coordinator:
+Top-level (framework-agnostic) fields:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Always `1` |
+| `framework` | `atom` |
+| `gpu_arch` | `mi300x` / `mi355x` (labels the run) |
+| `enforce_thresholds` | `true` = metrics gate PASS/FAIL; `false` = record-only |
+| `threshold_json` | Sibling threshold filename |
+| `run_card` | Optional metadata (`atom_image_pin`, `upstream_run_url`, `notes`) logged at session start |
+| `paths` | `shared_fs`, `models_dir`, `log_dir`, `hf_token_file` |
+| `model` | `id`, `remote` (0 = already cached), `precision` (label) |
+| `container` | `lifetime`, `name`, `image`, `runtime` (docker `args`: network/ipc/privileged/shm-size/volumes/devices) |
+
+### `params` block
+
+| Field | Meaning |
+|---|---|
+| `driver` | `atom`, `vllm_atom`, `sglang`, or interim `vllm` |
+| `tensor_parallelism` | TP size (W1: `8`) |
+| `pipeline_parallel_size` | PP size (`1` single-node; `2` on multinode stems) |
+| `nnodes` | Node count (`1` or `2` on shipped variants) |
+| `master_addr` / `master_port` | Multinode coordinator (vLLM / SGLang) |
+| `port_no` | Server HTTP port (default `8000`) |
+| `num_prompts` | Benchmark prompt count per cell |
+| `max_model_length` | Server MML; must cover `(ISL+OSL) × (1+random_range_ratio)` |
+| `random_range_ratio` | Random workload ratio passed to bench client |
+| `metric_percentiles` | Tail percentiles requested (e.g. `95,99`) |
+| `reuse_server_across_sweep` | `true` = keep server warm across cells with matching session key |
+| `scaling_baseline_output_throughput` | Single-node output tok/s baseline for `scaling.efficiency_pct` |
+| `bench_extra_args` | Extra bench client tokens (MTP3 variants) |
+| `server_*` / `client_*` poll waits | Timeouts for server ready and client completion |
+
+### `roles.server` block
+
+| Field | Meaning |
+|---|---|
+| `atom_args` | Extra CLI tokens for `python -m atom.entrypoints.openai_server` (`driver=atom`) |
+| `serve_args` | Dict merged into `vllm serve` argv (`driver=vllm_atom` / `vllm`) |
+| `sglang_args` | Args for `sglang.launch_server` (`driver=sglang`) |
+| `env` | Exported in `/tmp/server_env_script.sh` (orchestrator-managed NCCL keys are stripped) |
+| `ib_hca_devices` | `"auto"` or explicit HCA list for `NCCL_IB_HCA` |
+| `ib_netdev` | `"auto"` or explicit socket interface for `NCCL/GLOO/TP_SOCKET_IFNAME` |
+
+### Execution drivers (`params.driver`)
+
+Standalone ATOM has **no native pipeline parallel**. Multinode PP requires a
+framework coordinator:
 
 | Driver | When to use | Server | Multinode PP |
-|--------|-------------|--------|--------------|
-| `atom` | W1 single-node (`*_single`, baseline sweep, MTP3) | `atom.entrypoints.openai_server` | No — single host only |
-| `vllm_atom` | **2-node PP=2** (shipped multinode stems) | `vllm serve` + ATOM ROCm env | Yes — vLLM `--pipeline-parallel-size`, `--node-rank` |
-| `sglang` | **2-node PP=2** SGLang path | `sglang.launch_server` | Yes — `--pp-size`, `--dist-init-addr` |
-| `vllm` | GPT-OSS uplift placeholder only | `vllm serve` | Same PP flags as `vllm_atom` when configured |
+|---|---|---|---|
+| `atom` | Single-node W1, baseline sweep, MTP3 | `atom.entrypoints.openai_server` | No |
+| `vllm_atom` | Shipped 2-node PP stems | `vllm serve` + ATOM ROCm env | Yes |
+| `sglang` | Shipped SGLang multinode stem | `sglang.launch_server` | Yes |
+| `vllm` | GPT-OSS placeholder | `vllm serve` | When PP flags configured |
 
-**Before a multinode PP lab run**, set in the copied config:
+Multinode fabric is probed once per run in `test_discover_topology` (on the
+**cluster host OS**, not inside the container). Probes can be skipped on
+single-node (`nnodes=1`). Lazy resolution also runs on first `build_server_cmd`
+if topology discovery is omitted via a smoke `-k` filter.
 
-- `container.image` — vLLM+ATOM or SGLang-capable image (shipped configs use `<changeme>`)
-- `params.master_addr` — head node VPC IP (replace `{head-node-ip}`)
+### `sweep` block
 
-Multinode fabric is probed once per run in `test_discover_topology` (or lazily on first `build_server_cmd` if that test is omitted from a smoke `-k` filter). Probes run on the **cluster host OS** (not inside the container), where `ip` and `ibv_devinfo` are available:
+| Field | Meaning |
+|---|---|
+| `sequence_combinations` | Named `(isl, osl)` shapes, e.g. `{name, isl, osl}` |
+| `runs` | `{combo, concurrency}` pairs — one benchmark cell each |
 
-- `roles.server.ib_hca_devices: "auto"` (default) → `NCCL_IB_HCA` from `ibv_devinfo -l`
-- `roles.server.ib_netdev: "auto"` (default on distributed stems) → `GLOO_SOCKET_IFNAME` / `NCCL_SOCKET_IFNAME` from the cluster IP on each node
+Each run produces a **threshold cell key** via `cell_key()`:
 
-Override `ib_netdev` only when auto-discovery fails (asymmetric interface names) or you need a non-default NIC. Do **not** set `mlx5_*` — those are IB HCAs, not IP netdevs.
+- Single-node: `ISL=1024,OSL=1024,TP=8,CONC=128`
+- Multinode PP: `ISL=1024,OSL=1024,TP=8,PP=2,NNODES=2,CONC=128`
 
-Threshold cell keys for multinode PP: `ISL=…,OSL=…,TP=8,PP=2,NNODES=2,CONC=…`.
+The key must match a top-level entry in the threshold file. Parametrize IDs in
+pytest look like `w1_1k_1k-conc128` or `w1_1k_1k-conc128-throughput` (metric
+tier suffix on gate rows).
 
-**Model cache path:** shipped configs set `paths.models_dir` to `/home/models` and mount `/home/models:/home/models` into the container. Logs and HF token paths still use `{shared_fs}` under the SSH user home.
+## Threshold files
+
+A threshold file maps each **cell key** to `{metric: spec}`. Metrics use the
+`client.*` namespace (plus `scaling.efficiency_pct` on multinode). A metric is
+gated only when `enforce_thresholds: true`, the metric belongs to the tier under
+test, and a spec exists; otherwise it is recorded. Metrics missing from the
+benchmark artifact are skipped (ATOM may omit tail percentiles).
+
+Threshold kinds:
+
+| kind | Passes when | Notes |
+|---|---|---|
+| `min` | `actual >= value` | lower bound (e.g. success_rate) |
+| `max` | `actual <= value` | upper bound (e.g. failed count) |
+| `max_ms` | `actual <= value` | upper bound, `ms` in the message |
+| `min_tok_s` | `actual >= value` | lower bound, `tok/s` in the message |
+| `within` | `value +/- tolerance_pct%` | needs `tolerance_pct` |
+| `min_ratio` | `actual / actuals[reference] >= value` | needs `reference` |
+| `info` | always | record-only; retains a default `value` to calibrate later |
+
+Example single-node cell:
+
+```json
+"ISL=1024,OSL=1024,TP=8,CONC=128": {
+  "client.total_token_throughput": { "kind": "min_tok_s", "value": 3000 },
+  "client.output_throughput":        { "kind": "min_tok_s", "value": 1500 },
+  "client.per_gpu_throughput":       { "kind": "min_tok_s", "value": 375 },
+  "client.p99_ttft_ms":              { "kind": "max_ms", "value": 1000000 },
+  "client.success_rate":             { "kind": "min", "value": 1 },
+  "client.failed":                   { "kind": "max", "value": 0 }
+}
+```
+
+Example multinode cell (adds scaling):
+
+```json
+"ISL=1024,OSL=1024,TP=8,PP=2,NNODES=2,CONC=128": {
+  "client.output_throughput":        { "kind": "min_tok_s", "value": 2500 },
+  "client.p99_ttft_ms":              { "kind": "max_ms", "value": 5000 },
+  "scaling.efficiency_pct":          { "kind": "min", "value": 80 }
+}
+```
+
+To start gating a metric currently marked `info`: replace `"kind": "info"` with
+`min`/`max`/etc. and set a calibrated `value`. The threshold cell key must match
+the sweep cell exactly (including `PP` and `NNODES` on multinode), or the metric
+falls back to record-only.
 
 ## Cluster file
 
-Ship one template: `cvs/input/cluster_file/atom_cluster.json`. Copy it to `~/input/cluster_file/atom_cluster.json` and edit IPs, SSH user, and key path.
-
-**Host count must match the variant:** `len(node_dict)` must equal `params.nnodes` in the config you pass to `--config_file`.
+Template: `cvs/input/cluster_file/atom_cluster.json`. Copy to
+`~/input/cluster_file/atom_cluster.json` and edit IPs, `username`, and
+`priv_key_file`.
 
 | Variant type | `params.nnodes` | `node_dict` |
-|--------------|-----------------|-------------|
-| Single-node (`*_single`, baseline sweep, MTP3) | `1` (default) | **Head node only** — remove the worker entry |
-| Multinode PP (`*_distributed`, `*_baseline_sweep_distributed`, `*_sglang_distributed`) | `2` | Head + worker; use lab subdirs `distributed/` or `sglang_distributed/` |
+|---|---|---|
+| Single-node (`*_single`, baseline sweep, MTP3) | `1` | Head node only |
+| Multinode PP (`*_distributed`, `*_baseline_sweep_distributed`, `*_sglang_distributed`) | `2` | Head + worker |
 
-For multinode PP variants, set `params.master_addr` to the head VPC IP and a coordinator-capable `container.image`. Fabric netdev/HCAs are discovered in `test_discover_topology` unless overridden. `test_setup_sshd` runs when `len(node_dict) > 1`.
+`test_setup_sshd` runs when `len(node_dict) > 1`.
 
-## Shared suite helpers (reusable by other inference suites)
+## Running on a lab machine
 
-| Module | Purpose |
-|--------|---------|
-| `cvs/lib/inference/utils/inference_suite_lifecycle.py` | Lifecycle stage tests, `InferenceLifecycle`, pytest HTML hooks |
-| `cvs/lib/inference/utils/inference_suite_results_table.py` | Configurable results table (`make_print_results_table`) |
-| `cvs/lib/inference/unittests/fake_orch.py` | `FakeOrch` for Job parse unit tests |
+**Launcher vs GPU node:** CVS pytest runs on the launcher;
+`ContainerOrchestrator` SSHes to cluster nodes and runs `sudo docker` there.
 
-`atom` imports these today; `vllm_single` may adopt them in a follow-up without duplicating code.
+| Item | Launcher | GPU node |
+|---|---|---|
+| `cvs run`, venv, `~/input/`, `~/cvs_results/` | Yes | No |
+| `priv_key_file`, HF token file | Yes | No |
+| `/home/models` (when `model.remote: 0`) | No | Yes |
+| Container image, `sudo docker` | No | Yes |
+| `~/LOGS/` (via volume mount) | No | Yes |
 
-## Pytest layout
+After `git pull`, run **`make install` first**, then **`source .cvs_venv/bin/activate`**
+(do not activate the venv before `make install`).
 
-1. `test_launch_container` → `test_setup_sshd` → `test_model_fetch`
-2. `test_atom_inference` (per sweep cell; reuses server when `reuse_server_across_sweep: true`)
-3. `test_cell_metrics` (one HTML row per **metric tier** per cell: throughput, ttft, tpot, health, record)
-4. `test_print_results_table` → `test_teardown`
-
-W1 MI300X single with two concurrency cells expects **~17** pytest rows (not one row per scalar metric).
-
-## Before the first lab run
-
-- On the **launcher** host after `git checkout` / `git pull`: run **`make install` first**, then **`source .cvs_venv/bin/activate`**. Do not activate `.cvs_venv` before `make install` — the Makefile manages that venv and install can fail if it is already active.
+Typical workflow:
 
 ```bash
 cd ~/cvs
-git fetch origin hnimrama/atom-multinode
-git reset --hard origin/hnimrama/atom-multinode
 make install
-source .cvs_venv/bin/activate
-```
-
-- Edit `~/input/cluster_file/atom_cluster.json`: node IPs, `username`, `priv_key_file`. Trim `node_dict` to one host for single-node variants.
-- **Launcher vs GPU node:** CVS pytest runs on the launcher; `ContainerOrchestrator` SSHes to cluster nodes and runs `sudo docker` there. Local Docker on the launcher is not used. Prerequisites split by host:
-
-  | Item | Launcher | GPU node (cluster `mgmt_ip`) |
-  |------|----------|------------------------------|
-  | `cvs run`, venv, `~/input/`, `~/cvs_results/` | Yes | No |
-  | `priv_key_file`, `~/.hf_token` (read locally by pytest) | Yes | No |
-  | `/home/models` (when `model.remote: 0`) | No | Yes |
-  | `rocm/atom-dev` image, `sudo docker` | No | Yes |
-  | `~/LOGS/` (server/bench logs via volume mount) | No | Yes |
-
-- Preflight from the launcher: `ssh -i ~/.ssh/<key> <user>@<mgmt_ip> 'sudo docker images | grep atom-dev; du -sh /home/models'`
-
-## W1 single-node (MI300X, `driver=atom`)
-
-Two concurrency cells (C=128, C=256), 1000 prompts. Second cell reuses the ATOM server when `reuse_server_across_sweep: true`. For a quick smoke, add `-k "w1_1k_1k-conc128"`.
-
-```bash
-cd ~/cvs
-make install   # after git pull only; run before activating venv
 source .cvs_venv/bin/activate
 
 SINGLE_DIR=~/input/config_file/inference/atom/single
@@ -146,238 +276,35 @@ cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_single.json \
   --output "$SINGLE_DIR/mi300x_atom_deepseek-r1_fp8_single.json"
 cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_single_threshold.json \
   --output "$SINGLE_DIR/mi300x_atom_deepseek-r1_fp8_single_threshold.json"
+cvs copy-config atom_cluster.json --output ~/input/cluster_file/atom_cluster.json
+
+# Edit cluster IPs; trim node_dict to one host for single-node variants.
 
 TS=$(date +%Y%m%d_%H%M%S)
-HTML=~/cvs_results/${TS}_atom-w1-single_mi300x.html
-LOG=~/cvs_results/${TS}_atom-w1-single_mi300x.log
-
 cvs run atom \
   --cluster_file ~/input/cluster_file/atom_cluster.json \
   --config_file "$SINGLE_DIR/mi300x_atom_deepseek-r1_fp8_single.json" \
-  --html="$HTML" \
+  --html=~/cvs_results/${TS}_atom-w1-single_mi300x.html \
   --self-contained-html \
-  --log-file="$LOG" \
+  --log-file=~/cvs_results/${TS}_atom-w1-single_mi300x.log \
   -vvv -s
-
-echo "HTML: $HTML"
-echo "LOG:  $LOG"
 ```
 
-When `--html` is set, the **ATOM Run Deck** (`atom_run_deck.html`, `.json`,
-`_viewer.html`) is generated at session end and bundled into the pytest zip.
-See `cvs/lib/report/README.md` for wiring other suites. Open the pytest HTML **Reports**
-section for links. Render-only; does not affect gates.
+For multinode PP variants, use a two-host cluster file, copy the matching
+`*_distributed*` (or `*_sglang_distributed*`) config pair into its own
+subdirectory, set `container.image`, `params.master_addr`, and verify fabric
+discovery (or set `roles.server.ib_netdev` explicitly).
 
-## W1 perf baseline sweep (MI300X) — DTNI matrix
+Smoke a single cell with `-k`, for example `-k "w1_1k_1k-conc128"`.
 
-DTNI baseline matrix: **1K/1K** and **8K/1K** at **C=4, 8, 16, 32, 64, 128, 256** (14 cells). `max_model_length=10240`. Expect a long run (~several hours); server is reused within each shape.
+When `--html` is set, the **ATOM Run Deck** is generated at session end and
+bundled into the pytest zip (render-only; does not affect gates). See
+`cvs/lib/report/README.md`.
 
-```bash
-cd ~/cvs
-make install
-source .cvs_venv/bin/activate
+## Related docs
 
-BASELINE_DIR=~/input/config_file/inference/atom/baseline_sweep
-mkdir -p "$BASELINE_DIR"
-
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_baseline_sweep.json \
-  --output "$BASELINE_DIR/mi300x_atom_deepseek-r1_fp8_baseline_sweep.json"
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_baseline_sweep_threshold.json \
-  --output "$BASELINE_DIR/mi300x_atom_deepseek-r1_fp8_baseline_sweep_threshold.json"
-
-TS=$(date +%Y%m%d_%H%M%S)
-HTML=~/cvs_results/${TS}_atom-baseline-sweep_mi300x.html
-LOG=~/cvs_results/${TS}_atom-baseline-sweep_mi300x.log
-
-cvs run atom \
-  --cluster_file ~/input/cluster_file/atom_cluster.json \
-  --config_file "$BASELINE_DIR/mi300x_atom_deepseek-r1_fp8_baseline_sweep.json" \
-  --html="$HTML" \
-  --self-contained-html \
-  --log-file="$LOG" \
-  -vvv -s
-
-echo "HTML: $HTML"
-echo "LOG:  $LOG"
-```
-
-## W1 perf baseline sweep multinode (MI300X, 2-node)
-
-Same **14-cell** DTNI matrix as single-node baseline sweep (1K/1K + 8K/1K × C=4–256), with `nnodes=2`, **`driver=vllm_atom`**, **`pipeline_parallel_size=2`** (true pipeline parallel via vLLM coordinator + ATOM kernels; cell keys use `PP=2`), and `scaling.efficiency_pct` gates. Set `roles.server.ib_netdev` and a vLLM+ATOM container image before lab run. Expect a long run (~4–8 hours). Use a **2-host** `atom_cluster.json` and set `params.master_addr` to the head VPC IP after `copy-config` (replace `{head-node-ip}` placeholder).
-
-```bash
-cd ~/cvs
-make install
-source .cvs_venv/bin/activate
-
-BASELINE_MULTI_DIR=~/input/config_file/inference/atom/baseline_sweep_distributed
-mkdir -p "$BASELINE_MULTI_DIR"
-
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed.json \
-  --output "$BASELINE_MULTI_DIR/mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed.json"
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed_threshold.json \
-  --output "$BASELINE_MULTI_DIR/mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed_threshold.json"
-cvs copy-config atom_cluster.json --output ~/input/cluster_file/atom_cluster.json
-
-# Ensure node_dict lists head + worker. Edit cluster IPs and set master_addr in the copied config.
-
-TS=$(date +%Y%m%d_%H%M%S)
-HTML=~/cvs_results/${TS}_atom-baseline-sweep-multinode_mi300x.html
-LOG=~/cvs_results/${TS}_atom-baseline-sweep-multinode_mi300x.log
-
-cvs run atom \
-  --cluster_file ~/input/cluster_file/atom_cluster.json \
-  --config_file "$BASELINE_MULTI_DIR/mi300x_atom_deepseek-r1_fp8_baseline_sweep_distributed.json" \
-  --html="$HTML" \
-  --self-contained-html \
-  --log-file="$LOG" \
-  -vvv -s
-
-echo "HTML: $HTML"
-echo "LOG:  $LOG"
-```
-
-## W1 perf multinode (MI300X, 2-node, `driver=vllm_atom`)
-
-15-cell W1 scaling matrix with **`pipeline_parallel_size=2`**, **`driver=vllm_atom`**, and `scaling.efficiency_pct` gates. Requires vLLM+ATOM container, `ib_netdev`, and 2-node cluster. Recalibrate thresholds after the first true PP=2 lab run.
-
-```bash
-cd ~/cvs
-make install   # after git pull only; run before activating venv
-source .cvs_venv/bin/activate
-
-DISTRIBUTED_DIR=~/input/config_file/inference/atom/distributed
-mkdir -p "$DISTRIBUTED_DIR"
-
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_distributed.json \
-  --output "$DISTRIBUTED_DIR/mi300x_atom_deepseek-r1_fp8_distributed.json"
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_distributed_threshold.json \
-  --output "$DISTRIBUTED_DIR/mi300x_atom_deepseek-r1_fp8_distributed_threshold.json"
-cvs copy-config atom_cluster.json --output ~/input/cluster_file/atom_cluster.json
-
-# Ensure node_dict lists head + worker. Edit cluster IPs, ib_netdev, container.image,
-# and set params.master_addr in the copied config.
-
-TS=$(date +%Y%m%d_%H%M%S)
-HTML=~/cvs_results/${TS}_atom-w1-perf-multi_mi300x.html
-LOG=~/cvs_results/${TS}_atom-w1-perf-multi_mi300x.log
-
-cvs run atom \
-  --cluster_file ~/input/cluster_file/atom_cluster.json \
-  --config_file "$DISTRIBUTED_DIR/mi300x_atom_deepseek-r1_fp8_distributed.json" \
-  --html="$HTML" \
-  --self-contained-html \
-  --log-file="$LOG" \
-  -vvv -s
-
-echo "HTML: $HTML"
-echo "LOG:  $LOG"
-```
-
-## W1 perf multinode SGLang (MI300X, 2-node, `driver=sglang`)
-
-Same 15-cell sweep as vLLM-ATOM multinode, using SGLang pipeline parallel. `enforce_thresholds: false` until lab confirms — seed thresholds only.
-
-```bash
-cd ~/cvs
-make install
-source .cvs_venv/bin/activate
-
-SGLANG_DIR=~/input/config_file/inference/atom/sglang_distributed
-mkdir -p "$SGLANG_DIR"
-
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_sglang_distributed.json \
-  --output "$SGLANG_DIR/mi300x_atom_deepseek-r1_fp8_sglang_distributed.json"
-cvs copy-config inference/atom/mi300x_atom_deepseek-r1_fp8_sglang_distributed_threshold.json \
-  --output "$SGLANG_DIR/mi300x_atom_deepseek-r1_fp8_sglang_distributed_threshold.json"
-cvs copy-config atom_cluster.json --output ~/input/cluster_file/atom_cluster.json
-
-# Edit cluster IPs, ib_netdev, SGLang container.image, params.master_addr.
-
-TS=$(date +%Y%m%d_%H%M%S)
-HTML=~/cvs_results/${TS}_atom-w1-perf-multi-sglang_mi300x.html
-LOG=~/cvs_results/${TS}_atom-w1-perf-multi-sglang_mi300x.log
-
-cvs run atom \
-  --cluster_file ~/input/cluster_file/atom_cluster.json \
-  --config_file "$SGLANG_DIR/mi300x_atom_deepseek-r1_fp8_sglang_distributed.json" \
-  --html="$HTML" \
-  --self-contained-html \
-  --log-file="$LOG" \
-  -vvv -s
-
-echo "HTML: $HTML"
-echo "LOG:  $LOG"
-```
-
-## W1 perf multinode (MI355X, 2-node, `driver=vllm_atom`)
-
-Same sweep matrix as MI300X multinode (`vllm_atom`, PP=2). Thresholds are seeded from the MI355X single-node CI reference; `enforce_thresholds` stays `false` until a 2-node MI355X lab run confirms.
-
-```bash
-cd ~/cvs
-make install   # after git pull only; run before activating venv
-source .cvs_venv/bin/activate
-
-DISTRIBUTED_DIR=~/input/config_file/inference/atom/mi355x_distributed
-mkdir -p "$DISTRIBUTED_DIR"
-
-cvs copy-config inference/atom/mi355x_atom_deepseek-r1_fp8_distributed.json \
-  --output "$DISTRIBUTED_DIR/mi355x_atom_deepseek-r1_fp8_distributed.json"
-cvs copy-config inference/atom/mi355x_atom_deepseek-r1_fp8_distributed_threshold.json \
-  --output "$DISTRIBUTED_DIR/mi355x_atom_deepseek-r1_fp8_distributed_threshold.json"
-cvs copy-config atom_cluster.json --output ~/input/cluster_file/atom_cluster.json
-
-# Ensure node_dict lists head + worker (params.nnodes=2 in multinode variant).
-
-# Edit cluster + config: replace {head-node-ip} / {worker-node-ip} and set params.master_addr.
-
-TS=$(date +%Y%m%d_%H%M%S)
-HTML=~/cvs_results/${TS}_atom-w1-perf-multi_mi355x.html
-LOG=~/cvs_results/${TS}_atom-w1-perf-multi_mi355x.log
-
-cvs run atom \
-  --cluster_file ~/input/cluster_file/atom_cluster.json \
-  --config_file "$DISTRIBUTED_DIR/mi355x_atom_deepseek-r1_fp8_distributed.json" \
-  --html="$HTML" \
-  --self-contained-html \
-  --log-file="$LOG" \
-  -vvv -s
-
-echo "HTML: $HTML"
-echo "LOG:  $LOG"
-```
-
-## W1 single-node (MI355X, `driver=atom`)
-
-Thresholds are seeded from [ROCm/ATOM run 27912164002](https://github.com/ROCm/ATOM/actions/runs/27912164002). `enforce_thresholds` stays `false` until an MI355X lab run confirms.
-
-```bash
-cd ~/cvs
-make install   # after git pull only; run before activating venv
-source .cvs_venv/bin/activate
-
-SINGLE_DIR=~/input/config_file/inference/atom/mi355x_single
-mkdir -p "$SINGLE_DIR"
-
-cvs copy-config inference/atom/mi355x_atom_deepseek-r1_fp8_single.json \
-  --output "$SINGLE_DIR/mi355x_atom_deepseek-r1_fp8_single.json"
-cvs copy-config inference/atom/mi355x_atom_deepseek-r1_fp8_single_threshold.json \
-  --output "$SINGLE_DIR/mi355x_atom_deepseek-r1_fp8_single_threshold.json"
-cvs copy-config atom_cluster.json --output ~/input/cluster_file/atom_cluster.json
-
-TS=$(date +%Y%m%d_%H%M%S)
-HTML=~/cvs_results/${TS}_atom-w1-single_mi355x.html
-LOG=~/cvs_results/${TS}_atom-w1-single_mi355x.log
-
-cvs run atom \
-  --cluster_file ~/input/cluster_file/atom_cluster.json \
-  --config_file "$SINGLE_DIR/mi355x_atom_deepseek-r1_fp8_single.json" \
-  --html="$HTML" \
-  --self-contained-html \
-  --log-file="$LOG" \
-  -vvv -s
-
-echo "HTML: $HTML"
-echo "LOG:  $LOG"
-```
+| Doc | Purpose |
+|---|---|
+| `cvs/tests/inference/atom/README.md` | Suite lifecycle, sweeps, metric tiers, quick start |
+| `cvs/lib/inference/utils/docs/atom-parsing.md` | `client.*` metric vocabulary and tiers |
+| `docs/reference/configuration-files/atom.rst` | Published config reference (Sphinx) |

--- a/cvs/tests/inference/atom/README.md
+++ b/cvs/tests/inference/atom/README.md
@@ -1,0 +1,202 @@
+# ATOM Inference Suite (single-node and multinode)
+
+Cluster validation suite that runs **ATOM** (and ATOM-coordinated vLLM / SGLang)
+serving benchmarks on AMD Instinct GPUs and gates each sweep cell on tiered
+performance and health metrics with a PASS/FAIL HTML report.
+
+## Overview
+
+The suite drives a serving + benchmark-serving job inside a container on one or
+more cluster nodes, then parses the benchmark artifact to produce `client.*`
+metrics and verdicts. It provides:
+
+1. **One unified suite** — `atom` handles single-node and multinode PP from the
+   same entry point; topology and driver behaviour come from the variant config.
+2. **Execution drivers** — `params.driver` selects the server/client stack:
+   `atom` (native openai_server), `vllm_atom` (vLLM PP coordinator + ATOM
+   kernels), `sglang`, or interim `vllm`.
+3. **Parameter sweeps** — one benchmark run per sweep cell (ISL/OSL shape ×
+   concurrency), each with its own result rows in the report.
+4. **Tiered metric gating** — one pytest row per **metric tier** per cell
+   (throughput, TTFT, TPOT, health, scaling, record) against threshold specs.
+5. **Server reuse** — optional reuse of a warm server across sweep cells when
+   `reuse_server_across_sweep: true` and the session key matches.
+6. **Multinode fabric discovery** — `test_discover_topology` resolves IB HCAs
+   and socket netdev before the sweep when `params.nnodes > 1`.
+7. **HTML report + Run Deck** — pytest HTML rows, console results tables, and
+   (when `--html` is set) an ATOM Run Deck bundle for interactive charts.
+
+Single-node vs multinode is determined by `params.nnodes` and the cluster file
+host count, not by a separate suite name.
+
+## Quick Start
+
+Single-node W1 run (MI300X, `driver=atom`):
+
+```bash
+cvs run atom \
+  --cluster_file ~/input/cluster_file/atom_cluster.json \
+  --config_file ~/input/config_file/inference/atom/single/mi300x_atom_deepseek-r1_fp8_single.json \
+  --html ~/cvs_results/atom-w1-single.html --self-contained-html -vvv
+```
+
+Multinode PP run (2-node, `driver=vllm_atom`):
+
+```bash
+cvs run atom \
+  --cluster_file ~/input/cluster_file/atom_cluster.json \
+  --config_file ~/input/config_file/inference/atom/distributed/mi300x_atom_deepseek-r1_fp8_distributed.json \
+  --html ~/cvs_results/atom-w1-distributed.html --self-contained-html -vvv
+```
+
+- `--cluster_file` — JSON describing the node(s); `len(node_dict)` must match
+  `params.nnodes` in the config.
+- `--config_file` — a variant JSON under
+  `cvs/input/config_file/inference/atom/` (see that folder's README for the
+  variable-by-variable reference, copy-config flow, and lab prerequisites).
+- `--html` / `--self-contained-html` — write the pytest report; a sibling
+  bundle directory holds per-test logs and, when the report engine is enabled,
+  the ATOM Run Deck artifacts.
+
+> Use a **single-host** cluster file with `nnodes=1` variants and a **two-host**
+> cluster file with multinode PP variants (`vllm_atom` or `sglang`). The config's
+> `params.driver` and `params.nnodes` must match the intended topology.
+
+For smoke runs, filter with `-k`, for example `-k "w1_1k_1k-conc128"`.
+
+## Suite layout
+
+| Item | File | Role |
+|---|---|---|
+| Suite (`cvs run atom`) | `atom.py` | Lifecycle tests, sweep inference, tiered metric gates |
+| Fixtures / ordering | `conftest.py` | Cluster + variant load, orchestrator, lifecycle rank |
+| Results table | `_shared.py` | Console + HTML results table (`test_print_results_table`) |
+
+`conftest.py` and `_shared.py` are helpers, not runnable suites.
+
+## Test lifecycle (report rows)
+
+Tests run in this pinned order. `[cell]` = one row per sweep cell;
+`[cell-tier]` = one row per metric tier per cell.
+
+| Order | Test | Runs on | Purpose |
+|---|---|---|---|
+| 1 | `test_launch_container` | once | Launch and verify the container |
+| 2 | `test_setup_sshd` | multinode | SSH daemon setup across nodes |
+| 3 | `test_discover_topology` | once | Resolve IB HCAs + socket netdev (skipped work on single-node) |
+| 4 | `test_model_fetch` | once | Verify / fetch the model cache |
+| 5 | `test_atom_inference[cell]` | per cell | Build server env, start server, run bench client, parse results |
+| 6 | `test_cell_metrics[cell-tier]` | per cell × tier | Threshold PASS/FAIL for that tier's metrics |
+| 7 | `test_print_results_table` | once | Console tables + consolidated results |
+| 8 | `test_teardown` | once | Tear the container down |
+
+On inference failure, `lifecycle.failed` is set so downstream cells and metric
+rows are skipped. Server reuse skips restart when the session key
+(`server_session_key`) matches the prior cell.
+
+## Sweeps
+
+A **sweep cell** is one `(sequence shape, concurrency)` pair declared under
+`sweep.sequence_combinations` and `sweep.runs`. Parametrize IDs look like
+`w1_1k_1k-conc128` or, when metric tiers are collected,
+`w1_1k_1k-conc128-throughput`.
+
+Each cell's **threshold key** is built by `cell_key()`, for example:
+
+- Single-node: `ISL=1024,OSL=1024,TP=8,CONC=128`
+- Multinode PP: `ISL=1024,OSL=1024,TP=8,PP=2,NNODES=2,CONC=128`
+
+That key must exist in the sibling threshold file referenced by
+`threshold_json`.
+
+## Metrics and PASS/FAIL
+
+Each `test_cell_metrics[cell-tier]` evaluates metrics for one tier against the
+cell's threshold specs and reports one of:
+
+| Status | Meaning |
+|---|---|
+| PASS | value satisfies the threshold |
+| FAIL | value violates the threshold (row is red) |
+| skip | prior stage failed, cell did not run, or tier not applicable (e.g. scaling on single-node) |
+| RECORD | `enforce_thresholds: false` or `record` tier — value logged, not gated |
+
+**Metric tiers** (namespace `client.*` unless noted):
+
+| Tier | Example metrics |
+|---|---|
+| `throughput` | `total_token_throughput`, `output_throughput`, `per_gpu_throughput`, `output_tput_per_gpu` |
+| `ttft` | `mean_ttft_ms`, `p99_ttft_ms` |
+| `tpot` | `mean_tpot_ms`, `p99_tpot_ms` |
+| `health` | `success_rate`, `failed` |
+| `scaling` | `scaling.efficiency_pct` (multinode) |
+| `record` | remaining client metrics not in a gate tier |
+
+Gating requires `enforce_thresholds: true` in the config. ATOM may omit some
+tail percentiles even when `metric_percentiles` requests them; the suite only
+gates metrics present in the benchmark artifact. See
+`cvs/input/config_file/inference/atom/README.md` for threshold kinds and
+variant-specific enforcement policy.
+
+## Reports and logs
+
+- **Results table** — one row per test; metric tier rows reflect threshold
+  verdicts.
+- **Full Log** — each test row links to its captured log when HTML reporting is
+  enabled.
+- **Console summary** — `test_print_results_table` prints per-cell tables with
+  throughput, latency, and health columns.
+- **Run Deck** — when `--html` is set, the inference report engine emits
+  `atom_run_deck.html`, `.json`, and `_viewer.html` at session end (bundled
+  into the pytest zip). See `cvs/lib/report/README.md`.
+
+Server and client logs for each cell are written under the variant
+`paths.log_dir` on the cluster nodes.
+
+## Config and threshold files
+
+Variant configs and thresholds live in `cvs/input/config_file/inference/atom/`
+as flat sibling pairs:
+
+```text
+{gpu}_atom_{model}_{precision}[_{mode}].json
+{gpu}_atom_{model}_{precision}[_{mode}]_threshold.json
+```
+
+On a lab machine, copy each variant into its **own subdirectory** so threshold
+discovery is unambiguous (see the input-config README).
+
+| Example config | Mode | Driver |
+|---|---|---|
+| `mi300x_atom_deepseek-r1_fp8_single` | single-node W1 | `atom` |
+| `mi300x_atom_deepseek-r1_fp8_baseline_sweep` | DTNI baseline matrix | `atom` |
+| `mi300x_atom_deepseek-r1_fp8_distributed` | 2-node PP W1 | `vllm_atom` |
+| `mi300x_atom_deepseek-r1_fp8_sglang_distributed` | 2-node PP W1 | `sglang` |
+| `mi300x_atom_deepseek-r1_fp8_mtp3` | single-node MTP3 | `atom` |
+
+See `cvs/input/config_file/inference/atom/README.md` for the full variant
+catalog, copy-config commands, cluster-file editing, and step-by-step lab run
+recipes.
+
+## Prerequisites
+
+- Passwordless SSH from the control host to each cluster node (key in the
+  cluster file), and Docker available on the GPU nodes.
+- A container image with ATOM (and vLLM or SGLang when using those drivers);
+  shipped configs use `<changeme>` until pinned for your lab.
+- A Hugging Face token file at `paths.hf_token_file` when fetching models.
+- Model cache at `paths.models_dir` on GPU nodes when `model.remote: 0`.
+- For multinode runs: a shared or reachable log path, matching host count in
+  the cluster file, `params.master_addr` set to the head VPC IP, and IB/socket
+  interfaces discoverable (or explicit `roles.server.ib_hca_devices` /
+  `roles.server.ib_netdev` overrides).
+
+## Related code
+
+| Module | Purpose |
+|---|---|
+| `cvs/lib/inference/atom/atom_orch.py` | `AtomJob` — server/client lifecycle, result parsing |
+| `cvs/lib/inference/atom/atom_config_loader.py` | Typed variant load, sweep expansion, session keys |
+| `cvs/lib/inference/atom/atom_parsing.py` | Metric tiers, `client.*` mapping, scaling efficiency |
+| `cvs/lib/inference/utils/inference_suite_lifecycle.py` | Shared lifecycle stages (`test_launch_container`, …) |
+| `cvs/lib/utils/ib_discovery.py` | Multinode IB HCA and socket netdev discovery |

--- a/cvs/tests/inference/atom/README.md
+++ b/cvs/tests/inference/atom/README.md
@@ -1,8 +1,8 @@
 # ATOM Inference Suite (single-node and multinode)
 
-Cluster validation suite that runs **ATOM** (and ATOM-coordinated vLLM / SGLang)
-serving benchmarks on AMD Instinct GPUs and gates each sweep cell on tiered
-performance and health metrics with a PASS/FAIL HTML report.
+Cluster validation suite that runs **ATOM** serving benchmarks on AMD Instinct
+GPUs and gates each sweep cell on tiered performance and health metrics with a
+PASS/FAIL HTML report.
 
 ## Overview
 
@@ -12,9 +12,8 @@ metrics and verdicts. It provides:
 
 1. **One unified suite** — `atom` handles single-node and multinode PP from the
    same entry point; topology and driver behaviour come from the variant config.
-2. **Execution drivers** — `params.driver` selects the server/client stack:
-   `atom` (native openai_server), `vllm_atom` (vLLM PP coordinator + ATOM
-   kernels), `sglang`, or interim `vllm`.
+2. **Execution drivers** — `params.driver` is `atom` on single-node variants
+   (native `openai_server`) or `vllm_atom` on shipped multinode PP stems.
 3. **Parameter sweeps** — one benchmark run per sweep cell (ISL/OSL shape ×
    concurrency), each with its own result rows in the report.
 4. **Tiered metric gating** — one pytest row per **metric tier** per cell
@@ -59,7 +58,7 @@ cvs run atom \
   the ATOM Run Deck artifacts.
 
 > Use a **single-host** cluster file with `nnodes=1` variants and a **two-host**
-> cluster file with multinode PP variants (`vllm_atom` or `sglang`). The config's
+> cluster file with multinode PP variants (`driver=vllm_atom`). The config's
 > `params.driver` and `params.nnodes` must match the intended topology.
 
 For smoke runs, filter with `-k`, for example `-k "w1_1k_1k-conc128"`.
@@ -171,7 +170,6 @@ discovery is unambiguous (see the input-config README).
 | `mi300x_atom_deepseek-r1_fp8_single` | single-node W1 | `atom` |
 | `mi300x_atom_deepseek-r1_fp8_baseline_sweep` | DTNI baseline matrix | `atom` |
 | `mi300x_atom_deepseek-r1_fp8_distributed` | 2-node PP W1 | `vllm_atom` |
-| `mi300x_atom_deepseek-r1_fp8_sglang_distributed` | 2-node PP W1 | `sglang` |
 | `mi300x_atom_deepseek-r1_fp8_mtp3` | single-node MTP3 | `atom` |
 
 See `cvs/input/config_file/inference/atom/README.md` for the full variant
@@ -182,8 +180,8 @@ recipes.
 
 - Passwordless SSH from the control host to each cluster node (key in the
   cluster file), and Docker available on the GPU nodes.
-- A container image with ATOM (and vLLM or SGLang when using those drivers);
-  shipped configs use `<changeme>` until pinned for your lab.
+- A container image with ATOM; shipped multinode configs use `<changeme>` until
+  pinned for your lab.
 - A Hugging Face token file at `paths.hf_token_file` when fetching models.
 - Model cache at `paths.models_dir` on GPU nodes when `model.remote: 0`.
 - For multinode runs: a shared or reachable log path, matching host count in


### PR DESCRIPTION
# Add ATOM inference suite and config READMEs

**Branch:** `hnimrama/atom-test-readme`  
**Base:** `dev/dtni`

## Summary

Add documentation for the ATOM inference suite, modeled after the JAX MaxText training READMEs:

- New **`cvs/tests/inference/atom/README.md`** — how to run `cvs run atom`, lifecycle, sweeps, metric tiers, quick start
- Updated **`cvs/input/config_file/inference/atom/README.md`** — config/threshold reference (file inventory, must-change table, structure, thresholds, lab workflow)

Docs focus on ATOM workloads only (`driver=atom` single-node, `driver=vllm_atom` multinode PP).

## Test plan

- [x] Docs-only change — review for accuracy against existing variant configs and `atom.py` lifecycle