### PR TITLE
AIMVT-298: Detect scheduler type (SPUR/SLURM/bare-metal)

### DIFF
--- a/cvs/core/scheduler.py
+++ b/cvs/core/scheduler.py
@@ -1,0 +1,60 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+import shutil
+import subprocess
+from enum import Enum
+import os
+
+CHECK_TIMEOUT = 5
+SCHEDULER_ENV_VAR = "CVS_SCHEDULER"
+
+
+class Scheduler(Enum):
+    SPUR = 'spur'
+    SLURM = 'slurm'
+    BARE_METAL = 'bare_metal'
+
+
+# SPUR must be checked before SLURM or a spur cluster gets misclassified.
+SCHEDULER_CHECK_COMMANDS = {
+    Scheduler.SPUR: [["spur", "version"]],
+    Scheduler.SLURM: [["scontrol", "version"]],
+}
+
+
+def _command_succeeds(cmd: list[str]) -> bool:
+    if shutil.which(cmd[0]) is None:
+        return False
+    try:
+        result = subprocess.run(cmd, timeout=CHECK_TIMEOUT, capture_output=True, text=True)
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+def detect_scheduler() -> Scheduler:
+    """Detect which scheduler, if any, manages this cluster's compute nodes."""
+    scheduler = os.environ.get(SCHEDULER_ENV_VAR)
+    if scheduler is not None:
+        normalized = scheduler.strip().lower()
+        try:
+            return Scheduler(normalized)
+        except ValueError as exc:
+            valid = [s.value for s in Scheduler]
+            raise ValueError(
+                f"Unknown scheduler type {scheduler!r} in {SCHEDULER_ENV_VAR}, expected one of: {valid}"
+            ) from exc
+    for scheduler, cmds in SCHEDULER_CHECK_COMMANDS.items():
+        if all(_command_succeeds(cmd) for cmd in cmds):
+            return scheduler
+    return Scheduler.BARE_METAL
+
+
+def is_managed_compute() -> bool:
+    """True if compute nodes are managed by a scheduler (SPUR/SLURM), False for baremetal SSH."""
+    return detect_scheduler() != Scheduler.BARE_METAL

--- a/cvs/core/scheduler.py
+++ b/cvs/core/scheduler.py
@@ -55,6 +55,25 @@ def detect_scheduler() -> Scheduler:
     return Scheduler.BARE_METAL
 
 
+def _running_in_job_step() -> bool:
+    """True if this process was itself launched by srun as part of a job step.
+
+    scontrol/spur version succeeding only means scheduler tooling is installed
+    and the controller is reachable from wherever this process happens to run
+    (e.g. a plain SSH login to a scheduler-managed head node) - it says nothing
+    about whether this invocation is actually a step srun launched. SLURM_JOB_ID
+    alone is also insufficient: salloc sets it for a bare allocation with no
+    step. SLURM_STEP_ID/SLURM_PROCID are only set once srun has launched a step,
+    which is what "managed compute" actually needs to gate on. Verified
+    identical on SPUR (SLURM_JOB_ID/SLURM_STEP_ID/SLURM_PROCID) and real SLURM.
+    """
+    return (
+        os.environ.get("SLURM_JOB_ID") is not None
+        and os.environ.get("SLURM_STEP_ID") is not None
+        and os.environ.get("SLURM_PROCID") is not None
+    )
+
+
 def is_managed_compute() -> bool:
-    """True if compute nodes are managed by a scheduler (SPUR/SLURM), False for baremetal SSH."""
-    return detect_scheduler() != Scheduler.BARE_METAL
+    """True if this process is running inside a scheduler-launched job step, False otherwise."""
+    return detect_scheduler() != Scheduler.BARE_METAL and _running_in_job_step()

--- a/cvs/core/unittests/test_scheduler.py
+++ b/cvs/core/unittests/test_scheduler.py
@@ -14,7 +14,9 @@ import subprocess
 import unittest
 from unittest.mock import patch
 
-from cvs.core.scheduler import Scheduler, detect_scheduler, is_managed_compute
+from cvs.core.scheduler import Scheduler, _running_in_job_step, detect_scheduler, is_managed_compute
+
+JOB_STEP_ENV = {"SLURM_JOB_ID": "123", "SLURM_STEP_ID": "0", "SLURM_PROCID": "0"}
 
 
 def _which_only(*present):
@@ -101,17 +103,61 @@ class TestDetectScheduler(unittest.TestCase):
             detect_scheduler()
 
 
+class TestRunningInJobStep(unittest.TestCase):
+    def setUp(self):
+        patcher = patch.dict(os.environ, {}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @patch.dict(os.environ, JOB_STEP_ENV)
+    def test_true_when_all_three_vars_present(self):
+        self.assertTrue(_running_in_job_step())
+
+    def test_false_when_no_vars_present(self):
+        self.assertFalse(_running_in_job_step())
+
+    @patch.dict(os.environ, {"SLURM_STEP_ID": "0", "SLURM_PROCID": "0"})
+    def test_false_when_job_id_missing(self):
+        # e.g. plain SSH login to a scheduler-managed head node with scheduler
+        # tooling installed, but no srun step actually launched this process.
+        self.assertFalse(_running_in_job_step())
+
+    @patch.dict(os.environ, {"SLURM_JOB_ID": "123", "SLURM_PROCID": "0"})
+    def test_false_when_step_id_missing(self):
+        # e.g. salloc grants a bare allocation without launching a step.
+        self.assertFalse(_running_in_job_step())
+
+    @patch.dict(os.environ, {"SLURM_JOB_ID": "123", "SLURM_STEP_ID": "0"})
+    def test_false_when_procid_missing(self):
+        self.assertFalse(_running_in_job_step())
+
+
 class TestIsManagedCompute(unittest.TestCase):
+    def setUp(self):
+        patcher = patch.dict(os.environ, {}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     @patch("cvs.core.scheduler.detect_scheduler", return_value=Scheduler.SPUR)
-    def test_true_for_spur(self, _mock_detect):
+    @patch.dict(os.environ, JOB_STEP_ENV)
+    def test_true_for_spur_in_job_step(self, _mock_detect):
         self.assertTrue(is_managed_compute())
 
     @patch("cvs.core.scheduler.detect_scheduler", return_value=Scheduler.SLURM)
-    def test_true_for_slurm(self, _mock_detect):
+    @patch.dict(os.environ, JOB_STEP_ENV)
+    def test_true_for_slurm_in_job_step(self, _mock_detect):
         self.assertTrue(is_managed_compute())
 
     @patch("cvs.core.scheduler.detect_scheduler", return_value=Scheduler.BARE_METAL)
-    def test_false_for_bare_metal(self, _mock_detect):
+    @patch.dict(os.environ, JOB_STEP_ENV)
+    def test_false_for_bare_metal_even_in_job_step(self, _mock_detect):
+        self.assertFalse(is_managed_compute())
+
+    @patch("cvs.core.scheduler.detect_scheduler", return_value=Scheduler.SLURM)
+    def test_false_when_scheduler_managed_but_not_in_job_step(self, _mock_detect):
+        # The exact scenario from the PR review: scheduler tooling works (e.g. a
+        # plain SSH login to a managed head node) but this process was never
+        # launched via srun, so it must not be treated as managed compute.
         self.assertFalse(is_managed_compute())
 
 

--- a/cvs/core/unittests/test_scheduler.py
+++ b/cvs/core/unittests/test_scheduler.py
@@ -1,0 +1,119 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+# Unit tests for cvs/core/scheduler.py: scheduler-type detection used to decide
+# managed (SPUR/SLURM) vs unmanaged (baremetal SSH) orchestration. Mocks shutil.which
+# and subprocess.run so tests run with no scheduler binaries or live cluster access.
+
+import os
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from cvs.core.scheduler import Scheduler, detect_scheduler, is_managed_compute
+
+
+def _which_only(*present):
+    def fake_which(cmd):
+        return f"/usr/local/bin/{cmd}" if cmd in present else None
+
+    return fake_which
+
+
+class TestDetectScheduler(unittest.TestCase):
+    def setUp(self):
+        # CVS_SCHEDULER must not leak in from the ambient environment, since it
+        # short-circuits detection entirely and several tests rely on the
+        # command-probing path actually running.
+        patcher = patch.dict(os.environ, {}, clear=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @patch("cvs.core.scheduler.subprocess.run")
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only("spur"))
+    def test_spur_present_and_responding(self, _mock_which, mock_run):
+        mock_run.return_value.returncode = 0
+        self.assertEqual(detect_scheduler(), Scheduler.SPUR)
+        mock_run.assert_called_once_with(["spur", "version"], timeout=5, capture_output=True, text=True)
+
+    @patch("cvs.core.scheduler.subprocess.run")
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only("scontrol"))
+    def test_slurm_present_and_responding(self, _mock_which, mock_run):
+        mock_run.return_value.returncode = 0
+        self.assertEqual(detect_scheduler(), Scheduler.SLURM)
+
+    @patch("cvs.core.scheduler.subprocess.run")
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only("spur", "scontrol"))
+    def test_spur_checked_before_slurm(self, _mock_which, mock_run):
+        # spur ships its own scontrol/sinfo/squeue shims, so a spur cluster would also
+        # pass a generic scontrol check. SPUR must win when both are present.
+        mock_run.return_value.returncode = 0
+        self.assertEqual(detect_scheduler(), Scheduler.SPUR)
+
+    @patch("cvs.core.scheduler.subprocess.run")
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only())
+    def test_no_scheduler_binaries_on_path(self, _mock_which, mock_run):
+        self.assertEqual(detect_scheduler(), Scheduler.BARE_METAL)
+        mock_run.assert_not_called()
+
+    @patch("cvs.core.scheduler.subprocess.run")
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only("spur", "scontrol"))
+    def test_falls_through_to_slurm_when_spur_command_fails(self, _mock_which, mock_run):
+        # Regression test for the original bug: a failed spur check must not abort
+        # detection outright, it must fall through and still check SLURM.
+        def fake_run(cmd, **_kwargs):
+            result = unittest.mock.Mock()
+            result.returncode = 0 if cmd[0] == "scontrol" else 1
+            return result
+
+        mock_run.side_effect = fake_run
+        self.assertEqual(detect_scheduler(), Scheduler.SLURM)
+
+    @patch("cvs.core.scheduler.subprocess.run")
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only("spur", "scontrol"))
+    def test_both_commands_fail_returns_bare_metal(self, _mock_which, mock_run):
+        mock_run.return_value.returncode = 1
+        self.assertEqual(detect_scheduler(), Scheduler.BARE_METAL)
+
+    @patch("cvs.core.scheduler.subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="spur", timeout=5))
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only("spur"))
+    def test_hanging_command_treated_as_failure(self, _mock_which, _mock_run):
+        self.assertEqual(detect_scheduler(), Scheduler.BARE_METAL)
+
+    @patch("cvs.core.scheduler.subprocess.run")
+    @patch("cvs.core.scheduler.shutil.which", side_effect=_which_only())
+    @patch.dict(os.environ, {"CVS_SCHEDULER": "slurm"})
+    def test_env_override_takes_precedence_over_probing(self, _mock_which, mock_run):
+        self.assertEqual(detect_scheduler(), Scheduler.SLURM)
+        mock_run.assert_not_called()
+
+    @patch.dict(os.environ, {"CVS_SCHEDULER": "  SPUR  "})
+    def test_env_override_normalizes_case_and_whitespace(self):
+        self.assertEqual(detect_scheduler(), Scheduler.SPUR)
+
+    @patch.dict(os.environ, {"CVS_SCHEDULER": "kubernetes"})
+    def test_env_override_rejects_unknown_value(self):
+        with self.assertRaisesRegex(ValueError, "Unknown scheduler type 'kubernetes'"):
+            detect_scheduler()
+
+
+class TestIsManagedCompute(unittest.TestCase):
+    @patch("cvs.core.scheduler.detect_scheduler", return_value=Scheduler.SPUR)
+    def test_true_for_spur(self, _mock_detect):
+        self.assertTrue(is_managed_compute())
+
+    @patch("cvs.core.scheduler.detect_scheduler", return_value=Scheduler.SLURM)
+    def test_true_for_slurm(self, _mock_detect):
+        self.assertTrue(is_managed_compute())
+
+    @patch("cvs.core.scheduler.detect_scheduler", return_value=Scheduler.BARE_METAL)
+    def test_false_for_bare_metal(self, _mock_detect):
+        self.assertFalse(is_managed_compute())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `cvs/core/scheduler.py` with `detect_scheduler()` / `is_managed_compute()` to classify the cluster as SPUR, SLURM, or bare-metal, by probing for `spur version` / `scontrol version` on `PATH` (SPUR checked first, since it ships SLURM-compatible shims). Detection can be forced via the `CVS_SCHEDULER` env var.
- This is scoped to scheduler-type detection only (per ticket discussion) — no in-job rank/worker detection (`SLURM_PROCID`/`SLURM_NTASKS`/etc.), since those envs are only available once inside an active job/step.
- Adds unit tests under `cvs/core/unittests/test_scheduler.py` covering detection ordering, fallback to bare-metal, timeout/hang handling, and the `CVS_SCHEDULER` override (including normalization and invalid-value errors).

Ticket: AIMVT-298 (subtask of AIMVT-297, CVS in scheduler(SLURM/SPUR) environment)

## Test plan
- [x] `python -m unittest cvs.core.unittests.test_scheduler -v` — 13 tests pass
- [x] `ruff format --check` / `ruff check` clean