### PR TITLE
fix(megatron_training_lib): compare verify_network_errors as the string it is

### DIFF
--- a/cvs/lib/megatron_training_lib.py
+++ b/cvs/lib/megatron_training_lib.py
@@ -781,7 +781,7 @@ class MegatronLlamaTrainingJob:
 
         # Check if RDMA and Ethtool stats have errors ..
         if self.distributed_training is True:
-            if self.verify_network_errors is True:
+            if self.verify_network_errors == 'True':
                 self.rdma_stats_dict_after = linux_utils.get_rdma_stats_dict(self.phdl)
                 self.ethtool_stats_dict_after = linux_utils.get_nic_ethtool_stats_dict(self.phdl)
 


### PR DESCRIPTION
Part 1 of 14 in a stack for AIMVT-276.

### Why
`self.verify_network_errors` is always the string `'True'`/`'False'` parsed from JSON config, never a Python bool. `if self.verify_network_errors is True:` can therefore never be true, so the post-run RDMA/ethtool error-counter comparison silently never runs for distributed training jobs, regardless of what the config says.

### What changed
- `cvs/lib/megatron_training_lib.py` — compare with `== 'True'` instead of `is True`, matching the working pattern already used for the same field in `torchtitan_training_lib.py`.