### PR TITLE
feat(pssh): support inactivity_timeout in exec_cmd_list

### DIFF
--- a/cvs/lib/parallel/multiprocess_pssh.py
+++ b/cvs/lib/parallel/multiprocess_pssh.py
@@ -247,10 +247,17 @@ class MultiProcessPssh(ShardableSshInterface):
 
         return cmd_output
 
-    def exec_cmd_list(self, cmd_list, timeout=None, print_console=True):
-        """Execute command list with automatic sharding if needed."""
+    def exec_cmd_list(self, cmd_list, timeout=None, print_console=True, inactivity_timeout=None):
+        """Execute command list with automatic sharding if needed.
+
+        inactivity_timeout (see Pssh.exec) is threaded through to both the direct
+        single-process path and the sharded worker path, so a per-line inactivity
+        timeout applies regardless of host count.
+        """
         if self.pssh is not None:
-            result = self.pssh.exec_cmd_list(cmd_list, timeout=timeout, print_console=print_console)
+            result = self.pssh.exec_cmd_list(
+                cmd_list, timeout=timeout, print_console=print_console, inactivity_timeout=inactivity_timeout
+            )
             self._sync_pssh_state()
             return result
 
@@ -283,7 +290,12 @@ class MultiProcessPssh(ShardableSshInterface):
 
         # Log command list execution
         if self.log:
-            if timeout is not None:
+            if inactivity_timeout is not None:
+                self.log.debug(
+                    f"Executing command list on {len(self.reachable_hosts)} host(s) "
+                    f"[inactivity_timeout={inactivity_timeout}s]"
+                )
+            elif timeout is not None:
                 self.log.debug(f"Executing command list on {len(self.reachable_hosts)} host(s) [timeout={timeout}s]")
             else:
                 self.log.debug(f"Executing command list on {len(self.reachable_hosts)} host(s)")
@@ -299,7 +311,12 @@ class MultiProcessPssh(ShardableSshInterface):
             offset += k
             payloads.append(
                 self.sharder.create_payloads(
-                    'exec_cmd_list', [shard_hosts], self._shard_init_kwargs(), cmd_list=shard_commands, timeout=timeout
+                    'exec_cmd_list',
+                    [shard_hosts],
+                    self._shard_init_kwargs(),
+                    cmd_list=shard_commands,
+                    timeout=timeout,
+                    inactivity_timeout=inactivity_timeout,
                 )[0]
             )
 

--- a/cvs/lib/parallel/pssh.py
+++ b/cvs/lib/parallel/pssh.py
@@ -326,6 +326,9 @@ class Pssh:
         inactivity_timeout is set, the underlying read_timeout is disabled so there
         is no total cap. Pass at most one of the two.
         """
+        if timeout is not None and inactivity_timeout is not None:
+            raise ValueError("Pass at most one of timeout and inactivity_timeout, not both.")
+
         if self.env_prefix:
             full_cmd = f"{self.env_prefix} ; {cmd}"
         else:
@@ -386,6 +389,9 @@ class Pssh:
         inactivity_timeout is set, the underlying read_timeout is disabled so there
         is no total cap. Pass at most one of the two.
         """
+        if timeout is not None and inactivity_timeout is not None:
+            raise ValueError("Pass at most one of timeout and inactivity_timeout, not both.")
+
         if self.env_prefix:
             cmd_list = [f"{self.env_prefix} ; {cmd}" for cmd in cmd_list]
         else:

--- a/cvs/lib/parallel/pssh.py
+++ b/cvs/lib/parallel/pssh.py
@@ -371,11 +371,19 @@ class Pssh:
 
         return cmd_output
 
-    def exec_cmd_list(self, cmd_list, timeout=None, print_console=True):
+    def exec_cmd_list(self, cmd_list, timeout=None, print_console=True, inactivity_timeout=None):
         """
         Run different commands on different hosts compared to to exec
         which runs the same command on all hosts.
         Returns a dictionary of host as key and command output as values
+
+        timeout is parallel-ssh's read_timeout: a TOTAL wall-clock cap on reading
+        the command's output (it is NOT reset by activity). inactivity_timeout is
+        an alternative that measures the gap between output lines instead: the
+        command may run arbitrarily long as long as it keeps producing output, and
+        is aborted only after inactivity_timeout seconds of silence. When
+        inactivity_timeout is set, the underlying read_timeout is disabled so there
+        is no total cap. Pass at most one of the two.
         """
         if self.env_prefix:
             cmd_list = [f"{self.env_prefix} ; {cmd}" for cmd in cmd_list]
@@ -386,19 +394,30 @@ class Pssh:
 
         # Log command list execution
         if self.log:
-            if timeout is not None:
+            if inactivity_timeout is not None:
+                self.log.debug(
+                    f"Executing command list on {len(self.reachable_hosts)} host(s) "
+                    f"[inactivity_timeout={inactivity_timeout}s]"
+                )
+            elif timeout is not None:
                 self.log.debug(f"Executing command list on {len(self.reachable_hosts)} host(s) [timeout={timeout}s]")
             else:
                 self.log.debug(f"Executing command list on {len(self.reachable_hosts)} host(s)")
 
-        if timeout is None:
+        # With an inactivity timeout the total read_timeout must be disabled, so
+        # the per-line gevent timer in _process_output is the only limiter.
+        if inactivity_timeout is not None:
+            output = self._run_command_with_session_retry('%s', host_args=cmd_list, stop_on_errors=self.stop_on_errors)
+        elif timeout is None:
             output = self._run_command_with_session_retry('%s', host_args=cmd_list, stop_on_errors=self.stop_on_errors)
         else:
             output = self._run_command_with_session_retry(
                 '%s', host_args=cmd_list, read_timeout=timeout, stop_on_errors=self.stop_on_errors
             )
 
-        cmd_output = self._process_output(output, cmd_list=cmd_list, print_console=print_console)
+        cmd_output = self._process_output(
+            output, cmd_list=cmd_list, print_console=print_console, inactivity_timeout=inactivity_timeout
+        )
 
         # Log per-host command execution (only for processed output)
         if self.process_output and self.log and isinstance(cmd_output, dict):

--- a/cvs/lib/parallel/unittests/test_pssh.py
+++ b/cvs/lib/parallel/unittests/test_pssh.py
@@ -1354,6 +1354,16 @@ class TestPsshInactivityTimeout(unittest.TestCase):
         with self.assertRaises(Timeout):
             self.pssh.exec("run", inactivity_timeout=0.3)
 
+    def test_exec_rejects_timeout_and_inactivity_timeout_together(self):
+        with self.assertRaises(ValueError):
+            self.pssh.exec("run", timeout=10, inactivity_timeout=0.3)
+        self.mock_client.run_command.assert_not_called()
+
+    def test_exec_cmd_list_rejects_timeout_and_inactivity_timeout_together(self):
+        with self.assertRaises(ValueError):
+            self.pssh.exec_cmd_list(["run"], timeout=10, inactivity_timeout=0.3)
+        self.mock_client.run_command.assert_not_called()
+
 
 class TestPsshDestroyClients(unittest.TestCase):
     """destroy_clients must actually tear the SSH transport down.


### PR DESCRIPTION
Part 5 of 12 in a stack that replaces #184. Base: #317.

### Why
`exec()` already accepts `inactivity_timeout` (a per-line silence timer). `timeout` is parallel-ssh's `read_timeout` — a **total** wall-clock cap that activity does not reset. `exec_cmd_list` only had the latter, so callers running long per-host commands had no way to distinguish "still working" from "hung": the cap has to be set to the worst plausible runtime, and a genuine hang then burns that entire budget.

### What changed
- `Pssh.exec_cmd_list` accepts `inactivity_timeout` and disables `read_timeout` when it is set.
- `MultiProcessPssh.exec_cmd_list` threads it through both the direct and the sharded worker path, so behaviour is identical regardless of host count.
- Docstring spells out the difference between the two parameters.

Defaults to `None`; existing `timeout` callers are unaffected.

### Known gap
No unit test covers the `exec_cmd_list` inactivity path specifically — the underlying per-line timer in `_process_output` is already exercised via `exec`. Happy to add one here if reviewers want it before merge.
