### PR TITLE
fix(pssh): retry once with a fresh client on SessionError

### DIFF
--- a/cvs/lib/parallel/pssh.py
+++ b/cvs/lib/parallel/pssh.py
@@ -105,6 +105,7 @@ class Pssh:
                 e,
             )
             self.log.debug("ParallelSSH session retry detail", exc_info=True)
+            self.destroy_clients()
             self._recreate_parallel_client()
             return self.client.run_command(*args, **kwargs)
 

--- a/cvs/lib/parallel/pssh.py
+++ b/cvs/lib/parallel/pssh.py
@@ -80,6 +80,10 @@ class Pssh:
             self.log.info("%s", self.reachable_hosts)
             self.log.info("%s", self.user)
             self.log.info("%s", self.pkey)
+        self._recreate_parallel_client()
+
+    def _recreate_parallel_client(self):
+        if self.password is None:
             self.client = ParallelSSHClient(
                 self.reachable_hosts, user=self.user, pkey=self.pkey, keepalive_seconds=30, **self.ssh_client_kwargs
             )
@@ -91,6 +95,18 @@ class Pssh:
                 keepalive_seconds=30,
                 **self.ssh_client_kwargs,
             )
+
+    def _run_command_with_session_retry(self, *args, **kwargs):
+        try:
+            return self.client.run_command(*args, **kwargs)
+        except SessionError as e:
+            self.log.info(
+                "ParallelSSH: SessionError on first attempt; recreating client and retrying once (%s).",
+                e,
+            )
+            self.log.debug("ParallelSSH session retry detail", exc_info=True)
+            self._recreate_parallel_client()
+            return self.client.run_command(*args, **kwargs)
 
     def check_connectivity(self, hosts):
         """
@@ -333,11 +349,13 @@ class Pssh:
         # With an inactivity timeout the total read_timeout must be disabled, so
         # the per-line gevent timer in _process_output is the only limiter.
         if inactivity_timeout is not None:
-            output = self.client.run_command(full_cmd, stop_on_errors=self.stop_on_errors)
+            output = self._run_command_with_session_retry(full_cmd, stop_on_errors=self.stop_on_errors)
         elif timeout is None:
-            output = self.client.run_command(full_cmd, stop_on_errors=self.stop_on_errors)
+            output = self._run_command_with_session_retry(full_cmd, stop_on_errors=self.stop_on_errors)
         else:
-            output = self.client.run_command(full_cmd, read_timeout=timeout, stop_on_errors=self.stop_on_errors)
+            output = self._run_command_with_session_retry(
+                full_cmd, read_timeout=timeout, stop_on_errors=self.stop_on_errors
+            )
         cmd_output = self._process_output(
             output,
             cmd=full_cmd,
@@ -374,9 +392,9 @@ class Pssh:
                 self.log.debug(f"Executing command list on {len(self.reachable_hosts)} host(s)")
 
         if timeout is None:
-            output = self.client.run_command('%s', host_args=cmd_list, stop_on_errors=self.stop_on_errors)
+            output = self._run_command_with_session_retry('%s', host_args=cmd_list, stop_on_errors=self.stop_on_errors)
         else:
-            output = self.client.run_command(
+            output = self._run_command_with_session_retry(
                 '%s', host_args=cmd_list, read_timeout=timeout, stop_on_errors=self.stop_on_errors
             )
 

--- a/cvs/lib/parallel/unittests/test_pssh.py
+++ b/cvs/lib/parallel/unittests/test_pssh.py
@@ -4,14 +4,16 @@ from cvs.lib.parallel.pssh import Pssh  # Test basic Pssh class directly
 
 
 class TestPsshExec(unittest.TestCase):
-    @patch("cvs.lib.parallel.pssh.ParallelSSHClient")
-    def setUp(self, mock_pssh_client):
+    def setUp(self):
+        self.patcher = patch("cvs.lib.parallel.pssh.ParallelSSHClient")
+        self.mock_pssh_client = self.patcher.start()
+        self.addCleanup(self.patcher.stop)
         self.mock_client = MagicMock()
-        mock_pssh_client.return_value = self.mock_client
-        self.mock_pssh_client = mock_pssh_client
+        self.mock_pssh_client.return_value = self.mock_client
         self.host_list = ["host1", "host2"]
         self.mock_log = MagicMock()
         self.pssh = Pssh(self.mock_log, self.host_list, user="user", password="pass")
+        self.pssh.log = self.mock_log
 
     def test_exec_successful(self):
         # Test: Execute command successfully on all hosts
@@ -36,6 +38,75 @@ class TestPsshExec(unittest.TestCase):
         self.assertIn("host2", result)
         self.assertIn("output1 line1", result["host1"])
         self.assertIn("output2 line1", result["host2"])
+
+    def test_exec_retries_once_on_session_error(self):
+        from pssh.exceptions import SessionError
+
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        mock_output1.stdout = ["ok1"]
+        mock_output1.stderr = []
+        mock_output1.exception = None
+
+        mock_output2 = MagicMock()
+        mock_output2.host = "host2"
+        mock_output2.stdout = ["ok2"]
+        mock_output2.stderr = []
+        mock_output2.exception = None
+
+        stale = SessionError("stale session")
+        self.mock_client.run_command.side_effect = [stale, [mock_output1, mock_output2]]
+
+        result = self.pssh.exec("echo hello")
+
+        self.assertEqual(self.mock_client.run_command.call_count, 2)
+        self.assertEqual(self.mock_pssh_client.call_count, 2)
+        self.assertIn("ok1", result["host1"])
+        self.assertIn("ok2", result["host2"])
+        self.mock_log.info.assert_any_call(
+            "ParallelSSH: SessionError on first attempt; recreating client and retrying once (%s).",
+            stale,
+        )
+        self.mock_log.debug.assert_any_call("ParallelSSH session retry detail", exc_info=True)
+
+    def test_exec_retries_once_on_session_error_with_timeout(self):
+        from pssh.exceptions import SessionError
+
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        mock_output1.stdout = ["ok"]
+        mock_output1.stderr = []
+        mock_output1.exception = None
+
+        mock_output2 = MagicMock()
+        mock_output2.host = "host2"
+        mock_output2.stdout = ["ok"]
+        mock_output2.stderr = []
+        mock_output2.exception = None
+
+        self.mock_client.run_command.side_effect = [
+            SessionError("stale session"),
+            [mock_output1, mock_output2],
+        ]
+
+        self.pssh.exec("slow_cmd", timeout=120)
+
+        self.assertEqual(self.mock_client.run_command.call_count, 2)
+        self.mock_client.run_command.assert_called_with("slow_cmd", read_timeout=120, stop_on_errors=True)
+
+    def test_exec_propagates_session_error_after_failed_retry(self):
+        from pssh.exceptions import SessionError
+
+        self.mock_client.run_command.side_effect = [
+            SessionError("first"),
+            SessionError("second"),
+        ]
+
+        with self.assertRaises(SessionError) as cm:
+            self.pssh.exec("echo hello")
+
+        self.assertIn("second", str(cm.exception))
+        self.assertEqual(self.mock_client.run_command.call_count, 2)
 
     def test_exec_with_connection_error_stop_on_errors_true(self):
         # Test: Handle exceptions with stop_on_errors=True (default)
@@ -558,14 +629,16 @@ class TestPsshExec(unittest.TestCase):
 
 
 class TestPsshExecCmdList(unittest.TestCase):
-    @patch("cvs.lib.parallel.pssh.ParallelSSHClient")
-    def setUp(self, mock_pssh_client):
+    def setUp(self):
+        self.patcher = patch("cvs.lib.parallel.pssh.ParallelSSHClient")
+        self.mock_pssh_client = self.patcher.start()
+        self.addCleanup(self.patcher.stop)
         self.mock_client = MagicMock()
-        mock_pssh_client.return_value = self.mock_client
-        self.mock_pssh_client = mock_pssh_client
+        self.mock_pssh_client.return_value = self.mock_client
         self.host_list = ["host1", "host2"]
         self.mock_log = MagicMock()
         self.pssh = Pssh(self.mock_log, self.host_list, user="user", password="pass")
+        self.pssh.log = self.mock_log
 
     def test_exec_cmd_list_successful(self):
         # Test: Execute different commands on different hosts successfully
@@ -591,6 +664,49 @@ class TestPsshExecCmdList(unittest.TestCase):
         self.assertIn("host2", result)
         self.assertIn("host1", result["host1"])
         self.assertIn("host2", result["host2"])
+
+    def test_exec_cmd_list_retries_once_on_session_error(self):
+        from pssh.exceptions import SessionError
+
+        cmd_list = ["echo host1", "echo host2"]
+        mock_output1 = MagicMock()
+        mock_output1.host = "host1"
+        mock_output1.stdout = ["h1"]
+        mock_output1.stderr = []
+        mock_output1.exception = None
+
+        mock_output2 = MagicMock()
+        mock_output2.host = "host2"
+        mock_output2.stdout = ["h2"]
+        mock_output2.stderr = []
+        mock_output2.exception = None
+
+        self.mock_client.run_command.side_effect = [
+            SessionError("stale session"),
+            [mock_output1, mock_output2],
+        ]
+
+        result = self.pssh.exec_cmd_list(cmd_list)
+
+        self.assertEqual(self.mock_client.run_command.call_count, 2)
+        self.assertEqual(self.mock_pssh_client.call_count, 2)
+        self.assertIn("h1", result["host1"])
+        self.assertIn("h2", result["host2"])
+
+    def test_exec_cmd_list_propagates_session_error_after_failed_retry(self):
+        from pssh.exceptions import SessionError
+
+        cmd_list = ["echo a", "echo b"]
+        self.mock_client.run_command.side_effect = [
+            SessionError("first"),
+            SessionError("second"),
+        ]
+
+        with self.assertRaises(SessionError) as cm:
+            self.pssh.exec_cmd_list(cmd_list)
+
+        self.assertIn("second", str(cm.exception))
+        self.assertEqual(self.mock_client.run_command.call_count, 2)
 
     @patch.object(Pssh, "check_connectivity")
     def test_exec_cmd_list_with_connection_error_stop_on_errors_false(self, mock_check_connectivity):

--- a/cvs/lib/parallel/unittests/test_pssh.py
+++ b/cvs/lib/parallel/unittests/test_pssh.py
@@ -69,6 +69,18 @@ class TestPsshExec(unittest.TestCase):
         )
         self.mock_log.debug.assert_any_call("ParallelSSH session retry detail", exc_info=True)
 
+    def test_exec_session_retry_destroys_stale_client_before_recreating(self):
+        # The stale client's greenlets/transports must be torn down before a
+        # replacement is built, or the old sshd sessions leak.
+        from pssh.exceptions import SessionError
+
+        self.mock_client.run_command.side_effect = [SessionError("stale session"), []]
+        with patch.object(self.pssh, "destroy_clients", wraps=self.pssh.destroy_clients) as mock_destroy:
+            self.pssh.exec("echo hello")
+
+        mock_destroy.assert_called_once()
+        self.assertEqual(self.mock_pssh_client.call_count, 2)
+
     def test_exec_retries_once_on_session_error_with_timeout(self):
         from pssh.exceptions import SessionError
 


### PR DESCRIPTION
Part 4 of 12 in a stack that replaces #184. Base: #316.

### Why
Long-running suites reuse a single `ParallelSSHClient` for the whole module. If the underlying session goes stale — common after a benchmark step that leaves the connection idle for tens of minutes — the next `run_command` raises `SessionError` and the test fails on a trivial follow-up command rather than on anything it was validating.

### What changed
- `_recreate_parallel_client()` — the client-construction block lifted out of `__init__` verbatim; `__init__` now calls it, so there is one construction path.
- `_run_command_with_session_retry()` — logs, rebuilds the client, retries **once**. A second failure propagates unchanged, so a genuinely broken host still fails fast.
- `exec()` and `exec_cmd_list()` route their `run_command` calls through it.

### Tests
The two `setUp` methods move from a decorator-scoped `@patch` to `patcher.start()` + `addCleanup`, because the retry constructs a client during the test body, not just during `setUp`. New coverage: retry-then-succeed (with and without a timeout) and retry-then-fail, on both exec paths.
