### PR TITLE
chore(utils_lib): add cvs_package_root(), dedupe ad-hoc root resolution

### DIFF
--- a/cvs/cli_plugins/copy_config_plugin.py
+++ b/cvs/cli_plugins/copy_config_plugin.py
@@ -1,5 +1,6 @@
 from .base import SubcommandPlugin
 from cvs.extension import ExtensionConfig
+from cvs.lib.utils_lib import cvs_package_root
 import os
 import shutil
 
@@ -49,8 +50,7 @@ Copy-Config Commands:
         1. Core cvs package (cvs/input/config_file, cvs/input/cluster_file, cvs/input/env_file)
         2. Extension packages configured via extension.ini (e.g., cvs_extension/input)
         """
-        plugin_dir = os.path.dirname(__file__)
-        cvs_dir = os.path.dirname(plugin_dir)  # cvs/
+        cvs_dir = cvs_package_root()
         config_root = os.path.join(cvs_dir, "input", "config_file")
         cluster_root = os.path.join(cvs_dir, "input", "cluster_file")
         env_root = os.path.join(cvs_dir, "input", "env_file")

--- a/cvs/lib/run_config_paths.py
+++ b/cvs/lib/run_config_paths.py
@@ -31,10 +31,9 @@ def resolve_runner_results_base(run_config: dict) -> str:
 
 
 def _cvs_baseline_data_dir() -> str:
-    import cvs
+    from cvs.lib.utils_lib import cvs_package_root
 
-    root = os.path.dirname(os.path.abspath(cvs.__file__))
-    return os.path.normpath(os.path.join(root, "baseline_data"))
+    return os.path.normpath(os.path.join(cvs_package_root(), "baseline_data"))
 
 
 def resolve_baseline_csv_folder(run_config: dict) -> Optional[str]:

--- a/cvs/lib/unittests/test_utils_lib.py
+++ b/cvs/lib/unittests/test_utils_lib.py
@@ -1,7 +1,9 @@
 # cvs/lib/unittests/test_utils_lib.py
+import os
 import unittest
 from unittest.mock import patch
 
+import cvs
 import cvs.lib.utils_lib as utils_lib
 from cvs.parsers.schemas import AortaBenchmarkConfigFile
 
@@ -18,6 +20,13 @@ class TestUtilsLib(unittest.TestCase):
         out_dict = {'host1': 'some output success'}
         utils_lib.scan_test_results(out_dict)
         mock_fail_test.assert_not_called()
+
+    def test_cvs_package_root_matches_cvs_module_directory(self):
+        expected = os.path.dirname(os.path.abspath(cvs.__file__))
+        self.assertEqual(utils_lib.cvs_package_root(), expected)
+
+    def test_cvs_package_root_contains_input_dir(self):
+        self.assertTrue(os.path.isdir(os.path.join(utils_lib.cvs_package_root(), 'input')))
 
 
 class TestResolveTestConfigPlaceholdersAorta(unittest.TestCase):

--- a/cvs/lib/utils_lib.py
+++ b/cvs/lib/utils_lib.py
@@ -16,6 +16,18 @@ from cvs.lib import globals
 log = globals.log
 
 
+def cvs_package_root():
+    """Absolute path to the installed/editable cvs package directory.
+
+    This is the root cvs/input/, cvs/tests/, cvs/baseline_data/, etc. hang off
+    of -- not the repo root and not the process cwd -- so it resolves the same
+    way whether cvs was pip-installed or run from an editable checkout.
+    """
+    import cvs
+
+    return os.path.dirname(os.path.abspath(cvs.__file__))
+
+
 def fail_test(msg):
     """
     Record and report a test failure without immediately raising an exception.


### PR DESCRIPTION
Part 2 of 14 in a stack for AIMVT-276. Base: #334.

### Why
`run_config_paths.py` and `copy_config_plugin.py` each independently computed the installed cvs package directory — one via `os.path.dirname(os.path.abspath(cvs.__file__))`, the other via `dirname(dirname(__file__))`. A third call site (the upcoming config parameter registry) needs the same path, which would make a third divergent implementation.

### What changed
- `cvs/lib/utils_lib.py` — added `cvs_package_root()`.
- `cvs/lib/run_config_paths.py`, `cvs/cli_plugins/copy_config_plugin.py` — switched their existing ad-hoc logic to call it.
- `cvs/lib/unittests/test_utils_lib.py` — added tests for the new helper.