### PR TITLE
fix(utils_lib): detect MI350 by device ID when rocm-smi omits the model name

### DIFF
--- a/cvs/lib/unittests/test_utils_lib.py
+++ b/cvs/lib/unittests/test_utils_lib.py
@@ -22,6 +22,20 @@ class TestUtilsLib(unittest.TestCase):
         utils_lib.scan_test_results(out_dict)
         mock_fail_test.assert_not_called()
 
+    def test_get_model_from_rocm_smi_output_matches_marketing_name(self):
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI300X'), 'mi300x')
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI325X'), 'mi325')
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI350X'), 'mi350')
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI355X'), 'mi355')
+
+    def test_get_model_from_rocm_smi_output_falls_back_to_device_id_for_mi350(self):
+        smi_output = 'Device Name:        AMD Radeon Graphics\nDevice ID:          0x75a0\nGFX Version:        gfx950\n'
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output(smi_output), 'mi350')
+
+    def test_get_model_from_rocm_smi_output_defaults_to_mi300x_when_unrecognized(self):
+        smi_output = 'Device Name:        AMD Radeon Graphics\nDevice ID:          0x1234\n'
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output(smi_output), 'mi300x')
+
 
 class TestResolveTestConfigPlaceholdersAorta(unittest.TestCase):
     """Aorta benchmark YAML uses the same resolver as other CVS test suites (see tests/benchmark/test_aorta.py)."""

--- a/cvs/lib/unittests/test_utils_lib.py
+++ b/cvs/lib/unittests/test_utils_lib.py
@@ -32,6 +32,10 @@ class TestUtilsLib(unittest.TestCase):
         smi_output = 'Device Name:        AMD Radeon Graphics\nDevice ID:          0x75a0\nGFX Version:        gfx950\n'
         self.assertEqual(utils_lib.get_model_from_rocm_smi_output(smi_output), 'mi350')
 
+    def test_get_model_from_rocm_smi_output_falls_back_to_device_id_for_mi355(self):
+        smi_output = 'Device Name:        AMD Radeon Graphics\nDevice ID:          0x75a3\nGFX Version:        gfx950\n'
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output(smi_output), 'mi355')
+
     def test_get_model_from_rocm_smi_output_defaults_to_mi300x_when_unrecognized(self):
         smi_output = 'Device Name:        AMD Radeon Graphics\nDevice ID:          0x1234\n'
         self.assertEqual(utils_lib.get_model_from_rocm_smi_output(smi_output), 'mi300x')

--- a/cvs/lib/unittests/test_utils_lib.py
+++ b/cvs/lib/unittests/test_utils_lib.py
@@ -19,6 +19,20 @@ class TestUtilsLib(unittest.TestCase):
         utils_lib.scan_test_results(out_dict)
         mock_fail_test.assert_not_called()
 
+    def test_get_model_from_rocm_smi_output_matches_marketing_name(self):
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI300X'), 'mi300x')
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI325X'), 'mi325')
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI350X'), 'mi350')
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output('Card series: AMD Instinct MI355X'), 'mi355')
+
+    def test_get_model_from_rocm_smi_output_falls_back_to_device_id_for_mi350(self):
+        smi_output = 'Device Name:        AMD Radeon Graphics\nDevice ID:          0x75a0\nGFX Version:        gfx950\n'
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output(smi_output), 'mi350')
+
+    def test_get_model_from_rocm_smi_output_defaults_to_mi300x_when_unrecognized(self):
+        smi_output = 'Device Name:        AMD Radeon Graphics\nDevice ID:          0x1234\n'
+        self.assertEqual(utils_lib.get_model_from_rocm_smi_output(smi_output), 'mi300x')
+
 
 class TestResolveTestConfigPlaceholdersAorta(unittest.TestCase):
     """Aorta benchmark YAML uses the same resolver as other CVS test suites (see tests/benchmark/test_aorta.py)."""

--- a/cvs/lib/utils_lib.py
+++ b/cvs/lib/utils_lib.py
@@ -205,9 +205,14 @@ def get_model_from_rocm_smi_output(smi_output):
       - Some driver/rocm-smi versions emit no marketing-name string at all (observed on
         MI350: only "Device ID: 0x75a0" and "GFX Version: gfx950", no "MI350" substring
         anywhere in `rocm-smi -a`); in that case, falls back to matching the known Device ID.
+        MI355X is affected by the same omission (ROCM-21360), hence the second entry below.
       - Falls back to 'mi300x' if nothing matches (conservative default).
 
     """
+    device_id_to_model = {
+        '0x75a0': 'mi350',
+        '0x75a3': 'mi355',
+    }
     if re.search('MI300X', smi_output, re.I):
         model = 'mi300x'
     elif re.search('MI325', smi_output, re.I):
@@ -216,10 +221,12 @@ def get_model_from_rocm_smi_output(smi_output):
         model = 'mi350'
     elif re.search('MI355', smi_output, re.I):
         model = 'mi355'
-    elif re.search(r'Device ID:\s*0x75a0', smi_output, re.I):
-        model = 'mi350'
     else:
         model = 'mi300x'
+        for device_id, mapped_model in device_id_to_model.items():
+            if re.search(rf'Device ID:\s*{re.escape(device_id)}', smi_output, re.I):
+                model = mapped_model
+                break
     return model
 
 

--- a/cvs/lib/utils_lib.py
+++ b/cvs/lib/utils_lib.py
@@ -202,7 +202,10 @@ def get_model_from_rocm_smi_output(smi_output):
       - Performs case-insensitive regex searches for specific model tokens in the provided
         rocm-smi output (e.g., "MI300X", "MI325", "MI350", "MI355").
       - Returns the corresponding normalized lowercase token (e.g., 'mi300x').
-      - Falls back to 'mi300x' if no pattern matches (conservative default).
+      - Some driver/rocm-smi versions emit no marketing-name string at all (observed on
+        MI350: only "Device ID: 0x75a0" and "GFX Version: gfx950", no "MI350" substring
+        anywhere in `rocm-smi -a`); in that case, falls back to matching the known Device ID.
+      - Falls back to 'mi300x' if nothing matches (conservative default).
 
     """
     if re.search('MI300X', smi_output, re.I):
@@ -213,6 +216,8 @@ def get_model_from_rocm_smi_output(smi_output):
         model = 'mi350'
     elif re.search('MI355', smi_output, re.I):
         model = 'mi355'
+    elif re.search(r'Device ID:\s*0x75a0', smi_output, re.I):
+        model = 'mi350'
     else:
         model = 'mi300x'
     return model


### PR DESCRIPTION
Part 3 of 12 in a stack that replaces #184. Base: #315.

### Why
On some driver / rocm-smi versions an MI350 node reports no marketing-name string anywhere in `rocm-smi -a` — only `Device ID: 0x75a0` and `GFX Version: gfx950`. `get_model_from_rocm_smi_output` then fell through to its conservative `'mi300x'` default, so MI350 nodes silently picked the MI300X entry in `expected_results` and were graded against the wrong performance threshold.

### What changed
- `cvs/lib/utils_lib.py` — added a `Device ID: 0x75a0` fallback *after* the existing marketing-name checks, so the name-based path is unchanged whenever a name is present.
- `cvs/lib/unittests/test_utils_lib.py` — tests for all four marketing names, the device-ID fallback, and the unrecognized-input default.
