### PR TITLE
fix(tests): make missing-file test self-contained

### DIFF
--- a/cvs/monitors/unittests/test_check_cluster_health.py
+++ b/cvs/monitors/unittests/test_check_cluster_health.py
@@ -61,8 +61,10 @@ class TestLoadClusterFile(unittest.TestCase):
         self.assertEqual(pkey, "/home/bob/.ssh/id_rsa")
 
     def test_missing_file_raises(self):
-        with self.assertRaises(FileNotFoundError):
-            load_cluster_file("/nonexistent/path/cluster.json")
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_path = os.path.join(tmp, "does-not-exist", "cluster.json")
+            with self.assertRaises(FileNotFoundError):
+                load_cluster_file(missing_path)
 
     def test_invalid_json_raises_value_error(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/cvs/tests/ibperf/ib_perf_bw_test.py
+++ b/cvs/tests/ibperf/ib_perf_bw_test.py
@@ -262,7 +262,7 @@ def test_ib_bw_perf(shdl, phdl, bw_test, config_dict):
                     config_dict['expected_results'],
                 )
 
-    log.info('%%%%%%%%% ib_bw_dict %%%%%%%%%%')
+    log.info('========= ib_bw_dict ==========')
     log.info("%s", ib_bw_dict)
     update_test_result()
 


### PR DESCRIPTION
Part 2 of 12 in a stack that replaces #184. Base: #314.

### Why
`test_missing_file_raises` asserted `FileNotFoundError` against the hardcoded absolute path `/nonexistent/path/cluster.json`. That is environment-dependent (AGENTS.md forbids it) and would stop testing what it claims to test if such a path ever existed.

### What changed
- `cvs/monitors/unittests/test_check_cluster_health.py` — build the missing path inside a `TemporaryDirectory`, matching the sibling `test_invalid_json_raises_value_error`.
- `cvs/tests/ibperf/ib_perf_bw_test.py` — one log separator `%%%%%%%%%` → `=========`.

The ibperf line is unrelated drive-by cleanup. The same `%%%` style appears elsewhere in `ib_perf_bw_test.py`, `rccl_lib.py` and `mori_lib.py` and is untouched, so this leaves the file internally inconsistent — happy to drop that hunk if reviewers prefer.
