### PR TITLE
CVS RCCL: Capture amd-smi ECC counters before and after test on each node and warn if any counter delta > 0

### DIFF
--- a/cvs/input/config_file/rccl/rccl_config.json
+++ b/cvs/input/config_file/rccl/rccl_config.json
@@ -36,6 +36,10 @@
         "_comment_cvs_params": "The rccl_result_file.json will be appended by rccl_test_params.data_types. When it's float the file name will be rccl_result_file_float.json on the head node.",
         "cvs_params": {
             "cluster_snapshot_debug": "False",
+            "verify_ecc_delta": "False",
+            "_comment_verify_ecc_delta": "Set True to capture amd-smi ECC_BLOCKS (UMC, SDMA, GFX, MMHUB, PCIE_BIF, HDP, XGMI_WAFL CE/UE/DE) and log a post-test INFO table. Warns (does not fail) if any counter increases. Uses 'amd-smi metric -g all --json'. Raw amd-smi JSON is DEBUG-only. Requires passwordless sudo (same gate as dmesg).",
+            "verify_ecc_blocks": [],
+            "_comment_verify_ecc_blocks": "Optional list when verify_ecc_delta is True. Only these ECC blocks are captured, compared, and reported (e.g. [\"UMC\", \"XGMI_WAFL\"]). Omit or leave empty for all blocks.",
             "_comment_nic_model": "Set nic_model for validations (eg., 'thor' , 'ainic', 'connectx')",
             "nic_model": "thor",
             "verify_bus_bw": "False",

--- a/cvs/lib/rocm_plib.py
+++ b/cvs/lib/rocm_plib.py
@@ -5,7 +5,27 @@ The year included in the foregoing notice is the year of creation of the work.
 All code contained here is Property of Advanced Micro Devices, Inc.
 '''
 
+import json
+
 from cvs.lib.utils_lib import *
+
+RCCL_ECC_BLOCKS = (
+    'UMC',
+    'SDMA',
+    'GFX',
+    'MMHUB',
+    'PCIE_BIF',
+    'HDP',
+    'XGMI_WAFL',
+)
+ECC_COUNTER_FIELDS = ('correctable_count', 'uncorrectable_count', 'deferred_count')
+ECC_TABLE_COLUMNS = (
+    ('correctable_count', 'CE'),
+    ('uncorrectable_count', 'UE'),
+    ('deferred_count', 'DE'),
+)
+_ECC_BLOCK_COL_W = 10
+_ECC_NUM_COL_W = 9
 
 
 def _amd_smi_json_command(args: str) -> str:
@@ -18,6 +38,293 @@ def _amd_smi_json_command(args: str) -> str:
         "\"${AMD_SMI}\" "
         f"{args} --json'"
     )
+
+
+def _iter_amd_smi_gpu_dicts(node_payload):
+    if isinstance(node_payload, dict) and 'gpu_data' in node_payload:
+        return list(node_payload['gpu_data'])
+    if isinstance(node_payload, list):
+        return node_payload
+    return []
+
+
+def _to_int_counter(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _parse_amd_smi_json_payload(node, payload):
+    if payload is None or payload == '':
+        log.warning('ECC_BLOCKS: empty amd-smi output on node=%s; skipping', node)
+        return None
+    if isinstance(payload, (dict, list)):
+        return payload
+    try:
+        return json.loads(payload)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        log.warning('ECC_BLOCKS: failed to parse amd-smi JSON on node=%s; skipping', node)
+        return None
+
+
+def _ecc_blocks_or_default(blocks):
+    return blocks if blocks is not None else RCCL_ECC_BLOCKS
+
+
+def _project_ecc_blocks(raw_blocks, node, gpu_id, log_missing=True, blocks=None):
+    projected = {}
+    raw_blocks = raw_blocks if isinstance(raw_blocks, dict) else {}
+    for block in _ecc_blocks_or_default(blocks):
+        raw_fields = raw_blocks.get(block)
+        if not isinstance(raw_fields, dict):
+            if log_missing:
+                log.debug(
+                    'ECC_BLOCKS: node=%s gpu=%s block=%s not present in amd-smi output; treating counters as 0',
+                    node,
+                    gpu_id,
+                    block,
+                )
+            projected[block] = {field: 0 for field in ECC_COUNTER_FIELDS}
+            continue
+        projected[block] = {field: _to_int_counter(raw_fields.get(field, 0)) for field in ECC_COUNTER_FIELDS}
+    return projected
+
+
+def _format_ecc_block_fields(block_dict, blocks=None):
+    parts = []
+    for block in _ecc_blocks_or_default(blocks):
+        fields = block_dict.get(block, {})
+        for field in ECC_COUNTER_FIELDS:
+            parts.append(f'{block}.{field}={_to_int_counter(fields.get(field, 0))}')
+    return ' '.join(parts)
+
+
+def get_amd_smi_ecc_blocks_dict(phdl, blocks=None):
+    """Capture named ECC_BLOCKS counters from ``amd-smi metric -g all --json``.
+
+    Does not call fail_test: missing amd-smi or bad JSON is logged and skipped.
+    Extra amd-smi blocks outside RCCL_ECC_BLOCKS are ignored. Top-level ``ecc``
+    totals are ignored (those are what ``metric --ecc`` reports).
+
+    Args:
+        blocks: Optional subset of RCCL_ECC_BLOCKS to capture. Defaults to all blocks.
+    """
+    ecc_dict = {}
+    raw_by_node = phdl.exec(_amd_smi_json_command('metric -g all'), print_console=False)
+    for node, payload in raw_by_node.items():
+        log.debug('amd-smi metric -g all output node=%s:\n%s', node, payload)
+        parsed = _parse_amd_smi_json_payload(node, payload)
+        ecc_dict[node] = {}
+        if parsed is None:
+            continue
+        for gpu_dict in _iter_amd_smi_gpu_dicts(parsed):
+            if not isinstance(gpu_dict, dict):
+                continue
+            gpu_id = gpu_dict.get('gpu', 0)
+            ecc_dict[node][gpu_id] = _project_ecc_blocks(gpu_dict.get('ecc_blocks'), node, gpu_id, blocks=blocks)
+    return ecc_dict
+
+
+def log_ecc_blocks_snapshot(label, ecc_dict, blocks=None):
+    for node in sorted(ecc_dict.keys(), key=str):
+        for gpu_id in sorted(ecc_dict[node].keys(), key=str):
+            log.debug(
+                'ECC_BLOCKS %s: node=%s gpu=%s %s',
+                label,
+                node,
+                gpu_id,
+                _format_ecc_block_fields(ecc_dict[node][gpu_id], blocks=blocks),
+            )
+
+
+def _gpu_id_map(node_gpus):
+    return {str(gpu_id): gpu_id for gpu_id in node_gpus}
+
+
+def _ecc_delta_result(n_increased, n_decreased):
+    if n_increased and n_decreased:
+        return 'MIXED'
+    if n_increased:
+        return 'INCREASED'
+    if n_decreased:
+        return 'DECREASED'
+    return 'CLEAN'
+
+
+def _format_signed_delta(delta):
+    if delta > 0:
+        return f'+{delta}'
+    return str(delta)
+
+
+def _ecc_table_header():
+    parts = [f'{"block":<{_ECC_BLOCK_COL_W}}']
+    for _field, prefix in ECC_TABLE_COLUMNS:
+        for suffix in ('before', 'after', 'Delta'):
+            parts.append(f'{f"{prefix} {suffix}":>{_ECC_NUM_COL_W}}')
+    return '  '.join(parts)
+
+
+def _ecc_table_row(block, values):
+    parts = [f'{block:<{_ECC_BLOCK_COL_W}}']
+    for value in values:
+        parts.append(f'{value:>{_ECC_NUM_COL_W}}')
+    return '  '.join(parts)
+
+
+def _gpu_ecc_rows(before_blocks, after_blocks, blocks=None):
+    rows = []
+    n_increased = 0
+    n_decreased = 0
+    changes = []
+    for block in _ecc_blocks_or_default(blocks):
+        cells = []
+        for field, _prefix in ECC_TABLE_COLUMNS:
+            before_val = _to_int_counter(before_blocks.get(block, {}).get(field, 0))
+            after_val = _to_int_counter(after_blocks.get(block, {}).get(field, 0))
+            delta = after_val - before_val
+            cells.extend([str(before_val), str(after_val), _format_signed_delta(delta)])
+            if delta != 0:
+                changes.append(
+                    {
+                        'block': block,
+                        'field': field,
+                        'before': before_val,
+                        'after': after_val,
+                        'delta': delta,
+                    }
+                )
+            if delta > 0:
+                n_increased += 1
+            elif delta < 0:
+                n_decreased += 1
+        rows.append(_ecc_table_row(block, cells))
+    return rows, n_increased, n_decreased, changes
+
+
+def format_ecc_blocks_report(before, after, collective=None, blocks=None):
+    """Build the post-test ECC_BLOCKS INFO table (one section per node)."""
+    sections = []
+    nodes = sorted(set(before) | set(after), key=str)
+    for node in nodes:
+        before_gpus = _gpu_id_map(before.get(node, {}))
+        after_gpus = _gpu_id_map(after.get(node, {}))
+        gpu_keys = sorted(set(before_gpus) | set(after_gpus), key=str)
+        gpu_sections = []
+        node_increased = 0
+        node_decreased = 0
+        for gpu_key in gpu_keys:
+            gpu_id = after_gpus.get(gpu_key, before_gpus.get(gpu_key))
+            before_blocks = before.get(node, {}).get(before_gpus.get(gpu_key, gpu_id), {})
+            after_blocks = after.get(node, {}).get(after_gpus.get(gpu_key, gpu_id), {})
+            rows, n_increased, n_decreased, _changes = _gpu_ecc_rows(before_blocks, after_blocks, blocks=blocks)
+            node_increased += n_increased
+            node_decreased += n_decreased
+            gpu_result = _ecc_delta_result(n_increased, n_decreased)
+            gpu_lines = [f'  gpu={gpu_id}  result={gpu_result}', f'    {_ecc_table_header()}']
+            gpu_lines.extend(f'    {row}' for row in rows)
+            gpu_sections.append('\n'.join(gpu_lines))
+        header = 'ECC_BLOCKS'
+        if collective:
+            header += f'  collective={collective}'
+        header += (
+            f'  node={node}  result={_ecc_delta_result(node_increased, node_decreased)}'
+            f'  increased={node_increased}  decreased={node_decreased}'
+        )
+        sections.append(header + '\n' + '\n'.join(gpu_sections))
+    return '\n'.join(sections)
+
+
+def compare_ecc_blocks_snapshots(before, after, collective=None, blocks=None):
+    """Log a post-test ECC_BLOCKS table and warn on counter increases.
+
+    INFO is one aligned table per node (CE/UE/DE before, after, Delta). Capture
+    one-liners stay at DEBUG. Never calls fail_test.
+    Returns a list of increase dicts for unit tests.
+    """
+    increases = []
+    nodes = sorted(set(before) | set(after), key=str)
+    for node in nodes:
+        before_gpus = _gpu_id_map(before.get(node, {}))
+        after_gpus = _gpu_id_map(after.get(node, {}))
+        gpu_keys = sorted(set(before_gpus) | set(after_gpus), key=str)
+        for gpu_key in gpu_keys:
+            gpu_id = after_gpus.get(gpu_key, before_gpus.get(gpu_key))
+            before_blocks = before.get(node, {}).get(before_gpus.get(gpu_key, gpu_id), {})
+            after_blocks = after.get(node, {}).get(after_gpus.get(gpu_key, gpu_id), {})
+            _rows, _n_inc, _n_dec, changes = _gpu_ecc_rows(before_blocks, after_blocks, blocks=blocks)
+            for change in changes:
+                if change['delta'] > 0:
+                    log.warning(
+                        'ECC_BLOCKS increased: node=%s gpu=%s block=%s field=%s before=%s after=%s delta=%s',
+                        node,
+                        gpu_id,
+                        change['block'],
+                        change['field'],
+                        change['before'],
+                        change['after'],
+                        change['delta'],
+                    )
+                    increases.append({'node': node, 'gpu': gpu_id, **change})
+                elif change['delta'] < 0:
+                    log.warning(
+                        'ECC_BLOCKS decreased: node=%s gpu=%s block=%s field=%s before=%s after=%s delta=%s',
+                        node,
+                        gpu_id,
+                        change['block'],
+                        change['field'],
+                        change['before'],
+                        change['after'],
+                        change['delta'],
+                    )
+    report = format_ecc_blocks_report(before, after, collective=collective, blocks=blocks)
+    if report:
+        log.info('%s', f'======== ECC_BLOCKS report ========\n{report}')
+    return increases
+
+
+def ecc_delta_check_enabled(config_dict):
+    return bool(re.search('True', str(config_dict.get('cvs_params', {}).get('verify_ecc_delta', 'False')), re.I))
+
+
+_RCCL_ECC_BLOCKS_BY_UPPER = {block.upper(): block for block in RCCL_ECC_BLOCKS}
+
+
+def resolve_ecc_blocks(config_dict):
+    """Return the ECC block subset to capture/compare from cvs_params.verify_ecc_blocks."""
+    raw = config_dict.get('cvs_params', {}).get('verify_ecc_blocks')
+    if not raw:
+        return RCCL_ECC_BLOCKS
+    if isinstance(raw, str):
+        raw = [entry.strip() for entry in raw.split(',') if entry.strip()]
+    if not isinstance(raw, (list, tuple)):
+        log.warning('ECC_BLOCKS: verify_ecc_blocks must be a list; using all blocks')
+        return RCCL_ECC_BLOCKS
+    resolved = []
+    unknown = []
+    for entry in raw:
+        name = str(entry).strip().upper()
+        if not name:
+            continue
+        canonical = _RCCL_ECC_BLOCKS_BY_UPPER.get(name)
+        if canonical is None:
+            unknown.append(entry)
+            continue
+        if canonical not in resolved:
+            resolved.append(canonical)
+    if unknown:
+        log.warning('ECC_BLOCKS: unknown verify_ecc_blocks entries %s; ignoring', unknown)
+    if not resolved:
+        log.warning('ECC_BLOCKS: no valid verify_ecc_blocks entries; using all blocks')
+        return RCCL_ECC_BLOCKS
+    return tuple(resolved)
+
+
+def capture_ecc_blocks_snapshot(phdl, label, blocks=None):
+    ecc_dict = get_amd_smi_ecc_blocks_dict(phdl, blocks=blocks)
+    log_ecc_blocks_snapshot(label, ecc_dict, blocks=blocks)
+    return ecc_dict
 
 
 def get_rocm_smi_dict(phdl):
@@ -53,13 +360,8 @@ def get_amd_smi_ras_metrics_dict(phdl):
         ras_dict[node] = {}
         log.info('^^^^^')
         log.info("%s", ras_dict_t[node])
-        if isinstance(ras_dict_t[node], dict):
-            if 'gpu_data' in ras_dict_t[node].keys():
-                for gpu_dict in list(ras_dict_t[node]['gpu_data']):
-                    ras_dict[node][gpu_dict['gpu']] = gpu_dict['ecc']
-        elif isinstance(ras_dict_t[node], list):
-            for gpu_dict in ras_dict_t[node]:
-                ras_dict[node][gpu_dict['gpu']] = gpu_dict['ecc']
+        for gpu_dict in _iter_amd_smi_gpu_dicts(ras_dict_t[node]):
+            ras_dict[node][gpu_dict['gpu']] = gpu_dict['ecc']
 
     return ras_dict
 
@@ -69,13 +371,8 @@ def get_amd_smi_pcie_metrics_dict(phdl):
     pcie_dict_t = convert_phdl_json_to_dict(phdl.exec(_amd_smi_json_command('metric --pcie')))
     for node in pcie_dict_t.keys():
         pcie_dict[node] = {}
-        if isinstance(pcie_dict_t[node], dict):
-            if 'gpu_data' in pcie_dict_t[node].keys():
-                for gpu_dict in list(pcie_dict_t[node]['gpu_data']):
-                    pcie_dict[node][gpu_dict['gpu']] = gpu_dict['pcie']
-        elif isinstance(pcie_dict_t[node], list):
-            for gpu_dict in pcie_dict_t[node]:
-                pcie_dict[node][gpu_dict['gpu']] = gpu_dict['pcie']
+        for gpu_dict in _iter_amd_smi_gpu_dicts(pcie_dict_t[node]):
+            pcie_dict[node][gpu_dict['gpu']] = gpu_dict['pcie']
     return pcie_dict
 
 

--- a/cvs/lib/unittests/test_rocm_plib.py
+++ b/cvs/lib/unittests/test_rocm_plib.py
@@ -1,0 +1,293 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import cvs.lib.rocm_plib as rocm_plib
+
+
+def _zero_blocks():
+    return {block: {field: 0 for field in rocm_plib.ECC_COUNTER_FIELDS} for block in rocm_plib.RCCL_ECC_BLOCKS}
+
+
+def _blocks_with(**overrides):
+    blocks = _zero_blocks()
+    for block, fields in overrides.items():
+        blocks[block].update(fields)
+    return blocks
+
+
+def _logged_text(mock_log):
+    chunks = []
+    for call in mock_log.call_args_list:
+        args = call[0]
+        if len(args) == 1:
+            chunks.append(str(args[0]))
+        else:
+            chunks.append(args[0] % args[1:])
+    return '\n'.join(chunks)
+
+
+def _metric_gpu(gpu_id, ecc_blocks, extra_ecc=None):
+    gpu = {'gpu': gpu_id, 'ecc_blocks': ecc_blocks}
+    if extra_ecc is not None:
+        gpu['ecc'] = extra_ecc
+    return gpu
+
+
+class TestIterAmdSmiGpuDicts(unittest.TestCase):
+    def test_list_payload(self):
+        gpus = [{'gpu': 0}, {'gpu': 1}]
+        self.assertEqual(rocm_plib._iter_amd_smi_gpu_dicts(gpus), gpus)
+
+    def test_gpu_data_wrapper(self):
+        gpus = [{'gpu': 0}]
+        self.assertEqual(rocm_plib._iter_amd_smi_gpu_dicts({'gpu_data': gpus}), gpus)
+
+    def test_empty_or_unknown(self):
+        self.assertEqual(rocm_plib._iter_amd_smi_gpu_dicts({}), [])
+        self.assertEqual(rocm_plib._iter_amd_smi_gpu_dicts(None), [])
+
+
+class TestGetAmdSmiEccBlocksDict(unittest.TestCase):
+    def test_parses_list_shaped_metric_json(self):
+        blocks = _blocks_with(UMC={'correctable_count': 1, 'uncorrectable_count': 2})
+        payload = json.dumps([_metric_gpu(0, blocks)])
+        phdl = MagicMock()
+        phdl.exec.return_value = {'node1': payload}
+
+        result = rocm_plib.get_amd_smi_ecc_blocks_dict(phdl)
+        self.assertEqual(result['node1'][0]['UMC']['correctable_count'], 1)
+        self.assertEqual(result['node1'][0]['UMC']['uncorrectable_count'], 2)
+        self.assertEqual(result['node1'][0]['UMC']['deferred_count'], 0)
+        self.assertEqual(result['node1'][0]['GFX']['correctable_count'], 0)
+        phdl.exec.assert_called_once()
+        self.assertIn('metric -g all', phdl.exec.call_args[0][0])
+        self.assertFalse(phdl.exec.call_args.kwargs.get('print_console', True))
+
+    def test_parses_gpu_data_wrapper(self):
+        blocks = _zero_blocks()
+        payload = json.dumps({'gpu_data': [_metric_gpu(1, blocks)]})
+        phdl = MagicMock()
+        phdl.exec.return_value = {'node1': payload}
+
+        result = rocm_plib.get_amd_smi_ecc_blocks_dict(phdl)
+        self.assertIn(1, result['node1'])
+
+    def test_ignores_extra_blocks_and_numeric_strings(self):
+        raw = _zero_blocks()
+        raw['UMC'] = {'correctable_count': '4', 'uncorrectable_count': '0', 'deferred_count': '2'}
+        raw['FOO'] = {'correctable_count': 9, 'uncorrectable_count': 9}
+        payload = json.dumps([_metric_gpu(0, raw)])
+        phdl = MagicMock()
+        phdl.exec.return_value = {'node1': payload}
+
+        result = rocm_plib.get_amd_smi_ecc_blocks_dict(phdl)
+        self.assertEqual(result['node1'][0]['UMC']['correctable_count'], 4)
+        self.assertEqual(result['node1'][0]['UMC']['deferred_count'], 2)
+        self.assertNotIn('FOO', result['node1'][0])
+
+    def test_ecc_totals_without_ecc_blocks_are_zero(self):
+        gpu = {
+            'gpu': 0,
+            'ecc': {
+                'total_correctable_count': 11,
+                'total_uncorrectable_count': 7,
+            },
+        }
+        phdl = MagicMock()
+        phdl.exec.return_value = {'node1': json.dumps([gpu])}
+
+        with patch.object(rocm_plib.log, 'debug') as mock_debug:
+            result = rocm_plib.get_amd_smi_ecc_blocks_dict(phdl)
+        self.assertEqual(result['node1'][0], _zero_blocks())
+        self.assertFalse(any('total_correctable_count=11' in str(c) for c in mock_debug.call_args_list))
+        missing_blocks = [c.args[3] for c in mock_debug.call_args_list if c.args and 'not present' in c.args[0]]
+        self.assertEqual(missing_blocks, list(rocm_plib.RCCL_ECC_BLOCKS))
+
+    def test_empty_amd_smi_skips_without_fail_test(self):
+        phdl = MagicMock()
+        phdl.exec.return_value = {'node1': '[]'}
+        with patch('cvs.lib.rocm_plib.fail_test') as mock_fail:
+            result = rocm_plib.get_amd_smi_ecc_blocks_dict(phdl)
+        self.assertEqual(result, {'node1': {}})
+        mock_fail.assert_not_called()
+
+    def test_invalid_json_warns_without_fail_test(self):
+        phdl = MagicMock()
+        phdl.exec.return_value = {'node1': 'not-json'}
+        with patch.object(rocm_plib.log, 'warning') as mock_warn, patch('cvs.lib.rocm_plib.fail_test') as mock_fail:
+            result = rocm_plib.get_amd_smi_ecc_blocks_dict(phdl)
+        self.assertEqual(result, {'node1': {}})
+        mock_fail.assert_not_called()
+        mock_warn.assert_called()
+
+
+class TestCompareEccBlocksSnapshots(unittest.TestCase):
+    def test_no_delta_logs_table_not_warning(self):
+        snap = {'node1': {0: _zero_blocks()}}
+        with patch.object(rocm_plib.log, 'info') as mock_info, patch.object(rocm_plib.log, 'warning') as mock_warn:
+            increases = rocm_plib.compare_ecc_blocks_snapshots(snap, snap, collective='all_reduce_perf')
+        self.assertEqual(increases, [])
+        mock_warn.assert_not_called()
+        text = _logged_text(mock_info)
+        self.assertTrue(text.startswith('======== ECC_BLOCKS report ========\nECC_BLOCKS  collective=all_reduce_perf'))
+        self.assertIn('ECC_BLOCKS  collective=all_reduce_perf  node=node1  result=CLEAN', text)
+        self.assertIn('gpu=0  result=CLEAN', text)
+        self.assertIn('CE before', text)
+        self.assertIn('CE Delta', text)
+        self.assertIn('UE Delta', text)
+        self.assertIn('DE Delta', text)
+        self.assertIn('UMC', text)
+        self.assertIn('XGMI_WAFL', text)
+        self.assertNotIn('ECC_BLOCKS before:', text)
+        self.assertNotIn('ECC_BLOCKS after:', text)
+        self.assertNotIn('ECC_BLOCKS delta:', text)
+
+    def test_correctable_increase_table_and_warn(self):
+        before = {'node1': {0: _zero_blocks()}}
+        after = {'node1': {0: _blocks_with(UMC={'correctable_count': 3})}}
+        with patch.object(rocm_plib.log, 'info') as mock_info, patch.object(rocm_plib.log, 'warning') as mock_warn:
+            increases = rocm_plib.compare_ecc_blocks_snapshots(before, after)
+        self.assertEqual(len(increases), 1)
+        self.assertEqual(increases[0]['field'], 'correctable_count')
+        text = _logged_text(mock_info)
+        self.assertIn('result=INCREASED', text)
+        self.assertIn('+3', text)
+        self.assertIn('increased', mock_warn.call_args[0][0])
+
+    def test_uncorrectable_increase_warns(self):
+        before = {'node1': {0: _zero_blocks()}}
+        after = {'node1': {0: _blocks_with(SDMA={'uncorrectable_count': 1})}}
+        increases = rocm_plib.compare_ecc_blocks_snapshots(before, after)
+        self.assertEqual(increases[0]['block'], 'SDMA')
+        self.assertEqual(increases[0]['field'], 'uncorrectable_count')
+
+    def test_deferred_increase_warns(self):
+        before = {'node1': {0: _zero_blocks()}}
+        after = {'node1': {0: _blocks_with(GFX={'deferred_count': 2})}}
+        with patch.object(rocm_plib.log, 'info') as mock_info:
+            increases = rocm_plib.compare_ecc_blocks_snapshots(before, after)
+        self.assertEqual(increases[0]['field'], 'deferred_count')
+        self.assertEqual(increases[0]['delta'], 2)
+        self.assertIn('+2', _logged_text(mock_info))
+
+    def test_missing_block_after_treated_as_zero(self):
+        before = {'node1': {0: _blocks_with(GFX={'correctable_count': 2})}}
+        after = {'node1': {0: {}}}
+        increases = rocm_plib.compare_ecc_blocks_snapshots(before, after)
+        self.assertEqual(increases, [])
+
+    def test_decrease_warns_but_is_not_an_increase(self):
+        before = {'node1': {0: _blocks_with(HDP={'correctable_count': 4})}}
+        after = {'node1': {0: _zero_blocks()}}
+        with patch.object(rocm_plib.log, 'warning') as mock_warn, patch.object(rocm_plib.log, 'info') as mock_info:
+            increases = rocm_plib.compare_ecc_blocks_snapshots(before, after)
+        self.assertEqual(increases, [])
+        self.assertIn('decreased', mock_warn.call_args[0][0])
+        text = _logged_text(mock_info)
+        self.assertIn('result=DECREASED', text)
+        self.assertIn('-4', text)
+
+    def test_mixed_increase_and_decrease(self):
+        before = {'node1': {0: _blocks_with(UMC={'correctable_count': 1}, HDP={'correctable_count': 4})}}
+        after = {'node1': {0: _blocks_with(UMC={'correctable_count': 5})}}
+        with patch.object(rocm_plib.log, 'info') as mock_info:
+            increases = rocm_plib.compare_ecc_blocks_snapshots(before, after)
+        self.assertEqual(len(increases), 1)
+        text = _logged_text(mock_info)
+        self.assertIn('result=MIXED', text)
+        self.assertIn('+4', text)
+        self.assertIn('-4', text)
+
+    def test_snapshot_log_is_debug_not_info(self):
+        snap = {'node1': {0: _zero_blocks()}}
+        with patch.object(rocm_plib.log, 'debug') as mock_debug, patch.object(rocm_plib.log, 'info') as mock_info:
+            rocm_plib.log_ecc_blocks_snapshot('before', snap)
+        mock_info.assert_not_called()
+        line = _logged_text(mock_debug)
+        self.assertIn('ECC_BLOCKS before:', line)
+        for block in rocm_plib.RCCL_ECC_BLOCKS:
+            self.assertIn(f'{block}.correctable_count=', line)
+            self.assertIn(f'{block}.deferred_count=', line)
+
+
+class TestEccDeltaCheckEnabled(unittest.TestCase):
+    def test_default_false_when_key_missing(self):
+        self.assertFalse(rocm_plib.ecc_delta_check_enabled({}))
+        self.assertTrue(rocm_plib.ecc_delta_check_enabled({'cvs_params': {'verify_ecc_delta': 'True'}}))
+        self.assertFalse(rocm_plib.ecc_delta_check_enabled({'cvs_params': {'verify_ecc_delta': 'False'}}))
+
+
+class TestResolveEccBlocks(unittest.TestCase):
+    def test_missing_key_returns_all_blocks(self):
+        self.assertEqual(rocm_plib.resolve_ecc_blocks({}), rocm_plib.RCCL_ECC_BLOCKS)
+        self.assertEqual(
+            rocm_plib.resolve_ecc_blocks({'cvs_params': {'verify_ecc_blocks': []}}),
+            rocm_plib.RCCL_ECC_BLOCKS,
+        )
+
+    def test_subset_from_list(self):
+        blocks = rocm_plib.resolve_ecc_blocks({'cvs_params': {'verify_ecc_blocks': ['UMC', 'SDMA']}})
+        self.assertEqual(blocks, ('UMC', 'SDMA'))
+
+    def test_normalizes_case(self):
+        blocks = rocm_plib.resolve_ecc_blocks({'cvs_params': {'verify_ecc_blocks': ['umc', 'xgmi_wafl']}})
+        self.assertEqual(blocks, ('UMC', 'XGMI_WAFL'))
+
+    def test_comma_separated_string(self):
+        blocks = rocm_plib.resolve_ecc_blocks({'cvs_params': {'verify_ecc_blocks': 'UMC, GFX'}})
+        self.assertEqual(blocks, ('UMC', 'GFX'))
+
+    def test_unknown_entries_warn_and_fallback_to_all(self):
+        with patch.object(rocm_plib.log, 'warning') as mock_warn:
+            blocks = rocm_plib.resolve_ecc_blocks({'cvs_params': {'verify_ecc_blocks': ['FOO']}})
+        self.assertEqual(blocks, rocm_plib.RCCL_ECC_BLOCKS)
+        messages = [call[0][0] for call in mock_warn.call_args_list]
+        self.assertIn('ECC_BLOCKS: unknown verify_ecc_blocks entries %s; ignoring', messages)
+        self.assertIn('ECC_BLOCKS: no valid verify_ecc_blocks entries; using all blocks', messages)
+
+    def test_mixed_valid_and_unknown_keeps_valid_only(self):
+        with patch.object(rocm_plib.log, 'warning') as mock_warn:
+            blocks = rocm_plib.resolve_ecc_blocks({'cvs_params': {'verify_ecc_blocks': ['UMC', 'FOO']}})
+        self.assertEqual(blocks, ('UMC',))
+        mock_warn.assert_called_once()
+
+    def test_invalid_type_warns_and_returns_all(self):
+        with patch.object(rocm_plib.log, 'warning') as mock_warn:
+            blocks = rocm_plib.resolve_ecc_blocks({'cvs_params': {'verify_ecc_blocks': 42}})
+        self.assertEqual(blocks, rocm_plib.RCCL_ECC_BLOCKS)
+        self.assertIn('must be a list', mock_warn.call_args[0][0])
+
+
+class TestFilteredEccBlocks(unittest.TestCase):
+    def test_get_amd_smi_projects_subset_only(self):
+        blocks = _blocks_with(UMC={'correctable_count': 1}, GFX={'correctable_count': 9})
+        payload = json.dumps([_metric_gpu(0, blocks)])
+        phdl = MagicMock()
+        phdl.exec.return_value = {'node1': payload}
+
+        result = rocm_plib.get_amd_smi_ecc_blocks_dict(phdl, blocks=('UMC',))
+        self.assertEqual(set(result['node1'][0].keys()), {'UMC'})
+        self.assertEqual(result['node1'][0]['UMC']['correctable_count'], 1)
+
+    def test_compare_ignores_non_selected_blocks(self):
+        before = {'node1': {0: _zero_blocks()}}
+        after = {'node1': {0: _blocks_with(GFX={'correctable_count': 5})}}
+        with patch.object(rocm_plib.log, 'info') as mock_info, patch.object(rocm_plib.log, 'warning') as mock_warn:
+            increases = rocm_plib.compare_ecc_blocks_snapshots(before, after, blocks=('UMC',))
+        self.assertEqual(increases, [])
+        mock_warn.assert_not_called()
+        text = _logged_text(mock_info)
+        self.assertIn('UMC', text)
+        self.assertNotIn('GFX', text)
+
+    def test_compare_reports_selected_block_increase(self):
+        before = {'node1': {0: _zero_blocks()}}
+        after = {'node1': {0: _blocks_with(UMC={'correctable_count': 2})}}
+        increases = rocm_plib.compare_ecc_blocks_snapshots(before, after, blocks=('UMC',))
+        self.assertEqual(len(increases), 1)
+        self.assertEqual(increases[0]['block'], 'UMC')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/tests/rccl/README.md
+++ b/cvs/tests/rccl/README.md
@@ -160,3 +160,4 @@ The RCCL config keeps benchmark intent and validation settings, while RCCL/NCCL/
 - **Regression cases**: Each combination in the Cartesian product gets its own result file suffix
 - **Single env dump**: Only `test_print_env_once` prints the environment; other tests focus on performance
 - **Tree filter**: Algorithm restrictions apply to maintain compatibility
+- **ECC_BLOCKS**: When `cvs_params.verify_ecc_delta` is `"True"` (default `"False"`), `rccl_perf` and `rccl_regression` capture UMC/SDMA/GFX/MMHUB/PCIE_BIF/HDP/XGMI_WAFL CE/UE/DE counters and log one post-test INFO table per node. Optionally set `cvs_params.verify_ecc_blocks` to a list of block names (e.g. `["UMC", "XGMI_WAFL"]`) to limit capture and delta reporting to those blocks only; omit or leave empty for all blocks. Grep the pytest log for `ECC_BLOCKS`. Requires passwordless sudo.

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -284,14 +284,18 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
     Flow:
       1) Capture start time to bound dmesg checks later.
       2) Optionally snapshot cluster metrics before the test (for debugging/compare).
-      3) Optionally source environment script if provided in config.
-      4) Invoke rccl_lib.rccl_cluster_test with parameters built from config and fixtures.
-      5) Capture end time and verify dmesg for errors between start/end.
-      6) Optionally snapshot metrics again and compare before/after.
-      7) Call update_test_result() to finalize test status.
+      3) Optionally capture ECC_BLOCKS counters before the test.
+      4) Optionally source environment script if provided in config.
+      5) Invoke rccl_lib.rccl_cluster_test with parameters built from config and fixtures.
+      6) Optionally capture ECC_BLOCKS after the test, log deltas, and warn on increases.
+      7) Capture end time and verify dmesg for errors between start/end.
+      8) Optionally snapshot metrics again and compare before/after.
+      9) Call update_test_result() to finalize test status.
 
     Notes:
-      - cluster_snapshot_debug controls whether before/after snapshots are taken.
+      - cluster_snapshot_debug controls whether before/after cluster snapshots are taken.
+      - verify_ecc_delta (default False) logs a post-test ECC_BLOCKS table (CE/UE/DE before, after, Delta).
+      - verify_ecc_blocks (optional list) limits capture/compare to named blocks when verify_ecc_delta is True.
     """
 
     globals.error_list = []
@@ -300,8 +304,8 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
     if not can_use_sudo:
         no_sudo_nodes = [node for node, ok in sudo_status.items() if not ok]
         log.warning(
-            "Skipping dmesg markers/verification and sudo-only snapshots because passwordless sudo is unavailable "
-            "on nodes: %s",
+            "Skipping dmesg markers/verification, ECC_BLOCKS capture, and sudo-only snapshots because "
+            "passwordless sudo is unavailable on nodes: %s",
             no_sudo_nodes,
         )
 
@@ -328,6 +332,12 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
     ):
         cluster_dict_before = create_cluster_metrics_snapshot(phdl)
 
+    verify_ecc_delta = ecc_delta_check_enabled(config_dict)
+    ecc_blocks = resolve_ecc_blocks(config_dict) if verify_ecc_delta else None
+    ecc_before = {}
+    if can_use_sudo and verify_ecc_delta:
+        ecc_before = capture_ecc_blocks_snapshot(phdl, 'before', blocks=ecc_blocks)
+
     # Use the new grouped parameter function
     env_script = config_dict.get('env_source_script', '/dev/null')
     result_dict = rccl_lib.rccl_perf(
@@ -345,6 +355,10 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
     log.info("%s", result_dict)
     key_name = f'{rccl_collective}'
     rccl_res_dict[key_name] = result_dict
+
+    if can_use_sudo and verify_ecc_delta:
+        ecc_after = capture_ecc_blocks_snapshot(phdl, 'after', blocks=ecc_blocks)
+        compare_ecc_blocks_snapshots(ecc_before, ecc_after, collective=rccl_collective, blocks=ecc_blocks)
 
     # Scan dmesg between start and end times cluster wide ..
     # end_time = phdl.exec('date')

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -354,14 +354,18 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     Flow:
       1) Capture start time to bound dmesg checks later.
       2) Optionally snapshot cluster metrics before the test (for debugging/compare).
-      3) Build env_overrides dict from all regression parameters.
-      4) Invoke rccl_lib.rccl_regression with parameters built from config and fixtures.
-      5) Capture end time and verify dmesg for errors between start/end.
-      6) Optionally snapshot metrics again and compare before/after.
-      7) Call update_test_result() to finalize test status.
+      3) Optionally capture ECC_BLOCKS counters before the test.
+      4) Build env_overrides dict from all regression parameters.
+      5) Invoke rccl_lib.rccl_regression with parameters built from config and fixtures.
+      6) Optionally capture ECC_BLOCKS after the test, log deltas, and warn on increases.
+      7) Capture end time and verify dmesg for errors between start/end.
+      8) Optionally snapshot metrics again and compare before/after.
+      9) Call update_test_result() to finalize test status.
 
     Notes:
-      - cluster_snapshot_debug controls whether before/after snapshots are taken.
+      - cluster_snapshot_debug controls whether before/after cluster snapshots are taken.
+      - verify_ecc_delta (default False) logs a post-test ECC_BLOCKS table (CE/UE/DE before, after, Delta).
+      - verify_ecc_blocks (optional list) limits capture/compare to named blocks when verify_ecc_delta is True.
     """
 
     globals.error_list = []
@@ -370,8 +374,8 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     if not can_use_sudo:
         no_sudo_nodes = [node for node, ok in sudo_status.items() if not ok]
         log.warning(
-            "Skipping dmesg markers/verification and sudo-only snapshots because passwordless sudo is unavailable "
-            "on nodes: %s",
+            "Skipping dmesg markers/verification, ECC_BLOCKS capture, and sudo-only snapshots because "
+            "passwordless sudo is unavailable on nodes: %s",
             no_sudo_nodes,
         )
 
@@ -399,6 +403,12 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     ):
         cluster_dict_before = create_cluster_metrics_snapshot(phdl)
 
+    verify_ecc_delta = ecc_delta_check_enabled(config_dict)
+    ecc_blocks = resolve_ecc_blocks(config_dict) if verify_ecc_delta else None
+    ecc_before = {}
+    if can_use_sudo and verify_ecc_delta:
+        ecc_before = capture_ecc_blocks_snapshot(phdl, 'before', blocks=ecc_blocks)
+
     # Build env_overrides from all regression parameters (convert values to strings)
     env_overrides = {k: str(v) for k, v in regression_params.items()}
 
@@ -419,6 +429,10 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     log.info("%s", result_dict)
     key_name = f'{rccl_collective}-{params_str}'
     rccl_res_dict[key_name] = result_dict
+
+    if can_use_sudo and verify_ecc_delta:
+        ecc_after = capture_ecc_blocks_snapshot(phdl, 'after', blocks=ecc_blocks)
+        compare_ecc_blocks_snapshots(ecc_before, ecc_after, collective=rccl_collective, blocks=ecc_blocks)
 
     # Scan dmesg between start and end times cluster wide ..
     # end_time = phdl.exec('date')

--- a/docs/reference/configuration-files/rccl.rst
+++ b/docs/reference/configuration-files/rccl.rst
@@ -105,6 +105,7 @@ Main config file used by ``rccl_perf`` and ``rccl_regression``:
           "verify_bw_dip": "True",
           "verify_lat_dip": "True",
           "cluster_snapshot_debug": "False",
+          "verify_ecc_delta": "False",
           "rccl_result_file": "/home/{user-id}/rccl_result_file.json"
         },
         "results": {}
@@ -237,6 +238,9 @@ Configuration parameters for RCCL suites:
    * - ``cluster_snapshot_debug``
      - ``"False"``
      - Enables before/after cluster metric snapshots around tests.
+   * - ``verify_ecc_delta``
+     - ``"False"``
+     - Capture ``amd-smi metric -g all --json`` before and after each RCCL test. After the test, logs one INFO table per node with UMC, SDMA, GFX, MMHUB, PCIE_BIF, HDP, and XGMI_WAFL counters (CE/UE/DE before, after, and Delta). Warns if any counter increases. Does not fail the test. Skipped without passwordless sudo. Independent of ``cluster_snapshot_debug``. Raw ``amd-smi`` JSON and capture one-liners are DEBUG.
    * - ``results``
      - ``{}``
      - Expected threshold values used for pass/fail validation.


### PR DESCRIPTION
… capture and delta reporting

## Motivation

Capture amd-smi ECC counters on each node before and after the test, and warn when any counter increases. This makes it easier to spot silent ECC activity during validation and flag nodes that may need further investigation.

## Technical Details

RCCL ECC delta checking is opt-in via cvs_params.verify_ecc_delta ("True"; default "False") in rccl_perf and rccl_regression. It captures amd-smi ECC counters (amd-smi metric -g all --json) before and after each collective and logs one INFO table per node (CE/UE/DE before/after/delta for all seven blocks by default). Use verify_ecc_blocks (e.g. ["UMC", "XGMI_WAFL"]) to limit which blocks are checked; omit or leave empty for all blocks. Requires passwordless sudo (same gate as dmesg). Counter increases log WARNING but do not fail the test. Grep the pytest log for ECC_BLOCKS.

Ticket: AIMVT-307 (DCCS-6489)

## Test Plan

Run RCCL on a live cluster with verify_ecc_delta enabled and disabled, varying verify_ecc_blocks (omitted, empty, lowercase, valid subset, mixed valid/invalid, and invalid syntax), and confirm ECC capture, logging, warnings, and pass/fail behavior match expectations.

## Test Result

Ran RCCL with varied cvs_params ECC settings on a live cluster. With verify_ecc_delta: "False" (or omitted), no ECC_BLOCKS output. With verify_ecc_delta: "True", confirmed full before/after ECC tables when verify_ecc_blocks is omitted or [], and block-filtered output for lowercase names and mixed valid/invalid lists (e.g. ["UMC","test","SDMA"] reports only UMC and SDMA). Invalid block names emit WARNING and fall back to all blocks when none remain valid. Invalid verify_ecc_blocks syntax is handled without breaking the run. ECC warnings do not fail the test when the collective itself fails.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [ ] Ran `make fmt-check`, `make lint`, and `make test` (or `make ut`) locally and all checks pass.
- [ ] Added/updated unit tests in `cvs/lib/unittests/test_rocm_plib.py` for new ECC delta helpers.
- [ ] Updated RCCL docs and config (`docs/reference/configuration-files/rccl.rst`, `cvs/tests/rccl/README.md`, `rccl_config.json` comments).
- [ ] Verified on a live cluster with `verify_ecc_delta` enabled/disabled and varied `verify_ecc_blocks` settings.
- [ ] Confirmed default behavior is unchanged (`verify_ecc_delta` defaults to `"False"`).
- [ ] No cluster credentials, SSH keys, or customer-specific values committed.