### PR TITLE
fix(docker): use sudo_prefix() for pull_image, repair two failing UTs

### DIFF
--- a/cvs/cli_plugins/unittests/test_run_plugin.py
+++ b/cvs/cli_plugins/unittests/test_run_plugin.py
@@ -102,7 +102,8 @@ class TestRunPlugin(unittest.TestCase):
         mock_pytest_main.return_value = 0
 
         with patch.object(self.plugin, "get_test_file", return_value="/mock/path/test.py"):
-            self.plugin.run(args)
+            with patch.object(self.plugin, "_validate_json_config"):
+                self.plugin.run(args)
 
         expected_args = [
             "/mock/path/test.py",

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -352,9 +352,17 @@ class DockerRuntime:
         return args
 
     def pull_image(self, image_name, timeout=None):
-        """Pull container image on all hosts."""
+        """Pull container image on all hosts.
+
+        Uses sudo_prefix() like every other docker call in this class. A
+        hardcoded `sudo` would pull as root while registry_login() -- which
+        does honor sudo_prefix() -- authenticated as the SSH user, so a private
+        image would fail with "pull access denied" on any cluster without
+        passwordless sudo. Bare `sudo` also drops the `-n`, letting a password
+        prompt block until the timeout instead of failing fast.
+        """
         timeout = timeout or 600
-        cmd = f"sudo docker pull {shlex.quote(image_name)}"
+        cmd = f"{self.orchestrator.sudo_prefix()}docker pull {shlex.quote(image_name)}"
         self.log.info(f"Pulling image on all hosts: {image_name}")
         return self.orchestrator.all.exec(cmd, timeout=timeout, detailed=True)
 

--- a/cvs/core/runtimes/unittests/test_docker.py
+++ b/cvs/core/runtimes/unittests/test_docker.py
@@ -20,6 +20,7 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 #     retry, which double-runs the caller's payload whenever it fails for any
 #     reason (not just permission-denied).
 
+import shlex
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -137,7 +138,8 @@ class TestDockerRuntimeSetupContainers(unittest.TestCase):
                     f"[{label}] '--gpus all' must never appear in docker cmd:\n{captured[0]}",
                 )
 
-    def test_pulls_image_when_missing_before_run(self):
+    def _run_missing_image_setup(self, sudo_prefix):
+        """setup_containers with the image absent, returning every rendered cmd."""
         calls = []
 
         def _fake_exec(cmd, timeout=None, detailed=False, print_console=True):
@@ -149,6 +151,7 @@ class TestDockerRuntimeSetupContainers(unittest.TestCase):
         orchestrator = MagicMock()
         orchestrator.hosts = ["host1"]
         orchestrator.all.exec.side_effect = _fake_exec
+        orchestrator.sudo_prefix.return_value = sudo_prefix
         rt = DockerRuntime(MagicMock(), orchestrator)
 
         result = rt.setup_containers(
@@ -156,9 +159,36 @@ class TestDockerRuntimeSetupContainers(unittest.TestCase):
             container_name="cvs_iter_test",
             volumes=["/home/u:/workspace"],
         )
+        return result, calls
+
+    def test_pulls_image_when_missing_before_run(self):
+        result, calls = self._run_missing_image_setup("sudo -n ")
+
         self.assertTrue(result)
         self.assertTrue(any("docker pull" in c for c in calls))
-        self.assertTrue(any(c.startswith("sudo docker run") for c in calls))
+        self.assertTrue(any(c.startswith("sudo -n docker run") for c in calls))
+
+    def test_pull_uses_sudo_prefix_not_hardcoded_sudo(self):
+        """The pull must carry the same prefix as every other docker call.
+
+        A hardcoded `sudo docker pull` pulls as root while registry_login --
+        which honors sudo_prefix() -- authenticated as the SSH user, so root
+        reads an empty /root/.docker/config.json and a private image fails with
+        "pull access denied" on any cluster without passwordless sudo. Bare
+        `sudo` also loses the `-n`, so a password prompt blocks until timeout.
+        """
+        for sudo_prefix in ("", "sudo -n "):
+            with self.subTest(sudo_prefix=sudo_prefix or "<none>"):
+                _, calls = self._run_missing_image_setup(sudo_prefix)
+
+                pulls = [c for c in calls if "docker pull" in c]
+                self.assertEqual(len(pulls), 1, f"expected exactly one pull, got: {pulls}")
+                self.assertEqual(pulls[0], f"{sudo_prefix}docker pull {shlex.quote('img:test')}")
+                self.assertNotIn(
+                    "sudo docker pull",
+                    pulls[0],
+                    "pull must use sudo_prefix(), never a hardcoded unconditional `sudo`",
+                )
 
 
 class TestDockerRuntimeRegistryLogin(unittest.TestCase):


### PR DESCRIPTION
## Summary

`DockerRuntime.pull_image` was the only docker invocation in the class that
hardcoded `sudo` instead of `orchestrator.sudo_prefix()`. Because
`setup_containers()` now pulls whenever `check_image_exists()` reports the image
missing, that call sits on the container-orchestrator startup path for every
suite, including the RVS and AGFHC health suites.

## Change

- `pull_image` uses `sudo_prefix()`. This removes two failure modes on clusters
  without passwordless sudo: `registry_login()` already honors `sudo_prefix()`,
  so the login authenticated as the SSH user while the pull ran as root against
  an empty `/root/.docker/config.json` — a private image then fails with "pull
  access denied" despite a clean login. Bare `sudo` also drops `-n`, letting a
  password prompt block for the full 600s timeout instead of failing fast.
- `test_pulls_image_when_missing_before_run` asserted against a `MagicMock`
  orchestrator whose `sudo_prefix()` returned a Mock rather than a string.
- `test_run_test_omits_log_file_when_not_set` did not patch
  `_validate_json_config`, so the new pre-flight check called `sys.exit` on the
  mock config path.
- Out of scope: `check_image_exists` false-negatives on untagged images (causes
  a spurious but harmless re-pull); the 19 `fmt-check` and 17 `lint` failures
  already present on `dev/dtni`.

## Tests

- `test_pull_uses_sudo_prefix_not_hardcoded_sudo` (new), pinning the rendered
  command for both the sudo and no-sudo cluster shapes.
- Gate: `.test_venv/bin/python run_all_unittests.py` — 1151 tests, 2 failures,
  both pre-existing in `cvs/lib/inference/unittests/test_inferencing_config_loader.py`
  and untouched by this branch.
