### PR TITLE
fix(preflight): disable MI4XX fabric checks by default

### DIFF
--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -36,7 +36,7 @@ The preflight configuration file follows this structure:
         "inter_full_mesh_group_pairs_per_wave": "auto"
       },
       "ifoe": {
-        "fabric_checks": true,
+        "fabric_checks": false,
         "l2ping": {
           "enabled": true,
           "pings_per_port": 3
@@ -224,7 +224,8 @@ They now follow this fixed policy:
 | `per_ping_timeout` / `ssh_timeout` | Derive conservative timeouts from the requested workload |
 
 - **`fabric_checks`** (default: `false`)
-  - Adds AIFM/AFM/vPOD, station-mask, and IFoE port admission to node health
+  - Enables MI4XX-only AIFM/AFM/vPOD, station-mask, and IFoE port admission checks
+  - Set to `true` only on MI4XX systems; it remains disabled for MI3XX systems
   - Requires `node_check.enabled: true`
 
 ##### L2 ping (`connectivity_check.ifoe.l2ping`)

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -74,8 +74,8 @@
         "_comment_loss_threshold_pct": "Maximum tolerated packet loss percentage per traffic type. Defaults to 0.0 (any failure marks the node as FAIL).",
         "_comment_ssh_timeout": "Overall SSH timeout (seconds) for each afmctl invocation. Increase for large port counts or high pings_per_port values.",
 
-        "fabric_checks": true,
-        "_comment_fabric_checks": "Add AIFM/AFM/vPOD, station-mask, and IFoE port admission to node health.",
+        "fabric_checks": false,
+        "_comment_fabric_checks": "Enable MI4XX-only AIFM/AFM/vPOD, station-mask, and IFoE port admission checks.",
 
         "_comment_policy": "CVS owns afmctl discovery, privilege handling, BDF and port discovery, strict coverage, traffic selection, and timeout derivation.",
 

--- a/cvs/tests/preflight/README.md
+++ b/cvs/tests/preflight/README.md
@@ -77,7 +77,7 @@ Located at: `cvs/input/config_file/preflight/preflight_config.json`
         "connectivity_mode": "skip"
       },
       "ifoe": {
-        "fabric_checks": true,
+        "fabric_checks": false,
         "l2ping": {
           "enabled": true,
           "pings_per_port": 3
@@ -105,7 +105,7 @@ Located at: `cvs/input/config_file/preflight/preflight_config.json`
 
 - **`node_check.enabled`**: Run GPU node-health and ROCm validation
 - **`node_check.gpus_per_node`**: Exact GPU count expected on every node
-- **`connectivity_check.ifoe.fabric_checks`**: Add MI4XX AIFM/AFM/vPOD and IFoE station/port checks
+- **`connectivity_check.ifoe.fabric_checks`**: Opt in to MI4XX AIFM/AFM/vPOD and IFoE station/port checks; disabled by default
 - **`connectivity_check.rdma.connectivity_mode`**: `"basic"`, `"full_mesh"`, or `"skip"`
 - **`connectivity_check.ifoe.l2ping.enabled`**: Run the strict IFoE L2 connectivity gate
 - **`connectivity_check.ifoe.l2ping.pings_per_port`**: Samples per discovered UP port pair


### PR DESCRIPTION
## Summary
- disable MI4XX IFoE fabric admission checks in the default preflight configuration
- document these checks as an MI4XX-only opt-in and keep MI3XX defaults compatible

## Test plan
- [x] `python -m json.tool cvs/input/config_file/preflight/preflight_config.json`
- [ ] `python -m unittest cvs.lib.preflight.unittests.test_scaleup_fabric` (blocked: `nodescraper` is not installed in this checkout)

Made with [Cursor](https://cursor.com)