### PR TITLE
feat(aorta): multi_node configuration surface (schema, yaml, docs)

### DIFF
--- a/cvs/input/config_file/aorta/aorta_benchmark.yaml
+++ b/cvs/input/config_file/aorta/aorta_benchmark.yaml
@@ -69,6 +69,42 @@ analysis:
   gemm_script: scripts/gemm_analysis/run_tracelens_analysis.sh
   skip_if_exists: false
 
+# Multi-node disaggregated launch.
+#
+# When the cluster file has more than one node entry, the runner launches a
+# `torchrun` rank-group on every node in parallel (one per node), all
+# rendezvous-ing on the head node. Mirrors aorta's own
+# scripts/multi_node/local_launch.sh pattern, so a single cluster.json with N
+# host entries is enough -- you no longer need N cluster files.
+#
+# `master_launch_mode: auto` keeps current single-node behavior (delegates to
+# experiment_script) for 1-node clusters and switches to disaggregated
+# torchrun for >1-node clusters. Force one or the other with `script` /
+# `torchrun` if you want to override the auto-detection.
+#
+# When master_launch_mode resolves to torchrun, `experiment_script` is NOT
+# used -- the runner builds:
+#   torchrun --nnodes <N> --node_rank <R> --nproc_per_node <P>
+#            --master_addr <head> --master_port <PORT>
+#            <container_mount_path>/<train_script>
+#            --config <container_mount_path>/<base_config>
+#            [--override training_overrides...]
+#
+# extra_env is exported inside each container before torchrun -- use it for
+# transport-specific knobs that depend on the cluster (NCCL_SOCKET_IFNAME,
+# NCCL_IB_HCA, NCCL_IB_GID_INDEX, ...). On a single ethernet network you can
+# usually leave it empty.
+multi_node:
+  master_launch_mode: auto
+  # nproc_per_node: 8       # defaults to gpus_per_node
+  # master_port: 29500      # default: pick a free ephemeral port
+  # master_addr: 10.0.0.1   # default: head node from cluster.json
+  train_script: train.py
+  extra_torchrun_args: []
+  extra_train_args: []
+  extra_env: {}
+  collect_traces: true
+
 # Expected results: default thresholds for gfx942 (e.g. MI300). Change these as per your
 # testing config (GPU, node count, workload); see docs/reference/configuration-files/aorta.rst.
 # Tuned for host raw-trace parsing; use stricter values (e.g. min_compute_ratio 0.5+) with TraceLens Excel reports.

--- a/cvs/input/config_file/aorta/aorta_benchmark.yaml
+++ b/cvs/input/config_file/aorta/aorta_benchmark.yaml
@@ -69,6 +69,42 @@ analysis:
   gemm_script: scripts/gemm_analysis/run_tracelens_analysis.sh
   skip_if_exists: false
 
+# Multi-node disaggregated launch.
+#
+# When the cluster file has more than one node entry, the runner launches a
+# `torchrun` rank-group on every node in parallel (one per node), all
+# rendezvous-ing on the head node. Mirrors aorta's own
+# scripts/multi_node/local_launch.sh pattern, so a single cluster.json with N
+# host entries is enough -- you no longer need N cluster files.
+#
+# `master_launch_mode: auto` keeps current single-node behavior (delegates to
+# experiment_script) for 1-node clusters and switches to disaggregated
+# torchrun for >1-node clusters. Force one or the other with `script` /
+# `torchrun` if you want to override the auto-detection.
+#
+# When master_launch_mode resolves to torchrun, `experiment_script` is NOT
+# used -- the runner builds:
+#   torchrun --nnodes <N> --node_rank <R> --nproc_per_node <P>
+#            --master_addr <head> --master_port <PORT>
+#            <container_mount_path>/<train_script>
+#            --config <container_mount_path>/<base_config>
+#            [--override training_overrides...]
+#
+# extra_env is exported inside each container before torchrun -- use it for
+# transport-specific knobs that depend on the cluster (NCCL_SOCKET_IFNAME,
+# NCCL_IB_HCA, NCCL_IB_GID_INDEX, ...). On a single ethernet network you can
+# usually leave it empty.
+multi_node:
+  master_launch_mode: auto
+  # nproc_per_node: 8       # defaults to gpus_per_node
+  # master_port: 29500      # default: pick a free ephemeral port
+  # master_addr: 10.0.0.1   # default: head node from cluster.json
+  train_script: train.py
+  extra_torchrun_args: []
+  extra_train_args: []
+  extra_env: {}
+  collect_traces: true
+
 # Expected results: default thresholds for gfx942 (e.g. MI300). Change these as per your
 # testing config (GPU, node count, workload); see docs/reference/configuration-files/training/aorta.rst.
 # Tuned for host raw-trace parsing; use stricter values (e.g. min_compute_ratio 0.5+) with TraceLens Excel reports.

--- a/cvs/input/config_file/aorta/aorta_benchmark.yaml
+++ b/cvs/input/config_file/aorta/aorta_benchmark.yaml
@@ -98,7 +98,9 @@ multi_node:
   master_launch_mode: auto
   # nproc_per_node: 8       # defaults to gpus_per_node
   # master_port: 29500      # default: pick a free ephemeral port
-  # master_addr: 10.0.0.1   # default: head node from cluster.json
+  # master_addr: 10.0.0.1   # default: head node's node_vpc_ips entry, else its
+  #                         # plain identifier. Don't pin this to the SSH/mgmt
+  #                         # address on a fabric-separated cluster.
   train_script: train.py
   extra_torchrun_args: []
   extra_train_args: []

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -466,6 +466,96 @@ class AortaAnalysisConfigFile(BaseModel):
     )
 
 
+class AortaMultiNodeConfigFile(BaseModel):
+    """
+    Schema for the optional ``multi_node`` section in aorta_benchmark.yaml.
+
+    When the cluster file contains more than one node, the runner launches a
+    disaggregated ``torchrun`` invocation on every node (one per ``node_dict``
+    entry), rendezvous-ing on the head node. This block tunes that path.
+
+    Single-node clusters ignore this block; ``master_launch_mode`` defaults to
+    ``auto`` which means: ``script`` (current behavior, single-node) when the
+    cluster has one node, ``torchrun`` (multi-node disaggregated) when it has
+    more than one.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    master_launch_mode: str = Field(
+        default="auto",
+        description=(
+            "How the experiment is launched on each node. 'auto' picks 'script' "
+            "for single-node clusters and 'torchrun' for multi-node clusters. "
+            "'script' always uses the configured experiment_script (single-node only). "
+            "'torchrun' always builds a multi-node torchrun command and ignores "
+            "experiment_script."
+        ),
+    )
+    nproc_per_node: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Processes (GPUs) per node passed to torchrun --nproc_per_node. "
+            "Defaults to the top-level gpus_per_node when unset."
+        ),
+    )
+    master_port: Optional[int] = Field(
+        default=None,
+        ge=1024,
+        le=65535,
+        description=(
+            "Port used for torchrun rendezvous (--master_port). When unset the "
+            "runner picks a free ephemeral port on the head node."
+        ),
+    )
+    master_addr: Optional[str] = Field(
+        default=None,
+        description=(
+            "Override the master address (--master_addr). Defaults to the head node hostname/IP from the cluster file."
+        ),
+    )
+    train_script: str = Field(
+        default="train.py",
+        description=(
+            "Path to the Aorta training entry script relative to aorta_path. "
+            "Used when master_launch_mode resolves to 'torchrun'."
+        ),
+    )
+    extra_torchrun_args: List[str] = Field(
+        default_factory=list,
+        description="Additional CLI flags appended to the torchrun command.",
+    )
+    extra_train_args: List[str] = Field(
+        default_factory=list,
+        description="Additional CLI flags appended to train.py after --config.",
+    )
+    extra_env: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Extra environment variables to export inside the container before "
+            "torchrun. Useful for NCCL_SOCKET_IFNAME, NCCL_IB_HCA, "
+            "NCCL_IB_GID_INDEX, and similar transport-tuning knobs."
+        ),
+    )
+    collect_traces: bool = Field(
+        default=True,
+        description=(
+            "When true, copy each node's torch_profiler artifacts back to the "
+            "head node under <aorta_path>/combined_traces/node_<rank>/ so the "
+            "host parsers see one unified trace tree."
+        ),
+    )
+
+    @field_validator('master_launch_mode')
+    @classmethod
+    def validate_launch_mode(cls, v: str) -> str:
+        allowed = {"auto", "script", "torchrun"}
+        if v not in allowed:
+            raise ValueError(f"master_launch_mode must be one of {sorted(allowed)}, got {v!r}")
+        return v
+
+
 class AortaBenchmarkConfigFile(BaseModel):
     """
     Schema for the entire aorta_benchmark.yaml configuration file.
@@ -534,6 +624,16 @@ class AortaBenchmarkConfigFile(BaseModel):
         default_factory=AortaAnalysisConfigFile, description="Post-benchmark analysis configuration"
     )
 
+    # Multi-node disaggregated launch (one container + torchrun rank per node)
+    multi_node: AortaMultiNodeConfigFile = Field(
+        default_factory=AortaMultiNodeConfigFile,
+        description=(
+            "Multi-node launch configuration. Used when the cluster file lists "
+            "more than one node; ignored for single-node clusters unless "
+            "master_launch_mode is forced to 'torchrun'."
+        ),
+    )
+
     @field_validator('aorta_path')
     @classmethod
     def validate_aorta_path_not_placeholder(cls, v: str) -> str:
@@ -572,6 +672,11 @@ class AortaBenchmarkConfigFile(BaseModel):
             exp_script = aorta / self.experiment_script
             if not exp_script.exists():
                 errors.append(f"experiment_script does not exist: {exp_script}")
+
+            if self.multi_node.master_launch_mode == "torchrun":
+                train_script_path = aorta / self.multi_node.train_script
+                if not train_script_path.exists():
+                    errors.append(f"multi_node.train_script does not exist: {train_script_path}")
 
             # Check analysis scripts if enabled
             if self.analysis.enable_tracelens:

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -474,10 +474,11 @@ class AortaMultiNodeConfigFile(BaseModel):
     disaggregated ``torchrun`` invocation on every node (one per ``node_dict``
     entry), rendezvous-ing on the head node. This block tunes that path.
 
-    Single-node clusters ignore this block; ``master_launch_mode`` defaults to
-    ``auto`` which means: ``script`` (current behavior, single-node) when the
-    cluster has one node, ``torchrun`` (multi-node disaggregated) when it has
-    more than one.
+    Single-node clusters ignore this block only under the ``auto`` default,
+    which resolves to ``script`` (current behavior) for one node and
+    ``torchrun`` (multi-node disaggregated) for more than one. Explicitly
+    setting ``master_launch_mode: torchrun`` on a single-node cluster still
+    activates ``train_script``, ``extra_env``, and ``master_addr``.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -512,7 +513,11 @@ class AortaMultiNodeConfigFile(BaseModel):
     master_addr: Optional[str] = Field(
         default=None,
         description=(
-            "Override the master address (--master_addr). Defaults to the head node hostname/IP from the cluster file."
+            "Override the master address (--master_addr). When unset, resolves to the "
+            "head node's node_vpc_ips entry if the cluster file defines one, otherwise "
+            "falls back to the head node's plain identifier. Do not pin this to the "
+            "SSH/management address on a fabric-separated cluster: other nodes rendezvous "
+            "over the RDMA fabric, and node_vpc_ips exists precisely to prefer that address."
         ),
     )
     train_script: str = Field(

--- a/cvs/parsers/unittests/test_schemas.py
+++ b/cvs/parsers/unittests/test_schemas.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the config-file Pydantic schemas in ``cvs/parsers/schemas.py``.
+
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from cvs.parsers.schemas import AortaBenchmarkConfigFile
+
+
+class TestAortaMultiNodeBlock(unittest.TestCase):
+    def test_default_multi_node_block_has_auto_mode(self):
+        cfg = AortaBenchmarkConfigFile.model_validate({"aorta_path": "/tmp/aorta"})
+        self.assertEqual(cfg.multi_node.master_launch_mode, "auto")
+        self.assertTrue(cfg.multi_node.collect_traces)
+        self.assertEqual(cfg.multi_node.train_script, "train.py")
+
+    def test_yaml_without_multi_node_block_still_validates(self):
+        # Backward compatibility: configs written before this block existed.
+        cfg = AortaBenchmarkConfigFile.model_validate({"aorta_path": "/tmp/aorta"})
+        self.assertIsNotNone(cfg.multi_node)
+
+    def test_extra_keys_under_multi_node_are_rejected(self):
+        raw = {"aorta_path": "/tmp/aorta", "multi_node": {"bogus_key": "value"}}
+        with self.assertRaises(ValidationError):
+            AortaBenchmarkConfigFile.model_validate(raw)
+
+    def test_invalid_master_launch_mode_rejected(self):
+        raw = {"aorta_path": "/tmp/aorta", "multi_node": {"master_launch_mode": "magic"}}
+        with self.assertRaises(ValidationError):
+            AortaBenchmarkConfigFile.model_validate(raw)
+
+    def test_out_of_range_master_port_rejected(self):
+        raw = {"aorta_path": "/tmp/aorta", "multi_node": {"master_port": 80}}
+        with self.assertRaises(ValidationError):
+            AortaBenchmarkConfigFile.model_validate(raw)
+
+
+class TestAortaTrainScriptPathCheck(unittest.TestCase):
+    """``validate_paths_exist`` should only demand train_script in torchrun mode."""
+
+    def _config(self, root: Path, mode: str) -> AortaBenchmarkConfigFile:
+        for rel in ("config/distributed.yaml", "scripts/build_rccl.sh", "scripts/rccl_exp.sh"):
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+        return AortaBenchmarkConfigFile.model_validate(
+            {
+                "aorta_path": str(root),
+                "build_script": "scripts/build_rccl.sh",
+                "experiment_script": "scripts/rccl_exp.sh",
+                "analysis": {"enable_tracelens": False, "enable_gemm_analysis": False},
+                "multi_node": {"master_launch_mode": mode},
+            }
+        )
+
+    def test_torchrun_mode_reports_missing_train_script(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            errors = self._config(Path(tmp), "torchrun").validate_paths_exist()
+            self.assertTrue(any("train_script" in e for e in errors), errors)
+
+    def test_torchrun_mode_passes_when_train_script_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = self._config(Path(tmp), "torchrun")
+            (Path(tmp) / "train.py").touch()
+            self.assertEqual(cfg.validate_paths_exist(), [])
+
+    def test_script_mode_does_not_require_train_script(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(self._config(Path(tmp), "script").validate_paths_exist(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/runners/aorta.py
+++ b/cvs/runners/aorta.py
@@ -95,6 +95,26 @@ class AortaAnalysisConfig:
 
 
 @dataclass
+class AortaMultiNodeConfig:
+    """
+    Multi-node disaggregated launch configuration.
+
+    See ``AortaMultiNodeConfigFile`` in ``cvs/parsers/schemas.py`` for the
+    YAML-facing description of each field.
+    """
+
+    master_launch_mode: str = "auto"
+    nproc_per_node: Optional[int] = None
+    master_port: Optional[int] = None
+    master_addr: Optional[str] = None
+    train_script: str = "train.py"
+    extra_torchrun_args: List[str] = field(default_factory=list)
+    extra_train_args: List[str] = field(default_factory=list)
+    extra_env: Dict[str, str] = field(default_factory=dict)
+    collect_traces: bool = True
+
+
+@dataclass
 class AortaConfig(RunConfig):
     """
     Configuration for Aorta benchmark runner.
@@ -130,6 +150,16 @@ class AortaConfig(RunConfig):
 
     # Analysis configuration (use Aorta's built-in scripts)
     analysis: AortaAnalysisConfig = field(default_factory=AortaAnalysisConfig)
+
+    # Multi-node disaggregated launch configuration
+    multi_node: AortaMultiNodeConfig = field(default_factory=AortaMultiNodeConfig)
+
+    # Maps a `nodes` entry to its VPC/RDMA-fabric address, when the cluster has one
+    # distinct from the orchestrator-reachable address. Used to resolve master_addr
+    # for torchrun rendezvous so other nodes connect over the fabric, not the
+    # (possibly orchestrator-only) SSH network. Empty by default: falls back to the
+    # plain node identifier, matching prior behavior for single-network clusters.
+    node_vpc_ips: Dict[str, str] = field(default_factory=dict)
 
     # Scripts to execute (relative to container mount)
     build_script: str = "scripts/build_rccl.sh"

--- a/cvs/runners/aorta.py
+++ b/cvs/runners/aorta.py
@@ -96,6 +96,26 @@ class AortaAnalysisConfig:
 
 
 @dataclass
+class AortaMultiNodeConfig:
+    """
+    Multi-node disaggregated launch configuration.
+
+    See ``AortaMultiNodeConfigFile`` in ``cvs/parsers/schemas.py`` for the
+    YAML-facing description of each field.
+    """
+
+    master_launch_mode: str = "auto"
+    nproc_per_node: Optional[int] = None
+    master_port: Optional[int] = None
+    master_addr: Optional[str] = None
+    train_script: str = "train.py"
+    extra_torchrun_args: List[str] = field(default_factory=list)
+    extra_train_args: List[str] = field(default_factory=list)
+    extra_env: Dict[str, str] = field(default_factory=dict)
+    collect_traces: bool = True
+
+
+@dataclass
 class AortaConfig(RunConfig):
     """
     Configuration for Aorta benchmark runner.
@@ -131,6 +151,16 @@ class AortaConfig(RunConfig):
 
     # Analysis configuration (use Aorta's built-in scripts)
     analysis: AortaAnalysisConfig = field(default_factory=AortaAnalysisConfig)
+
+    # Multi-node disaggregated launch configuration
+    multi_node: AortaMultiNodeConfig = field(default_factory=AortaMultiNodeConfig)
+
+    # Maps a `nodes` entry to its VPC/RDMA-fabric address, when the cluster has one
+    # distinct from the orchestrator-reachable address. Used to resolve master_addr
+    # for torchrun rendezvous so other nodes connect over the fabric, not the
+    # (possibly orchestrator-only) SSH network. Empty by default: falls back to the
+    # plain node identifier, matching prior behavior for single-network clusters.
+    node_vpc_ips: Dict[str, str] = field(default_factory=dict)
 
     # Scripts to execute (relative to container mount)
     build_script: str = "scripts/build_rccl.sh"

--- a/cvs/tests/benchmark/test_aorta.py
+++ b/cvs/tests/benchmark/test_aorta.py
@@ -24,6 +24,7 @@ from cvs.runners.aorta import (
     RcclConfig,
     AortaEnvironment,
     AortaAnalysisConfig,
+    AortaMultiNodeConfig,
 )
 from cvs.runners._base_runner import RunStatus
 from cvs.parsers.aorta_report import AortaReportParser
@@ -137,6 +138,11 @@ def aorta_runner_config(
     # Extract node list from validated cluster config
     node_list = list(validated_cluster_config.node_dict.keys())
 
+    # Each node's VPC/RDMA-fabric address (may differ from the SSH-reachable
+    # node_dict key on clusters with a dedicated VPC network). Used to resolve
+    # torchrun's master_addr so other nodes rendezvous over the fabric.
+    node_vpc_ips = {node: validated_cluster_config.node_dict[node].vpc_ip for node in node_list}
+
     # Build Docker config from validated aorta config
     docker_config = AortaDockerConfig(
         image=validated_aorta_config.docker.image,
@@ -173,6 +179,21 @@ def aorta_runner_config(
         skip_if_exists=analysis_cfg.skip_if_exists,
     )
 
+    # Build multi-node config (used when cluster has >1 node, or when
+    # multi_node.master_launch_mode is forced to 'torchrun').
+    mn_cfg = validated_aorta_config.multi_node
+    multi_node_config = AortaMultiNodeConfig(
+        master_launch_mode=mn_cfg.master_launch_mode,
+        nproc_per_node=mn_cfg.nproc_per_node,
+        master_port=mn_cfg.master_port,
+        master_addr=mn_cfg.master_addr,
+        train_script=mn_cfg.train_script,
+        extra_torchrun_args=list(mn_cfg.extra_torchrun_args),
+        extra_train_args=list(mn_cfg.extra_train_args),
+        extra_env=dict(mn_cfg.extra_env),
+        collect_traces=mn_cfg.collect_traces,
+    )
+
     # Build full runner config
     return AortaConfig(
         nodes=node_list,
@@ -188,6 +209,8 @@ def aorta_runner_config(
         rccl=rccl_config,
         environment=env_config,
         analysis=analysis_config,
+        multi_node=multi_node_config,
+        node_vpc_ips=node_vpc_ips,
         build_script=validated_aorta_config.build_script,
         experiment_script=validated_aorta_config.experiment_script,
         gpus_per_node=validated_aorta_config.gpus_per_node,

--- a/docs/reference/configuration-files/aorta.rst
+++ b/docs/reference/configuration-files/aorta.rst
@@ -72,6 +72,14 @@ You may instead use fully absolute paths with no placeholders. Other entry point
       gemm_script: scripts/gemm_analysis/run_tracelens_analysis.sh
       skip_if_exists: false
 
+    multi_node:
+      master_launch_mode: auto
+      train_script: train.py
+      extra_torchrun_args: []
+      extra_train_args: []
+      extra_env: {}
+      collect_traces: true
+
     expected_results:
       max_avg_iteration_ms: 12000
       min_compute_ratio: 0.01
@@ -186,6 +194,33 @@ The **dropdown above** is the full **shipped** ``aorta_benchmark.yaml``. Where t
    * - ``analysis.skip_if_exists``
      - ``false``
      - Skip analysis if ``tracelens_analysis`` already exists.
+   * - ``multi_node.master_launch_mode``
+     - ``auto``
+     - ``auto`` picks ``script`` for single-node clusters and ``torchrun`` for multi-node clusters. Set to ``script`` to force the single-node ``experiment_script`` path (errors out on >1 node), or ``torchrun`` to always build a disaggregated ``torchrun`` command.
+   * - ``multi_node.nproc_per_node``
+     - ``null`` (defaults to ``gpus_per_node``)
+     - Processes/GPUs per node passed as ``torchrun --nproc_per_node``.
+   * - ``multi_node.master_port``
+     - ``null`` (free ephemeral port)
+     - Port for the ``torchrun`` rendezvous (``--master_port``). Pin this when you need a deterministic port (e.g., firewalled environments).
+   * - ``multi_node.master_addr``
+     - ``null`` (head node from cluster.json)
+     - Override the rendezvous address (``--master_addr``).
+   * - ``multi_node.train_script``
+     - ``train.py``
+     - Aorta training entry script relative to ``aorta_path``. Used in ``torchrun`` mode.
+   * - ``multi_node.extra_torchrun_args``
+     - ``[]``
+     - Additional ``torchrun`` flags appended before the training script.
+   * - ``multi_node.extra_train_args``
+     - ``[]``
+     - Additional ``train.py`` flags appended after ``--config``.
+   * - ``multi_node.extra_env``
+     - ``{}``
+     - Extra environment variables exported inside each container before ``torchrun``. Use for transport tuning (``NCCL_SOCKET_IFNAME``, ``NCCL_IB_HCA``, ``NCCL_IB_GID_INDEX``, ...).
+   * - ``multi_node.collect_traces``
+     - ``true``
+     - When true, the runner pulls each node's ``torch_profiler/`` trees back to ``<aorta_path>/combined_traces/node_<rank>/`` on the head node so host parsers see one unified trace tree.
    * - ``expected_results.max_avg_iteration_ms``
      - optional
      - Maximum acceptable average iteration time (ms).
@@ -215,6 +250,33 @@ Use the **CVS package directory** as the working directory: the directory that c
 Provide a valid ``cluster_file``. Ensure ``aorta_path`` exists after placeholder resolution, or enable auto-clone with a valid URL. With ``skip_rccl_build: false``, the runner builds RCCL from ``rccl.clone_url`` unless skipped; with ``skip_rccl_build: true``, the experiment script runs without that build step. The runner collects ``torch_traces`` (PyTorch profiler output) and optionally runs TraceLens inside the container. Parsing and threshold checks run on the host.
 
 Alternate mirrors for ``rccl.clone_url`` may work if they track the same upstream; the canonical default string in schema, runner, and sample is ``https://github.com/ROCmSoftwarePlatform/rccl.git``.
+
+Multi-node disaggregated launch
+===============================
+
+By default, when the cluster file contains more than one node, ``test_aorta`` runs a disaggregated launch: a single Aorta container is started on every node, then the runner kicks off ``torchrun`` in parallel on each container with ``--nnodes``, ``--node_rank``, ``--master_addr``, and ``--master_port`` set so the ranks rendezvous on the head node. This mirrors Aorta's own ``scripts/multi_node/local_launch.sh`` pattern and brings the benchmark in line with the other multi-node CVS suites (sglang, pytorch-xdit), which only require **one** ``cluster.json`` for a multi-node run.
+
+The multi-node behavior is controlled by the ``multi_node`` block in ``aorta_benchmark.yaml``:
+
+.. code:: yaml
+
+  multi_node:
+    master_launch_mode: auto      # auto | script | torchrun
+    nproc_per_node: 8             # defaults to gpus_per_node
+    master_port: 29500            # default: free ephemeral port
+    master_addr: 10.0.0.1         # default: head node from cluster.json
+    train_script: train.py
+    extra_torchrun_args: []
+    extra_train_args: []
+    extra_env:
+      NCCL_SOCKET_IFNAME: bond0
+      NCCL_IB_HCA: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
+      NCCL_IB_GID_INDEX: "3"
+    collect_traces: true
+
+Single-node clusters keep using the configured ``experiment_script`` (``master_launch_mode: auto`` resolves to ``script``). Force the disaggregated path with ``master_launch_mode: torchrun`` if you want it for a single-node cluster too.
+
+When ``collect_traces`` is true, every node's ``torch_profiler/`` directories are rsynced back to ``<aorta_path>/combined_traces/node_<rank>/`` on the head node and exposed as the ``torch_traces`` artifact, so the existing host parsers and threshold checks see one unified tree without further configuration.
 
 Expected results and artifacts
 ==============================

--- a/docs/reference/configuration-files/training/aorta.rst
+++ b/docs/reference/configuration-files/training/aorta.rst
@@ -72,6 +72,14 @@ You may instead use fully absolute paths with no placeholders. Other entry point
       gemm_script: scripts/gemm_analysis/run_tracelens_analysis.sh
       skip_if_exists: false
 
+    multi_node:
+      master_launch_mode: auto
+      train_script: train.py
+      extra_torchrun_args: []
+      extra_train_args: []
+      extra_env: {}
+      collect_traces: true
+
     expected_results:
       max_avg_iteration_ms: 12000
       min_compute_ratio: 0.01
@@ -186,6 +194,33 @@ The **dropdown above** is the full **shipped** ``aorta_benchmark.yaml``. Where t
    * - ``analysis.skip_if_exists``
      - ``false``
      - Skip analysis if ``tracelens_analysis`` already exists.
+   * - ``multi_node.master_launch_mode``
+     - ``auto``
+     - ``auto`` picks ``script`` for single-node clusters and ``torchrun`` for multi-node clusters. Set to ``script`` to force the single-node ``experiment_script`` path (errors out on >1 node), or ``torchrun`` to always build a disaggregated ``torchrun`` command.
+   * - ``multi_node.nproc_per_node``
+     - ``null`` (defaults to ``gpus_per_node``)
+     - Processes/GPUs per node passed as ``torchrun --nproc_per_node``.
+   * - ``multi_node.master_port``
+     - ``null`` (free ephemeral port)
+     - Port for the ``torchrun`` rendezvous (``--master_port``). Pin this when you need a deterministic port (e.g., firewalled environments).
+   * - ``multi_node.master_addr``
+     - ``null`` (head node from cluster.json)
+     - Override the rendezvous address (``--master_addr``).
+   * - ``multi_node.train_script``
+     - ``train.py``
+     - Aorta training entry script relative to ``aorta_path``. Used in ``torchrun`` mode.
+   * - ``multi_node.extra_torchrun_args``
+     - ``[]``
+     - Additional ``torchrun`` flags appended before the training script.
+   * - ``multi_node.extra_train_args``
+     - ``[]``
+     - Additional ``train.py`` flags appended after ``--config``.
+   * - ``multi_node.extra_env``
+     - ``{}``
+     - Extra environment variables exported inside each container before ``torchrun``. Use for transport tuning (``NCCL_SOCKET_IFNAME``, ``NCCL_IB_HCA``, ``NCCL_IB_GID_INDEX``, ...).
+   * - ``multi_node.collect_traces``
+     - ``true``
+     - When true, the runner pulls each node's ``torch_profiler/`` trees back to ``<aorta_path>/combined_traces/node_<rank>/`` on the head node so host parsers see one unified trace tree.
    * - ``expected_results.max_avg_iteration_ms``
      - optional
      - Maximum acceptable average iteration time (ms).
@@ -215,6 +250,33 @@ Use the **CVS package directory** as the working directory: the directory that c
 Provide a valid ``cluster_file``. Ensure ``aorta_path`` exists after placeholder resolution, or enable auto-clone with a valid URL. With ``skip_rccl_build: false``, the runner builds RCCL from ``rccl.clone_url`` unless skipped; with ``skip_rccl_build: true``, the experiment script runs without that build step. The runner collects ``torch_traces`` (PyTorch profiler output) and optionally runs TraceLens inside the container. Parsing and threshold checks run on the host.
 
 Alternate mirrors for ``rccl.clone_url`` may work if they track the same upstream; the canonical default string in schema, runner, and sample is ``https://github.com/ROCmSoftwarePlatform/rccl.git``.
+
+Multi-node disaggregated launch
+===============================
+
+By default, when the cluster file contains more than one node, ``test_aorta`` runs a disaggregated launch: a single Aorta container is started on every node, then the runner kicks off ``torchrun`` in parallel on each container with ``--nnodes``, ``--node_rank``, ``--master_addr``, and ``--master_port`` set so the ranks rendezvous on the head node. This mirrors Aorta's own ``scripts/multi_node/local_launch.sh`` pattern and brings the benchmark in line with the other multi-node CVS suites (sglang, pytorch-xdit), which only require **one** ``cluster.json`` for a multi-node run.
+
+The multi-node behavior is controlled by the ``multi_node`` block in ``aorta_benchmark.yaml``:
+
+.. code:: yaml
+
+  multi_node:
+    master_launch_mode: auto      # auto | script | torchrun
+    nproc_per_node: 8             # defaults to gpus_per_node
+    master_port: 29500            # default: free ephemeral port
+    master_addr: 10.0.0.1         # default: head node from cluster.json
+    train_script: train.py
+    extra_torchrun_args: []
+    extra_train_args: []
+    extra_env:
+      NCCL_SOCKET_IFNAME: bond0
+      NCCL_IB_HCA: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
+      NCCL_IB_GID_INDEX: "3"
+    collect_traces: true
+
+Single-node clusters keep using the configured ``experiment_script`` (``master_launch_mode: auto`` resolves to ``script``). Force the disaggregated path with ``master_launch_mode: torchrun`` if you want it for a single-node cluster too.
+
+When ``collect_traces`` is true, every node's ``torch_profiler/`` directories are rsynced back to ``<aorta_path>/combined_traces/node_<rank>/`` on the head node and exposed as the ``torch_traces`` artifact, so the existing host parsers and threshold checks see one unified tree without further configuration.
 
 Expected results and artifacts
 ==============================

--- a/docs/reference/configuration-files/training/aorta.rst
+++ b/docs/reference/configuration-files/training/aorta.rst
@@ -204,8 +204,8 @@ The **dropdown above** is the full **shipped** ``aorta_benchmark.yaml``. Where t
      - ``null`` (free ephemeral port)
      - Port for the ``torchrun`` rendezvous (``--master_port``). Pin this when you need a deterministic port (e.g., firewalled environments).
    * - ``multi_node.master_addr``
-     - ``null`` (head node from cluster.json)
-     - Override the rendezvous address (``--master_addr``).
+     - ``null`` (head node's ``node_vpc_ips`` entry, else its plain identifier)
+     - Override the rendezvous address (``--master_addr``). Do not pin this to the SSH/management address on a fabric-separated cluster -- other nodes rendezvous over the RDMA fabric, and ``node_vpc_ips`` exists precisely to prefer that address.
    * - ``multi_node.train_script``
      - ``train.py``
      - Aorta training entry script relative to ``aorta_path``. Used in ``torchrun`` mode.
@@ -264,7 +264,7 @@ The multi-node behavior is controlled by the ``multi_node`` block in ``aorta_ben
     master_launch_mode: auto      # auto | script | torchrun
     nproc_per_node: 8             # defaults to gpus_per_node
     master_port: 29500            # default: free ephemeral port
-    master_addr: 10.0.0.1         # default: head node from cluster.json
+    master_addr: 10.0.0.1         # default: head node's node_vpc_ips entry, else its identifier
     train_script: train.py
     extra_torchrun_args: []
     extra_train_args: []


### PR DESCRIPTION
**Stack 3/6** — splits #171. Base: #327.

### Why

Declares the `multi_node:` block that the disaggregated torchrun launch consumes. **Config plumbing only — nothing reads these values yet, so behavior is unchanged.** Split out so the launch logic in #329 is reviewable on its own; review this one for names, defaults, and docs.

### What changed

- `cvs/parsers/schemas.py` — `AortaMultiNodeConfigFile` (`extra="forbid"`, `master_launch_mode` restricted to `auto`/`script`/`torchrun`), wired in with a default factory so yamls predating the block still validate. `validate_paths_exist()` checks `train_script` only when the mode is explicitly `torchrun`.
- `cvs/runners/aorta.py` — matching `AortaMultiNodeConfig` dataclass, plus `AortaConfig.node_vpc_ips` so `master_addr` can later resolve to the head node's RDMA-fabric address rather than its mgmt/SSH address (the same `node_dict` vs `vpc_ip` split `rccl_perf.py` already uses).
- `aorta_benchmark.yaml` / `docs/.../aorta.rst` — the block with inline docs and a parameter table.
- `cvs/tests/benchmark/test_aorta.py` — fixture maps the validated block onto the dataclass and populates `node_vpc_ips` from the cluster file.

### Test

`ruff` clean. Unit tests 595 → 603. Adds `cvs/parsers/unittests/` (per AGENTS.md, the package had none): schema defaults, unknown-key and bad-mode rejection, conditional `train_script` check, and backward compat for configs with no `multi_node:` block.