### PR TITLE
refactor(cli_plugins): hoist _emit_error onto SubcommandPlugin

### DIFF
--- a/cvs/cli_plugins/base.py
+++ b/cvs/cli_plugins/base.py
@@ -1,3 +1,6 @@
+import sys
+
+
 class SubcommandPlugin:
     """Base class for CLI subcommand plugins."""
 
@@ -5,6 +8,10 @@ class SubcommandPlugin:
         "monitor": 999,
         "exec": 1000,  # High number to ensure exec appears last
     }
+
+    def _emit_error(self, msg, json_mode):
+        """Print an error message. In JSON mode, writes to stderr so stdout stays valid JSON."""
+        print(msg, file=sys.stderr if json_mode else sys.stdout)
 
     def get_name(self):
         raise NotImplementedError

--- a/cvs/cli_plugins/exec_plugin.py
+++ b/cvs/cli_plugins/exec_plugin.py
@@ -160,10 +160,6 @@ Exec Commands:
 
         return True, output
 
-    def _emit_error(self, msg, json_mode):
-        """Print an error message. In JSON mode, writes to stderr so stdout stays valid JSON."""
-        print(msg, file=sys.stderr if json_mode else sys.stdout)
-
     def _print_text_output(self, label, host_output):
         """Print host results in human-readable format."""
         for host, out in host_output.items():


### PR DESCRIPTION
Part 4 of 14 in a stack for AIMVT-276. Base: #336.

### Why
`_emit_error` (print to stderr in `--json` mode so stdout stays valid JSON, else stdout) lived only on `ExecPlugin`. A second plugin needing identical behavior is coming later in this stack — better to share it than paste a second copy.

### What changed
- `cvs/cli_plugins/base.py` — added `_emit_error` to `SubcommandPlugin`.
- `cvs/cli_plugins/exec_plugin.py` — removed its now-redundant copy.