### PR TITLE
Added nodesmoke tier 3 support and fixed few issues inpreflight confi…

### DIFF
--- a/cvs/input/config_file/preflight/README_preflight_config.md
+++ b/cvs/input/config_file/preflight/README_preflight_config.md
@@ -61,7 +61,7 @@ The preflight configuration file follows this structure:
     },
     "reporting": {
       "generate_html_report": true,
-      "artifacts_root_dir": "/tmp/{user-id}/preflight",
+      "artifacts_root_dir": "/home/{user-id}/preflight",
       "generate_rdma_pairs_csv": false
     },
     "debug": {
@@ -334,7 +334,7 @@ Tier 2 runs need a longer SSH budget; when `tier2_perf` is enabled the effective
   - Whether to generate detailed HTML report
   - Set to `false` to disable HTML report generation
 
-- **`artifacts_root_dir`** (default: `"/tmp/{user-id}/preflight"`)
+- **`artifacts_root_dir`** (default: `"/home/{user-id}/preflight"`)
   - Root directory where preflight artifacts are saved
   - Includes HTML reports and RDMA full_mesh workspace logs under `rdma_connectivity_workspace/`
   - Must be writable by the user running the tests
@@ -490,7 +490,7 @@ Tier 2 runs need a longer SSH budget; when `tier2_perf` is enabled the effective
     },
     "reporting": {
       "generate_html_report": true,
-      "artifacts_root_dir": "/tmp/{user-id}/preflight",
+      "artifacts_root_dir": "/home/{user-id}/preflight",
       "generate_rdma_pairs_csv": true
     }
   }

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -11,7 +11,7 @@
       "_comment_gpus_per_node": "Exact number of AMD GPUs expected on every node.",
 
       "_example_expected_rocm_version": "6.2.0",
-      "expected_rocm_version": "<changemea>",
+      "expected_rocm_version": "10.0.0",
       "_comment_expected_rocm_version": "Expected ROCm version across all cluster nodes. Must match the output of 'amd-smi version' on all nodes. Format: 'major.minor.patch' (e.g., '6.2.0', '5.7.1')."
     },
 
@@ -168,7 +168,7 @@
       "_comment_dump_path": "Directory for per-node smoke/*.json output. Leave empty to use <reporting.artifacts_root_dir>/node_smoke.",
 
       "expected_rdma_nics": null,
-      "_comment_expected_rdma_nics": "Hard-fail when training RDMA NIC count differs. null defaults to len(node_check.rdma_interfaces). Example: 8.",
+      "_comment_expected_rdma_nics": "Hard-fail when training RDMA NIC count differs. null defaults to len(connectivity_check.rdma.interfaces). Example: 8.",
 
       "ulimit_l_min_gb": 32,
       "_comment_ulimit_l_min_gb": "FAIL when RLIMIT_MEMLOCK is below this many GiB. 0 disables.",
@@ -195,10 +195,10 @@
       "_comment_gloo_socket_ifname": "Optional GLOO_SOCKET_IFNAME override (defaults to nccl_socket_ifname when empty).",
 
       "nccl_ib_hca": "",
-      "_comment_nccl_ib_hca": "Optional NCCL_IB_HCA override. Defaults to comma-joined node_check.rdma_interfaces.",
+      "_comment_nccl_ib_hca": "Optional NCCL_IB_HCA override. Defaults to comma-joined connectivity_check.rdma.interfaces.",
 
       "nccl_ib_gid_index": null,
-      "_comment_nccl_ib_gid_index": "Optional NCCL_IB_GID_INDEX override. Defaults to node_check.gid_index.",
+      "_comment_nccl_ib_gid_index": "Optional NCCL_IB_GID_INDEX override. Defaults to connectivity_check.rdma.gid_index.",
 
       "ssh_timeout": 300,
       "_comment_ssh_timeout": "SSH timeout in seconds for each node's node_smoke invocation (~30s Tier 1; use 600+ with tier2_perf).",
@@ -229,7 +229,7 @@
       "_comment": "Primus Tier 3 Host/GPU/Network info via primus-cli direct -- preflight --host --gpu --network (opt-in; default skip). No Slurm.",
 
       "connectivity_mode": "skip",
-      "_comment_connectivity_mode": "Options: 'run' (cluster-wide preflight --host --gpu --network) or 'skip' (default).",
+      "_comment_connectivity_mode": "Options: 'run' or 'skip' (default). Independent of node_smoke.connectivity_mode — enabling node_smoke does not enable Tier 3.",
 
       "auto_setup": true,
       "_comment_auto_setup": "When true, clone/update Primus and create venv before Tier 3 (falls back to node_smoke paths).",
@@ -265,10 +265,10 @@
       "_comment_gloo_socket_ifname": "Optional GLOO_SOCKET_IFNAME override.",
 
       "nccl_ib_hca": "",
-      "_comment_nccl_ib_hca": "Optional NCCL_IB_HCA override.",
+      "_comment_nccl_ib_hca": "Optional NCCL_IB_HCA override. Defaults to comma-joined connectivity_check.rdma.interfaces when empty.",
 
       "nccl_ib_gid_index": null,
-      "_comment_nccl_ib_gid_index": "Optional NCCL_IB_GID_INDEX override.",
+      "_comment_nccl_ib_gid_index": "Optional NCCL_IB_GID_INDEX override. Defaults to connectivity_check.rdma.gid_index when null.",
 
       "ssh_timeout": 600,
       "_comment_ssh_timeout": "SSH timeout in seconds for the parallel Tier 3 cluster run.",

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -11,7 +11,7 @@
       "_comment_gpus_per_node": "Exact number of AMD GPUs expected on every node.",
 
       "_example_expected_rocm_version": "6.2.0",
-      "expected_rocm_version": "10.0.0",
+      "expected_rocm_version": "<changeme>",
       "_comment_expected_rocm_version": "Expected ROCm version across all cluster nodes. Must match the output of 'amd-smi version' on all nodes. Format: 'major.minor.patch' (e.g., '6.2.0', '5.7.1')."
     },
 

--- a/cvs/input/config_file/preflight/preflight_config.json
+++ b/cvs/input/config_file/preflight/preflight_config.json
@@ -6,12 +6,12 @@
       "enabled": true,
       "_comment_enabled": "Enable GPU visibility, AMDGPU/KFD, kernel-health, and ROCm validation.",
 
-      "_example_gpus_per_node": 4,
-      "gpus_per_node": 4,
+      "_example_gpus_per_node": 8,
+      "gpus_per_node": 8,
       "_comment_gpus_per_node": "Exact number of AMD GPUs expected on every node.",
 
       "_example_expected_rocm_version": "6.2.0",
-      "expected_rocm_version": "<changeme>",
+      "expected_rocm_version": "<changemea>",
       "_comment_expected_rocm_version": "Expected ROCm version across all cluster nodes. Must match the output of 'amd-smi version' on all nodes. Format: 'major.minor.patch' (e.g., '6.2.0', '5.7.1')."
     },
 
@@ -25,11 +25,11 @@
         "_comment_connectivity_mode": "RDMA connectivity testing mode. Options: 'basic' (test adjacent node pairs, fast, ~14% coverage for 8 nodes), 'full_mesh' (test all possible node pairs, comprehensive, 100% coverage), 'skip' (skip RDMA connectivity testing entirely).",
 
         "_example_gid_index": "3",
-        "gid_index": "3",
+        "gid_index": "<changeme>",
         "_comment_gid_index": "GID index to check on all RDMA interfaces. Typically '3' for RoCE (RDMA over Converged Ethernet). Must be a valid GID index for your InfiniBand/RoCE setup.",
 
         "_example_interfaces": ["rocep28s0", "rocep62s0", "rocep79s0", "rocep96s0", "rocep158s0", "rocep190s0", "rocep206s0", "rocep222s0"],
-        "interfaces": ["enp4s0np0"],
+        "interfaces": ["<changeme>"],
         "_comment_interfaces": "List of specific RDMA interface names that should be present on all cluster nodes. Examples: ['rocep28s0', 'rocep62s0'] for standard setup, ['mlx5_0', 'mlx5_1'] for Mellanox, ['ib0', 'ib1'] for generic InfiniBand.",
 
         "nodes_per_full_mesh_group": 32,
@@ -82,7 +82,7 @@
         "l2ping": {
           "_comment": "Strict afmctl L2 connectivity gate executed before TransferBench and RDMA",
 
-          "enabled": true,
+          "enabled": false,
           "_comment_enabled": "Enable IFoE L2 connectivity validation.",
 
           "pings_per_port": 3,
@@ -92,7 +92,7 @@
         "transferbench": {
           "_comment": "TransferBench IFoE data-path validation executed before RDMA",
 
-          "enabled": true,
+          "enabled": false,
           "_comment_enabled": "Enable the TransferBench preflight gate.",
 
           "scope": "node",
@@ -225,13 +225,65 @@
       "_comment_extra_args": "Additional node_smoke CLI flags forwarded to primus-cli. Example: [\"--no-clean-dump-path\"]."
     },
 
+    "tier3_info": {
+      "_comment": "Primus Tier 3 Host/GPU/Network info via primus-cli direct -- preflight --host --gpu --network (opt-in; default skip). No Slurm.",
+
+      "connectivity_mode": "skip",
+      "_comment_connectivity_mode": "Options: 'run' (cluster-wide preflight --host --gpu --network) or 'skip' (default).",
+
+      "auto_setup": true,
+      "_comment_auto_setup": "When true, clone/update Primus and create venv before Tier 3 (falls back to node_smoke paths).",
+
+      "primus_dir": "",
+      "_comment_primus_dir": "Optional override; empty uses node_smoke.primus_dir.",
+
+      "venv_activate": "",
+      "_comment_venv_activate": "Optional override; empty uses node_smoke.venv_activate.",
+
+      "gpus_per_node": 8,
+      "_comment_gpus_per_node": "GPUs per node for torchrun.",
+
+      "master_port": 1234,
+      "_comment_master_port": "MASTER_PORT for the distributed env CVS sets across SSH-launched nodes.",
+
+      "dump_path": "",
+      "_comment_dump_path": "Report output directory. Empty uses <reporting.artifacts_root_dir>/tier3_info.",
+
+      "report_file_name": "tier3_info",
+      "_comment_report_file_name": "Base name for Primus markdown/PDF report files.",
+
+      "dist_timeout_sec": 120,
+      "_comment_dist_timeout_sec": "Timeout for torch.distributed init while aggregating the multi-node info report.",
+
+      "save_pdf": false,
+      "_comment_save_pdf": "When true, Primus also emits a PDF report.",
+
+      "nccl_socket_ifname": "",
+      "_comment_nccl_socket_ifname": "Optional NCCL_SOCKET_IFNAME override.",
+
+      "gloo_socket_ifname": "",
+      "_comment_gloo_socket_ifname": "Optional GLOO_SOCKET_IFNAME override.",
+
+      "nccl_ib_hca": "",
+      "_comment_nccl_ib_hca": "Optional NCCL_IB_HCA override.",
+
+      "nccl_ib_gid_index": null,
+      "_comment_nccl_ib_gid_index": "Optional NCCL_IB_GID_INDEX override.",
+
+      "ssh_timeout": 600,
+      "_comment_ssh_timeout": "SSH timeout in seconds for the parallel Tier 3 cluster run.",
+
+      "extra_args": [],
+      "_comment_extra_args": "Additional preflight CLI flags forwarded to primus-cli."
+    },
+
     "reporting": {
       "_comment": "Post-test reporting and output",
 
       "generate_html_report": true,
       "_comment_generate_html_report": "Whether to generate detailed HTML report. Set to 'false' to disable HTML report generation.",
 
-      "artifacts_root_dir": "/tmp/{user-id}/preflight",
+      "artifacts_root_dir": "/home/{user-id}/preflight",
       "_comment_artifacts_root_dir": "Root directory for preflight artifacts. HTML reports are saved here, and RDMA full_mesh ScriptLet logs use <artifacts_root_dir>/rdma_connectivity_workspace/<session>/<round>/ on each node (NFS-friendly). Must be writable by the user running the tests.",
 
       "generate_rdma_pairs_csv": false,

--- a/cvs/lib/preflight/node_smoke.py
+++ b/cvs/lib/preflight/node_smoke.py
@@ -58,7 +58,7 @@ def _normalize_mode(mode) -> str:
 
 def _resolve_dump_path(cfg: dict) -> str:
     """Return node_smoke dump directory; empty config uses reporting artifacts root."""
-    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", "/tmp/preflight")
+    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", "/home/{user-id}/preflight")
     default_dump = f"{str(artifacts_root).rstrip('/')}/node_smoke"
     configured = get_nested_config(cfg, "node_smoke", "dump_path", default_dump)
     configured_s = str(configured or "").strip()

--- a/cvs/lib/preflight/node_smoke.py
+++ b/cvs/lib/preflight/node_smoke.py
@@ -17,6 +17,10 @@ from typing import Any, Dict, List, Optional
 
 from cvs.lib.preflight.base import PreflightCheck
 
+# Writable fallback when reporting.artifacts_root_dir is omitted from config.
+# Do not use ``{user-id}`` here — in-code defaults bypass resolve_test_config_placeholders.
+DEFAULT_ARTIFACTS_ROOT_DIR = "/tmp/preflight"
+
 _JSON_BEGIN = "---CVS_NODE_SMOKE_JSON_BEGIN---"
 _JSON_END = "---CVS_NODE_SMOKE_JSON_END---"
 _STATUS_RE = re.compile(r"\bstatus=(PASS|FAIL)\b", re.IGNORECASE)
@@ -40,6 +44,36 @@ def get_nested_config(config_dict, section, key, default):
     return default
 
 
+def resolve_rdma_interfaces(cfg: dict) -> List[str]:
+    """Return RDMA interface names from ``connectivity_check.rdma.interfaces``.
+
+    Legacy ``node_check.rdma_interfaces`` is supported for older configs only.
+    """
+    ifaces = get_nested_config(cfg, "connectivity_check.rdma", "interfaces", None)
+    if not ifaces:
+        node_check = cfg.get("node_check") or {}
+        ifaces = node_check.get("rdma_interfaces")
+    if isinstance(ifaces, str):
+        return [ifaces.strip()] if ifaces.strip() else []
+    if isinstance(ifaces, list):
+        return [str(item).strip() for item in ifaces if str(item).strip()]
+    return []
+
+
+def resolve_rdma_gid_index(cfg: dict, default=None):
+    """Return RoCE GID index from ``connectivity_check.rdma.gid_index``.
+
+    Legacy ``node_check.gid_index`` is supported for older configs only.
+    """
+    gid_index = get_nested_config(cfg, "connectivity_check.rdma", "gid_index", None)
+    if gid_index in (None, ""):
+        node_check = cfg.get("node_check") or {}
+        gid_index = node_check.get("gid_index")
+    if gid_index in (None, ""):
+        return default
+    return gid_index
+
+
 def _config_flag_enabled(value, default=False):
     if value is None:
         return default
@@ -58,7 +92,7 @@ def _normalize_mode(mode) -> str:
 
 def _resolve_dump_path(cfg: dict) -> str:
     """Return node_smoke dump directory; empty config uses reporting artifacts root."""
-    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", "/home/{user-id}/preflight")
+    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", DEFAULT_ARTIFACTS_ROOT_DIR)
     default_dump = f"{str(artifacts_root).rstrip('/')}/node_smoke"
     configured = get_nested_config(cfg, "node_smoke", "dump_path", default_dump)
     configured_s = str(configured or "").strip()
@@ -251,7 +285,6 @@ class NodeSmokeCheck(PreflightCheck):
 
     def _load_settings(self):
         cfg = self.config_dict or {}
-        node_check = cfg.get("node_check") or {}
 
         self.mode = _normalize_mode(get_nested_config(cfg, "node_smoke", "connectivity_mode", "skip"))
         self.primus_dir = get_nested_config(cfg, "node_smoke", "primus_dir", "")
@@ -262,7 +295,7 @@ class NodeSmokeCheck(PreflightCheck):
 
         self.dump_path = _resolve_dump_path(cfg)
 
-        rdma_ifaces = node_check.get("rdma_interfaces") or []
+        rdma_ifaces = resolve_rdma_interfaces(cfg)
         default_rdma_nics = len(rdma_ifaces) if rdma_ifaces else None
         expected_rdma = get_nested_config(cfg, "node_smoke", "expected_rdma_nics", default_rdma_nics)
         self.expected_rdma_nics = int(expected_rdma) if expected_rdma not in (None, "", 0) else None
@@ -298,7 +331,7 @@ class NodeSmokeCheck(PreflightCheck):
 
         gid_index = get_nested_config(cfg, "node_smoke", "nccl_ib_gid_index", None)
         if gid_index is None:
-            gid_index = node_check.get("gid_index")
+            gid_index = resolve_rdma_gid_index(cfg)
         self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
 
         extra = get_nested_config(cfg, "node_smoke", "extra_args", [])

--- a/cvs/lib/preflight/node_smoke.py
+++ b/cvs/lib/preflight/node_smoke.py
@@ -44,32 +44,52 @@ def get_nested_config(config_dict, section, key, default):
     return default
 
 
+def _is_unresolved_placeholder(value) -> bool:
+    if value is None:
+        return False
+    return "<changeme>" in str(value).lower()
+
+
+def parse_optional_int(value, default=None):
+    """Parse an optional integer config value, ignoring unresolved placeholders."""
+    if value in (None, ""):
+        return default
+    if _is_unresolved_placeholder(value):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def resolve_rdma_interfaces(cfg: dict) -> List[str]:
     """Return RDMA interface names from ``connectivity_check.rdma.interfaces``.
 
     Legacy ``node_check.rdma_interfaces`` is supported for older configs only.
+    Unresolved ``<changeme>`` placeholders are ignored.
     """
     ifaces = get_nested_config(cfg, "connectivity_check.rdma", "interfaces", None)
     if not ifaces:
         node_check = cfg.get("node_check") or {}
         ifaces = node_check.get("rdma_interfaces")
     if isinstance(ifaces, str):
-        return [ifaces.strip()] if ifaces.strip() else []
-    if isinstance(ifaces, list):
-        return [str(item).strip() for item in ifaces if str(item).strip()]
-    return []
+        ifaces = [ifaces.strip()] if ifaces.strip() else []
+    elif not isinstance(ifaces, list):
+        return []
+    return [str(item).strip() for item in ifaces if str(item).strip() and not _is_unresolved_placeholder(item)]
 
 
 def resolve_rdma_gid_index(cfg: dict, default=None):
     """Return RoCE GID index from ``connectivity_check.rdma.gid_index``.
 
     Legacy ``node_check.gid_index`` is supported for older configs only.
+    Unresolved ``<changeme>`` placeholders return ``default``.
     """
     gid_index = get_nested_config(cfg, "connectivity_check.rdma", "gid_index", None)
     if gid_index in (None, ""):
         node_check = cfg.get("node_check") or {}
         gid_index = node_check.get("gid_index")
-    if gid_index in (None, ""):
+    if gid_index in (None, "") or _is_unresolved_placeholder(gid_index):
         return default
     return gid_index
 
@@ -332,7 +352,7 @@ class NodeSmokeCheck(PreflightCheck):
         gid_index = get_nested_config(cfg, "node_smoke", "nccl_ib_gid_index", None)
         if gid_index is None:
             gid_index = resolve_rdma_gid_index(cfg)
-        self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
+        self.nccl_ib_gid_index = parse_optional_int(gid_index)
 
         extra = get_nested_config(cfg, "node_smoke", "extra_args", [])
         self.extra_args = [str(arg) for arg in extra if arg] if isinstance(extra, (list, tuple)) else []

--- a/cvs/lib/preflight/node_smoke.py
+++ b/cvs/lib/preflight/node_smoke.py
@@ -44,52 +44,32 @@ def get_nested_config(config_dict, section, key, default):
     return default
 
 
-def _is_unresolved_placeholder(value) -> bool:
-    if value is None:
-        return False
-    return "<changeme>" in str(value).lower()
-
-
-def parse_optional_int(value, default=None):
-    """Parse an optional integer config value, ignoring unresolved placeholders."""
-    if value in (None, ""):
-        return default
-    if _is_unresolved_placeholder(value):
-        return default
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return default
-
-
 def resolve_rdma_interfaces(cfg: dict) -> List[str]:
     """Return RDMA interface names from ``connectivity_check.rdma.interfaces``.
 
     Legacy ``node_check.rdma_interfaces`` is supported for older configs only.
-    Unresolved ``<changeme>`` placeholders are ignored.
     """
     ifaces = get_nested_config(cfg, "connectivity_check.rdma", "interfaces", None)
     if not ifaces:
         node_check = cfg.get("node_check") or {}
         ifaces = node_check.get("rdma_interfaces")
     if isinstance(ifaces, str):
-        ifaces = [ifaces.strip()] if ifaces.strip() else []
-    elif not isinstance(ifaces, list):
-        return []
-    return [str(item).strip() for item in ifaces if str(item).strip() and not _is_unresolved_placeholder(item)]
+        return [ifaces.strip()] if ifaces.strip() else []
+    if isinstance(ifaces, list):
+        return [str(item).strip() for item in ifaces if str(item).strip()]
+    return []
 
 
 def resolve_rdma_gid_index(cfg: dict, default=None):
     """Return RoCE GID index from ``connectivity_check.rdma.gid_index``.
 
     Legacy ``node_check.gid_index`` is supported for older configs only.
-    Unresolved ``<changeme>`` placeholders return ``default``.
     """
     gid_index = get_nested_config(cfg, "connectivity_check.rdma", "gid_index", None)
     if gid_index in (None, ""):
         node_check = cfg.get("node_check") or {}
         gid_index = node_check.get("gid_index")
-    if gid_index in (None, "") or _is_unresolved_placeholder(gid_index):
+    if gid_index in (None, ""):
         return default
     return gid_index
 
@@ -352,7 +332,7 @@ class NodeSmokeCheck(PreflightCheck):
         gid_index = get_nested_config(cfg, "node_smoke", "nccl_ib_gid_index", None)
         if gid_index is None:
             gid_index = resolve_rdma_gid_index(cfg)
-        self.nccl_ib_gid_index = parse_optional_int(gid_index)
+        self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
 
         extra = get_nested_config(cfg, "node_smoke", "extra_args", [])
         self.extra_args = [str(arg) for arg in extra if arg] if isinstance(extra, (list, tuple)) else []

--- a/cvs/lib/preflight/primus_setup.py
+++ b/cvs/lib/preflight/primus_setup.py
@@ -206,39 +206,55 @@ def parse_setup_output(output: str) -> Dict[str, Any]:
 class PrimusSetup(PreflightCheck):
     """Clone/update Primus and prepare the preflight venv on cluster nodes."""
 
-    def __init__(self, phdl, node_list: List[str], config_dict=None):
+    def __init__(
+        self,
+        phdl,
+        node_list: List[str],
+        config_dict=None,
+        config_section: str = "node_smoke",
+        fallback_section: Optional[str] = None,
+    ):
         super().__init__(phdl, config_dict)
         self.node_list = list(node_list)
+        self.config_section = config_section
+        self.fallback_section = fallback_section
         self._load_settings()
 
-    def _load_settings(self):
+    def _resolve_setting(self, key: str, default=None):
         cfg = self.config_dict or {}
-        self.primus_dir = get_nested_config(cfg, "node_smoke", "primus_dir", "")
-        self.venv_activate = get_nested_config(cfg, "node_smoke", "venv_activate", "")
-        self.git_url = get_nested_config(
-            cfg, "node_smoke", "primus_git_url", "https://github.com/AMD-AIG-AIMA/Primus.git"
-        )
-        self.git_branch = get_nested_config(cfg, "node_smoke", "primus_git_branch", "dev/preflight-direct-test")
+        value = get_nested_config(cfg, self.config_section, key, None)
+        if value not in (None, ""):
+            return value
+        if self.fallback_section and self.fallback_section != self.config_section:
+            value = get_nested_config(cfg, self.fallback_section, key, None)
+            if value not in (None, ""):
+                return value
+        return default
+
+    def _load_settings(self):
+        self.primus_dir = self._resolve_setting("primus_dir", "")
+        self.venv_activate = self._resolve_setting("venv_activate", "")
+        self.git_url = self._resolve_setting("primus_git_url", "https://github.com/AMD-AIG-AIMA/Primus.git")
+        self.git_branch = self._resolve_setting("primus_git_branch", "dev/preflight-direct-test")
         self.recurse_submodules = _config_flag_enabled(
-            get_nested_config(cfg, "node_smoke", "primus_git_recurse_submodules", False), default=False
+            self._resolve_setting("primus_git_recurse_submodules", False), default=False
         )
-        self.force_reclone = _config_flag_enabled(get_nested_config(cfg, "node_smoke", "force_reclone", False))
-        self.pip_install_mode = get_nested_config(cfg, "node_smoke", "pip_install_mode", "minimal")
-        self.torch_pip_index_url = get_nested_config(cfg, "node_smoke", "torch_pip_index_url", _DEFAULT_TORCH_INDEX)
-        self.setup_timeout = int(get_nested_config(cfg, "node_smoke", "setup_timeout", 600))
-        self.shared_install = _config_flag_enabled(
-            get_nested_config(cfg, "node_smoke", "shared_install", True), default=True
-        )
+        self.force_reclone = _config_flag_enabled(self._resolve_setting("force_reclone", False))
+        self.pip_install_mode = self._resolve_setting("pip_install_mode", "minimal")
+        self.torch_pip_index_url = self._resolve_setting("torch_pip_index_url", _DEFAULT_TORCH_INDEX)
+        self.setup_timeout = int(self._resolve_setting("setup_timeout", 600))
+        self.shared_install = _config_flag_enabled(self._resolve_setting("shared_install", True), default=True)
 
     def _validate(self) -> Optional[str]:
+        section = self.config_section
         if not self.primus_dir:
-            return "node_smoke.primus_dir is required for auto_setup"
+            return f"{section}.primus_dir is required for auto_setup"
         if not self.venv_activate:
-            return "node_smoke.venv_activate is required for auto_setup"
+            return f"{section}.venv_activate is required for auto_setup"
         if not self.git_url:
-            return "node_smoke.primus_git_url is required for auto_setup"
+            return f"{section}.primus_git_url is required for auto_setup"
         if not self.git_branch:
-            return "node_smoke.primus_git_branch is required for auto_setup"
+            return f"{section}.primus_git_branch is required for auto_setup"
         if not self.node_list:
             return "no reachable nodes for Primus auto_setup"
         return None

--- a/cvs/lib/preflight/rdma_connectivity.py
+++ b/cvs/lib/preflight/rdma_connectivity.py
@@ -103,7 +103,7 @@ class RdmaConnectivityCheck(PreflightCheck):
 
     def _artifacts_root_dir(self) -> str:
         cfg = self.config_dict or {}
-        root = get_nested_config(cfg, 'reporting', 'artifacts_root_dir', '/tmp/preflight')
+        root = get_nested_config(cfg, 'reporting', 'artifacts_root_dir', '/home/{user-id}/preflight')
         return str(root).rstrip('/')
 
     def _remote_rdma_workspace_root(self) -> str:

--- a/cvs/lib/preflight/rdma_connectivity.py
+++ b/cvs/lib/preflight/rdma_connectivity.py
@@ -10,7 +10,8 @@ from cvs.lib.verify_lib import *
 from cvs.lib import globals
 from collections import defaultdict
 
-from cvs.lib.preflight.base import PreflightCheck, partition_nodes_into_groups
+from cvs.lib.preflight.base import PreflightCheck
+from cvs.lib.preflight.node_smoke import DEFAULT_ARTIFACTS_ROOT_DIR
 import re
 import shlex
 import time
@@ -103,7 +104,7 @@ class RdmaConnectivityCheck(PreflightCheck):
 
     def _artifacts_root_dir(self) -> str:
         cfg = self.config_dict or {}
-        root = get_nested_config(cfg, 'reporting', 'artifacts_root_dir', '/home/{user-id}/preflight')
+        root = get_nested_config(cfg, 'reporting', 'artifacts_root_dir', DEFAULT_ARTIFACTS_ROOT_DIR)
         return str(root).rstrip('/')
 
     def _remote_rdma_workspace_root(self) -> str:

--- a/cvs/lib/preflight/rdma_connectivity.py
+++ b/cvs/lib/preflight/rdma_connectivity.py
@@ -10,7 +10,7 @@ from cvs.lib.verify_lib import *
 from cvs.lib import globals
 from collections import defaultdict
 
-from cvs.lib.preflight.base import PreflightCheck
+from cvs.lib.preflight.base import PreflightCheck, partition_nodes_into_groups
 from cvs.lib.preflight.node_smoke import DEFAULT_ARTIFACTS_ROOT_DIR
 import re
 import shlex

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -103,6 +103,7 @@ class PreflightReportGenerator(PreflightCheck):
         ifoe_l2_results = self.results.get('ifoe_l2_connectivity', {})
         tb_smoke_results = self.results.get('transferbench_smoke', {})
         node_smoke_results = self.results.get('node_smoke', {})
+        tier3_info_results = self.results.get('tier3_info', {})
         reachability_results = self.results.get('node_reachability')
         ssh_connectivity_results = self.results.get('ssh_connectivity')
         summary = {
@@ -112,6 +113,7 @@ class PreflightReportGenerator(PreflightCheck):
                 'node_health': self._summarize_node_health_results(node_health_results),
                 'gid_consistency': self._summarize_gid_results(gid_results),
                 'node_smoke': self._summarize_node_smoke_results(node_smoke_results),
+                'tier3_info': self._summarize_tier3_info_results(tier3_info_results),
                 'ifoe_l2_connectivity': self._summarize_ifoe_l2_results(ifoe_l2_results),
                 'transferbench_smoke': self._summarize_transferbench_smoke_results(tb_smoke_results),
                 'rdma_connectivity': self._summarize_connectivity_results(connectivity_results),
@@ -176,6 +178,15 @@ class PreflightReportGenerator(PreflightCheck):
                 "Consider enabling node_smoke.connectivity_mode='run' for per-node GPU/RDMA health screening"
             )
 
+        if summary['checks']['tier3_info']['status'] == 'FAIL':
+            summary['recommendations'].append(
+                "Review Primus Tier 3 preflight info failures (Host/GPU/Network inventory) before benchmarking"
+            )
+        elif summary['checks']['tier3_info']['status'] == 'SKIPPED':
+            summary['recommendations'].append(
+                "Consider enabling tier3_info.connectivity_mode='run' for full Host/GPU/Network info screening"
+            )
+
         if summary['overall_status'] == 'PASS':
             summary['recommendations'].append("All preflight checks passed - cluster is ready for performance testing")
 
@@ -191,7 +202,7 @@ class PreflightReportGenerator(PreflightCheck):
 
         if output_path is None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            output_dir = get_nested_config(self.config_dict, 'reporting', 'artifacts_root_dir', '/tmp/preflight')
+            output_dir = get_nested_config(self.config_dict, 'reporting', 'artifacts_root_dir', '/home/{user-id}/preflight')
             Path(output_dir).mkdir(parents=True, exist_ok=True)
             output_path = Path(output_dir) / f"preflight_report_{timestamp}.html"
         else:
@@ -564,6 +575,45 @@ class PreflightReportGenerator(PreflightCheck):
             'summary': summary_text,
         }
 
+    def _summarize_tier3_info_results(self, tier3_info_results):
+        """Summarize Primus Tier 3 preflight info check results."""
+        if not tier3_info_results or tier3_info_results.get('skipped'):
+            msg = (
+                tier3_info_results.get('message')
+                if isinstance(tier3_info_results, dict)
+                else 'Primus Tier 3 preflight info check not performed'
+            )
+            return {
+                'status': 'SKIPPED',
+                'total_nodes': 0,
+                'passing_nodes': 0,
+                'failed_nodes': [],
+                'summary': msg or 'Primus Tier 3 preflight info check skipped',
+            }
+
+        node_results = tier3_info_results.get('node_results') or {}
+        total_nodes = len(node_results)
+        failed_nodes = list(
+            tier3_info_results.get('failed_nodes') or [n for n, r in node_results.items() if r.get('status') == 'FAIL']
+        )
+        unknown_nodes = list(
+            tier3_info_results.get('unknown_nodes')
+            or [n for n, r in node_results.items() if r.get('status') not in ('PASS', 'FAIL', 'WARN')]
+        )
+        passing_nodes = total_nodes - len(failed_nodes) - len(unknown_nodes)
+        status = 'FAIL' if failed_nodes or unknown_nodes else 'PASS'
+        summary_text = f"{passing_nodes}/{total_nodes} nodes passed Primus Tier 3 preflight info"
+        if unknown_nodes:
+            summary_text += f"; {len(unknown_nodes)} unknown"
+        return {
+            'status': status,
+            'total_nodes': total_nodes,
+            'passing_nodes': passing_nodes,
+            'failed_nodes': failed_nodes,
+            'unknown_nodes': unknown_nodes,
+            'summary': summary_text,
+        }
+
     def _summarize_reachability_results(self, reachability_results):
         """Summarize SSH reachability check results."""
         if not reachability_results:
@@ -667,6 +717,7 @@ class PreflightReportGenerator(PreflightCheck):
             {self._generate_node_health_html(results.get('node_health', {}))}
             {self._generate_gid_consistency_html(results.get('gid_consistency', {}))}
             {self._generate_node_smoke_html(results.get('node_smoke', {}))}
+            {self._generate_tier3_info_html(results.get('tier3_info', {}))}
             {self._generate_ifoe_l2_html(results.get('ifoe_l2_connectivity', {}))}
             {self._generate_transferbench_smoke_html(results.get('transferbench_smoke', {}))}
             {self._generate_connectivity_html(results.get('rdma_connectivity', {}))}
@@ -1282,6 +1333,90 @@ class PreflightReportGenerator(PreflightCheck):
         if dump_path:
             html_out += (
                 f"<p>Per-node JSON written under <code>{html.escape(str(dump_path))}/smoke/</code> on each node.</p>"
+            )
+        html_out += """
+        </section>
+        """
+        return html_out
+
+    def _generate_tier3_info_html(self, tier3_info_results):
+        """Generate Primus Tier 3 preflight info section."""
+        if not tier3_info_results:
+            return ""
+
+        if tier3_info_results.get('skipped'):
+            msg = tier3_info_results.get('message', 'Primus Tier 3 preflight info check skipped')
+            return f"""
+        <section>
+            <h2>Primus Tier 3 Preflight Info</h2>
+            <p><em>{html.escape(msg)}</em></p>
+        </section>
+        """
+
+        node_results = tier3_info_results.get('node_results') or {}
+        if not node_results:
+            return ""
+
+        failed_nodes = {n: r for n, r in node_results.items() if r.get('status') in ('FAIL', 'UNKNOWN')}
+        dump_path = tier3_info_results.get('dump_path', '')
+        report_name = tier3_info_results.get('report_file_name', 'tier3_info')
+        report_md = tier3_info_results.get('report_markdown')
+
+        if not failed_nodes:
+            passing = len([n for n, r in node_results.items() if r.get('status') == 'PASS'])
+            html_out = f"""
+        <section>
+            <h2>Primus Tier 3 Preflight Info</h2>
+            <p>All <code>{passing}</code> launcher node(s) passed <code>preflight --host --gpu --network</code>.</p>
+        """
+            if dump_path:
+                html_out += (
+                    f"<p>Markdown report: <code>{html.escape(str(dump_path))}/{html.escape(str(report_name))}.md</code></p>"
+                )
+            if report_md:
+                preview = report_md[:4000]
+                if len(report_md) > 4000:
+                    preview += "\n\n... (truncated)"
+                html_out += f"<pre>{html.escape(preview)}</pre>"
+            html_out += """
+        </section>
+        """
+            return html_out
+
+        html_out = """
+        <section>
+            <h2>Primus Tier 3 Preflight Info — Failures</h2>
+            <p class="error-summary">The following nodes failed Tier 3 preflight info checks:</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Node</th>
+                        <th>Status</th>
+                        <th>Fail Reasons</th>
+                    </tr>
+                </thead>
+                <tbody>
+        """
+
+        for node, result in sorted(failed_nodes.items()):
+            reasons = result.get('fail_reasons') or []
+            reasons_str = html.escape('; '.join(str(r) for r in reasons) if reasons else 'See node logs')
+            status = html.escape(str(result.get('status', 'FAIL')))
+            html_out += f"""
+                <tr>
+                    <td>{html.escape(node)}</td>
+                    <td>{status}</td>
+                    <td>{reasons_str}</td>
+                </tr>
+            """
+
+        html_out += """
+                </tbody>
+            </table>
+        """
+        if dump_path:
+            html_out += (
+                f"<p>Report directory: <code>{html.escape(str(dump_path))}/{html.escape(str(report_name))}.md</code></p>"
             )
         html_out += """
         </section>

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 
 from cvs.lib.preflight.base import PreflightCheck
+from cvs.lib.preflight.node_smoke import DEFAULT_ARTIFACTS_ROOT_DIR
 from cvs.lib import globals
 
 log = globals.log
@@ -203,7 +204,7 @@ class PreflightReportGenerator(PreflightCheck):
         if output_path is None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             output_dir = get_nested_config(
-                self.config_dict, 'reporting', 'artifacts_root_dir', '/home/{user-id}/preflight'
+                self.config_dict, 'reporting', 'artifacts_root_dir', DEFAULT_ARTIFACTS_ROOT_DIR
             )
             Path(output_dir).mkdir(parents=True, exist_ok=True)
             output_path = Path(output_dir) / f"preflight_report_{timestamp}.html"

--- a/cvs/lib/preflight/report.py
+++ b/cvs/lib/preflight/report.py
@@ -202,7 +202,9 @@ class PreflightReportGenerator(PreflightCheck):
 
         if output_path is None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            output_dir = get_nested_config(self.config_dict, 'reporting', 'artifacts_root_dir', '/home/{user-id}/preflight')
+            output_dir = get_nested_config(
+                self.config_dict, 'reporting', 'artifacts_root_dir', '/home/{user-id}/preflight'
+            )
             Path(output_dir).mkdir(parents=True, exist_ok=True)
             output_path = Path(output_dir) / f"preflight_report_{timestamp}.html"
         else:
@@ -1370,9 +1372,7 @@ class PreflightReportGenerator(PreflightCheck):
             <p>All <code>{passing}</code> launcher node(s) passed <code>preflight --host --gpu --network</code>.</p>
         """
             if dump_path:
-                html_out += (
-                    f"<p>Markdown report: <code>{html.escape(str(dump_path))}/{html.escape(str(report_name))}.md</code></p>"
-                )
+                html_out += f"<p>Markdown report: <code>{html.escape(str(dump_path))}/{html.escape(str(report_name))}.md</code></p>"
             if report_md:
                 preview = report_md[:4000]
                 if len(report_md) > 4000:
@@ -1415,9 +1415,7 @@ class PreflightReportGenerator(PreflightCheck):
             </table>
         """
         if dump_path:
-            html_out += (
-                f"<p>Report directory: <code>{html.escape(str(dump_path))}/{html.escape(str(report_name))}.md</code></p>"
-            )
+            html_out += f"<p>Report directory: <code>{html.escape(str(dump_path))}/{html.escape(str(report_name))}.md</code></p>"
         html_out += """
         </section>
         """

--- a/cvs/lib/preflight/tier3_info.py
+++ b/cvs/lib/preflight/tier3_info.py
@@ -22,7 +22,6 @@ from cvs.lib.preflight.node_smoke import (
     _config_flag_enabled,
     _normalize_mode,
     get_nested_config,
-    parse_optional_int,
     resolve_rdma_gid_index,
     resolve_rdma_interfaces,
 )
@@ -261,7 +260,7 @@ class Tier3InfoCheck(PreflightCheck):
         gid_index = resolve_tier3_setting(cfg, "nccl_ib_gid_index", None)
         if gid_index is None:
             gid_index = resolve_rdma_gid_index(cfg)
-        self.nccl_ib_gid_index = parse_optional_int(gid_index)
+        self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
 
         extra = resolve_tier3_setting(cfg, "extra_args", [])
         self.extra_args = [str(arg) for arg in extra if arg] if isinstance(extra, (list, tuple)) else []

--- a/cvs/lib/preflight/tier3_info.py
+++ b/cvs/lib/preflight/tier3_info.py
@@ -1,0 +1,415 @@
+"""
+Primus preflight Tier 3 info checks.
+
+Launches ``primus-cli direct -- preflight --host --gpu --network`` across
+reachable cluster nodes in parallel via SSH (no Slurm).  Uses torchrun on each
+node with a shared ``MASTER_ADDR`` / ``NODE_RANK`` rendezvous so Primus can
+aggregate the Host / GPU / Network info report on rank 0.
+
+Reference: Primus ``docs/02-user-guide/preflight.md`` on branch
+``dev/preflight-direct-test``.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Any, Dict, List, Optional
+
+from cvs.lib.preflight.base import PreflightCheck
+from cvs.lib.preflight.node_smoke import (
+    _config_flag_enabled,
+    _normalize_mode,
+    get_nested_config,
+)
+
+_REPORT_BEGIN = "---CVS_TIER3_REPORT_BEGIN---"
+_REPORT_END = "---CVS_TIER3_REPORT_END---"
+_STATUS_RE = re.compile(
+    r"\[Primus:Preflight\]\s+checks=(?P<checks>[^\s]+)\s+host=(?P<host>\S+)\s+status=(?P<status>PASS|FAIL|WARN)",
+    re.IGNORECASE,
+)
+_FINDINGS_RE = re.compile(
+    r"\[Primus:Preflight\]\s+(?P<level>FAIL|WARN):\s+(?P<message>.+)$",
+    re.IGNORECASE,
+)
+
+
+def resolve_tier3_setting(cfg: dict, key: str, default=None):
+    """Read ``tier3_info.<key>``, falling back to ``node_smoke.<key>``."""
+    value = get_nested_config(cfg, "tier3_info", key, None)
+    if value not in (None, ""):
+        return value
+    return get_nested_config(cfg, "node_smoke", key, default)
+
+
+def _resolve_dump_path(cfg: dict) -> str:
+    """Return Tier 3 dump directory; empty config uses reporting artifacts root."""
+    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", "/home/{user-id}/preflight")
+    default_dump = f"{str(artifacts_root).rstrip('/')}/tier3_info"
+    configured = resolve_tier3_setting(cfg, "dump_path", default_dump)
+    configured_s = str(configured or "").strip()
+    return configured_s if configured_s else default_dump
+
+
+def build_preflight_info_flags(
+    *,
+    dump_path: str = "output/preflight",
+    report_file_name: str = "tier3_info",
+    dist_timeout_sec: Optional[int] = None,
+    save_pdf: bool = False,
+    extra_args: Optional[List[str]] = None,
+) -> str:
+    """Build ``primus-cli preflight --host --gpu --network`` CLI flags."""
+    effective_dump = str(dump_path or "").strip() or "output/preflight"
+    flags: List[str] = [
+        "--host",
+        "--gpu",
+        "--network",
+        f"--dump-path {shlex.quote(effective_dump)}",
+        f"--report-file-name {shlex.quote(str(report_file_name or 'tier3_info'))}",
+    ]
+
+    if dist_timeout_sec is not None and int(dist_timeout_sec) > 0:
+        flags.append(f"--dist-timeout-sec {int(dist_timeout_sec)}")
+
+    if not save_pdf:
+        flags.append("--disable-pdf")
+
+    if extra_args:
+        for arg in extra_args:
+            if arg:
+                flags.append(str(arg))
+
+    return " ".join(flags)
+
+
+def build_remote_preflight_info_command(
+    *,
+    primus_dir: str,
+    venv_activate: str,
+    node_rank: int,
+    nnodes: int,
+    master_addr: str,
+    master_port: int,
+    gpus_per_node: int,
+    dump_path: str,
+    preflight_flags: str,
+    report_file_name: str,
+    nccl_socket_ifname: Optional[str] = None,
+    gloo_socket_ifname: Optional[str] = None,
+    nccl_ib_hca: Optional[str] = None,
+    nccl_ib_gid_index: Optional[int] = None,
+) -> str:
+    """Build the remote shell command for one node's Tier 3 preflight run."""
+    primus_q = shlex.quote(primus_dir)
+    venv_q = shlex.quote(venv_activate)
+    effective_dump = str(dump_path or "").strip() or "output/preflight"
+    report_md_q = shlex.quote(f"{effective_dump.rstrip('/')}/{report_file_name}.md")
+
+    env_lines = [
+        f"export VENV_ACTIVATE={venv_q}",
+        f"export NNODES={nnodes}",
+        f"export NODE_RANK={node_rank}",
+        f"export MASTER_ADDR={shlex.quote(master_addr)}",
+        f"export MASTER_PORT={master_port}",
+        f"export GPUS_PER_NODE={gpus_per_node}",
+    ]
+    if nccl_socket_ifname:
+        env_lines.append(f"export NCCL_SOCKET_IFNAME={shlex.quote(nccl_socket_ifname)}")
+    if gloo_socket_ifname:
+        env_lines.append(f"export GLOO_SOCKET_IFNAME={shlex.quote(gloo_socket_ifname)}")
+    if nccl_ib_hca:
+        env_lines.append(f"export NCCL_IB_HCA={shlex.quote(nccl_ib_hca)}")
+    if nccl_ib_gid_index is not None:
+        env_lines.append(f"export NCCL_IB_GID_INDEX={int(nccl_ib_gid_index)}")
+
+    primus_cli = f"{primus_q}/runner/primus-cli"
+    run_cmd = f"{primus_cli} direct -- preflight {preflight_flags}"
+
+    report_cat = (
+        f"echo '{_REPORT_BEGIN}'; "
+        f'if [ -f {report_md_q} ]; then cat {report_md_q}; fi; '
+        f"echo '{_REPORT_END}'"
+    )
+
+    if node_rank == 0:
+        return (
+            f"cd {primus_q} && "
+            f"{' && '.join(env_lines)} && "
+            f"{run_cmd}; "
+            f"rc=$?; {report_cat}; exit $rc"
+        )
+
+    return f"cd {primus_q} && {' && '.join(env_lines)} && {run_cmd}"
+
+
+def _worst_status(current: str, new: str) -> str:
+    order = {"FAIL": 3, "WARN": 2, "PASS": 1, "UNKNOWN": 0}
+    cur = str(current or "UNKNOWN").upper()
+    nxt = str(new or "UNKNOWN").upper()
+    return nxt if order.get(nxt, 0) > order.get(cur, 0) else cur
+
+
+def parse_preflight_info_output(output: str) -> Dict[str, Any]:
+    """Parse Tier 3 preflight stdout/stderr for per-host status and report text."""
+    result: Dict[str, Any] = {
+        "status": "UNKNOWN",
+        "checks": [],
+        "fail_reasons": [],
+        "host_statuses": {},
+        "report_markdown": None,
+    }
+
+    if not output or not str(output).strip():
+        result["fail_reasons"].append("empty output from preflight --host --gpu --network")
+        result["status"] = "FAIL"
+        return result
+
+    text = str(output)
+
+    begin = text.find(_REPORT_BEGIN)
+    end = text.find(_REPORT_END)
+    if begin != -1 and end != -1 and end > begin:
+        report_blob = text[begin + len(_REPORT_BEGIN) : end].strip()
+        if report_blob:
+            result["report_markdown"] = report_blob
+
+    host_statuses: Dict[str, str] = {}
+    checks_seen: List[str] = []
+    for match in _STATUS_RE.finditer(text):
+        host = match.group("host")
+        status = match.group("status").upper()
+        checks = match.group("checks")
+        if checks and checks not in checks_seen:
+            checks_seen.append(checks)
+        host_statuses[host] = _worst_status(host_statuses.get(host, "UNKNOWN"), status)
+
+    for match in _FINDINGS_RE.finditer(text):
+        level = match.group("level").upper()
+        message = match.group("message").strip()
+        if level == "FAIL":
+            result["fail_reasons"].append(message)
+
+    if "ABORT: Host Unreachable Error" in text:
+        result["status"] = "FAIL"
+        result["fail_reasons"].append("SSH unreachable")
+        return result
+
+    if "[Primus:Preflight] ERROR: distributed init failed" in text:
+        result["status"] = "FAIL"
+        result["fail_reasons"].append("distributed init failed during Tier 3 preflight")
+        return result
+
+    result["host_statuses"] = host_statuses
+    result["checks"] = checks_seen
+
+    if host_statuses:
+        statuses = list(host_statuses.values())
+        if any(status == "FAIL" for status in statuses):
+            result["status"] = "FAIL"
+        elif any(status == "WARN" for status in statuses):
+            result["status"] = "WARN"
+        else:
+            result["status"] = "PASS"
+    elif result["fail_reasons"]:
+        result["status"] = "FAIL"
+    else:
+        result["status"] = "FAIL"
+        result["fail_reasons"].append("could not determine Tier 3 preflight status from output")
+
+    return result
+
+
+class Tier3InfoCheck(PreflightCheck):
+    """Run Primus preflight Host/GPU/Network info checks across cluster nodes via SSH."""
+
+    CONFIG_SECTION = "tier3_info"
+
+    def __init__(self, phdl, node_list: List[str], config_dict=None):
+        super().__init__(phdl, config_dict)
+        self.node_list = list(node_list)
+        self._load_settings()
+
+    def _load_settings(self):
+        cfg = self.config_dict or {}
+        node_check = cfg.get("node_check") or {}
+
+        self.mode = _normalize_mode(resolve_tier3_setting(cfg, "connectivity_mode", "skip"))
+        self.primus_dir = str(resolve_tier3_setting(cfg, "primus_dir", "") or "")
+        self.venv_activate = str(resolve_tier3_setting(cfg, "venv_activate", "") or "")
+        self.gpus_per_node = int(resolve_tier3_setting(cfg, "gpus_per_node", 8))
+        self.master_port = int(resolve_tier3_setting(cfg, "master_port", 1234))
+        self.ssh_timeout = int(resolve_tier3_setting(cfg, "ssh_timeout", 600))
+        self.dist_timeout_sec = int(resolve_tier3_setting(cfg, "dist_timeout_sec", 120))
+        self.report_file_name = str(resolve_tier3_setting(cfg, "report_file_name", "tier3_info") or "tier3_info")
+        self.save_pdf = _config_flag_enabled(resolve_tier3_setting(cfg, "save_pdf", False))
+        self.dump_path = _resolve_dump_path(cfg)
+
+        rdma_ifaces = node_check.get("rdma_interfaces") or []
+        self.nccl_socket_ifname = resolve_tier3_setting(cfg, "nccl_socket_ifname", "") or None
+        self.gloo_socket_ifname = (
+            resolve_tier3_setting(cfg, "gloo_socket_ifname", self.nccl_socket_ifname) or None
+        )
+
+        nccl_ib_hca = resolve_tier3_setting(cfg, "nccl_ib_hca", None)
+        if not nccl_ib_hca and rdma_ifaces:
+            nccl_ib_hca = ",".join(rdma_ifaces)
+        self.nccl_ib_hca = nccl_ib_hca or None
+
+        gid_index = resolve_tier3_setting(cfg, "nccl_ib_gid_index", None)
+        if gid_index is None:
+            gid_index = node_check.get("gid_index")
+        self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
+
+        extra = resolve_tier3_setting(cfg, "extra_args", [])
+        self.extra_args = [str(arg) for arg in extra if arg] if isinstance(extra, (list, tuple)) else []
+        self.auto_setup = _config_flag_enabled(resolve_tier3_setting(cfg, "auto_setup", True), default=True)
+
+    def _validate_prerequisites(self) -> Optional[str]:
+        if not self.primus_dir:
+            return "tier3_info.primus_dir (or node_smoke.primus_dir) is required when connectivity_mode is 'run'"
+        if not self.venv_activate:
+            return "tier3_info.venv_activate (or node_smoke.venv_activate) is required when connectivity_mode is 'run'"
+        if not self.node_list:
+            return "no reachable nodes available for Tier 3 preflight info"
+        return None
+
+    def _preflight_flags(self) -> str:
+        return build_preflight_info_flags(
+            dump_path=self.dump_path,
+            report_file_name=self.report_file_name,
+            dist_timeout_sec=self.dist_timeout_sec,
+            save_pdf=self.save_pdf,
+            extra_args=self.extra_args,
+        )
+
+    def run(self) -> Dict[str, Any]:
+        if self.mode in ("skip", "off", "disabled", "false", "0"):
+            return {
+                "mode": self.mode,
+                "skipped": True,
+                "message": "Primus Tier 3 preflight info check skipped by configuration",
+                "node_results": {},
+            }
+
+        err = self._validate_prerequisites()
+        if err:
+            return {
+                "mode": self.mode,
+                "skipped": True,
+                "message": err,
+                "node_results": {},
+            }
+
+        hosts = [h for h in self.node_list if h in self.phdl.reachable_hosts]
+        if not hosts:
+            return {
+                "mode": self.mode,
+                "skipped": True,
+                "message": "no reachable hosts remain for Tier 3 preflight info",
+                "node_results": {},
+            }
+
+        setup_results = None
+        if self.auto_setup:
+            from cvs.lib.preflight.primus_setup import PrimusSetup
+
+            setup = PrimusSetup(
+                self.phdl,
+                hosts,
+                self.config_dict,
+                config_section=self.CONFIG_SECTION,
+                fallback_section="node_smoke",
+            )
+            setup_results = setup.run()
+            if setup_results.get("status") == "FAIL":
+                return {
+                    "mode": self.mode,
+                    "skipped": True,
+                    "status": "FAIL",
+                    "message": "Primus auto_setup failed — fix setup errors before Tier 3 preflight info",
+                    "setup_results": setup_results,
+                    "node_results": {},
+                }
+
+        nnodes = len(hosts)
+        master_addr = hosts[0]
+        preflight_flags = self._preflight_flags()
+        hosts_set = set(hosts)
+        host_ranks = {host: rank for rank, host in enumerate(hosts)}
+
+        self.log_info(
+            f"Launching Primus preflight --host --gpu --network on {nnodes} node(s) "
+            f"(primus_dir={self.primus_dir}, dump_path={self.dump_path}, "
+            f"dist_timeout_sec={self.dist_timeout_sec})"
+        )
+
+        commands: List[str] = []
+        for h in self.phdl.reachable_hosts:
+            if h not in hosts_set:
+                commands.append("true")
+            else:
+                commands.append(
+                    build_remote_preflight_info_command(
+                        primus_dir=self.primus_dir,
+                        venv_activate=self.venv_activate,
+                        node_rank=host_ranks[h],
+                        nnodes=nnodes,
+                        master_addr=master_addr,
+                        master_port=self.master_port,
+                        gpus_per_node=self.gpus_per_node,
+                        dump_path=self.dump_path,
+                        preflight_flags=preflight_flags,
+                        report_file_name=self.report_file_name,
+                        nccl_socket_ifname=self.nccl_socket_ifname,
+                        gloo_socket_ifname=self.gloo_socket_ifname,
+                        nccl_ib_hca=self.nccl_ib_hca,
+                        nccl_ib_gid_index=self.nccl_ib_gid_index,
+                    )
+                )
+
+        out_dict = self.phdl.exec_cmd_list(commands, timeout=self.ssh_timeout)
+
+        node_results: Dict[str, Any] = {}
+        cluster_report = None
+        for host, output in out_dict.items():
+            if host not in hosts_set:
+                continue
+            parsed = parse_preflight_info_output(output)
+            node_results[host] = {
+                "status": parsed["status"],
+                "fail_reasons": parsed["fail_reasons"],
+                "node_rank": host_ranks[host],
+                "host_statuses": parsed.get("host_statuses") or {},
+                "checks": parsed.get("checks") or [],
+            }
+            if parsed.get("report_markdown"):
+                cluster_report = parsed["report_markdown"]
+            if parsed["status"] == "FAIL":
+                for reason in parsed["fail_reasons"]:
+                    self.log_error(f"Node {host} Tier 3 preflight info: {reason}")
+
+        failed_nodes = [n for n, r in node_results.items() if r.get("status") == "FAIL"]
+        passing_nodes = [n for n, r in node_results.items() if r.get("status") == "PASS"]
+        unknown_nodes = [n for n, r in node_results.items() if r.get("status") not in ("PASS", "FAIL", "WARN")]
+
+        summary_status = "FAIL" if failed_nodes or unknown_nodes else "PASS"
+        self.results = {
+            "mode": self.mode,
+            "skipped": False,
+            "status": summary_status,
+            "total_nodes": len(node_results),
+            "passing_nodes": passing_nodes,
+            "failed_nodes": failed_nodes,
+            "unknown_nodes": unknown_nodes,
+            "node_results": node_results,
+            "dump_path": self.dump_path,
+            "report_file_name": self.report_file_name,
+            "report_markdown": cluster_report,
+            "primus_dir": self.primus_dir,
+            "dist_timeout_sec": self.dist_timeout_sec,
+        }
+        if setup_results is not None:
+            self.results["setup_results"] = setup_results
+        return self.results

--- a/cvs/lib/preflight/tier3_info.py
+++ b/cvs/lib/preflight/tier3_info.py
@@ -127,19 +127,10 @@ def build_remote_preflight_info_command(
     primus_cli = f"{primus_q}/runner/primus-cli"
     run_cmd = f"{primus_cli} direct -- preflight {preflight_flags}"
 
-    report_cat = (
-        f"echo '{_REPORT_BEGIN}'; "
-        f'if [ -f {report_md_q} ]; then cat {report_md_q}; fi; '
-        f"echo '{_REPORT_END}'"
-    )
+    report_cat = f"echo '{_REPORT_BEGIN}'; if [ -f {report_md_q} ]; then cat {report_md_q}; fi; echo '{_REPORT_END}'"
 
     if node_rank == 0:
-        return (
-            f"cd {primus_q} && "
-            f"{' && '.join(env_lines)} && "
-            f"{run_cmd}; "
-            f"rc=$?; {report_cat}; exit $rc"
-        )
+        return f"cd {primus_q} && {' && '.join(env_lines)} && {run_cmd}; rc=$?; {report_cat}; exit $rc"
 
     return f"cd {primus_q} && {' && '.join(env_lines)} && {run_cmd}"
 
@@ -248,9 +239,7 @@ class Tier3InfoCheck(PreflightCheck):
 
         rdma_ifaces = node_check.get("rdma_interfaces") or []
         self.nccl_socket_ifname = resolve_tier3_setting(cfg, "nccl_socket_ifname", "") or None
-        self.gloo_socket_ifname = (
-            resolve_tier3_setting(cfg, "gloo_socket_ifname", self.nccl_socket_ifname) or None
-        )
+        self.gloo_socket_ifname = resolve_tier3_setting(cfg, "gloo_socket_ifname", self.nccl_socket_ifname) or None
 
         nccl_ib_hca = resolve_tier3_setting(cfg, "nccl_ib_hca", None)
         if not nccl_ib_hca and rdma_ifaces:

--- a/cvs/lib/preflight/tier3_info.py
+++ b/cvs/lib/preflight/tier3_info.py
@@ -22,6 +22,7 @@ from cvs.lib.preflight.node_smoke import (
     _config_flag_enabled,
     _normalize_mode,
     get_nested_config,
+    parse_optional_int,
     resolve_rdma_gid_index,
     resolve_rdma_interfaces,
 )
@@ -260,7 +261,7 @@ class Tier3InfoCheck(PreflightCheck):
         gid_index = resolve_tier3_setting(cfg, "nccl_ib_gid_index", None)
         if gid_index is None:
             gid_index = resolve_rdma_gid_index(cfg)
-        self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
+        self.nccl_ib_gid_index = parse_optional_int(gid_index)
 
         extra = resolve_tier3_setting(cfg, "extra_args", [])
         self.extra_args = [str(arg) for arg in extra if arg] if isinstance(extra, (list, tuple)) else []

--- a/cvs/lib/preflight/tier3_info.py
+++ b/cvs/lib/preflight/tier3_info.py
@@ -18,9 +18,12 @@ from typing import Any, Dict, List, Optional
 
 from cvs.lib.preflight.base import PreflightCheck
 from cvs.lib.preflight.node_smoke import (
+    DEFAULT_ARTIFACTS_ROOT_DIR,
     _config_flag_enabled,
     _normalize_mode,
     get_nested_config,
+    resolve_rdma_gid_index,
+    resolve_rdma_interfaces,
 )
 
 _REPORT_BEGIN = "---CVS_TIER3_REPORT_BEGIN---"
@@ -34,18 +37,27 @@ _FINDINGS_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Only shared Primus install paths may inherit from node_smoke. Operational knobs
+# (connectivity_mode, timeouts, dump_path, NCCL overrides, etc.) must stay
+# tier3_info-local so enabling node_smoke does not silently launch Tier 3.
+_TIER3_NODE_SMOKE_FALLBACK_KEYS = frozenset({"primus_dir", "venv_activate"})
+
 
 def resolve_tier3_setting(cfg: dict, key: str, default=None):
-    """Read ``tier3_info.<key>``, falling back to ``node_smoke.<key>``."""
+    """Read ``tier3_info.<key>``, with a narrow ``node_smoke`` fallback for Primus paths."""
     value = get_nested_config(cfg, "tier3_info", key, None)
     if value not in (None, ""):
         return value
-    return get_nested_config(cfg, "node_smoke", key, default)
+    if key in _TIER3_NODE_SMOKE_FALLBACK_KEYS:
+        fallback = get_nested_config(cfg, "node_smoke", key, None)
+        if fallback not in (None, ""):
+            return fallback
+    return default
 
 
 def _resolve_dump_path(cfg: dict) -> str:
     """Return Tier 3 dump directory; empty config uses reporting artifacts root."""
-    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", "/home/{user-id}/preflight")
+    artifacts_root = get_nested_config(cfg, "reporting", "artifacts_root_dir", DEFAULT_ARTIFACTS_ROOT_DIR)
     default_dump = f"{str(artifacts_root).rstrip('/')}/tier3_info"
     configured = resolve_tier3_setting(cfg, "dump_path", default_dump)
     configured_s = str(configured or "").strip()
@@ -224,9 +236,8 @@ class Tier3InfoCheck(PreflightCheck):
 
     def _load_settings(self):
         cfg = self.config_dict or {}
-        node_check = cfg.get("node_check") or {}
 
-        self.mode = _normalize_mode(resolve_tier3_setting(cfg, "connectivity_mode", "skip"))
+        self.mode = _normalize_mode(get_nested_config(cfg, "tier3_info", "connectivity_mode", "skip"))
         self.primus_dir = str(resolve_tier3_setting(cfg, "primus_dir", "") or "")
         self.venv_activate = str(resolve_tier3_setting(cfg, "venv_activate", "") or "")
         self.gpus_per_node = int(resolve_tier3_setting(cfg, "gpus_per_node", 8))
@@ -237,7 +248,7 @@ class Tier3InfoCheck(PreflightCheck):
         self.save_pdf = _config_flag_enabled(resolve_tier3_setting(cfg, "save_pdf", False))
         self.dump_path = _resolve_dump_path(cfg)
 
-        rdma_ifaces = node_check.get("rdma_interfaces") or []
+        rdma_ifaces = resolve_rdma_interfaces(cfg)
         self.nccl_socket_ifname = resolve_tier3_setting(cfg, "nccl_socket_ifname", "") or None
         self.gloo_socket_ifname = resolve_tier3_setting(cfg, "gloo_socket_ifname", self.nccl_socket_ifname) or None
 
@@ -248,7 +259,7 @@ class Tier3InfoCheck(PreflightCheck):
 
         gid_index = resolve_tier3_setting(cfg, "nccl_ib_gid_index", None)
         if gid_index is None:
-            gid_index = node_check.get("gid_index")
+            gid_index = resolve_rdma_gid_index(cfg)
         self.nccl_ib_gid_index = int(gid_index) if gid_index not in (None, "") else None
 
         extra = resolve_tier3_setting(cfg, "extra_args", [])

--- a/cvs/lib/preflight/unittests/test_node_smoke.py
+++ b/cvs/lib/preflight/unittests/test_node_smoke.py
@@ -15,6 +15,8 @@ from cvs.lib.preflight.node_smoke import (
     build_node_smoke_flags,
     build_remote_node_smoke_command,
     parse_node_smoke_output,
+    resolve_rdma_gid_index,
+    resolve_rdma_interfaces,
 )
 
 
@@ -33,6 +35,10 @@ class TestBuildNodeSmokeFlags(unittest.TestCase):
             "node_smoke": {"dump_path": ""},
         }
         self.assertEqual(_resolve_dump_path(cfg), "/home/{user-id}/preflight/node_smoke")
+
+    def test_resolve_dump_path_without_reporting_section(self):
+        cfg = {"node_smoke": {"dump_path": ""}}
+        self.assertEqual(_resolve_dump_path(cfg), "/tmp/preflight/node_smoke")
 
     def test_rdma_and_host_limits(self):
         flags = build_node_smoke_flags(
@@ -124,6 +130,22 @@ class TestParseNodeSmokeOutput(unittest.TestCase):
     def test_empty_output_fails(self):
         parsed = parse_node_smoke_output("")
         self.assertEqual(parsed["status"], "FAIL")
+
+
+class TestResolveRdmaConfig(unittest.TestCase):
+    def test_interfaces_from_connectivity_check_rdma(self):
+        cfg = {
+            "connectivity_check": {"rdma": {"interfaces": ["rdma0", "rdma1"], "gid_index": "3"}},
+        }
+        self.assertEqual(resolve_rdma_interfaces(cfg), ["rdma0", "rdma1"])
+        self.assertEqual(resolve_rdma_gid_index(cfg), "3")
+
+    def test_legacy_node_check_fallback(self):
+        cfg = {
+            "node_check": {"rdma_interfaces": ["legacy0"], "gid_index": "7"},
+        }
+        self.assertEqual(resolve_rdma_interfaces(cfg), ["legacy0"])
+        self.assertEqual(resolve_rdma_gid_index(cfg), "7")
 
 
 class TestNodeSmokeCheckRun(unittest.TestCase):

--- a/cvs/lib/preflight/unittests/test_node_smoke.py
+++ b/cvs/lib/preflight/unittests/test_node_smoke.py
@@ -15,6 +15,7 @@ from cvs.lib.preflight.node_smoke import (
     build_node_smoke_flags,
     build_remote_node_smoke_command,
     parse_node_smoke_output,
+    parse_optional_int,
     resolve_rdma_gid_index,
     resolve_rdma_interfaces,
 )
@@ -147,8 +148,38 @@ class TestResolveRdmaConfig(unittest.TestCase):
         self.assertEqual(resolve_rdma_interfaces(cfg), ["legacy0"])
         self.assertEqual(resolve_rdma_gid_index(cfg), "7")
 
+    def test_changeme_placeholders_are_ignored(self):
+        cfg = {
+            "connectivity_check": {
+                "rdma": {"interfaces": ["<changeme>"], "gid_index": "<changeme>"},
+            },
+        }
+        self.assertEqual(resolve_rdma_interfaces(cfg), [])
+        self.assertIsNone(resolve_rdma_gid_index(cfg))
 
-class TestNodeSmokeCheckRun(unittest.TestCase):
+    def test_parse_optional_int_ignores_changeme(self):
+        self.assertIsNone(parse_optional_int("<changeme>"))
+        self.assertEqual(parse_optional_int("3"), 3)
+        self.assertIsNone(parse_optional_int("not-a-number"))
+
+
+class TestNodeSmokeCheckConstruction(unittest.TestCase):
+    def test_skip_mode_tolerates_shipped_default_rdma_placeholders(self):
+        cfg = {
+            "node_smoke": {"connectivity_mode": "skip"},
+            "connectivity_check": {
+                "rdma": {"interfaces": ["<changeme>"], "gid_index": "<changeme>"},
+            },
+        }
+        phdl = MagicMock()
+        phdl.reachable_hosts = ["node0"]
+        checker = NodeSmokeCheck(phdl, ["node0"], cfg)
+        self.assertIsNone(checker.nccl_ib_gid_index)
+        self.assertIsNone(checker.nccl_ib_hca)
+        results = checker.run()
+        self.assertTrue(results.get("skipped"))
+        phdl.exec_cmd_list.assert_not_called()
+
     def _config(self):
         return {
             "node_smoke": {

--- a/cvs/lib/preflight/unittests/test_node_smoke.py
+++ b/cvs/lib/preflight/unittests/test_node_smoke.py
@@ -15,7 +15,6 @@ from cvs.lib.preflight.node_smoke import (
     build_node_smoke_flags,
     build_remote_node_smoke_command,
     parse_node_smoke_output,
-    parse_optional_int,
     resolve_rdma_gid_index,
     resolve_rdma_interfaces,
 )
@@ -148,38 +147,8 @@ class TestResolveRdmaConfig(unittest.TestCase):
         self.assertEqual(resolve_rdma_interfaces(cfg), ["legacy0"])
         self.assertEqual(resolve_rdma_gid_index(cfg), "7")
 
-    def test_changeme_placeholders_are_ignored(self):
-        cfg = {
-            "connectivity_check": {
-                "rdma": {"interfaces": ["<changeme>"], "gid_index": "<changeme>"},
-            },
-        }
-        self.assertEqual(resolve_rdma_interfaces(cfg), [])
-        self.assertIsNone(resolve_rdma_gid_index(cfg))
 
-    def test_parse_optional_int_ignores_changeme(self):
-        self.assertIsNone(parse_optional_int("<changeme>"))
-        self.assertEqual(parse_optional_int("3"), 3)
-        self.assertIsNone(parse_optional_int("not-a-number"))
-
-
-class TestNodeSmokeCheckConstruction(unittest.TestCase):
-    def test_skip_mode_tolerates_shipped_default_rdma_placeholders(self):
-        cfg = {
-            "node_smoke": {"connectivity_mode": "skip"},
-            "connectivity_check": {
-                "rdma": {"interfaces": ["<changeme>"], "gid_index": "<changeme>"},
-            },
-        }
-        phdl = MagicMock()
-        phdl.reachable_hosts = ["node0"]
-        checker = NodeSmokeCheck(phdl, ["node0"], cfg)
-        self.assertIsNone(checker.nccl_ib_gid_index)
-        self.assertIsNone(checker.nccl_ib_hca)
-        results = checker.run()
-        self.assertTrue(results.get("skipped"))
-        phdl.exec_cmd_list.assert_not_called()
-
+class TestNodeSmokeCheckRun(unittest.TestCase):
     def _config(self):
         return {
             "node_smoke": {

--- a/cvs/lib/preflight/unittests/test_node_smoke.py
+++ b/cvs/lib/preflight/unittests/test_node_smoke.py
@@ -29,10 +29,10 @@ class TestBuildNodeSmokeFlags(unittest.TestCase):
 
     def test_resolve_dump_path_from_empty_config_value(self):
         cfg = {
-            "reporting": {"artifacts_root_dir": "/tmp/{user-id}/preflight"},
+            "reporting": {"artifacts_root_dir": "/home/{user-id}/preflight"},
             "node_smoke": {"dump_path": ""},
         }
-        self.assertEqual(_resolve_dump_path(cfg), "/tmp/{user-id}/preflight/node_smoke")
+        self.assertEqual(_resolve_dump_path(cfg), "/home/{user-id}/preflight/node_smoke")
 
     def test_rdma_and_host_limits(self):
         flags = build_node_smoke_flags(

--- a/cvs/lib/preflight/unittests/test_tier3_info.py
+++ b/cvs/lib/preflight/unittests/test_tier3_info.py
@@ -104,22 +104,6 @@ class TestResolveTier3Setting(unittest.TestCase):
         self.assertEqual(check.nccl_ib_hca, "rdma0,rdma1")
         self.assertEqual(check.nccl_ib_gid_index, 3)
 
-    def test_skip_mode_tolerates_shipped_default_rdma_placeholders(self):
-        cfg = {
-            "tier3_info": {"connectivity_mode": "skip"},
-            "connectivity_check": {
-                "rdma": {"interfaces": ["<changeme>"], "gid_index": "<changeme>"},
-            },
-        }
-        phdl = MagicMock()
-        phdl.reachable_hosts = ["node0"]
-        checker = Tier3InfoCheck(phdl, ["node0"], cfg)
-        self.assertIsNone(checker.nccl_ib_gid_index)
-        self.assertIsNone(checker.nccl_ib_hca)
-        results = checker.run()
-        self.assertTrue(results.get("skipped"))
-        phdl.exec_cmd_list.assert_not_called()
-
 
 class TestTier3InfoCheckRun(unittest.TestCase):
     def _config(self):

--- a/cvs/lib/preflight/unittests/test_tier3_info.py
+++ b/cvs/lib/preflight/unittests/test_tier3_info.py
@@ -1,0 +1,94 @@
+"""Unit tests for Primus Tier 3 preflight info integration."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+
+from cvs.lib.preflight.tier3_info import (
+    _REPORT_BEGIN,
+    _REPORT_END,
+    Tier3InfoCheck,
+    build_preflight_info_flags,
+    build_remote_preflight_info_command,
+    parse_preflight_info_output,
+    resolve_tier3_setting,
+)
+
+
+class TestBuildPreflightInfoFlags(unittest.TestCase):
+    def test_default_flags_include_host_gpu_network(self):
+        flags = build_preflight_info_flags(dump_path="/tmp/tier3")
+        self.assertIn("--host", flags)
+        self.assertIn("--gpu", flags)
+        self.assertIn("--network", flags)
+        self.assertIn("--dump-path /tmp/tier3", flags)
+        self.assertIn("--disable-pdf", flags)
+
+    def test_master_node_includes_report_markers(self):
+        cmd = build_remote_preflight_info_command(
+            primus_dir="/home/testuser/Primus",
+            venv_activate="/home/testuser/envs/preflight/.venv/bin/activate",
+            node_rank=0,
+            nnodes=4,
+            master_addr="node0",
+            master_port=1234,
+            gpus_per_node=8,
+            dump_path="/tmp/preflight/tier3_info",
+            preflight_flags="--host --gpu --network",
+            report_file_name="tier3_info",
+        )
+        self.assertIn("preflight --host", cmd)
+        self.assertNotIn("--single", cmd)
+        self.assertIn(_REPORT_BEGIN, cmd)
+
+
+class TestParsePreflightInfoOutput(unittest.TestCase):
+    def test_parse_status_and_report(self):
+        output = (
+            "[Primus:Preflight] checks=host,gpu,network host=node0 status=PASS\n"
+            f"{_REPORT_BEGIN}\n# Primus Preflight Report\n{_REPORT_END}\n"
+        )
+        parsed = parse_preflight_info_output(output)
+        self.assertEqual(parsed["status"], "PASS")
+        self.assertIn("# Primus Preflight Report", parsed["report_markdown"])
+
+
+class TestResolveTier3Setting(unittest.TestCase):
+    def test_falls_back_to_node_smoke(self):
+        cfg = {
+            "tier3_info": {"connectivity_mode": "run"},
+            "node_smoke": {"primus_dir": "/home/user/Primus"},
+        }
+        self.assertEqual(resolve_tier3_setting(cfg, "primus_dir"), "/home/user/Primus")
+
+
+class TestTier3InfoCheckRun(unittest.TestCase):
+    def _config(self):
+        return {
+            "tier3_info": {"connectivity_mode": "run", "auto_setup": False},
+            "node_smoke": {
+                "primus_dir": "/home/testuser/Primus",
+                "venv_activate": "/home/testuser/envs/preflight/.venv/bin/activate",
+            },
+        }
+
+    def test_parallel_ssh_launch(self):
+        phdl = MagicMock()
+        phdl.reachable_hosts = ["node0", "node1"]
+        phdl.exec_cmd_list.return_value = {
+            "node0": "[Primus:Preflight] checks=host,gpu,network host=node0 status=PASS\n",
+            "node1": "[Primus:Preflight] checks=host,gpu,network host=node1 status=PASS\n",
+        }
+
+        results = Tier3InfoCheck(phdl, ["node0", "node1"], self._config()).run()
+        self.assertEqual(results["status"], "PASS")
+        cmd_list = phdl.exec_cmd_list.call_args[0][0]
+        self.assertIn("export NODE_RANK=0", cmd_list[0])
+        self.assertIn("export NODE_RANK=1", cmd_list[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/preflight/unittests/test_tier3_info.py
+++ b/cvs/lib/preflight/unittests/test_tier3_info.py
@@ -104,6 +104,22 @@ class TestResolveTier3Setting(unittest.TestCase):
         self.assertEqual(check.nccl_ib_hca, "rdma0,rdma1")
         self.assertEqual(check.nccl_ib_gid_index, 3)
 
+    def test_skip_mode_tolerates_shipped_default_rdma_placeholders(self):
+        cfg = {
+            "tier3_info": {"connectivity_mode": "skip"},
+            "connectivity_check": {
+                "rdma": {"interfaces": ["<changeme>"], "gid_index": "<changeme>"},
+            },
+        }
+        phdl = MagicMock()
+        phdl.reachable_hosts = ["node0"]
+        checker = Tier3InfoCheck(phdl, ["node0"], cfg)
+        self.assertIsNone(checker.nccl_ib_gid_index)
+        self.assertIsNone(checker.nccl_ib_hca)
+        results = checker.run()
+        self.assertTrue(results.get("skipped"))
+        phdl.exec_cmd_list.assert_not_called()
+
 
 class TestTier3InfoCheckRun(unittest.TestCase):
     def _config(self):

--- a/cvs/lib/preflight/unittests/test_tier3_info.py
+++ b/cvs/lib/preflight/unittests/test_tier3_info.py
@@ -11,6 +11,7 @@ from cvs.lib.preflight.tier3_info import (
     _REPORT_BEGIN,
     _REPORT_END,
     Tier3InfoCheck,
+    _resolve_dump_path,
     build_preflight_info_flags,
     build_remote_preflight_info_command,
     parse_preflight_info_output,
@@ -26,6 +27,9 @@ class TestBuildPreflightInfoFlags(unittest.TestCase):
         self.assertIn("--network", flags)
         self.assertIn("--dump-path /tmp/tier3", flags)
         self.assertIn("--disable-pdf", flags)
+
+    def test_resolve_dump_path_without_reporting_section(self):
+        self.assertEqual(_resolve_dump_path({"tier3_info": {"dump_path": ""}}), "/tmp/preflight/tier3_info")
 
     def test_master_node_includes_report_markers(self):
         cmd = build_remote_preflight_info_command(
@@ -57,12 +61,48 @@ class TestParsePreflightInfoOutput(unittest.TestCase):
 
 
 class TestResolveTier3Setting(unittest.TestCase):
-    def test_falls_back_to_node_smoke(self):
+    def test_falls_back_to_node_smoke_for_primus_paths_only(self):
         cfg = {
             "tier3_info": {"connectivity_mode": "run"},
             "node_smoke": {"primus_dir": "/home/user/Primus"},
         }
         self.assertEqual(resolve_tier3_setting(cfg, "primus_dir"), "/home/user/Primus")
+
+    def test_connectivity_mode_does_not_inherit_node_smoke(self):
+        cfg = {
+            "node_smoke": {"connectivity_mode": "run", "primus_dir": "/home/user/Primus"},
+        }
+        self.assertEqual(resolve_tier3_setting(cfg, "connectivity_mode", "skip"), "skip")
+
+    def test_tier3_skipped_when_only_node_smoke_enabled(self):
+        phdl = MagicMock()
+        phdl.reachable_hosts = ["node0"]
+        cfg = {
+            "node_smoke": {
+                "connectivity_mode": "run",
+                "primus_dir": "/home/user/Primus",
+                "venv_activate": "/home/user/.venv/bin/activate",
+            },
+        }
+        results = Tier3InfoCheck(phdl, ["node0"], cfg).run()
+        self.assertTrue(results.get("skipped"))
+        self.assertEqual(results.get("mode"), "skip")
+        phdl.exec_cmd_list.assert_not_called()
+
+    def test_nccl_env_derived_from_connectivity_check_rdma(self):
+        cfg = {
+            "tier3_info": {"connectivity_mode": "run", "auto_setup": False},
+            "node_smoke": {
+                "primus_dir": "/home/user/Primus",
+                "venv_activate": "/home/user/.venv/bin/activate",
+            },
+            "connectivity_check": {
+                "rdma": {"interfaces": ["rdma0", "rdma1"], "gid_index": "3"},
+            },
+        }
+        check = Tier3InfoCheck(MagicMock(), ["node0"], cfg)
+        self.assertEqual(check.nccl_ib_hca, "rdma0,rdma1")
+        self.assertEqual(check.nccl_ib_gid_index, 3)
 
 
 class TestTier3InfoCheckRun(unittest.TestCase):

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -1279,6 +1279,48 @@ class PreflightNodeSmokeConfig(BaseModel):
         return v
 
 
+class PreflightTier3InfoConfig(BaseModel):
+    """Primus preflight Tier 3 Host/GPU/Network info (primus-cli direct -- preflight)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connectivity_mode: str = Field(
+        default="skip",
+        description="Tier 3 info mode: 'run' (preflight --host --gpu --network) or 'skip' (default)",
+    )
+    auto_setup: bool = Field(
+        default=True,
+        description="Clone/update Primus and prepare venv before Tier 3 (falls back to node_smoke settings)",
+    )
+    primus_dir: str = Field(default="", description="Primus checkout path (default: node_smoke.primus_dir)")
+    venv_activate: str = Field(default="", description="Venv activate script (default: node_smoke.venv_activate)")
+    gpus_per_node: int = Field(default=8, ge=1, description="GPUs per node for torchrun")
+    master_port: int = Field(default=1234, ge=1024, le=65535, description="Distributed master port")
+    dump_path: str = Field(
+        default="",
+        description="Tier 3 report directory (default: <artifacts_root_dir>/tier3_info)",
+    )
+    report_file_name: str = Field(default="tier3_info", description="Base name for Primus markdown/PDF reports")
+    dist_timeout_sec: int = Field(
+        default=120, ge=30, description="Timeout for torch.distributed init during aggregated report"
+    )
+    save_pdf: bool = Field(default=False, description="Generate PDF report via Primus")
+    nccl_socket_ifname: str = Field(default="", description="NCCL_SOCKET_IFNAME override")
+    gloo_socket_ifname: str = Field(default="", description="GLOO_SOCKET_IFNAME override")
+    nccl_ib_hca: str = Field(default="", description="NCCL_IB_HCA override")
+    nccl_ib_gid_index: Optional[int] = Field(default=None, description="NCCL_IB_GID_INDEX override")
+    ssh_timeout: int = Field(default=600, ge=30, description="SSH timeout in seconds for the Tier 3 cluster run")
+    extra_args: List[str] = Field(default_factory=list, description="Additional preflight CLI flags")
+
+    @field_validator("connectivity_mode")
+    @classmethod
+    def validate_tier3_info_mode(cls, v: str) -> str:
+        valid_modes = ["run", "skip"]
+        if v not in valid_modes:
+            raise ValueError(f"tier3_info.connectivity_mode must be one of: {', '.join(valid_modes)}")
+        return v
+
+
 class PreflightReportingConfig(BaseModel):
     """Report generation and output settings."""
 
@@ -1286,7 +1328,7 @@ class PreflightReportingConfig(BaseModel):
 
     generate_html_report: bool = Field(default=True, description="Whether to generate HTML report")
     artifacts_root_dir: str = Field(
-        default="/tmp/preflight",
+        default="/home/{user-id}/preflight",
         description=(
             "Root directory for preflight artifacts. HTML report output and RDMA full_mesh ScriptLet logs use "
             "<artifacts_root_dir>/rdma_connectivity_workspace/<session>/<round>/ on each node (NFS-friendly)."
@@ -1321,6 +1363,10 @@ class PreflightConfigFile(BaseModel):
     )
     node_smoke: PreflightNodeSmokeConfig = Field(
         default_factory=PreflightNodeSmokeConfig, description="Primus node_smoke checks"
+    )
+    tier3_info: PreflightTier3InfoConfig = Field(
+        default_factory=PreflightTier3InfoConfig,
+        description="Primus Tier 3 preflight Host/GPU/Network info checks",
     )
     reporting: PreflightReportingConfig = Field(
         default_factory=PreflightReportingConfig, description="Report generation and output settings"

--- a/cvs/parsers/schemas.py
+++ b/cvs/parsers/schemas.py
@@ -1202,7 +1202,7 @@ class PreflightNodeSmokeConfig(BaseModel):
     expected_rdma_nics: Optional[int] = Field(
         default=None,
         ge=1,
-        description="Hard-fail when training RDMA NIC count differs (default: len(node_check.rdma_interfaces))",
+        description="Hard-fail when training RDMA NIC count differs (default: len(connectivity_check.rdma.interfaces))",
     )
     ulimit_l_min_gb: float = Field(default=32.0, ge=0, description="Minimum RLIMIT_MEMLOCK in GiB (0 disables)")
     shm_min_gb: float = Field(default=8.0, ge=0, description="Minimum /dev/shm size in GiB (0 disables)")
@@ -1223,14 +1223,17 @@ class PreflightNodeSmokeConfig(BaseModel):
     gloo_socket_ifname: str = Field(
         default="", description="GLOO_SOCKET_IFNAME override (defaults to nccl_socket_ifname)"
     )
-    nccl_ib_hca: str = Field(default="", description="NCCL_IB_HCA override (defaults to node_check.rdma_interfaces)")
+    nccl_ib_hca: str = Field(
+        default="",
+        description="NCCL_IB_HCA override (defaults to comma-joined connectivity_check.rdma.interfaces)",
+    )
     nccl_ib_gid_index: Optional[int] = Field(
         default=None,
-        description="NCCL_IB_GID_INDEX override (defaults to node_check.gid_index)",
+        description="NCCL_IB_GID_INDEX override (defaults to connectivity_check.rdma.gid_index)",
     )
     rdma_nic_allowlist: str = Field(
         default="",
-        description="Training NIC allowlist for node_smoke (defaults to node_check.rdma_interfaces)",
+        description="Training NIC allowlist for node_smoke (defaults to connectivity_check.rdma.interfaces)",
     )
     ssh_timeout: int = Field(default=300, ge=30, description="SSH timeout in seconds for each node_smoke run")
     tier2_perf: bool = Field(
@@ -1290,10 +1293,16 @@ class PreflightTier3InfoConfig(BaseModel):
     )
     auto_setup: bool = Field(
         default=True,
-        description="Clone/update Primus and prepare venv before Tier 3 (falls back to node_smoke settings)",
+        description="Clone/update Primus and prepare venv before Tier 3 (uses node_smoke git/pip settings via PrimusSetup fallback)",
     )
-    primus_dir: str = Field(default="", description="Primus checkout path (default: node_smoke.primus_dir)")
-    venv_activate: str = Field(default="", description="Venv activate script (default: node_smoke.venv_activate)")
+    primus_dir: str = Field(
+        default="",
+        description="Primus checkout path; empty uses tier3_info then node_smoke.primus_dir",
+    )
+    venv_activate: str = Field(
+        default="",
+        description="Venv activate script; empty uses tier3_info then node_smoke.venv_activate",
+    )
     gpus_per_node: int = Field(default=8, ge=1, description="GPUs per node for torchrun")
     master_port: int = Field(default=1234, ge=1024, le=65535, description="Distributed master port")
     dump_path: str = Field(
@@ -1307,8 +1316,14 @@ class PreflightTier3InfoConfig(BaseModel):
     save_pdf: bool = Field(default=False, description="Generate PDF report via Primus")
     nccl_socket_ifname: str = Field(default="", description="NCCL_SOCKET_IFNAME override")
     gloo_socket_ifname: str = Field(default="", description="GLOO_SOCKET_IFNAME override")
-    nccl_ib_hca: str = Field(default="", description="NCCL_IB_HCA override")
-    nccl_ib_gid_index: Optional[int] = Field(default=None, description="NCCL_IB_GID_INDEX override")
+    nccl_ib_hca: str = Field(
+        default="",
+        description="NCCL_IB_HCA override (defaults to comma-joined connectivity_check.rdma.interfaces when empty)",
+    )
+    nccl_ib_gid_index: Optional[int] = Field(
+        default=None,
+        description="NCCL_IB_GID_INDEX override (defaults to connectivity_check.rdma.gid_index when null)",
+    )
     ssh_timeout: int = Field(default=600, ge=30, description="SSH timeout in seconds for the Tier 3 cluster run")
     extra_args: List[str] = Field(default_factory=list, description="Additional preflight CLI flags")
 
@@ -1328,10 +1343,11 @@ class PreflightReportingConfig(BaseModel):
 
     generate_html_report: bool = Field(default=True, description="Whether to generate HTML report")
     artifacts_root_dir: str = Field(
-        default="/home/{user-id}/preflight",
+        default="/tmp/preflight",
         description=(
             "Root directory for preflight artifacts. HTML report output and RDMA full_mesh ScriptLet logs use "
-            "<artifacts_root_dir>/rdma_connectivity_workspace/<session>/<round>/ on each node (NFS-friendly)."
+            "<artifacts_root_dir>/rdma_connectivity_workspace/<session>/<round>/ on each node (NFS-friendly). "
+            "Sample configs use /home/{user-id}/preflight; that placeholder is resolved only when present in JSON."
         ),
     )
     generate_rdma_pairs_csv: bool = Field(

--- a/cvs/tests/preflight/README.md
+++ b/cvs/tests/preflight/README.md
@@ -94,7 +94,7 @@ Located at: `cvs/input/config_file/preflight/preflight_config.json`
     },
     "reporting": {
       "generate_html_report": true,
-      "artifacts_root_dir": "/tmp/{user-id}/preflight",
+      "artifacts_root_dir": "/home/{user-id}/preflight",
       "generate_rdma_pairs_csv": false
     }
   }

--- a/cvs/tests/preflight/preflight_checks.py
+++ b/cvs/tests/preflight/preflight_checks.py
@@ -16,6 +16,7 @@ from cvs.lib.preflight.ifoe_l2_connectivity import IfoeL2ConnectivityCheck
 from cvs.lib.preflight.scaleup_fabric import NodeHealthCheck
 from cvs.lib.preflight.transferbench_smoke import TransferBenchSmokeCheck
 from cvs.lib.preflight.node_smoke import NodeSmokeCheck
+from cvs.lib.preflight.tier3_info import Tier3InfoCheck
 
 # RdmaConnectivityCheck not used - using legacy function temporarily
 from cvs.lib.preflight.report import PreflightReportGenerator
@@ -737,6 +738,58 @@ def test_node_smoke(phdl, config_dict):
     preflight_update_test_result()
 
 
+def test_tier3_info(phdl, config_dict):
+    """
+    Run Primus ``preflight --host --gpu --network`` info checks across the cluster.
+
+    Opt-in via ``tier3_info.connectivity_mode`` in the preflight config (default
+    ``skip``).  Uses parallel SSH with torchrun — no Slurm required.
+
+    Nodes that fail are reported but are **not** pruned from ``phdl``.
+    """
+    global preflight_results
+
+    if not phdl.reachable_hosts:
+        log.warning("Primus Tier 3 preflight info skipped: no reachable hosts remain after earlier preflight pruning")
+        preflight_results['tier3_info'] = {
+            'mode': 'skip',
+            'skipped': True,
+            'message': 'No reachable nodes available for Tier 3 preflight info',
+            'node_results': {},
+        }
+        preflight_update_test_result()
+        return
+
+    node_list = list(phdl.reachable_hosts)
+    log.info("Running Primus Tier 3 preflight info on %d reachable host(s)", len(node_list))
+
+    checker = Tier3InfoCheck(phdl, node_list, config_dict)
+    results = checker.run()
+    preflight_results['tier3_info'] = results
+
+    if results.get('skipped'):
+        log.info("Primus Tier 3 preflight info: %s", results.get('message', 'skipped'))
+        preflight_update_test_result()
+        return
+
+    failed_nodes = results.get('failed_nodes') or []
+    unknown_nodes = results.get('unknown_nodes') or []
+    total = results.get('total_nodes', 0)
+    passing = len(results.get('passing_nodes') or [])
+
+    if failed_nodes or unknown_nodes:
+        log.warning(
+            "Primus Tier 3 preflight info FAIL on %d/%d node(s): %s",
+            len(failed_nodes) + len(unknown_nodes),
+            total,
+            ", ".join(failed_nodes + unknown_nodes),
+        )
+    else:
+        log.info("Primus Tier 3 preflight info PASS on %d/%d nodes", passing, total)
+
+    preflight_update_test_result()
+
+
 def _l2ping_config(config_dict):
     """Return the customer-facing l2ping configuration."""
     config = _ifoe_config(config_dict).get('l2ping', {})
@@ -1299,6 +1352,7 @@ def test_generate_preflight_report(phdl, config_dict, request):
         'rocm_versions',
         'interface_names',
         'node_smoke',
+        'tier3_info',
         'ifoe_l2_connectivity',
         'transferbench_smoke',
         'rdma_connectivity',


### PR DESCRIPTION
Added Tier 3 preflight info (tier3_info.py, test_tier3_info.py, test_tier3_info in preflight_checks.py): runs primus-cli direct -- preflight --host --gpu --network across nodes via parallel SSH (no Slurm), mirroring the node_smoke pattern.

Config & schema: new tier3_info block in preflight_config.json (opt-in, default skip), PreflightTier3InfoConfig in schemas.py, Primus paths fall back to node_smoke, and gpus_per_node set to 8 for node health.

Reporting & setup: report.py adds Tier 3 summary/HTML; primus_setup.py supports tier3_info config section; default artifacts root moved to /home/{user-id}/preflight in node_smoke.py, rdma_connectivity.py, and docs.

Scope: Tier 3 runs Host/GPU/Network info checks only — not --perf-test (no intra/inter/ring bandwidth tests); unit tests added for flag building, output parsing, and parallel SSH launch.

Fixed the config file which was having transferbench and l2 ping default enabled