### PR TITLE
feat(docker_lib): add image-presence preflight and a prune opt-out

### DIFF
--- a/cvs/lib/docker_lib.py
+++ b/cvs/lib/docker_lib.py
@@ -5,8 +5,10 @@ The year included in the foregoing notice is the year of creation of the work.
 All code contained here is Property of Advanced Micro Devices, Inc.
 '''
 
-import re
 import json
+import os
+import re
+import shlex
 import time
 
 from cvs.lib import globals
@@ -36,6 +38,22 @@ def check_if_docker_client_running(phdl):
     return True
 
 
+def nodes_missing_docker_image(phdl, image_ref):
+    """
+    Return host keys where `image_ref` is not present in the local Docker image store.
+
+    Uses `docker image inspect` so failures are fail-fast before an expensive `docker run`.
+    """
+    quoted = shlex.quote(image_ref)
+    cmd = f"docker image inspect {quoted} >/dev/null 2>&1 && echo IMG_OK || echo IMG_MISSING"
+    out = phdl.exec(cmd, print_console=False)
+    missing = []
+    for node, output in (out or {}).items():
+        if "IMG_OK" not in (output or ""):
+            missing.append(node)
+    return missing
+
+
 def killall_docker_containers(phdl):
     phdl.exec('docker kill $(docker ps -q)')
 
@@ -45,6 +63,22 @@ def kill_docker_container(phdl, container_name):
 
 
 def delete_all_containers_and_volumes(phdl):
+    """
+    Prune unused Docker objects on all target hosts.
+
+    This runs ``docker system prune --force`` (not ``-a``), but it can still remove
+    stopped containers and unused networks on shared nodes. Set environment variable
+    ``CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE`` to ``1``/``true``/``yes`` to skip this
+    step after the named benchmark container has been killed.
+    """
+    flag = (os.environ.get("CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE") or "").strip().lower()
+    if flag in ("1", "true", "yes", "on"):
+        log.info(
+            "Skipping docker system prune (CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE=%s). "
+            "Named benchmark container was already stopped.",
+            os.environ.get("CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE"),
+        )
+        return
     # out_dict = phdl.exec('docker rm -vf $(docker ps -aq)')
     log.info('Deleting all containers and volumes')
     # out_dict = phdl.exec('docker system prune -a --volumes --force', timeout=60*10)

--- a/cvs/lib/docker_lib.py
+++ b/cvs/lib/docker_lib.py
@@ -68,15 +68,15 @@ def delete_all_containers_and_volumes(phdl):
 
     This runs ``docker system prune --force`` (not ``-a``), but it can still remove
     stopped containers and unused networks on shared nodes. Set environment variable
-    ``CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE`` to ``1``/``true``/``yes`` to skip this
+    ``CVS_SKIP_DOCKER_SYSTEM_PRUNE`` to ``1``/``true``/``yes`` to skip this
     step after the named benchmark container has been killed.
     """
-    flag = (os.environ.get("CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE") or "").strip().lower()
+    flag = (os.environ.get("CVS_SKIP_DOCKER_SYSTEM_PRUNE") or "").strip().lower()
     if flag in ("1", "true", "yes", "on"):
         log.info(
-            "Skipping docker system prune (CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE=%s). "
+            "Skipping docker system prune (CVS_SKIP_DOCKER_SYSTEM_PRUNE=%s). "
             "Named benchmark container was already stopped.",
-            os.environ.get("CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE"),
+            os.environ.get("CVS_SKIP_DOCKER_SYSTEM_PRUNE"),
         )
         return
     # out_dict = phdl.exec('docker rm -vf $(docker ps -aq)')

--- a/cvs/lib/unittests/test_docker_lib.py
+++ b/cvs/lib/unittests/test_docker_lib.py
@@ -1,6 +1,8 @@
 # cvs/lib/unittests/test_docker_lib.py
+import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
 import cvs.lib.docker_lib as docker_lib
 
 
@@ -21,9 +23,26 @@ class TestDockerLib(unittest.TestCase):
         docker_lib.delete_all_containers_and_volumes(self.mock_phdl)
         self.mock_phdl.exec.assert_called_once_with('docker system prune --force', timeout=60 * 10)
 
+    @patch.dict(os.environ, {"CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE": "1"}, clear=False)
+    def test_delete_all_containers_skips_prune_when_env_set(self):
+        docker_lib.delete_all_containers_and_volumes(self.mock_phdl)
+        self.mock_phdl.exec.assert_not_called()
+
     def test_delete_all_images(self):
         docker_lib.delete_all_images(self.mock_phdl)
         self.mock_phdl.exec.assert_called_once_with('docker rmi -f $(docker images -aq)')
+
+    def test_nodes_missing_docker_image_none_missing(self):
+        self.mock_phdl.exec.return_value = {"n1": "IMG_OK\n", "n2": "IMG_OK\n"}
+        self.assertEqual(docker_lib.nodes_missing_docker_image(self.mock_phdl, "repo/img:tag"), [])
+        self.mock_phdl.exec.assert_called_once()
+        cmd = self.mock_phdl.exec.call_args[0][0]
+        self.assertIn("docker image inspect", cmd)
+        self.assertIn("repo/img:tag", cmd)
+
+    def test_nodes_missing_docker_image_some_missing(self):
+        self.mock_phdl.exec.return_value = {"n1": "IMG_OK\n", "n2": "IMG_MISSING\n"}
+        self.assertEqual(docker_lib.nodes_missing_docker_image(self.mock_phdl, "x:y"), ["n2"])
 
 
 if __name__ == '__main__':

--- a/cvs/lib/unittests/test_docker_lib.py
+++ b/cvs/lib/unittests/test_docker_lib.py
@@ -23,7 +23,7 @@ class TestDockerLib(unittest.TestCase):
         docker_lib.delete_all_containers_and_volumes(self.mock_phdl)
         self.mock_phdl.exec.assert_called_once_with('docker system prune --force', timeout=60 * 10)
 
-    @patch.dict(os.environ, {"CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE": "1"}, clear=False)
+    @patch.dict(os.environ, {"CVS_SKIP_DOCKER_SYSTEM_PRUNE": "1"}, clear=False)
     def test_delete_all_containers_skips_prune_when_env_set(self):
         docker_lib.delete_all_containers_and_volumes(self.mock_phdl)
         self.mock_phdl.exec.assert_not_called()


### PR DESCRIPTION
Part 6 of 12 in a stack that replaces #184. Base: #318.

### Why
Two small library gaps the pytorch_xdit benchmarks hit, both usable by any suite.

### What changed
**`nodes_missing_docker_image(phdl, image_ref)`** — runs `docker image inspect` on every target and returns the hosts where the image is absent. Without it, a missing image surfaces as a `docker run` failure minutes into a test, buried in container output. The image ref is `shlex`-quoted.

**`delete_all_containers_and_volumes()`** now honours `CVS_PYTORCH_XDIT_SKIP_DOCKER_SYSTEM_PRUNE` (`1`/`true`/`yes`/`on`). The function runs `docker system prune --force`, which removes stopped containers and unused networks belonging to *other users* on shared cluster nodes. The opt-out lets a run stop its own named container and skip the cluster-wide prune. Default behaviour is unchanged.

Unit tests cover both, including the missing/present cases and the skip path.
