### PR TITLE
feat(JAX): jaxmaxtext model configs + smoke & checkpoint-resume tests + incremental log streaming

### DIFF
--- a/cvs/core/orchestrators/container.py
+++ b/cvs/core/orchestrators/container.py
@@ -651,7 +651,7 @@ class ContainerOrchestrator(BaremetalOrchestrator):
 
         return self.runtime.exec(self.container_id, cmd, hosts, timeout, detailed=detailed, print_console=print_console)
 
-    def exec_cmd_list(self, cmd_list, timeout=None):
+    def exec_cmd_list(self, cmd_list, timeout=None, print_console=True):
         """
         Execute different commands on different hosts inside the container.
 
@@ -662,6 +662,9 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         Args:
             cmd_list: List of commands, one per host in host order
             timeout: Command timeout
+            print_console: If False, the commands' output is returned but not
+                logged. Use for polling/bulk reads the caller surfaces itself,
+                so a repeated log tail is not re-echoed on every poll.
 
         Returns:
             Dictionary mapping hosts to execution results
@@ -672,7 +675,7 @@ class ContainerOrchestrator(BaremetalOrchestrator):
         if not self.container_id:
             raise RuntimeError("No containers running. Call setup_containers() first.")
 
-        return self.runtime.exec_cmd_list(self.container_id, cmd_list, timeout)
+        return self.runtime.exec_cmd_list(self.container_id, cmd_list, timeout, print_console=print_console)
 
     def exec_on_host(self, cmd, hosts=None, timeout=None, detailed=False, print_console=True):
         """Execute command on the cluster host OS (SSH), not inside the container."""

--- a/cvs/core/runtimes/docker.py
+++ b/cvs/core/runtimes/docker.py
@@ -267,7 +267,7 @@ class DockerRuntime:
 
         return self.orchestrator.all.exec(exec_cmd, timeout=timeout, detailed=detailed, print_console=print_console)
 
-    def exec_cmd_list(self, container_name, cmd_list, timeout=None):
+    def exec_cmd_list(self, container_name, cmd_list, timeout=None, print_console=True):
         """Execute different commands on different hosts inside the container.
 
         Each command is wrapped in `docker exec bash -c` — the parallel
@@ -278,13 +278,16 @@ class DockerRuntime:
             container_name: Running container name
             cmd_list: List of commands, one per host in host order
             timeout: Command timeout
+            print_console: If False, the commands' output is returned but not
+                logged. See exec(); use for polling/bulk reads the caller
+                surfaces itself.
 
         Returns:
             Dictionary mapping hosts to execution results
         """
         sudo_prefix = self.orchestrator.sudo_prefix()
         exec_cmd_list = [f"{sudo_prefix}docker exec {container_name} bash -c {shlex.quote(cmd)}" for cmd in cmd_list]
-        return self.orchestrator.all.exec_cmd_list(exec_cmd_list, timeout=timeout)
+        return self.orchestrator.all.exec_cmd_list(exec_cmd_list, timeout=timeout, print_console=print_console)
 
     def exec_on_head(self, container_name, cmd, timeout=None, detailed=False, print_console=True):
         """Execute command directly on head node (container). See exec() for

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "framework": "jaxmaxtext",
-  "gpu_arch": "mi325x",
+  "gpu_arch": "mi300x",
   "enforce_thresholds": true,
-  "threshold_json": "mi325x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json",
+  "threshold_json": "mi300x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "deepseek-v2-lite",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b",
+    "name": "rocm-jaxmaxtext-mi300x-deepseek-v2-lite",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -53,51 +53,48 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "DeepSeek-V2-Lite = MaxText preset 'deepseek2-16b' (16B MoE). maxtext_config mirrors MAD scripts/jax-maxtext/env_scripts/deepseek2_16b.yml (gfx942).",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "deepseek2-16b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
-      "dtype": "bfloat16",
-      "dataset_type": "synthetic",
-      "remat_policy": "full",
-      "use_iota_embed": true,
-      "scan_layers": true,
-      "per_device_batch_size": 3,
-      "max_target_length": 8192,
-      "async_checkpointing": false,
-      "quantization": "",
-      "weight_dtype": "bfloat16",
-      "shardy": true,
-      "logits_dot_in_fp32": false,
-      "megablox": false,
       "packing": true,
-      "enable_goodput_recording": false,
-      "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
-      "ici_fsdp_parallelism": 8,
-      "ici_data_parallelism": 1,
-      "ici_sequence_parallelism": 1,
-      "ici_tensor_parallelism": 1,
-      "ici_pipeline_parallelism": 1,
+      "log_period": 100,
       "dcn_data_parallelism": -1,
       "dcn_fsdp_parallelism": 1,
-      "dcn_pipeline_parallelism": 1,
-      "dcn_tensor_parallelism": 1,
-      "dcn_sequence_parallelism": 1,
+      "ici_fsdp_parallelism": 1,
+      "ici_data_parallelism": 1,
+      "ici_expert_parallelism": -1,
+      "remat_policy": "minimal_flash",
+      "use_iota_embed": true,
+      "scan_layers": true,
+      "async_checkpointing": false,
+      "logits_dot_in_fp32": false,
       "profiler": "",
+      "dtype": "bfloat16",
+      "quantization": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
       "kv_quant_dtype": "int8",
+      "weight_dtype": "bfloat16",
       "checkpoint_is_quantized": false,
-      "max_segments_per_seq": 32
+      "max_target_length": 4096,
+      "dataset_type": "synthetic",
+      "per_device_batch_size": 4,
+      "megablox": false,
+      "capacity_factor": 1.25,
+      "sparse_matmul": false,
+      "sharding_tolerance": 0.05,
+      "max_segments_per_seq": 32,
+      "shardy": true,
+      "enable_goodput_recording": false,
+      "monitor_goodput": false
     },
 
     "tokenizer": {
-      "hf_model_id": "NousResearch/Meta-Llama-3-70B",
-      "tokenizer_path": "{paths.models_dir}/Meta-Llama-70-B"
+      "hf_model_id": "deepseek-ai/DeepSeek-V2-Lite",
+      "tokenizer_path": "{paths.models_dir}/DeepSeek-V2-Lite"
     },
 
     "nic_type": "thor2",
@@ -109,7 +106,7 @@
     },
 
     "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
-    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_env_vars_comment": "Compute/NVTE/XLA-side vars mirror MAD scripts/jax-maxtext/env_scripts/deepseek2_env_16b.sh (gfx942); the NCCL_IB_* / NCCL_PROTO networking vars are CVS cluster-specific (bnxt_re TCP fallback) and are not from the MAD script.",
     "env_vars": {
       "NNODES": "auto",
       "GPU_MAX_HW_QUEUES": "2",
@@ -136,6 +133,7 @@
       "NVTE_FUSED_ATTN_AOTRITON": "0"
     },
 
+    "_xla_flags_comment": "Mirrors XLA_FLAGS from MAD scripts/jax-maxtext/env_scripts/deepseek2_env_16b.sh for deepseek2-16b (autotune_level=4).",
     "xla_flags": {
       "xla_gpu_memory_limit_slop_factor": "95",
       "xla_gpu_reduce_scatter_combine_threshold_bytes": "8589934592",
@@ -170,9 +168,9 @@
       "heartbeat_timeout_seconds": "900"
     },
 
-    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. Set to 0.0 = disabled (record-only). Populate from a prior MI325X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). Populate from a prior MI300X single-node run (tok/s/GPU * 8) to enable the metric.",
     "scaling_baseline": {
-      "tokens_per_sec_total": 394000.0,
+      "tokens_per_sec_total": 0.0,
       "num_nodes": 1
     },
 
@@ -202,32 +200,22 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. BF16 uses the base maxtext_config as-is. FP8 on MI300X/MI325X (CDNA3) must use quantization=nanoo_fp8 (the plain 'fp8' value is the NVIDIA path, also used on MI355X/MI350X). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels; per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. DeepSeek-V2-Lite is BF16-only here. enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=640,SEQLEN=4096",
         "maxtext_overrides": {
-          "per_device_batch_size": 3,
-          "max_target_length": 8192,
+          "per_device_batch_size": 4,
+          "max_target_length": 4096,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
           "quantization": ""
         }
-      },
-      {
-        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192",
-        "maxtext_overrides": {
-          "per_device_batch_size": 3,
-          "max_target_length": 8192,
-          "dtype": "bfloat16",
-          "weight_dtype": "bfloat16",
-          "quantization": "nanoo_fp8"
-        }
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
-      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192"
+      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=640,SEQLEN=4096"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -142,7 +142,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -186,6 +186,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for DeepSeek-V2-Lite (deepseek2-16b MoE) on MI300X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates -- replace with measured MI300X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=640,SEQLEN=4096": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 150.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 5000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -3,7 +3,7 @@
   "framework": "jaxmaxtext",
   "gpu_arch": "mi300x",
   "enforce_thresholds": true,
-  "threshold_json": "mi300x_jaxmaxtext_llama-3.3-70b_single_threshold.json",
+  "threshold_json": "mi300x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "llama3.1-8b",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b-single",
+    "name": "rocm-jaxmaxtext-mi300x-llama3.1-8b",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -32,6 +32,9 @@
         "ulimit": ["nofile=65535:65535"],
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
+          "/dev/infiniband:/dev/infiniband",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
       }
@@ -41,7 +44,7 @@
   "__maxtext_version<=26.3__train_script": "/workspace/maxtext/src/MaxText/train.py",
   "__maxtext_version>=26.4__train_script": "/workspace/maxtext/src/maxtext/trainers/pre_train/train.py",
   "training": {
-    "distributed": false,
+    "distributed": true,
     "gpus_per_node": 8,
     "steps": 30,
     "enable_checkpointing": false,
@@ -50,15 +53,15 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.1-8B rather than base.yml defaults.",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "llama3.1-8b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
       "dtype": "bfloat16",
       "dataset_type": "synthetic",
-      "remat_policy": "full",
+      "remat_policy": "minimal_flash",
       "use_iota_embed": true,
       "scan_layers": true,
       "per_device_batch_size": 2,
@@ -72,13 +75,11 @@
       "packing": true,
       "enable_goodput_recording": false,
       "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
+      "log_period": 100,
       "ici_fsdp_parallelism": 8,
       "ici_data_parallelism": 1,
-      "ici_sequence_parallelism": 1,
-      "ici_tensor_parallelism": 1,
-      "ici_pipeline_parallelism": 1,
+      "dcn_data_parallelism": -1,
+      "dcn_fsdp_parallelism": 1,
       "profiler": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
@@ -88,17 +89,22 @@
     },
 
     "tokenizer": {
-      "hf_model_id": "NousResearch/Meta-Llama-3-70B",
-      "tokenizer_path": "{paths.models_dir}/Meta-Llama-70-B"
+      "hf_model_id": "NousResearch/Meta-Llama-3.1-8B",
+      "tokenizer_path": "{paths.models_dir}/Meta-Llama-3.1-8B"
     },
 
-    "nic_type": "none",
+    "nic_type": "thor2",
 
-    "_NCCL_IB_DISABLE_comment": "Single-node run uses intra-node RCCL (no inter-node IB), so this is a no-op here; kept for parity with the distributed configs where IB/RoCE over Broadcom bnxt_re segfaults and TCP is required.",
+    "rdma_lib": {
+      "host_source_file": "/usr/local/lib/libbnxt_re-rdmav34.so",
+      "container_mount_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+      "container_dest_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so"
+    },
+
+    "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
     "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
     "env_vars": {
       "NNODES": "auto",
-      "NODE_RANK": "0",
       "GPU_MAX_HW_QUEUES": "2",
       "HSA_FORCE_FINE_GRAIN_PCIE": "1",
       "HIP_FORCE_DEV_KERNARG": "1",
@@ -106,6 +112,12 @@
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
       "NCCL_IB_DISABLE": "1",
+      "NCCL_PROTO": "Simple",
+      "NCCL_IB_TC": "41",
+      "NCCL_IB_SL": "0",
+      "NCCL_IB_GID_INDEX": "3",
+      "NCCL_CHECKS_DISABLE": "1",
+      "NCCL_CROSS_NIC": "0",
       "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "1",
       "NVTE_USE_HIPBLASLT": "1",
       "NVTE_FUSED_ATTN": "1",
@@ -129,13 +141,41 @@
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
+    "_nccl_comment": "Cluster-specific RDMA/NIC devices. Replace every '<changeme>' with your node's values (see the sibling _example_* entries); distributed runs hard-exit at config load until you do. Discover them with `ibv_devices` (HCAs) and `ip -br link` (host interface).",
+    "nccl": {
+      "_example_ib_hca_list": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca_list": "<changeme>",
+      "_example_ib_hca": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca": "<changeme>",
+      "_example_socket_ifname": "eno0",
+      "socket_ifname": "<changeme>",
+      "_example_gloo_socket_ifname": "eno0",
+      "gloo_socket_ifname": "<changeme>",
+      "ib_tc": "41",
+      "ib_sl": "0",
+      "ib_gid_index": "3"
+    },
+
+    "jax_distributed": {
+      "coordinator_ip": "auto",
+      "coordinator_port": "12346",
+      "initialization_timeout_seconds": "1800",
+      "heartbeat_timeout_seconds": "900"
+    },
+
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). Populate from a prior MI300X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "scaling_baseline": {
+      "tokens_per_sec_total": 0.0,
+      "num_nodes": 1
+    },
+
     "_convergence_comment": "to enable validation loss set eval_interval > 0 (and eval_steps) in maxtext_config; this needs a validation dataset (eval_split/eval_dataset_name). target_value <= 0 disables convergence (record-only). target_metric 'auto' uses eval_loss when eval runs, else training loss.",
     "convergence": {
       "target_metric": "auto",
-      "target_value": 0.0
+      "target_value": 10.0
     },
 
-    "_loss_curve_comment": "sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
+    "_loss_curve_comment": "Row 32: sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
     "loss_curve": {
       "sample_every": 10,
       "milestone_steps": [100, 500, 1000, 5000],
@@ -155,12 +195,12 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run; `name` is the threshold cell key. FP8 on MI300X (CDNA3) uses quantization=nanoo_fp8. STEPS/GBS/NNODES in the name are labels: steps comes from training.steps, GBS = per_device_batch_size * total GPUs, NNODES from the cluster. enabled_sweep_list selects which sweeps to run.",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (matching the reference); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. BF16 uses the base maxtext_config as-is. FP8 on MI300X/MI325X (CDNA3) uses quantization=nanoo_fp8 (MI355X/MI350X CDNA4 use fp8). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 2,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -168,9 +208,9 @@
         }
       },
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=2,GBS=128,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 2,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -179,8 +219,8 @@
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
-      "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192"
+      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
+      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=2,GBS=128,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -137,7 +137,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -181,6 +181,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for Llama-3.1-8B on MI300X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates -- replace with measured MI300X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 230.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 6000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  },
+
+  "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=2,GBS=128,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 270.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 8000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -145,7 +145,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -189,6 +189,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -54,8 +54,10 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
+    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
     "maxtext_config": {
       "base_config": "base.yml",
+      "model_name": "llama3.3-70b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
       "dtype": "bfloat16",
@@ -68,7 +70,7 @@
       "async_checkpointing": false,
       "quantization": "",
       "weight_dtype": "bfloat16",
-      "shardy": false,
+      "shardy": true,
       "logits_dot_in_fp32": false,
       "megablox": false,
       "packing": true,
@@ -86,10 +88,12 @@
       "dcn_pipeline_parallelism": 1,
       "dcn_tensor_parallelism": 1,
       "dcn_sequence_parallelism": 1,
-      "max_segments_per_seq": 32,
-      "skip_first_n_steps_for_profiler": 3,
-      "eval_interval": -1,
-      "eval_steps": -1
+      "profiler": "",
+      "quantize_kvcache": false,
+      "kv_quant_axis": "heads_and_dkv",
+      "kv_quant_dtype": "int8",
+      "checkpoint_is_quantized": false,
+      "max_segments_per_seq": 32
     },
 
     "tokenizer": {
@@ -106,13 +110,15 @@
     },
 
     "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
     "env_vars": {
-      "NNODES": "2",
+      "NNODES": "auto",
       "GPU_MAX_HW_QUEUES": "2",
       "HSA_FORCE_FINE_GRAIN_PCIE": "1",
       "HIP_FORCE_DEV_KERNARG": "1",
-      "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.93",
-      "NCCL_DEBUG": "ERROR",
+      "HSA_NO_SCRATCH_RECLAIM": "1",
+      "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
+      "NCCL_DEBUG": "VERSION",
       "NCCL_IB_DISABLE": "1",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
@@ -132,16 +138,14 @@
     },
 
     "xla_flags": {
-      "xla_gpu_enable_latency_hiding_scheduler": "True",
-      "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_memory_limit_slop_factor": "95",
-      "xla_gpu_enable_command_buffer": "''",
-      "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "0",
-      "xla_gpu_enable_reduce_scatter_combine_by_dim": "false",
       "xla_gpu_reduce_scatter_combine_threshold_bytes": "8589934592",
-      "xla_gpu_all_reduce_combine_threshold_bytes": "8589934592",
+      "xla_gpu_enable_command_buffer": "",
+      "xla_gpu_enable_latency_hiding_scheduler": "True",
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
+      "xla_gpu_enable_triton_gemm": "False",
+      "xla_gpu_enable_cublaslt": "True",
+      "xla_gpu_autotune_level": "4",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_single.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_single.json
@@ -125,7 +125,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -141,6 +141,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -3,7 +3,7 @@
   "framework": "jaxmaxtext",
   "gpu_arch": "mi325x",
   "enforce_thresholds": true,
-  "threshold_json": "mi325x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json",
+  "threshold_json": "mi325x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "deepseek-v2-lite",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b",
+    "name": "rocm-jaxmaxtext-mi325x-deepseek-v2-lite",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -53,51 +53,48 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "DeepSeek-V2-Lite = MaxText preset 'deepseek2-16b' (16B MoE). maxtext_config mirrors MAD scripts/jax-maxtext/env_scripts/deepseek2_16b.yml (gfx942).",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "deepseek2-16b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
-      "dtype": "bfloat16",
-      "dataset_type": "synthetic",
-      "remat_policy": "full",
-      "use_iota_embed": true,
-      "scan_layers": true,
-      "per_device_batch_size": 3,
-      "max_target_length": 8192,
-      "async_checkpointing": false,
-      "quantization": "",
-      "weight_dtype": "bfloat16",
-      "shardy": true,
-      "logits_dot_in_fp32": false,
-      "megablox": false,
       "packing": true,
-      "enable_goodput_recording": false,
-      "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
-      "ici_fsdp_parallelism": 8,
-      "ici_data_parallelism": 1,
-      "ici_sequence_parallelism": 1,
-      "ici_tensor_parallelism": 1,
-      "ici_pipeline_parallelism": 1,
+      "log_period": 100,
       "dcn_data_parallelism": -1,
       "dcn_fsdp_parallelism": 1,
-      "dcn_pipeline_parallelism": 1,
-      "dcn_tensor_parallelism": 1,
-      "dcn_sequence_parallelism": 1,
+      "ici_fsdp_parallelism": 1,
+      "ici_data_parallelism": 1,
+      "ici_expert_parallelism": -1,
+      "remat_policy": "minimal_flash",
+      "use_iota_embed": true,
+      "scan_layers": true,
+      "async_checkpointing": false,
+      "logits_dot_in_fp32": false,
       "profiler": "",
+      "dtype": "bfloat16",
+      "quantization": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
       "kv_quant_dtype": "int8",
+      "weight_dtype": "bfloat16",
       "checkpoint_is_quantized": false,
-      "max_segments_per_seq": 32
+      "max_target_length": 4096,
+      "dataset_type": "synthetic",
+      "per_device_batch_size": 10,
+      "megablox": false,
+      "capacity_factor": 1.25,
+      "sparse_matmul": false,
+      "sharding_tolerance": 0.05,
+      "max_segments_per_seq": 32,
+      "shardy": true,
+      "enable_goodput_recording": false,
+      "monitor_goodput": false
     },
 
     "tokenizer": {
-      "hf_model_id": "NousResearch/Meta-Llama-3-70B",
-      "tokenizer_path": "{paths.models_dir}/Meta-Llama-70-B"
+      "hf_model_id": "deepseek-ai/DeepSeek-V2-Lite",
+      "tokenizer_path": "{paths.models_dir}/DeepSeek-V2-Lite"
     },
 
     "nic_type": "thor2",
@@ -109,7 +106,7 @@
     },
 
     "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
-    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_env_vars_comment": "Compute/NVTE/XLA-side vars mirror MAD scripts/jax-maxtext/env_scripts/deepseek2_env_16b.sh (gfx942); the NCCL_IB_* / NCCL_PROTO networking vars are CVS cluster-specific (bnxt_re TCP fallback) and are not from the MAD script.",
     "env_vars": {
       "NNODES": "auto",
       "GPU_MAX_HW_QUEUES": "2",
@@ -136,6 +133,7 @@
       "NVTE_FUSED_ATTN_AOTRITON": "0"
     },
 
+    "_xla_flags_comment": "Mirrors XLA_FLAGS from MAD scripts/jax-maxtext/env_scripts/deepseek2_env_16b.sh for deepseek2-16b (autotune_level=4).",
     "xla_flags": {
       "xla_gpu_memory_limit_slop_factor": "95",
       "xla_gpu_reduce_scatter_combine_threshold_bytes": "8589934592",
@@ -170,9 +168,9 @@
       "heartbeat_timeout_seconds": "900"
     },
 
-    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. Set to 0.0 = disabled (record-only). Populate from a prior MI325X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). Populate from a prior MI325X single-node run (tok/s/GPU * 8) to enable the metric.",
     "scaling_baseline": {
-      "tokens_per_sec_total": 394000.0,
+      "tokens_per_sec_total": 0.0,
       "num_nodes": 1
     },
 
@@ -202,32 +200,22 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. BF16 uses the base maxtext_config as-is. FP8 on MI300X/MI325X (CDNA3) must use quantization=nanoo_fp8 (the plain 'fp8' value is the NVIDIA path, also used on MI355X/MI350X). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels; per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. DeepSeek-V2-Lite is BF16-only here. enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=10,GBS=80,SEQLEN=4096",
         "maxtext_overrides": {
-          "per_device_batch_size": 3,
-          "max_target_length": 8192,
+          "per_device_batch_size": 10,
+          "max_target_length": 4096,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
           "quantization": ""
         }
-      },
-      {
-        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192",
-        "maxtext_overrides": {
-          "per_device_batch_size": 3,
-          "max_target_length": 8192,
-          "dtype": "bfloat16",
-          "weight_dtype": "bfloat16",
-          "quantization": "nanoo_fp8"
-        }
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
-      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192"
+      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=10,GBS=80,SEQLEN=4096"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -142,7 +142,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -177,12 +177,12 @@
     "_convergence_comment": "to enable validation loss set eval_interval > 0 (and eval_steps) in maxtext_config; this needs a validation dataset (eval_split/eval_dataset_name). target_value <= 0 disables convergence (record-only). target_metric 'auto' uses eval_loss when eval runs, else training loss.",
     "convergence": {
       "target_metric": "auto",
-      "target_value": 10.0
+      "target_value": 11.8
     },
 
     "_loss_curve_comment": "Row 32: sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
     "loss_curve": {
-      "sample_every": 10,
+      "sample_every": 2,
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -188,6 +188,20 @@
       "enforce": true
     },
 
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
+    },
+
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",
     "error_patterns": {
       "NCCL ERROR": "NCCL ERROR|NCCL timeout|local work queue catastrophic error",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for DeepSeek-V2-Lite (deepseek2-16b MoE) on MI325X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates -- replace with measured MI325X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=10,GBS=80,SEQLEN=4096": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 160.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 5500.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -3,7 +3,7 @@
   "framework": "jaxmaxtext",
   "gpu_arch": "mi325x",
   "enforce_thresholds": true,
-  "threshold_json": "mi325x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json",
+  "threshold_json": "mi325x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "llama3.1-405b",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b",
+    "name": "rocm-jaxmaxtext-mi325x-llama3.1-405b",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -53,46 +53,45 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "Llama-3.1-405B = MaxText preset 'llama3.1-405b'. maxtext_config mirrors MAD scripts/jax-maxtext/env_scripts/gfx950_llama3.1_405b.yml (the only 405B reference in MAD): full FSDP sharding (ici/dcn_fsdp_parallelism=-1) because 405B does not fit with plain data parallelism. Env/XLA mirror the MAD llama3.3_70b_env.sh (gfx942).",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "llama3.1-405b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
-      "dtype": "bfloat16",
-      "dataset_type": "synthetic",
-      "remat_policy": "full",
-      "use_iota_embed": true,
-      "scan_layers": true,
-      "per_device_batch_size": 3,
-      "max_target_length": 8192,
-      "async_checkpointing": false,
-      "quantization": "",
-      "weight_dtype": "bfloat16",
-      "shardy": true,
-      "logits_dot_in_fp32": false,
-      "megablox": false,
-      "packing": true,
-      "enable_goodput_recording": false,
-      "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
-      "ici_fsdp_parallelism": 8,
+      "dcn_data_parallelism": 1,
+      "dcn_fsdp_parallelism": -1,
+      "dcn_pipeline_parallelism": 1,
+      "dcn_tensor_parallelism": 1,
+      "dcn_sequence_parallelism": 1,
+      "ici_fsdp_parallelism": -1,
       "ici_data_parallelism": 1,
       "ici_sequence_parallelism": 1,
       "ici_tensor_parallelism": 1,
       "ici_pipeline_parallelism": 1,
-      "dcn_data_parallelism": -1,
-      "dcn_fsdp_parallelism": 1,
-      "dcn_pipeline_parallelism": 1,
-      "dcn_tensor_parallelism": 1,
-      "dcn_sequence_parallelism": 1,
+      "remat_policy": "full",
+      "optimizer_memory_host_offload": false,
+      "param_scan_axis": 1,
+      "use_iota_embed": true,
+      "scan_layers": true,
       "profiler": "",
+      "skip_first_n_steps_for_profiler": 3,
+      "profiler_steps": 1,
+      "async_checkpointing": false,
+      "logits_dot_in_fp32": false,
+      "megablox": false,
+      "dtype": "bfloat16",
+      "quantization": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
       "kv_quant_dtype": "int8",
+      "weight_dtype": "bfloat16",
       "checkpoint_is_quantized": false,
-      "max_segments_per_seq": 32
+      "per_device_batch_size": 2,
+      "max_target_length": 8192,
+      "dataset_type": "synthetic",
+      "max_segments_per_seq": 32,
+      "shardy": true
     },
 
     "tokenizer": {
@@ -109,7 +108,7 @@
     },
 
     "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
-    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_env_vars_comment": "Compute/NVTE/XLA-side vars mirror MAD scripts/jax-maxtext/env_scripts/llama3.3_70b_env.sh (gfx942; MAD has no 405B-specific env); the NCCL_IB_* / NCCL_PROTO networking vars are CVS cluster-specific (bnxt_re TCP fallback) and are not from the MAD script.",
     "env_vars": {
       "NNODES": "auto",
       "GPU_MAX_HW_QUEUES": "2",
@@ -136,6 +135,7 @@
       "NVTE_FUSED_ATTN_AOTRITON": "0"
     },
 
+    "_xla_flags_comment": "Mirrors XLA_FLAGS from MAD scripts/jax-maxtext/env_scripts/llama3.3_70b_env.sh (autotune_level=4).",
     "xla_flags": {
       "xla_gpu_memory_limit_slop_factor": "95",
       "xla_gpu_reduce_scatter_combine_threshold_bytes": "8589934592",
@@ -170,9 +170,9 @@
       "heartbeat_timeout_seconds": "900"
     },
 
-    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. Set to 0.0 = disabled (record-only). Populate from a prior MI325X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). 405B does not fit on 1 node, so leave disabled; use a smaller reference (e.g. min node count that fits) if you want the metric.",
     "scaling_baseline": {
-      "tokens_per_sec_total": 394000.0,
+      "tokens_per_sec_total": 0.0,
       "num_nodes": 1
     },
 
@@ -202,12 +202,13 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. BF16 uses the base maxtext_config as-is. FP8 on MI300X/MI325X (CDNA3) must use quantization=nanoo_fp8 (the plain 'fp8' value is the NVIDIA path, also used on MI355X/MI350X). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden. The NNODES=8 in the sweep names is only a label (405B needs ~8 nodes with full FSDP).",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (405B assumed on 8 nodes = 64 GPUs); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. FP8 on MI300X/MI325X (CDNA3) uses quantization=nanoo_fp8 (MI355X/MI350X CDNA4 use fp8). BF16 uses a smaller per-device batch than FP8 (higher memory). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
+        "name": "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 3,
+          "per_device_batch_size": 2,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -215,9 +216,9 @@
         }
       },
       {
-        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192",
+        "name": "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 3,
+          "per_device_batch_size": 5,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -226,8 +227,8 @@
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
-      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192"
+      "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
+      "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -18,6 +18,8 @@
     "precision": "bfloat16"
   },
 
+  "__ex_image": "amdaccelcloud/jax:7.15.0a20260721-ubuntu24.04-jax0.10.0-TE2.10",
+  "__ex__image": "rocm/jax-training:maxtext-v26.4",
   "container": {
     "lifetime": "per_run",
     "name": "rocm-jaxmaxtext-mi325x-llama3.1-405b",
@@ -46,7 +48,7 @@
   "training": {
     "distributed": true,
     "gpus_per_node": 8,
-    "steps": 30,
+    "steps": 10,
     "enable_checkpointing": false,
     "train_script_paths": [
       "/workspace/maxtext/src/maxtext/trainers/pre_train/train.py",
@@ -144,7 +146,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -179,12 +181,12 @@
     "_convergence_comment": "to enable validation loss set eval_interval > 0 (and eval_steps) in maxtext_config; this needs a validation dataset (eval_split/eval_dataset_name). target_value <= 0 disables convergence (record-only). target_metric 'auto' uses eval_loss when eval runs, else training loss.",
     "convergence": {
       "target_metric": "auto",
-      "target_value": 10.0
+      "target_value": 11.8
     },
 
     "_loss_curve_comment": "Row 32: sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
     "loss_curve": {
-      "sample_every": 10,
+      "sample_every": 2,
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
@@ -202,11 +204,11 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden. The NNODES=8 in the sweep names is only a label (405B needs ~8 nodes with full FSDP).",
-    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (405B assumed on 8 nodes = 64 GPUs); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. FP8 on MI300X/MI325X (CDNA3) uses quantization=nanoo_fp8 (MI355X/MI350X CDNA4 use fp8). BF16 uses a smaller per-device batch than FP8 (higher memory). enabled_sweep_list selects which sweeps to run.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden. The NNODES=4 in the sweep names is only a label (405B on 4 nodes = 32 GPUs with full FSDP; per MAD, per_device_batch_size 3 for 4 nodes / 5 for 8 nodes).",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (405B on 4 nodes = 32 GPUs); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. FP8 on MI300X/MI325X (CDNA3) uses quantization=nanoo_fp8 (MI355X/MI350X CDNA4 use fp8). BF16 uses a smaller per-device batch than FP8 (higher memory). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
+        "name": "NNODES=4,STEPS=30,PRECISION=BF16,BATCH=2,GBS=64,SEQLEN=8192",
         "maxtext_overrides": {
           "per_device_batch_size": 2,
           "max_target_length": 8192,
@@ -216,9 +218,9 @@
         }
       },
       {
-        "name": "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192",
+        "name": "NNODES=4,STEPS=30,PRECISION=FP8,BATCH=3,GBS=96,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 3,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -227,8 +229,8 @@
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
-      "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192"
+      "NNODES=4,STEPS=30,PRECISION=BF16,BATCH=2,GBS=64,SEQLEN=8192",
+      "NNODES=4,STEPS=30,PRECISION=FP8,BATCH=3,GBS=96,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -192,6 +192,20 @@
       "enforce": true
     },
 
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
+    },
+
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",
     "error_patterns": {
       "NCCL ERROR": "NCCL ERROR|NCCL timeout|local work queue catastrophic error",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for Llama-3.1-405B on MI325X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates (405B: high tflops/GPU, low tokens/s/GPU) -- replace with measured MI325X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 250.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 150.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  },
+
+  "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 350.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 250.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
@@ -1,7 +1,7 @@
 {
   "_comment": "APPROXIMATE placeholder thresholds for Llama-3.1-405B on MI325X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates (405B: high tflops/GPU, low tokens/s/GPU) -- replace with measured MI325X numbers. Requires enforce_thresholds=true.",
 
-  "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192": {
+  "NNODES=4,STEPS=30,PRECISION=BF16,BATCH=2,GBS=64,SEQLEN=8192": {
     "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 250.0 },
     "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 150.0 },
     "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
@@ -17,7 +17,7 @@
     "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
   },
 
-  "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192": {
+  "NNODES=4,STEPS=30,PRECISION=FP8,BATCH=3,GBS=96,SEQLEN=8192": {
     "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 350.0 },
     "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 250.0 },
     "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -137,7 +137,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -181,6 +181,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "framework": "jaxmaxtext",
-  "gpu_arch": "mi300x",
+  "gpu_arch": "mi325x",
   "enforce_thresholds": true,
-  "threshold_json": "mi300x_jaxmaxtext_llama-3.3-70b_single_threshold.json",
+  "threshold_json": "mi325x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "llama3.1-8b",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b-single",
+    "name": "rocm-jaxmaxtext-mi325x-llama3.1-8b",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -32,6 +32,9 @@
         "ulimit": ["nofile=65535:65535"],
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
+          "/dev/infiniband:/dev/infiniband",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
       }
@@ -41,7 +44,7 @@
   "__maxtext_version<=26.3__train_script": "/workspace/maxtext/src/MaxText/train.py",
   "__maxtext_version>=26.4__train_script": "/workspace/maxtext/src/maxtext/trainers/pre_train/train.py",
   "training": {
-    "distributed": false,
+    "distributed": true,
     "gpus_per_node": 8,
     "steps": 30,
     "enable_checkpointing": false,
@@ -50,18 +53,18 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.1-8B rather than base.yml defaults.",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "llama3.1-8b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
       "dtype": "bfloat16",
       "dataset_type": "synthetic",
-      "remat_policy": "full",
+      "remat_policy": "minimal_flash",
       "use_iota_embed": true,
       "scan_layers": true,
-      "per_device_batch_size": 2,
+      "per_device_batch_size": 4,
       "max_target_length": 8192,
       "async_checkpointing": false,
       "quantization": "",
@@ -72,13 +75,11 @@
       "packing": true,
       "enable_goodput_recording": false,
       "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
+      "log_period": 100,
       "ici_fsdp_parallelism": 8,
       "ici_data_parallelism": 1,
-      "ici_sequence_parallelism": 1,
-      "ici_tensor_parallelism": 1,
-      "ici_pipeline_parallelism": 1,
+      "dcn_data_parallelism": -1,
+      "dcn_fsdp_parallelism": 1,
       "profiler": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
@@ -88,17 +89,22 @@
     },
 
     "tokenizer": {
-      "hf_model_id": "NousResearch/Meta-Llama-3-70B",
-      "tokenizer_path": "{paths.models_dir}/Meta-Llama-70-B"
+      "hf_model_id": "NousResearch/Meta-Llama-3.1-8B",
+      "tokenizer_path": "{paths.models_dir}/Meta-Llama-3.1-8B"
     },
 
-    "nic_type": "none",
+    "nic_type": "thor2",
 
-    "_NCCL_IB_DISABLE_comment": "Single-node run uses intra-node RCCL (no inter-node IB), so this is a no-op here; kept for parity with the distributed configs where IB/RoCE over Broadcom bnxt_re segfaults and TCP is required.",
+    "rdma_lib": {
+      "host_source_file": "/usr/local/lib/libbnxt_re-rdmav34.so",
+      "container_mount_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+      "container_dest_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so"
+    },
+
+    "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
     "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
     "env_vars": {
       "NNODES": "auto",
-      "NODE_RANK": "0",
       "GPU_MAX_HW_QUEUES": "2",
       "HSA_FORCE_FINE_GRAIN_PCIE": "1",
       "HIP_FORCE_DEV_KERNARG": "1",
@@ -106,6 +112,12 @@
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
       "NCCL_IB_DISABLE": "1",
+      "NCCL_PROTO": "Simple",
+      "NCCL_IB_TC": "41",
+      "NCCL_IB_SL": "0",
+      "NCCL_IB_GID_INDEX": "3",
+      "NCCL_CHECKS_DISABLE": "1",
+      "NCCL_CROSS_NIC": "0",
       "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "1",
       "NVTE_USE_HIPBLASLT": "1",
       "NVTE_FUSED_ATTN": "1",
@@ -129,13 +141,41 @@
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
+    "_nccl_comment": "Cluster-specific RDMA/NIC devices. Replace every '<changeme>' with your node's values (see the sibling _example_* entries); distributed runs hard-exit at config load until you do. Discover them with `ibv_devices` (HCAs) and `ip -br link` (host interface).",
+    "nccl": {
+      "_example_ib_hca_list": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca_list": "<changeme>",
+      "_example_ib_hca": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca": "<changeme>",
+      "_example_socket_ifname": "eno0",
+      "socket_ifname": "<changeme>",
+      "_example_gloo_socket_ifname": "eno0",
+      "gloo_socket_ifname": "<changeme>",
+      "ib_tc": "41",
+      "ib_sl": "0",
+      "ib_gid_index": "3"
+    },
+
+    "jax_distributed": {
+      "coordinator_ip": "auto",
+      "coordinator_port": "12346",
+      "initialization_timeout_seconds": "1800",
+      "heartbeat_timeout_seconds": "900"
+    },
+
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). Populate from a prior MI325X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "scaling_baseline": {
+      "tokens_per_sec_total": 0.0,
+      "num_nodes": 1
+    },
+
     "_convergence_comment": "to enable validation loss set eval_interval > 0 (and eval_steps) in maxtext_config; this needs a validation dataset (eval_split/eval_dataset_name). target_value <= 0 disables convergence (record-only). target_metric 'auto' uses eval_loss when eval runs, else training loss.",
     "convergence": {
       "target_metric": "auto",
-      "target_value": 0.0
+      "target_value": 10.0
     },
 
-    "_loss_curve_comment": "sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
+    "_loss_curve_comment": "Row 32: sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
     "loss_curve": {
       "sample_every": 10,
       "milestone_steps": [100, 500, 1000, 5000],
@@ -155,12 +195,12 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run; `name` is the threshold cell key. FP8 on MI300X (CDNA3) uses quantization=nanoo_fp8. STEPS/GBS/NNODES in the name are labels: steps comes from training.steps, GBS = per_device_batch_size * total GPUs, NNODES from the cluster. enabled_sweep_list selects which sweeps to run.",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (matching the reference); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. BF16 uses the base maxtext_config as-is. FP8 on MI300X/MI325X (CDNA3) uses quantization=nanoo_fp8 (MI355X/MI350X CDNA4 use fp8). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=128,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 4,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -168,9 +208,9 @@
         }
       },
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=4,GBS=128,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 4,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -179,8 +219,8 @@
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
-      "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192"
+      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=128,SEQLEN=8192",
+      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=4,GBS=128,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for Llama-3.1-8B on MI325X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates -- replace with measured MI325X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=128,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 250.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 7000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  },
+
+  "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=4,GBS=128,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 290.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 9000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -190,6 +190,20 @@
       "enforce": true
     },
 
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
+    },
+
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",
     "error_patterns": {
       "NCCL ERROR": "NCCL ERROR|NCCL timeout|local work queue catastrophic error",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -144,7 +144,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -142,7 +142,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -186,6 +186,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "framework": "jaxmaxtext",
-  "gpu_arch": "mi325x",
+  "gpu_arch": "mi355x",
   "enforce_thresholds": true,
-  "threshold_json": "mi325x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json",
+  "threshold_json": "mi355x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "deepseek-v2-lite",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b",
+    "name": "rocm-jaxmaxtext-mi355x-deepseek-v2-lite",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -53,51 +53,48 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "DeepSeek-V2-Lite = MaxText preset 'deepseek2-16b' (16B MoE). maxtext_config mirrors MAD scripts/jax-maxtext/env_scripts/gfx950_deepseek2_16b.yml (gfx950/MI355X).",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "deepseek2-16b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
-      "dtype": "bfloat16",
-      "dataset_type": "synthetic",
-      "remat_policy": "full",
-      "use_iota_embed": true,
-      "scan_layers": true,
-      "per_device_batch_size": 3,
-      "max_target_length": 8192,
-      "async_checkpointing": false,
-      "quantization": "",
-      "weight_dtype": "bfloat16",
-      "shardy": true,
-      "logits_dot_in_fp32": false,
-      "megablox": false,
       "packing": true,
-      "enable_goodput_recording": false,
-      "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
-      "ici_fsdp_parallelism": 8,
-      "ici_data_parallelism": 1,
-      "ici_sequence_parallelism": 1,
-      "ici_tensor_parallelism": 1,
-      "ici_pipeline_parallelism": 1,
+      "log_period": 100,
       "dcn_data_parallelism": -1,
       "dcn_fsdp_parallelism": 1,
-      "dcn_pipeline_parallelism": 1,
-      "dcn_tensor_parallelism": 1,
-      "dcn_sequence_parallelism": 1,
+      "ici_fsdp_parallelism": 1,
+      "ici_data_parallelism": 1,
+      "ici_expert_parallelism": -1,
+      "remat_policy": "minimal_flash",
+      "use_iota_embed": true,
+      "scan_layers": true,
+      "async_checkpointing": false,
+      "logits_dot_in_fp32": false,
       "profiler": "",
+      "dtype": "bfloat16",
+      "quantization": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
       "kv_quant_dtype": "int8",
+      "weight_dtype": "bfloat16",
       "checkpoint_is_quantized": false,
-      "max_segments_per_seq": 32
+      "max_target_length": 4096,
+      "dataset_type": "synthetic",
+      "per_device_batch_size": 12,
+      "megablox": false,
+      "capacity_factor": 1.25,
+      "sparse_matmul": false,
+      "sharding_tolerance": 0.05,
+      "max_segments_per_seq": 32,
+      "shardy": true,
+      "enable_goodput_recording": false,
+      "monitor_goodput": false
     },
 
     "tokenizer": {
-      "hf_model_id": "NousResearch/Meta-Llama-3-70B",
-      "tokenizer_path": "{paths.models_dir}/Meta-Llama-70-B"
+      "hf_model_id": "deepseek-ai/DeepSeek-V2-Lite",
+      "tokenizer_path": "{paths.models_dir}/DeepSeek-V2-Lite"
     },
 
     "nic_type": "thor2",
@@ -109,13 +106,13 @@
     },
 
     "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
-    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_env_vars_comment": "Compute/NVTE/XLA-side vars mirror MAD scripts/jax-maxtext/env_scripts/gfx950_deepseek2_env_16b.sh (gfx950/MI355X: RCCL_WARP_SPEED_AUTO=0, no HSA_NO_SCRATCH_RECLAIM); the NCCL_IB_* / NCCL_PROTO networking vars are CVS cluster-specific (bnxt_re TCP fallback) and are not from the MAD script.",
     "env_vars": {
       "NNODES": "auto",
       "GPU_MAX_HW_QUEUES": "2",
       "HSA_FORCE_FINE_GRAIN_PCIE": "1",
       "HIP_FORCE_DEV_KERNARG": "1",
-      "HSA_NO_SCRATCH_RECLAIM": "1",
+      "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
       "NCCL_IB_DISABLE": "1",
@@ -136,6 +133,7 @@
       "NVTE_FUSED_ATTN_AOTRITON": "0"
     },
 
+    "_xla_flags_comment": "Mirrors XLA_FLAGS from MAD scripts/jax-maxtext/env_scripts/gfx950_deepseek2_env_16b.sh for deepseek2-16b (autotune_level=4).",
     "xla_flags": {
       "xla_gpu_memory_limit_slop_factor": "95",
       "xla_gpu_reduce_scatter_combine_threshold_bytes": "8589934592",
@@ -170,9 +168,9 @@
       "heartbeat_timeout_seconds": "900"
     },
 
-    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. Set to 0.0 = disabled (record-only). Populate from a prior MI325X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). Populate from a prior MI355X single-node run (tok/s/GPU * 8) to enable the metric.",
     "scaling_baseline": {
-      "tokens_per_sec_total": 394000.0,
+      "tokens_per_sec_total": 0.0,
       "num_nodes": 1
     },
 
@@ -202,32 +200,22 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. BF16 uses the base maxtext_config as-is. FP8 on MI300X/MI325X (CDNA3) must use quantization=nanoo_fp8 (the plain 'fp8' value is the NVIDIA path, also used on MI355X/MI350X). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels; per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. DeepSeek-V2-Lite is BF16-only here. enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=12,GBS=768,SEQLEN=4096",
         "maxtext_overrides": {
-          "per_device_batch_size": 3,
-          "max_target_length": 8192,
+          "per_device_batch_size": 12,
+          "max_target_length": 4096,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
           "quantization": ""
         }
-      },
-      {
-        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192",
-        "maxtext_overrides": {
-          "per_device_batch_size": 3,
-          "max_target_length": 8192,
-          "dtype": "bfloat16",
-          "weight_dtype": "bfloat16",
-          "quantization": "nanoo_fp8"
-        }
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
-      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192"
+      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=12,GBS=768,SEQLEN=4096"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed_threshold.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for DeepSeek-V2-Lite (deepseek2-16b MoE) on MI355X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates -- replace with measured MI355X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=12,GBS=768,SEQLEN=4096": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 300.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 9000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -202,11 +202,11 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden. The NNODES=8 in the sweep names is only a label (405B needs ~8 nodes with full FSDP).",
-    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (405B assumed on 8 nodes = 64 GPUs); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. FP8 on MI355X/MI350X (CDNA4) uses quantization=fp8 (MI300X/MI325X CDNA3 use nanoo_fp8). BF16 uses a smaller per-device batch than FP8 (higher memory). enabled_sweep_list selects which sweeps to run.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden. The NNODES=4 in the sweep names is only a label (405B on 4 nodes = 32 GPUs with full FSDP; per MAD, per_device_batch_size 3 for 4 nodes / 5 for 8 nodes).",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (405B on 4 nodes = 32 GPUs); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. FP8 on MI355X/MI350X (CDNA4) uses quantization=fp8 (MI300X/MI325X CDNA3 use nanoo_fp8). BF16 uses a smaller per-device batch than FP8 (higher memory). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
+        "name": "NNODES=4,STEPS=30,PRECISION=BF16,BATCH=2,GBS=64,SEQLEN=8192",
         "maxtext_overrides": {
           "per_device_batch_size": 2,
           "max_target_length": 8192,
@@ -216,9 +216,9 @@
         }
       },
       {
-        "name": "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192",
+        "name": "NNODES=4,STEPS=30,PRECISION=FP8,BATCH=3,GBS=96,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 3,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -227,8 +227,8 @@
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
-      "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192"
+      "NNODES=4,STEPS=30,PRECISION=BF16,BATCH=2,GBS=64,SEQLEN=8192",
+      "NNODES=4,STEPS=30,PRECISION=FP8,BATCH=3,GBS=96,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "framework": "jaxmaxtext",
-  "gpu_arch": "mi325x",
+  "gpu_arch": "mi355x",
   "enforce_thresholds": true,
-  "threshold_json": "mi325x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json",
+  "threshold_json": "mi355x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "llama3.1-405b",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b",
+    "name": "rocm-jaxmaxtext-mi355x-llama3.1-405b",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -53,46 +53,45 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "Llama-3.1-405B = MaxText preset 'llama3.1-405b'. maxtext_config mirrors MAD scripts/jax-maxtext/env_scripts/gfx950_llama3.1_405b.yml: full FSDP sharding (ici/dcn_fsdp_parallelism=-1) because 405B does not fit with plain data parallelism. Env/XLA mirror the MAD gfx950_llama3.3_70b_env.sh (gfx950/MI355X).",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "llama3.1-405b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
-      "dtype": "bfloat16",
-      "dataset_type": "synthetic",
-      "remat_policy": "full",
-      "use_iota_embed": true,
-      "scan_layers": true,
-      "per_device_batch_size": 3,
-      "max_target_length": 8192,
-      "async_checkpointing": false,
-      "quantization": "",
-      "weight_dtype": "bfloat16",
-      "shardy": true,
-      "logits_dot_in_fp32": false,
-      "megablox": false,
-      "packing": true,
-      "enable_goodput_recording": false,
-      "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
-      "ici_fsdp_parallelism": 8,
+      "dcn_data_parallelism": 1,
+      "dcn_fsdp_parallelism": -1,
+      "dcn_pipeline_parallelism": 1,
+      "dcn_tensor_parallelism": 1,
+      "dcn_sequence_parallelism": 1,
+      "ici_fsdp_parallelism": -1,
       "ici_data_parallelism": 1,
       "ici_sequence_parallelism": 1,
       "ici_tensor_parallelism": 1,
       "ici_pipeline_parallelism": 1,
-      "dcn_data_parallelism": -1,
-      "dcn_fsdp_parallelism": 1,
-      "dcn_pipeline_parallelism": 1,
-      "dcn_tensor_parallelism": 1,
-      "dcn_sequence_parallelism": 1,
+      "remat_policy": "full",
+      "optimizer_memory_host_offload": false,
+      "param_scan_axis": 1,
+      "use_iota_embed": true,
+      "scan_layers": true,
       "profiler": "",
+      "skip_first_n_steps_for_profiler": 3,
+      "profiler_steps": 1,
+      "async_checkpointing": false,
+      "logits_dot_in_fp32": false,
+      "megablox": false,
+      "dtype": "bfloat16",
+      "quantization": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
       "kv_quant_dtype": "int8",
+      "weight_dtype": "bfloat16",
       "checkpoint_is_quantized": false,
-      "max_segments_per_seq": 32
+      "per_device_batch_size": 2,
+      "max_target_length": 8192,
+      "dataset_type": "synthetic",
+      "max_segments_per_seq": 32,
+      "shardy": true
     },
 
     "tokenizer": {
@@ -109,13 +108,13 @@
     },
 
     "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
-    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
+    "_env_vars_comment": "Compute/NVTE/XLA-side vars mirror MAD scripts/jax-maxtext/env_scripts/gfx950_llama3.3_70b_env.sh (gfx950/MI355X: RCCL_WARP_SPEED_AUTO=0, no HSA_NO_SCRATCH_RECLAIM; MAD has no 405B-specific env); the NCCL_IB_* / NCCL_PROTO networking vars are CVS cluster-specific (bnxt_re TCP fallback) and are not from the MAD script.",
     "env_vars": {
       "NNODES": "auto",
       "GPU_MAX_HW_QUEUES": "2",
       "HSA_FORCE_FINE_GRAIN_PCIE": "1",
       "HIP_FORCE_DEV_KERNARG": "1",
-      "HSA_NO_SCRATCH_RECLAIM": "1",
+      "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
       "NCCL_IB_DISABLE": "1",
@@ -136,6 +135,7 @@
       "NVTE_FUSED_ATTN_AOTRITON": "0"
     },
 
+    "_xla_flags_comment": "Mirrors XLA_FLAGS from MAD scripts/jax-maxtext/env_scripts/gfx950_llama3.3_70b_env.sh (autotune_level=4).",
     "xla_flags": {
       "xla_gpu_memory_limit_slop_factor": "95",
       "xla_gpu_reduce_scatter_combine_threshold_bytes": "8589934592",
@@ -170,9 +170,9 @@
       "heartbeat_timeout_seconds": "900"
     },
 
-    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. Set to 0.0 = disabled (record-only). Populate from a prior MI325X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). 405B does not fit on 1 node, so leave disabled; use a smaller reference (e.g. min node count that fits) if you want the metric.",
     "scaling_baseline": {
-      "tokens_per_sec_total": 394000.0,
+      "tokens_per_sec_total": 0.0,
       "num_nodes": 1
     },
 
@@ -202,12 +202,13 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. BF16 uses the base maxtext_config as-is. FP8 on MI300X/MI325X (CDNA3) must use quantization=nanoo_fp8 (the plain 'fp8' value is the NVIDIA path, also used on MI355X/MI350X). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
+    "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden. The NNODES=8 in the sweep names is only a label (405B needs ~8 nodes with full FSDP).",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (405B assumed on 8 nodes = 64 GPUs); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. FP8 on MI355X/MI350X (CDNA4) uses quantization=fp8 (MI300X/MI325X CDNA3 use nanoo_fp8). BF16 uses a smaller per-device batch than FP8 (higher memory). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
+        "name": "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 3,
+          "per_device_batch_size": 2,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -215,19 +216,19 @@
         }
       },
       {
-        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192",
+        "name": "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 3,
+          "per_device_batch_size": 5,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
-          "quantization": "nanoo_fp8"
+          "quantization": "fp8"
         }
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=3,GBS=48,SEQLEN=8192",
-      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=3,GBS=48,SEQLEN=8192"
+      "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192",
+      "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -144,7 +144,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -188,6 +188,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
@@ -1,7 +1,7 @@
 {
   "_comment": "APPROXIMATE placeholder thresholds for Llama-3.1-405B on MI355X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates (405B: high tflops/GPU, low tokens/s/GPU) -- replace with measured MI355X numbers. Requires enforce_thresholds=true.",
 
-  "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192": {
+  "NNODES=4,STEPS=30,PRECISION=BF16,BATCH=2,GBS=64,SEQLEN=8192": {
     "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 400.0 },
     "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 250.0 },
     "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
@@ -17,7 +17,7 @@
     "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
   },
 
-  "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192": {
+  "NNODES=4,STEPS=30,PRECISION=FP8,BATCH=3,GBS=96,SEQLEN=8192": {
     "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 600.0 },
     "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 400.0 },
     "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed_threshold.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for Llama-3.1-405B on MI355X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates (405B: high tflops/GPU, low tokens/s/GPU) -- replace with measured MI355X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=8,STEPS=30,PRECISION=BF16,BATCH=2,GBS=128,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 400.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 250.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  },
+
+  "NNODES=8,STEPS=30,PRECISION=FP8,BATCH=5,GBS=320,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 600.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 400.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "framework": "jaxmaxtext",
-  "gpu_arch": "mi300x",
+  "gpu_arch": "mi355x",
   "enforce_thresholds": true,
-  "threshold_json": "mi300x_jaxmaxtext_llama-3.3-70b_single_threshold.json",
+  "threshold_json": "mi355x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -13,14 +13,14 @@
   },
 
   "model": {
-    "id": "llama3.3-70b",
+    "id": "llama3.1-8b",
     "remote": 0,
     "precision": "bfloat16"
   },
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b-single",
+    "name": "rocm-jaxmaxtext-mi355x-llama3.1-8b",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -32,6 +32,9 @@
         "ulimit": ["nofile=65535:65535"],
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
+          "/dev/infiniband:/dev/infiniband",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
       }
@@ -41,7 +44,7 @@
   "__maxtext_version<=26.3__train_script": "/workspace/maxtext/src/MaxText/train.py",
   "__maxtext_version>=26.4__train_script": "/workspace/maxtext/src/maxtext/trainers/pre_train/train.py",
   "training": {
-    "distributed": false,
+    "distributed": true,
     "gpus_per_node": 8,
     "steps": 30,
     "enable_checkpointing": false,
@@ -50,18 +53,18 @@
       "/workspace/maxtext/src/MaxText/train.py"
     ],
 
-    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.3-70B rather than base.yml defaults.",
+    "_model_name_comment": "model_name selects the MaxText model preset (layers/heads/dims). Kept in maxtext_config so the run trains Llama-3.1-8B rather than base.yml defaults.",
     "maxtext_config": {
       "base_config": "base.yml",
-      "model_name": "llama3.3-70b",
+      "model_name": "llama3.1-8b",
       "hardware": "gpu",
       "attention": "cudnn_flash_te",
       "dtype": "bfloat16",
       "dataset_type": "synthetic",
-      "remat_policy": "full",
+      "remat_policy": "minimal_flash",
       "use_iota_embed": true,
       "scan_layers": true,
-      "per_device_batch_size": 2,
+      "per_device_batch_size": 4,
       "max_target_length": 8192,
       "async_checkpointing": false,
       "quantization": "",
@@ -72,13 +75,12 @@
       "packing": true,
       "enable_goodput_recording": false,
       "monitor_goodput": false,
-      "optimizer_memory_host_offload": false,
-      "param_scan_axis": 1,
+      "log_period": 100,
       "ici_fsdp_parallelism": 8,
       "ici_data_parallelism": 1,
-      "ici_sequence_parallelism": 1,
-      "ici_tensor_parallelism": 1,
-      "ici_pipeline_parallelism": 1,
+      "ici_tensor_sequence_parallelism": -1,
+      "dcn_data_parallelism": -1,
+      "dcn_fsdp_parallelism": 1,
       "profiler": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
@@ -88,24 +90,35 @@
     },
 
     "tokenizer": {
-      "hf_model_id": "NousResearch/Meta-Llama-3-70B",
-      "tokenizer_path": "{paths.models_dir}/Meta-Llama-70-B"
+      "hf_model_id": "NousResearch/Meta-Llama-3.1-8B",
+      "tokenizer_path": "{paths.models_dir}/Meta-Llama-3.1-8B"
     },
 
-    "nic_type": "none",
+    "nic_type": "thor2",
 
-    "_NCCL_IB_DISABLE_comment": "Single-node run uses intra-node RCCL (no inter-node IB), so this is a no-op here; kept for parity with the distributed configs where IB/RoCE over Broadcom bnxt_re segfaults and TCP is required.",
+    "rdma_lib": {
+      "host_source_file": "/usr/local/lib/libbnxt_re-rdmav34.so",
+      "container_mount_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+      "container_dest_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so"
+    },
+
+    "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
     "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
     "env_vars": {
       "NNODES": "auto",
-      "NODE_RANK": "0",
       "GPU_MAX_HW_QUEUES": "2",
       "HSA_FORCE_FINE_GRAIN_PCIE": "1",
       "HIP_FORCE_DEV_KERNARG": "1",
-      "HSA_NO_SCRATCH_RECLAIM": "1",
+      "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
       "NCCL_IB_DISABLE": "1",
+      "NCCL_PROTO": "Simple",
+      "NCCL_IB_TC": "41",
+      "NCCL_IB_SL": "0",
+      "NCCL_IB_GID_INDEX": "3",
+      "NCCL_CHECKS_DISABLE": "1",
+      "NCCL_CROSS_NIC": "0",
       "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "1",
       "NVTE_USE_HIPBLASLT": "1",
       "NVTE_FUSED_ATTN": "1",
@@ -129,13 +142,41 @@
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
+    "_nccl_comment": "Cluster-specific RDMA/NIC devices. Replace every '<changeme>' with your node's values (see the sibling _example_* entries); distributed runs hard-exit at config load until you do. Discover them with `ibv_devices` (HCAs) and `ip -br link` (host interface).",
+    "nccl": {
+      "_example_ib_hca_list": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca_list": "<changeme>",
+      "_example_ib_hca": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca": "<changeme>",
+      "_example_socket_ifname": "eno0",
+      "socket_ifname": "<changeme>",
+      "_example_gloo_socket_ifname": "eno0",
+      "gloo_socket_ifname": "<changeme>",
+      "ib_tc": "41",
+      "ib_sl": "0",
+      "ib_gid_index": "3"
+    },
+
+    "jax_distributed": {
+      "coordinator_ip": "auto",
+      "coordinator_port": "12346",
+      "initialization_timeout_seconds": "1800",
+      "heartbeat_timeout_seconds": "900"
+    },
+
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). Populate from a prior MI355X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "scaling_baseline": {
+      "tokens_per_sec_total": 0.0,
+      "num_nodes": 1
+    },
+
     "_convergence_comment": "to enable validation loss set eval_interval > 0 (and eval_steps) in maxtext_config; this needs a validation dataset (eval_split/eval_dataset_name). target_value <= 0 disables convergence (record-only). target_metric 'auto' uses eval_loss when eval runs, else training loss.",
     "convergence": {
       "target_metric": "auto",
-      "target_value": 0.0
+      "target_value": 10.0
     },
 
-    "_loss_curve_comment": "sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
+    "_loss_curve_comment": "Row 32: sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
     "loss_curve": {
       "sample_every": 10,
       "milestone_steps": [100, 500, 1000, 5000],
@@ -155,12 +196,12 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run; `name` is the threshold cell key. FP8 on MI300X (CDNA3) uses quantization=nanoo_fp8. STEPS/GBS/NNODES in the name are labels: steps comes from training.steps, GBS = per_device_batch_size * total GPUs, NNODES from the cluster. enabled_sweep_list selects which sweeps to run.",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (matching the reference); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. BF16 uses the base maxtext_config as-is. FP8 on MI355X/MI350X (CDNA4) uses quantization=fp8 (MI300X/MI325X CDNA3 use nanoo_fp8). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=256,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 4,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -168,19 +209,19 @@
         }
       },
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=6,GBS=384,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 6,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
-          "quantization": "nanoo_fp8"
+          "quantization": "fp8"
         }
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
-      "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192"
+      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=256,SEQLEN=8192",
+      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=6,GBS=384,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -138,7 +138,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -182,6 +182,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed_threshold.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for Llama-3.1-8B on MI355X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates -- replace with measured MI355X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=4,GBS=256,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 400.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 12000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  },
+
+  "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=6,GBS=384,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 550.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 18000.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "framework": "jaxmaxtext",
-  "gpu_arch": "mi300x",
+  "gpu_arch": "mi355x",
   "enforce_thresholds": true,
-  "threshold_json": "mi300x_jaxmaxtext_llama-3.3-70b_single_threshold.json",
+  "threshold_json": "mi355x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json",
 
   "paths": {
     "shared_fs": "/home/{user-id}",
@@ -20,7 +20,7 @@
 
   "container": {
     "lifetime": "per_run",
-    "name": "rocm-jaxmaxtext-llama3.3-70b-single",
+    "name": "rocm-jaxmaxtext-mi355x-llama3.3-70b",
     "image": "rocm/jax-training:maxtext-v26.4",
     "runtime": {
       "name": "docker",
@@ -32,6 +32,9 @@
         "ulimit": ["nofile=65535:65535"],
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
+          "/dev/infiniband:/dev/infiniband",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
       }
@@ -41,7 +44,7 @@
   "__maxtext_version<=26.3__train_script": "/workspace/maxtext/src/MaxText/train.py",
   "__maxtext_version>=26.4__train_script": "/workspace/maxtext/src/maxtext/trainers/pre_train/train.py",
   "training": {
-    "distributed": false,
+    "distributed": true,
     "gpus_per_node": 8,
     "steps": 30,
     "enable_checkpointing": false,
@@ -61,7 +64,7 @@
       "remat_policy": "full",
       "use_iota_embed": true,
       "scan_layers": true,
-      "per_device_batch_size": 2,
+      "per_device_batch_size": 6,
       "max_target_length": 8192,
       "async_checkpointing": false,
       "quantization": "",
@@ -79,6 +82,12 @@
       "ici_sequence_parallelism": 1,
       "ici_tensor_parallelism": 1,
       "ici_pipeline_parallelism": 1,
+      "ici_tensor_sequence_parallelism": -1,
+      "dcn_data_parallelism": -1,
+      "dcn_fsdp_parallelism": 1,
+      "dcn_pipeline_parallelism": 1,
+      "dcn_tensor_parallelism": 1,
+      "dcn_sequence_parallelism": 1,
       "profiler": "",
       "quantize_kvcache": false,
       "kv_quant_axis": "heads_and_dkv",
@@ -92,20 +101,31 @@
       "tokenizer_path": "{paths.models_dir}/Meta-Llama-70-B"
     },
 
-    "nic_type": "none",
+    "nic_type": "thor2",
 
-    "_NCCL_IB_DISABLE_comment": "Single-node run uses intra-node RCCL (no inter-node IB), so this is a no-op here; kept for parity with the distributed configs where IB/RoCE over Broadcom bnxt_re segfaults and TCP is required.",
+    "rdma_lib": {
+      "host_source_file": "/usr/local/lib/libbnxt_re-rdmav34.so",
+      "container_mount_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+      "container_dest_file": "/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so"
+    },
+
+    "_NCCL_IB_DISABLE_comment": "IB/RoCE over Broadcom bnxt_re segfaults in RCCL QP setup on these nodes (crashes on the first inter-node channel, independent of GDR / matched rdma-core / channel-count). TCP works. Remove this once the image ships an RCCL build validated against the bnxt_re RoCE stack.",
     "__comment_NNODES_": "NNODES is 'auto': the real node count is injected at runtime from the cluster_file (the training launcher exports NNODES=<num_nodes>), so this value is a placeholder and is overridden.",
     "env_vars": {
       "NNODES": "auto",
-      "NODE_RANK": "0",
       "GPU_MAX_HW_QUEUES": "2",
       "HSA_FORCE_FINE_GRAIN_PCIE": "1",
       "HIP_FORCE_DEV_KERNARG": "1",
-      "HSA_NO_SCRATCH_RECLAIM": "1",
+      "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
       "NCCL_IB_DISABLE": "1",
+      "NCCL_PROTO": "Simple",
+      "NCCL_IB_TC": "41",
+      "NCCL_IB_SL": "0",
+      "NCCL_IB_GID_INDEX": "3",
+      "NCCL_CHECKS_DISABLE": "1",
+      "NCCL_CROSS_NIC": "0",
       "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "1",
       "NVTE_USE_HIPBLASLT": "1",
       "NVTE_FUSED_ATTN": "1",
@@ -129,13 +149,41 @@
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
+    "_nccl_comment": "Cluster-specific RDMA/NIC devices. Replace every '<changeme>' with your node's values (see the sibling _example_* entries); distributed runs hard-exit at config load until you do. Discover them with `ibv_devices` (HCAs) and `ip -br link` (host interface).",
+    "nccl": {
+      "_example_ib_hca_list": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca_list": "<changeme>",
+      "_example_ib_hca": "rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7",
+      "ib_hca": "<changeme>",
+      "_example_socket_ifname": "eno0",
+      "socket_ifname": "<changeme>",
+      "_example_gloo_socket_ifname": "eno0",
+      "gloo_socket_ifname": "<changeme>",
+      "ib_tc": "41",
+      "ib_sl": "0",
+      "ib_gid_index": "3"
+    },
+
+    "jax_distributed": {
+      "coordinator_ip": "auto",
+      "coordinator_port": "12346",
+      "initialization_timeout_seconds": "1800",
+      "heartbeat_timeout_seconds": "900"
+    },
+
+    "_scaling_baseline_comment": "1-node total tokens/sec baseline for scaling-efficiency %. 0.0 = disabled (record-only). Populate from a prior MI355X single-node run (tok/s/GPU * 8) to enable the metric.",
+    "scaling_baseline": {
+      "tokens_per_sec_total": 0.0,
+      "num_nodes": 1
+    },
+
     "_convergence_comment": "to enable validation loss set eval_interval > 0 (and eval_steps) in maxtext_config; this needs a validation dataset (eval_split/eval_dataset_name). target_value <= 0 disables convergence (record-only). target_metric 'auto' uses eval_loss when eval runs, else training loss.",
     "convergence": {
       "target_metric": "auto",
-      "target_value": 0.0
+      "target_value": 10.0
     },
 
-    "_loss_curve_comment": "sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
+    "_loss_curve_comment": "Row 32: sample training loss every `sample_every` steps (plus milestone_steps) and pass when the least-squares slope < max_slope. enforce=false makes it record-only.",
     "loss_curve": {
       "sample_every": 10,
       "milestone_steps": [100, 500, 1000, 5000],
@@ -155,12 +203,12 @@
       "segfault": "Segmentation fault|SIGSEGV|core dumped|std::bad_alloc"
     },
 
-    "_sweeps_comment": "Each sweep = one full training run; `name` is the threshold cell key. FP8 on MI300X (CDNA3) uses quantization=nanoo_fp8. STEPS/GBS/NNODES in the name are labels: steps comes from training.steps, GBS = per_device_batch_size * total GPUs, NNODES from the cluster. enabled_sweep_list selects which sweeps to run.",
+    "_sweeps_comment": "Each sweep = one full training run with per-run maxtext overrides; `name` is the threshold cell key. NNODES/GBS in the name are informational labels (matching the reference); per_device_batch_size drives the run and the real global batch = per_device_batch_size * (nodes * gpus_per_node) at runtime. BF16 uses the base maxtext_config as-is. FP8 on MI355X/MI350X (CDNA4) uses quantization=fp8 (MI300X/MI325X CDNA3 use nanoo_fp8). weight_dtype stays bfloat16 (master weights). enabled_sweep_list selects which sweeps to run.",
     "sweeps": [
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=6,GBS=48,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 6,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
@@ -168,19 +216,19 @@
         }
       },
       {
-        "name": "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192",
+        "name": "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=4,GBS=32,SEQLEN=8192",
         "maxtext_overrides": {
-          "per_device_batch_size": 5,
+          "per_device_batch_size": 4,
           "max_target_length": 8192,
           "dtype": "bfloat16",
           "weight_dtype": "bfloat16",
-          "quantization": "nanoo_fp8"
+          "quantization": "fp8"
         }
       }
     ],
     "enabled_sweep_list": [
-      "NNODES=1,STEPS=30,PRECISION=BF16,BATCH=5,GBS=40,SEQLEN=8192",
-      "NNODES=1,STEPS=30,PRECISION=FP8,BATCH=5,GBS=40,SEQLEN=8192"
+      "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=6,GBS=48,SEQLEN=8192",
+      "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=4,GBS=32,SEQLEN=8192"
     ]
   }
 }

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -145,7 +145,7 @@
       "xla_gpu_all_gather_combine_threshold_bytes": "8589934592",
       "xla_gpu_enable_triton_gemm": "False",
       "xla_gpu_enable_cublaslt": "True",
-      "xla_gpu_autotune_level": "4",
+      "xla_gpu_autotune_level": "0",
       "xla_gpu_enable_all_gather_combine_by_dim": "FALSE"
     },
 
@@ -189,6 +189,20 @@
       "milestone_steps": [100, 500, 1000, 5000],
       "max_slope": 0.0,
       "enforce": true
+    },
+
+    "_checkpoint_resume_comment": "Opt-in checkpoint save+resume + I/O-time test (test_checkpoint_resume). enabled=false -> skipped. Runs ONE sweep (the `sweep` name, else the first enabled) twice: train steps_before_ckpt (checkpoint written at checkpoint_period), then resume + train steps_after_resume; passes if it restarts from the checkpoint step and the boundary loss matches within loss_tolerance. max_save_seconds/max_load_seconds gate checkpoint I/O time (0 = record-only). smoke_model_overrides can shrink the model while keeping the same tokenizer/vocab, e.g. {\"base_num_decoder_layers\": 4}; empty = the config's full model. delete_ckpt_dir=true deletes the checkpoint directory after the test to free disk (set false to keep the files for inspection).",
+    "checkpoint_resume": {
+      "enabled": false,
+      "sweep": "",
+      "steps_before_ckpt": 6,
+      "steps_after_resume": 6,
+      "checkpoint_period": 5,
+      "loss_tolerance": 0.1,
+      "max_save_seconds": 0.0,
+      "max_load_seconds": 0.0,
+      "delete_ckpt_dir": true,
+      "smoke_model_overrides": {}
     },
 
     "_error_patterns_comment": "Regexes (name -> pattern) scanned in each node's training.log during polling; a match fails that sweep's training_run with the matched name. Add/remove entries as you find new error signatures. Remove this block to use the built-in defaults. Escape backslashes per JSON (e.g. two backslashes for a regex \\d).",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed_threshold.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "APPROXIMATE placeholder thresholds for Llama-3.3-70B on MI355X distributed, keyed by sweep name. Gated metrics (min/max) drive PASS/FAIL; kind='info' metrics always PASS (record-only) but keep a default `value` to calibrate later. tflops/tokens mins are rough estimates -- replace with measured MI355X numbers. Requires enforce_thresholds=true.",
+
+  "NNODES=2,STEPS=30,PRECISION=BF16,BATCH=6,GBS=48,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 400.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 1500.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  },
+
+  "NNODES=2,STEPS=30,PRECISION=FP8,BATCH=4,GBS=32,SEQLEN=8192": {
+    "training.tflops_per_sec_per_gpu": { "kind": "min", "value": 550.0 },
+    "training.tokens_per_sec_per_gpu": { "kind": "min", "value": 2500.0 },
+    "training.tokens_per_sec_total":   { "kind": "info", "value": 0 },
+    "training.scaling_efficiency_pct": { "kind": "info", "value": 80.0 },
+    "training.step_time_seconds":      { "kind": "info", "value": 3600.0 },
+    "training.step_time_mean_ms":      { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p50_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.step_time_p95_ms":       { "kind": "info", "value": 3600000.0 },
+    "training.final_loss":             { "kind": "max", "value": 15.0 },
+    "training.loss_decreased":         { "kind": "min", "value": 1 },
+    "training.eval_loss":              { "kind": "info", "value": 100.0 },
+    "training.steps_to_target":        { "kind": "info", "value": 1000000 },
+    "training.time_to_target_seconds": { "kind": "info", "value": 1000000.0 }
+  }
+}

--- a/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
@@ -123,6 +123,12 @@ class MaxTextTrainingJob:
         self._scratch_dir = None  # resolved lazily to /tmp/<user>/jax
         self._train_script = None  # resolved lazily to the first existing candidate
 
+        # Per-node cursor (lines already surfaced) so polling STREAMS only the
+        # new training-log lines to the console once, instead of re-dumping a
+        # `tail -N` window every iteration (which bloated --log-file with
+        # repeated content).
+        self._log_line_cursor = [0] * self.num_nodes
+
     def _get_scratch_dir(self):
         """User-namespaced in-container scratch base (``/tmp/<user>/jax``).
 
@@ -394,6 +400,9 @@ class MaxTextTrainingJob:
 
         self.orch.exec_cmd_list(launch_cmds)
 
+        # Fresh run -> stream the log from the top.
+        self._log_line_cursor = [0] * self.num_nodes
+
         time.sleep(self._initial_wait_s)
 
     # ---------- polling ----------
@@ -414,7 +423,7 @@ class MaxTextTrainingJob:
             f"{shlex.quote(f'{self.out_dir}/out-node{i}/training.log')} 2>/dev/null || true"
             for i in range(self.num_nodes)
         ]
-        out = self.orch.exec_cmd_list(cmd_list)
+        out = self.orch.exec_cmd_list(cmd_list, print_console=False)
         if not out or len(out) < self.num_nodes:
             return False
         for _host, result in out.items():
@@ -424,32 +433,56 @@ class MaxTextTrainingJob:
                 return False
         return True
 
-    def _scan_for_errors(self):
-        """Scan each node's own training log for known error patterns.
+    def _scan_chunk_for_errors(self, host, i, text):
+        """Raise on the first known error signature (or NaN/Inf) in `text`."""
+        if not text:
+            return
+        if _NAN_INF_RE.search(text):
+            raise RuntimeError(f"NaN/Inf in training metrics on {host} (node {i}): {text[-500:]}")
+        for err_name, err_pattern in self.error_patterns.items():
+            if not err_pattern:
+                continue
+            if re.search(err_pattern, text, re.I):
+                raise RuntimeError(f"Training error '{err_name}' on {host} (node {i}): {text[-500:]}")
 
-        Reads all nodes' logs in one parallel ``orch.exec_cmd_list`` call
-        (``cmd_list[i]`` runs on ``hosts[i]``). Raises on the first match.
+    def _drain_new_log_lines(self):
+        """Fetch training-log lines written since the last poll, on every node,
+        in one parallel call, and advance each node's cursor.
+
+        Returns ``{node_index: new_text}``. ``print_console=False`` so the
+        orchestrator does NOT re-echo the bulk output -- the caller decides what
+        to surface (we stream node 0 and scan every node for errors). This is
+        what makes the console/--log-file carry each log line ONCE instead of a
+        repeated ``tail`` window per poll.
         """
         cmd_list = [
-            f"tail -2000 {shlex.quote(f'{self.out_dir}/out-node{i}/training.log')} 2>/dev/null"
+            f"tail -n +{self._log_line_cursor[i] + 1} "
+            f"{shlex.quote(f'{self.out_dir}/out-node{i}/training.log')} 2>/dev/null || true"
             for i in range(self.num_nodes)
         ]
-        out = self.orch.exec_cmd_list(cmd_list)
+        out = self.orch.exec_cmd_list(cmd_list, print_console=False)
         node_of = {h: i for i, h in enumerate(self.orch.hosts)}
-        for host, text in (out or {}).items():
-            text = text if isinstance(text, str) else (text or {}).get("output", "")
+        new_by_node = {}
+        for host, result in (out or {}).items():
+            text = result if isinstance(result, str) else (result or {}).get("output", "")
             text = text or ""
-            i = node_of.get(host, "?")
-            if _NAN_INF_RE.search(text):
-                raise RuntimeError(f"NaN/Inf in training metrics on {host} (node {i}): {text[-500:]}")
-            for err_name, err_pattern in self.error_patterns.items():
-                if not err_pattern:
-                    continue
-                if re.search(err_pattern, text, re.I):
-                    raise RuntimeError(f"Training error '{err_name}' on {host} (node {i}): {text[-500:]}")
+            i = node_of.get(host)
+            if i is None or not text:
+                continue
+            # Advance the cursor by the number of newly read lines so the next
+            # poll starts right after them.
+            self._log_line_cursor[i] += len(text.splitlines())
+            new_by_node[i] = text
+        return new_by_node
 
     def poll_for_completion(self, timeout_s=None):
-        """Poll is_complete() with error scanning until training finishes or times out."""
+        """Poll until training finishes or times out.
+
+        Each iteration streams only the NEW training-log lines (node 0 to the
+        console; all nodes scanned for error signatures), then checks for the
+        completion marker. A concise ``[poll]`` heartbeat makes the internal
+        polling visible without re-dumping the log.
+        """
         if timeout_s is None:
             timeout_s = self._poll_count * self._poll_wait_s
 
@@ -459,16 +492,28 @@ class MaxTextTrainingJob:
             if elapsed >= timeout_s:
                 raise RuntimeError(f"training did not complete within {timeout_s}s (polled {it} times)")
 
-            self._scan_for_errors()
+            new_by_node = self._drain_new_log_lines()
+
+            # Scan every node's new chunk for errors (raises on the first match).
+            for i, text in new_by_node.items():
+                self._scan_chunk_for_errors(self.orch.hosts[i], i, text)
+
+            # Stream node 0's (coordinator) new lines to the console once.
+            node0_new = (new_by_node.get(0) or "").rstrip()
+            if node0_new:
+                log.info("[train node0]\n%s", node0_new)
 
             if self.is_complete():
+                # Flush any tail lines written since the drain above (e.g. the
+                # final "completed step" marker) so the stream ends cleanly.
+                tail_new = (self._drain_new_log_lines().get(0) or "").rstrip()
+                if tail_new:
+                    log.info("[train node0]\n%s", tail_new)
                 log.info("training complete (poll iter=%d, %.0fs elapsed)", it, elapsed)
                 return
 
             log.info(
-                "training in progress (poll iter=%d, %.0fs elapsed)",
-                it,
-                elapsed,
+                "[poll] iter=%d elapsed=%.0fs (streaming node0 log; scanning %d node(s))", it, elapsed, self.num_nodes
             )
             time.sleep(self._poll_wait_s)
 

--- a/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
@@ -245,6 +245,12 @@ class MaxTextTrainingJob:
                 yml_lines.append(f'{k}: {v}')
             elif isinstance(v, bool):
                 yml_lines.append(f"{k}: {'true' if v else 'false'}")
+            elif isinstance(v, str) and v == "":
+                # Emit an explicit empty string ('key: ""'), not a bare 'key:'.
+                # A bare value parses as YAML null -> Python None, which breaks
+                # MaxText fields that are strict enums over "" (e.g. `profiler`
+                # accepts only '', 'xplane', 'nsys'; None raises a ValidationError).
+                yml_lines.append(f'{k}: ""')
             else:
                 yml_lines.append(f"{k}: {v}")
 

--- a/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
@@ -391,6 +391,21 @@ class MaxTextTrainingJob:
         self.training_start_time = self._host_date()
 
         scratch = self._get_scratch_dir()
+
+        # Clear each node's previous training.log BEFORE launch. The launcher
+        # only truncates the log once it reaches `python ... | tee training.log`;
+        # if this run dies earlier (env source fails, launcher never starts,
+        # etc.) a STALE log with an old "completed step: N" marker would remain
+        # and is_complete() would report success on the first poll -- a
+        # fail-open that lets smoke/training pass without this run doing the
+        # work. Removing it here means a run that never reaches `tee` leaves no
+        # log, so is_complete() stays false and the stage correctly times out.
+        clear_cmds = [
+            "bash -c " + shlex.quote(f"rm -f {shlex.quote(f'{self.out_dir}/out-node{i}/training.log')}")
+            for i in range(self.num_nodes)
+        ]
+        self.orch.exec_cmd_list(clear_cmds)
+
         launch_cmds = []
         for i in range(self.num_nodes):
             script_path = f"{scratch}/training_launcher_node{i}.sh"
@@ -504,11 +519,18 @@ class MaxTextTrainingJob:
                 log.info("[train node0]\n%s", node0_new)
 
             if self.is_complete():
-                # Flush any tail lines written since the drain above (e.g. the
-                # final "completed step" marker) so the stream ends cleanly.
-                tail_new = (self._drain_new_log_lines().get(0) or "").rstrip()
-                if tail_new:
-                    log.info("[train node0]\n%s", tail_new)
+                # Flush the tail lines written between the drain above and this
+                # completion check -- the final "completed step" marker, and
+                # anything after it (a shutdown traceback or a last-step NaN),
+                # land here. Scan EVERY node's final chunk for error signatures
+                # before declaring success (dropping non-0 nodes would hide a
+                # worker-only failure in this window), then stream node 0.
+                tail = self._drain_new_log_lines()
+                for i, text in tail.items():
+                    self._scan_chunk_for_errors(self.orch.hosts[i], i, text)
+                node0_tail = (tail.get(0) or "").rstrip()
+                if node0_tail:
+                    log.info("[train node0]\n%s", node0_tail)
                 log.info("training complete (poll iter=%d, %.0fs elapsed)", it, elapsed)
                 return
 

--- a/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
@@ -110,6 +110,7 @@ class MaxTextTrainingJob:
         self.step_metrics = []
         self.eval_metrics = []
         self.summary_metrics = {}
+        self.raw_log = ""
 
         # Host-side timestamp ({node: str}) captured when training launches, so
         # scan_dmesg_for_errors() can slice the kernel log to this run's window.
@@ -494,6 +495,7 @@ class MaxTextTrainingJob:
         if not log_text.strip():
             raise RuntimeError(f"empty/missing training log: {log_file}")
 
+        self.raw_log = log_text  # kept so callers (e.g. checkpoint I/O timing) can re-scan it
         self.step_metrics = extract_step_metrics(log_text)
         self.eval_metrics = extract_eval_metrics(log_text)
         self.summary_metrics = parse_training_log(log_text, self.num_gpus)

--- a/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
@@ -155,46 +155,72 @@ class IsCompleteTests(unittest.TestCase):
 
 class ScanForErrorsTests(unittest.TestCase):
     def test_clean_log_no_raise(self):
-        job, orch = _make_job(hosts=["h0"])
-        orch.exec_cmd_list.return_value = {"h0": _log()}
-        job._scan_for_errors()  # should not raise
+        job, _ = _make_job(hosts=["h0"])
+        job._scan_chunk_for_errors("h0", 0, _log())  # should not raise
+
+    def test_empty_chunk_no_raise(self):
+        job, _ = _make_job(hosts=["h0"])
+        job._scan_chunk_for_errors("h0", 0, "")  # should not raise
 
     def test_nccl_error_raises(self):
-        job, orch = _make_job(hosts=["h0"])
-        orch.exec_cmd_list.return_value = {"h0": "some log\nNCCL ERROR: unhandled\n"}
+        job, _ = _make_job(hosts=["h0"])
         with self.assertRaises(RuntimeError):
-            job._scan_for_errors()
+            job._scan_chunk_for_errors("h0", 0, "some log\nNCCL ERROR: unhandled\n")
 
     def test_nan_metric_raises(self):
-        job, orch = _make_job(hosts=["h0"])
-        orch.exec_cmd_list.return_value = {"h0": "completed step: 1, TFLOP/s/device: NaN\n"}
+        job, _ = _make_job(hosts=["h0"])
         with self.assertRaises(RuntimeError):
-            job._scan_for_errors()
+            job._scan_chunk_for_errors("h0", 0, "completed step: 1, TFLOP/s/device: NaN\n")
 
     def test_config_error_patterns_replace_defaults(self):
         # A config-provided error_patterns set fully REPLACES the built-in defaults.
-        job, orch = _make_job(hosts=["h0"], error_patterns={"custom": "MY_CUSTOM_ERR"})
+        job, _ = _make_job(hosts=["h0"], error_patterns={"custom": "MY_CUSTOM_ERR"})
         # The default NCCL signature is no longer active -> no raise.
-        orch.exec_cmd_list.return_value = {"h0": "some log\nNCCL ERROR: unhandled\n"}
-        job._scan_for_errors()
+        job._scan_chunk_for_errors("h0", 0, "some log\nNCCL ERROR: unhandled\n")
         # The custom signature IS active -> raises.
-        orch.exec_cmd_list.return_value = {"h0": "boom MY_CUSTOM_ERR here\n"}
         with self.assertRaises(RuntimeError):
-            job._scan_for_errors()
+            job._scan_chunk_for_errors("h0", 0, "boom MY_CUSTOM_ERR here\n")
 
     def test_default_error_patterns_used_when_config_empty(self):
         # No config error_patterns -> built-in defaults apply.
-        job, orch = _make_job(hosts=["h0"])
-        orch.exec_cmd_list.return_value = {"h0": "RESOURCE_EXHAUSTED: Out of memory\n"}
+        job, _ = _make_job(hosts=["h0"])
         with self.assertRaises(RuntimeError):
-            job._scan_for_errors()
+            job._scan_chunk_for_errors("h0", 0, "RESOURCE_EXHAUSTED: Out of memory\n")
 
     def test_default_segfault_pattern_raises(self):
         # segfault is part of the built-in default signatures.
-        job, orch = _make_job(hosts=["h0"])
-        orch.exec_cmd_list.return_value = {"h0": "worker: Segmentation fault (core dumped)\n"}
+        job, _ = _make_job(hosts=["h0"])
         with self.assertRaises(RuntimeError):
-            job._scan_for_errors()
+            job._scan_chunk_for_errors("h0", 0, "worker: Segmentation fault (core dumped)\n")
+
+
+class DrainNewLogLinesTests(unittest.TestCase):
+    def test_advances_cursor_and_returns_new_text(self):
+        job, orch = _make_job(hosts=["h0", "h1"])
+        orch.exec_cmd_list.return_value = {"h0": "l1\nl2\nl3\n", "h1": "a\nb\n"}
+        new = job._drain_new_log_lines()
+        self.assertEqual(new[0], "l1\nl2\nl3\n")
+        self.assertEqual(new[1], "a\nb\n")
+        # cursor advances by the number of lines read on each node.
+        self.assertEqual(job._log_line_cursor, [3, 2])
+
+    def test_uses_cursor_offset_in_tail_and_no_console_echo(self):
+        job, orch = _make_job(hosts=["h0"])
+        job._log_line_cursor = [5]
+        orch.exec_cmd_list.return_value = {"h0": "l6\n"}
+        job._drain_new_log_lines()
+        # tail starts at the line after the cursor (5 -> +6) ...
+        cmd = orch.exec_cmd_list.call_args.args[0][0]
+        self.assertIn("tail -n +6", cmd)
+        # ... and the bulk read is NOT echoed to the console.
+        self.assertEqual(orch.exec_cmd_list.call_args.kwargs.get("print_console"), False)
+
+    def test_empty_output_leaves_cursor_unchanged(self):
+        job, orch = _make_job(hosts=["h0"])
+        orch.exec_cmd_list.return_value = {"h0": ""}
+        new = job._drain_new_log_lines()
+        self.assertEqual(new, {})
+        self.assertEqual(job._log_line_cursor, [0])
 
 
 class ParseResultsTests(unittest.TestCase):

--- a/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
@@ -354,6 +354,16 @@ class WriteMaxtextYamlTests(unittest.TestCase):
         # scan_layers True -> lowercase bool
         self.assertIn("scan_layers: true", written)
 
+    def test_empty_string_rendered_as_quoted_not_bare(self):
+        # An empty-string maxtext param (e.g. profiler) must render as 'key: ""',
+        # never bare 'key:' (which YAML reads as null and breaks MaxText enums).
+        job, orch = _make_job()
+        job.maxtext_config["profiler"] = ""
+        job._write_maxtext_yaml()
+        written = "\n".join(str(c.args[0]) for c in orch.exec.call_args_list)
+        self.assertIn('profiler: ""', written)
+        self.assertNotIn("profiler: \n", written)
+
 
 class StartTrainingTests(unittest.TestCase):
     @patch("cvs.lib.training.jaxmaxtext.jaxmaxtext_training_lib.time.sleep")

--- a/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
@@ -396,10 +396,24 @@ class StartTrainingTests(unittest.TestCase):
     def test_launches_per_node_backgrounded(self, _sleep):
         job, orch = _make_job(hosts=["h0", "h1"])
         job.start_training()
-        cmds = orch.exec_cmd_list.call_args.args[0]
+        cmds = orch.exec_cmd_list.call_args.args[0]  # last call == launch
         self.assertEqual(len(cmds), 2)
         self.assertTrue(all("nohup bash" in c for c in cmds))
         _sleep.assert_called_once()
+
+    @patch("cvs.lib.training.jaxmaxtext.jaxmaxtext_training_lib.time.sleep")
+    def test_clears_stale_log_before_launch(self, _sleep):
+        # A stale training.log with an old "completed step" marker would make
+        # is_complete() pass on the first poll (fail-open). start_training must
+        # rm each node's log BEFORE launching.
+        job, orch = _make_job(hosts=["h0", "h1"])
+        job.start_training()
+        clear_cmds = orch.exec_cmd_list.call_args_list[0].args[0]
+        self.assertEqual(len(clear_cmds), 2)
+        self.assertTrue(all("rm -f" in c and "training.log" in c for c in clear_cmds))
+        # ... and the clear precedes the launch.
+        launch_cmds = orch.exec_cmd_list.call_args_list[-1].args[0]
+        self.assertTrue(all("nohup bash" in c for c in launch_cmds))
 
     @patch("cvs.lib.training.jaxmaxtext.jaxmaxtext_training_lib.time.sleep")
     def test_captures_host_start_time(self, _sleep):
@@ -411,6 +425,46 @@ class StartTrainingTests(unittest.TestCase):
         _wire_container_exec(orch)
         job.start_training()
         self.assertEqual(job.training_start_time, {"h0": "Mon Jan  2 03:04", "h1": "Mon Jan  2 03:04"})
+
+
+class PollForCompletionTests(unittest.TestCase):
+    _LIB = "cvs.lib.training.jaxmaxtext.jaxmaxtext_training_lib"
+
+    @patch(f"{_LIB}.time.sleep")
+    def test_completion_path_scans_final_drain_for_nan(self, _sleep):
+        # The chunk fetched on the completion path (final "completed step" +
+        # anything after) must be error-scanned before declaring success.
+        job, _ = _make_job(hosts=["h0"])
+        job.is_complete = MagicMock(return_value=True)
+        job._drain_new_log_lines = MagicMock(
+            side_effect=[
+                {},  # loop-body drain: nothing new yet
+                {0: "completed step: 2, TFLOP/s/device: NaN\n"},  # completion-path drain
+            ]
+        )
+        with self.assertRaises(RuntimeError):
+            job.poll_for_completion()
+
+    @patch(f"{_LIB}.time.sleep")
+    def test_completion_path_scans_worker_node_not_just_node0(self, _sleep):
+        # A worker-only (non-0) error in the completion window must still raise.
+        job, _ = _make_job(hosts=["h0", "h1"])
+        job.is_complete = MagicMock(return_value=True)
+        job._drain_new_log_lines = MagicMock(
+            side_effect=[
+                {},
+                {1: "some log\nNCCL ERROR: boom\n"},
+            ]
+        )
+        with self.assertRaises(RuntimeError):
+            job.poll_for_completion()
+
+    @patch(f"{_LIB}.time.sleep")
+    def test_clean_completion_returns(self, _sleep):
+        job, _ = _make_job(hosts=["h0"])
+        job.is_complete = MagicMock(return_value=True)
+        job._drain_new_log_lines = MagicMock(side_effect=[{}, {0: _log()}])
+        job.poll_for_completion()  # should not raise
 
 
 class ScanDmesgForErrorsTests(unittest.TestCase):

--- a/cvs/lib/training/jaxmaxtext/unittests/test_maxtext_parsing.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_maxtext_parsing.py
@@ -12,6 +12,7 @@ import unittest
 from cvs.lib.training.jaxmaxtext.utils.maxtext_parsing import (
     compute_convergence,
     evaluate_loss_decreasing,
+    extract_checkpoint_timings,
     extract_eval_metrics,
     parse_training_log,
     sample_loss_curve,
@@ -24,6 +25,58 @@ def _step_line(step, seconds, loss):
         f"seconds: {seconds}, TFLOP/s/device: 200.0, Tokens/s/device: 25000.0, "
         f"total_weights: 393216, loss: {loss}, lm_loss: {loss}, perplexity: 10.0"
     )
+
+
+class ExtractCheckpointTimingsTests(unittest.TestCase):
+    def test_empty_when_no_timing_lines(self):
+        log = "\n".join(_step_line(i, 0.5, 9.0 - i) for i in range(3))
+        self.assertEqual(extract_checkpoint_timings(log), {"save_seconds": None, "load_seconds": None})
+
+    def test_parses_save_and_load_durations(self):
+        log = (
+            "Saved a checkpoint at step 5 in 12.5 seconds\n"
+            "Restored checkpoint from step 5 took 3.2s\n"
+        )
+        out = extract_checkpoint_timings(log)
+        self.assertAlmostEqual(out["save_seconds"], 12.5)
+        self.assertAlmostEqual(out["load_seconds"], 3.2)
+
+    def test_save_only(self):
+        out = extract_checkpoint_timings("saving checkpoint duration: 7 s\n")
+        self.assertAlmostEqual(out["save_seconds"], 7.0)
+        self.assertIsNone(out["load_seconds"])
+
+    def test_never_raises_on_garbage(self):
+        self.assertEqual(
+            extract_checkpoint_timings(None), {"save_seconds": None, "load_seconds": None}
+        )
+
+    def test_orbax_save_uses_last_finished_save(self):
+        # Real orbax wording: event_tracking "[sync] Finished save in <X> seconds".
+        # Two saves (cold step 0, warm step 5) -> report the LAST (steady-state).
+        log = (
+            "event_tracking.py:138] [process=0] [sync] Finished save in 11.09 seconds "
+            "@ /LOGS/CKPT/checkpoints/0\n"
+            "event_tracking.py:125] [process=0] [sync] Finished blocking save in 3.87 seconds. "
+            "Continuing save @ /LOGS/CKPT/checkpoints/5.\n"
+            "event_tracking.py:138] [process=0] [sync] Finished save in 3.89 seconds "
+            "@ /LOGS/CKPT/checkpoints/5\n"
+        )
+        out = extract_checkpoint_timings(log)
+        self.assertAlmostEqual(out["save_seconds"], 3.89)
+
+    def test_orbax_load_uses_max_read_elapsed(self):
+        # Real orbax wording on restore: "/jax/orbax/read ... (time elapsed: <X> s)".
+        # Per-host lines -> report the MAX (slowest host bounds the restore).
+        log = (
+            "checkpointer.py:307] Restoring checkpoint from /LOGS/CKPT/checkpoints/5.\n"
+            "jax_array_handlers.py:862] [process=0] /jax/orbax/read/worker/io/requested "
+            "throughput: 7.257 GiB/s (total gbytes: 44.9 GiB) (time elapsed: 6.183607 s) (per-host)\n"
+            "jax_array_handlers.py:862] [process=1] /jax/orbax/read/worker/io/requested "
+            "throughput: 7.320 GiB/s (total gbytes: 44.9 GiB) (time elapsed: 6.130086 s) (per-host)\n"
+        )
+        out = extract_checkpoint_timings(log)
+        self.assertAlmostEqual(out["load_seconds"], 6.183607)
 
 
 class ExtractEvalMetricsTests(unittest.TestCase):

--- a/cvs/lib/training/jaxmaxtext/unittests/test_maxtext_parsing.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_maxtext_parsing.py
@@ -33,10 +33,7 @@ class ExtractCheckpointTimingsTests(unittest.TestCase):
         self.assertEqual(extract_checkpoint_timings(log), {"save_seconds": None, "load_seconds": None})
 
     def test_parses_save_and_load_durations(self):
-        log = (
-            "Saved a checkpoint at step 5 in 12.5 seconds\n"
-            "Restored checkpoint from step 5 took 3.2s\n"
-        )
+        log = "Saved a checkpoint at step 5 in 12.5 seconds\nRestored checkpoint from step 5 took 3.2s\n"
         out = extract_checkpoint_timings(log)
         self.assertAlmostEqual(out["save_seconds"], 12.5)
         self.assertAlmostEqual(out["load_seconds"], 3.2)
@@ -47,9 +44,7 @@ class ExtractCheckpointTimingsTests(unittest.TestCase):
         self.assertIsNone(out["load_seconds"])
 
     def test_never_raises_on_garbage(self):
-        self.assertEqual(
-            extract_checkpoint_timings(None), {"save_seconds": None, "load_seconds": None}
-        )
+        self.assertEqual(extract_checkpoint_timings(None), {"save_seconds": None, "load_seconds": None})
 
     def test_orbax_save_uses_last_finished_save(self):
         # Real orbax wording: event_tracking "[sync] Finished save in <X> seconds".

--- a/cvs/lib/training/jaxmaxtext/unittests/test_training_config_loader.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_training_config_loader.py
@@ -114,11 +114,13 @@ class RealConfigRoundTripTests(unittest.TestCase):
         for cell in expected:
             self.assertIn(cell, self.cfg.thresholds)
 
-    def test_eval_defaults_disabled(self):
-        # The config plumbs eval flags but leaves them disabled by default.
+    def test_eval_not_overridden(self):
+        # After aligning with the MAD scripts, the config no longer sets
+        # eval_interval / eval_steps explicitly -- eval is left to MaxText's
+        # default (disabled). Assert the keys are absent rather than pinned.
         mc = self.cfg.training.maxtext_config
-        self.assertEqual(mc.get("eval_interval"), -1)
-        self.assertEqual(mc.get("eval_steps"), -1)
+        self.assertNotIn("eval_interval", mc)
+        self.assertNotIn("eval_steps", mc)
 
 
 if __name__ == "__main__":

--- a/cvs/lib/training/jaxmaxtext/unittests/test_training_config_loader.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_training_config_loader.py
@@ -13,6 +13,7 @@ import warnings
 from pathlib import Path
 
 from cvs.lib.training.jaxmaxtext.utils.training_config_loader import (
+    CheckpointResume,
     Convergence,
     LossCurve,
     ScalingBaseline,
@@ -43,6 +44,18 @@ class SchemaDefaultsTests(unittest.TestCase):
         self.assertEqual(lc.milestone_steps, [100, 500, 1000, 5000])
         self.assertEqual(lc.max_slope, 0.0)
         self.assertTrue(lc.enforce)
+
+    def test_checkpoint_resume_defaults(self):
+        cr = CheckpointResume()
+        self.assertFalse(cr.enabled)  # opt-in: off by default
+        self.assertEqual(cr.sweep, "")
+        self.assertEqual(cr.steps_before_ckpt, 6)
+        self.assertEqual(cr.steps_after_resume, 6)
+        self.assertEqual(cr.checkpoint_period, 5)
+        self.assertEqual(cr.loss_tolerance, 0.1)
+        self.assertEqual(cr.max_save_seconds, 0.0)
+        self.assertEqual(cr.max_load_seconds, 0.0)
+        self.assertEqual(cr.smoke_model_overrides, {})
 
 
 class ValidateThresholdsCoverTrainingTests(unittest.TestCase):

--- a/cvs/lib/training/jaxmaxtext/utils/maxtext_parsing.py
+++ b/cvs/lib/training/jaxmaxtext/utils/maxtext_parsing.py
@@ -37,6 +37,15 @@ TRAINING_METRICS = [
 ]
 TRAINING_METRIC_UNITS = dict(TRAINING_METRICS)
 
+# Checkpoint I/O benchmark metrics. Kept OUT of TRAINING_METRICS on purpose so
+# they are NOT parametrized per sweep (test_metric) or printed in the per-sweep
+# results table -- they are produced only by the opt-in checkpoint_resume test,
+# which records their rows itself (under the "CKPT" label).
+CHECKPOINT_METRICS = [
+    ("checkpoint_save_seconds", "s"),
+    ("checkpoint_load_seconds", "s"),
+]
+
 # The SLO contract: the subset of TRAINING_METRICS a calibrated run must assert.
 # Membership = "out of range means FAILURE". Record-only by default: a NEW metric
 # is record-only until its name is added here. Covers throughput (perf) plus the
@@ -68,6 +77,30 @@ _LOSS_RE = re.compile(r"\bloss[:=]?\s*([\d.eE+\-]+)", re.I)
 # Config-dump lines ("Config param target_eval_loss: 0.0") mention eval + loss but
 # are not eval results -- exclude them so they never register as eval points.
 _CONFIG_LINE_RE = re.compile(r"config param|pyconfig", re.I)
+
+# Checkpoint I/O timing (checkpoint_resume test only). MaxText/orbax wording is
+# version-dependent, so match defensively: a "save"/"restore" line mentioning a
+# checkpoint and a duration in seconds. Returns None when unparseable -- the
+# caller falls back to a step-time proxy for save and record-only for load.
+# NOTE: confirm the exact orbax/MaxText wording on your image and tighten these.
+# orbax logs the total blocking save via event_tracking, e.g.
+#   "[sync] Finished save in 11.09 seconds @ .../checkpoints/0"
+# (there is also "Finished blocking save in ..." which we intentionally skip in
+# favor of the total). Multiple saves may appear (step 0 cold, later steps warm).
+_CKPT_SAVE_RE = re.compile(r"[Ff]inished save in\s*([\d.]+)\s*second", re.I)
+# The generic "saved/restored checkpoint ... <X>s" wording is kept as a fallback
+# for other image/orbax versions.
+_CKPT_SAVE_FALLBACK_RE = re.compile(
+    r"sav(?:e|ed|ing).*?checkpoint.*?(?:took|in|duration[:=]?)\s*([\d.]+)\s*s(?:ec|econds)?\b", re.I
+)
+# On restore, orbax logs the read throughput with an elapsed time, e.g.
+#   "/jax/orbax/read/worker/io/requested throughput: 7.257 GiB/s ... (time elapsed: 6.18 s) (per-host)"
+# This is the checkpoint read/load time (per host).
+_CKPT_LOAD_RE = re.compile(r"/jax/orbax/read\b.*?time elapsed:\s*([\d.]+)\s*s", re.I)
+_CKPT_LOAD_FALLBACK_RE = re.compile(
+    r"(?:restor(?:e|ed|ing)|load(?:ed|ing)?).*?checkpoint.*?(?:took|in|duration[:=]?)\s*([\d.]+)\s*s(?:ec|econds)?\b",
+    re.I,
+)
 
 
 def compute_scaling_efficiency(
@@ -314,6 +347,48 @@ def extract_eval_metrics(log_text):
         step = int(step_m.group(1)) if step_m else None
         evals.append({"step": step, "eval_loss": loss})
     return evals
+
+
+def _match_floats(patterns, line):
+    for pat in patterns:
+        m = pat.search(line)
+        if m:
+            try:
+                return float(m.group(1))
+            except ValueError:
+                return None
+    return None
+
+
+def extract_checkpoint_timings(log_text):
+    """Best-effort checkpoint save/load durations (seconds) from a MaxText log.
+
+    Save is taken from orbax's ``[sync] Finished save in <X> seconds`` lines; if
+    several checkpoints were written we return the LAST one (steady-state / the
+    checkpoint actually resumed from, rather than the cold first save). Load is
+    taken from orbax's restore read line ``/jax/orbax/read ... (time elapsed: <X>
+    s)``; we return the MAX across hosts (the slowest host bounds the restore).
+    Both fall back to a generic "saved/restored checkpoint ... <X>s" wording for
+    other image/orbax versions.
+
+    The exact wording is image/version-dependent, so this is defensive: it
+    returns ``{"save_seconds": None, "load_seconds": None}`` when nothing
+    matches. The checkpoint_resume test then falls back to a step-time proxy for
+    save time and treats a missing load time as record-only. Never raises.
+    """
+    save_vals = []
+    load_vals = []
+    for line in (log_text or "").splitlines():
+        s = _match_floats((_CKPT_SAVE_RE, _CKPT_SAVE_FALLBACK_RE), line)
+        if s is not None:
+            save_vals.append(s)
+        l = _match_floats((_CKPT_LOAD_RE, _CKPT_LOAD_FALLBACK_RE), line)
+        if l is not None:
+            load_vals.append(l)
+    return {
+        "save_seconds": save_vals[-1] if save_vals else None,
+        "load_seconds": max(load_vals) if load_vals else None,
+    }
 
 
 def parse_training_log(log_text, num_gpus, avg_last_n=10):

--- a/cvs/lib/training/jaxmaxtext/utils/maxtext_parsing.py
+++ b/cvs/lib/training/jaxmaxtext/utils/maxtext_parsing.py
@@ -379,12 +379,12 @@ def extract_checkpoint_timings(log_text):
     save_vals = []
     load_vals = []
     for line in (log_text or "").splitlines():
-        s = _match_floats((_CKPT_SAVE_RE, _CKPT_SAVE_FALLBACK_RE), line)
-        if s is not None:
-            save_vals.append(s)
-        l = _match_floats((_CKPT_LOAD_RE, _CKPT_LOAD_FALLBACK_RE), line)
-        if l is not None:
-            load_vals.append(l)
+        save_val = _match_floats((_CKPT_SAVE_RE, _CKPT_SAVE_FALLBACK_RE), line)
+        if save_val is not None:
+            save_vals.append(save_val)
+        load_val = _match_floats((_CKPT_LOAD_RE, _CKPT_LOAD_FALLBACK_RE), line)
+        if load_val is not None:
+            load_vals.append(load_val)
     return {
         "save_seconds": save_vals[-1] if save_vals else None,
         "load_seconds": max(load_vals) if load_vals else None,

--- a/cvs/lib/training/jaxmaxtext/utils/training_config_loader.py
+++ b/cvs/lib/training/jaxmaxtext/utils/training_config_loader.py
@@ -120,6 +120,40 @@ class LossCurve(_Allow):
     enforce: bool = True
 
 
+class CheckpointResume(_Allow):
+    """Checkpoint save + resume test (opt-in; off by default).
+
+    Runs ONE sweep twice: Phase 1 trains `steps_before_ckpt` steps with
+    checkpointing on (a checkpoint is written at `checkpoint_period`); Phase 2
+    resumes from that checkpoint and trains `steps_after_resume` more. Passes
+    when the resumed run restarts at the checkpoint step and the loss at the
+    resume boundary matches Phase 1 within `loss_tolerance` (state restored, not
+    reinitialized). Also benchmarks checkpoint I/O: `checkpoint_save_seconds` /
+    `checkpoint_load_seconds` are gated against `max_save_seconds` /
+    `max_load_seconds` when those are > 0 (else record-only).
+
+    `sweep` selects which sweep to use ("" -> first enabled). `smoke_model_overrides`
+    optionally shrinks the model for a fast run WITHOUT changing the tokenizer/
+    vocab (e.g. {"base_num_decoder_layers": 4}); empty -> the config's full model
+    (real-size checkpoint I/O).
+
+    `delete_ckpt_dir` (default true) removes the checkpoint directory after the
+    test to free disk space; set it false to keep the checkpoint files for
+    inspection.
+    """
+
+    enabled: bool = False
+    sweep: str = ""
+    steps_before_ckpt: int = 6
+    steps_after_resume: int = 6
+    checkpoint_period: int = 5
+    loss_tolerance: float = 0.1
+    max_save_seconds: float = 0.0
+    max_load_seconds: float = 0.0
+    delete_ckpt_dir: bool = True
+    smoke_model_overrides: Dict[str, Any] = {}
+
+
 class Sweep(_Allow):
     """One sweep entry = one full training run with per-run maxtext overrides.
 
@@ -168,6 +202,7 @@ class TrainingConfig(_Allow):
     scaling_baseline: ScalingBaseline = ScalingBaseline()
     convergence: Convergence = Convergence()
     loss_curve: LossCurve = LossCurve()
+    checkpoint_resume: CheckpointResume = CheckpointResume()
     sweeps: List[Sweep] = []
     enabled_sweep_list: List[str] = []
 

--- a/cvs/tests/training/jaxmaxtext/_common.py
+++ b/cvs/tests/training/jaxmaxtext/_common.py
@@ -511,9 +511,7 @@ def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecyc
 
     p1_last_loss = next((s["loss"] for s in reversed(p1_steps) if isinstance(s.get("loss"), (int, float))), None)
     p2_first_loss = next((s["loss"] for s in p2_steps if isinstance(s.get("loss"), (int, float))), None)
-    loss_delta = (
-        abs(p2_first_loss - p1_last_loss) if (p1_last_loss is not None and p2_first_loss is not None) else None
-    )
+    loss_delta = abs(p2_first_loss - p1_last_loss) if (p1_last_loss is not None and p2_first_loss is not None) else None
     loss_ok = loss_delta is not None and loss_delta <= cfg.loss_tolerance
 
     # --- checkpoint I/O timings ---
@@ -572,7 +570,13 @@ def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecyc
     lifecycle.record(request.node.nodeid, "checkpoint_resume", time.monotonic() - t0)
     log.info(
         "[checkpoint] resumed_step=%s loss_delta=%s (tol=%s) | save=%ss (%s) load=%ss (%s)",
-        resumed_step, loss_delta, cfg.loss_tolerance, save_seconds, save_status, load_seconds, load_status,
+        resumed_step,
+        loss_delta,
+        cfg.loss_tolerance,
+        save_seconds,
+        save_status,
+        load_seconds,
+        load_status,
     )
 
     # --- verdict: resume correctness (hard) + I/O gates (when configured) ---

--- a/cvs/tests/training/jaxmaxtext/_common.py
+++ b/cvs/tests/training/jaxmaxtext/_common.py
@@ -36,6 +36,7 @@ from cvs.lib.training.jaxmaxtext.utils.maxtext_parsing import (
     compute_convergence,
     sample_loss_curve,
     evaluate_loss_decreasing,
+    extract_checkpoint_timings,
 )
 from cvs.lib.training.jaxmaxtext.utils.loss_curve import render_loss_curve_png
 from cvs.lib.utils.verdict import evaluate_all, ThresholdViolation
@@ -356,6 +357,243 @@ def training_run(orch, variant_config, hf_token, sweep_name, training_res_dict, 
     }
 
 
+def _latest_checkpoint_step_path(orch, ckpt_dir):
+    """Path to the newest (highest-numbered) orbax checkpoint step dir under
+    `ckpt_dir`, or None if none exist. Used as a pre-Phase-2 sanity check that
+    Phase 1 actually wrote a checkpoint for MaxText to auto-resume from."""
+    try:
+        out = orch.exec("bash -c " + shlex.quote(f"ls -1 {shlex.quote(ckpt_dir)} 2>/dev/null"))
+    except Exception:  # noqa: BLE001
+        return None
+    raw = (out or {}).get(orch.hosts[0], "")
+    text = raw if isinstance(raw, str) else (raw or {}).get("output", "")
+    steps = [int(s.strip().rstrip("/")) for s in (text or "").splitlines() if s.strip().rstrip("/").isdigit()]
+    if not steps:
+        return None
+    return f"{ckpt_dir}/{max(steps)}"
+
+
+def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecycle, request):
+    """Opt-in: checkpoint save + resume + I/O timing (one sweep, two phases).
+
+    Phase 1 trains `steps_before_ckpt` steps with checkpointing on (a checkpoint
+    is written at `checkpoint_period`); Phase 2 resumes from it (same
+    out_dir/run_name -> MaxText auto-restores the latest checkpoint) and trains
+    `steps_after_resume` more. PASS = the resumed run restarts from a non-zero
+    (restored) step AND the loss at the resume boundary matches Phase 1 within
+    `loss_tolerance` (state restored, not reinitialized). Also benchmarks
+    checkpoint_save_seconds / checkpoint_load_seconds, gated inline against
+    max_save_seconds / max_load_seconds when > 0 (else record-only).
+
+    Skipped unless training.checkpoint_resume.enabled. Isolated: a failure here
+    does NOT set lifecycle.failed. Runs on ONE sweep only; smoke_model_overrides
+    can shrink the model (keeping the tokenizer/vocab) for a fast I/O check.
+    """
+    cfg = variant_config.training.checkpoint_resume
+    if not getattr(cfg, "enabled", False):
+        pytest.skip("checkpoint_resume disabled (training.checkpoint_resume.enabled=false)")
+    if lifecycle.failed:
+        pytest.skip("a prior lifecycle stage failed")
+
+    # Pick the sweep to exercise: config.sweep if set, else the first enabled one.
+    enabled = variant_config.enabled_sweeps()
+    chosen = None
+    if getattr(cfg, "sweep", ""):
+        chosen = next((s for s in enabled if s.name == cfg.sweep), None)
+    if chosen is None:
+        chosen = enabled[0] if enabled else SimpleNamespace(name="default", maxtext_overrides={})
+
+    base_overrides = dict(getattr(chosen, "maxtext_overrides", None) or {})
+    base_overrides.update(cfg.smoke_model_overrides or {})
+
+    def _mk_job(total_steps, extra_overrides, enable_ckpt):
+        # Deep copy so the CKPT run's steps/checkpointing never leak into the
+        # shared, module-scoped variant used by the perf sweeps.
+        v = variant_config.model_copy(deep=True)
+        v.training.steps = total_steps
+        v.training.enable_checkpointing = enable_ckpt
+        ov = dict(base_overrides)
+        ov.update(extra_overrides or {})
+        sweep = SimpleNamespace(name="CKPT", maxtext_overrides=ov)
+        return MaxTextTrainingJob(orch, v, hf_token, sweep=sweep)
+
+    # Phase 1: train + SAVE (checkpointing on, sync so the save flushes). Clean any
+    # stale CKPT output first so Phase 2 can only restore THIS run's checkpoint.
+    job1 = _mk_job(
+        cfg.steps_before_ckpt,
+        {"checkpoint_period": cfg.checkpoint_period, "async_checkpointing": False},
+        True,
+    )
+    run_name = f"jaxmaxtext_{variant_config.model.id}_{job1.sweep_tag}"
+    ckpt_dir = f"{job1.out_dir}/{run_name}/checkpoints"
+    try:
+        orch.exec("bash -c " + shlex.quote(f"rm -rf {shlex.quote(job1.out_dir)} 2>/dev/null || true"))
+    except Exception:  # noqa: BLE001
+        pass
+
+    t0 = time.monotonic()
+    try:
+        job1.setup_training_env()
+        job1.build_training_cmd()
+        job1.start_training()
+        job1.poll_for_completion()
+        job1.parse_results()
+    except Exception as e:  # noqa: BLE001
+        try:
+            job1.stop_training()
+        except Exception:  # noqa: BLE001
+            pass
+        pytest.fail(f"checkpoint save phase failed: {e}")
+    finally:
+        try:
+            job1.stop_training()
+        except Exception:  # noqa: BLE001
+            pass
+
+    p1_steps = list(job1.step_metrics or [])
+    p1_log = getattr(job1, "raw_log", "") or ""
+
+    # Phase 2: RESUME. Auto-restore Phase 1's latest checkpoint from the SAME
+    # base_output_directory/run_name (both phases use the "CKPT" sweep + same
+    # model, so out_dir/run_name are identical and MaxText auto-resumes the
+    # latest checkpoint). enable_checkpointing MUST stay true: this MaxText
+    # version rejects loading a checkpoint when enable_checkpointing=false
+    # (incl. via load_full_state_path) -> "You must set enable_checkpointing=True
+    # to load a checkpoint". To keep Phase 2 a resume (no extra checkpoint churn),
+    # push checkpoint_period beyond the total step count so no NEW periodic
+    # checkpoint is written while we train the extra steps.
+    total_steps = cfg.steps_before_ckpt + cfg.steps_after_resume
+    if not _latest_checkpoint_step_path(orch, ckpt_dir):
+        log.warning(
+            "[checkpoint] no saved checkpoint found under %s before Phase 2; "
+            "resume/loss-continuity checks will likely fail",
+            ckpt_dir,
+        )
+    job2 = _mk_job(total_steps, {"checkpoint_period": total_steps + 1000}, True)
+    try:
+        job2.setup_training_env()
+        job2.build_training_cmd()
+        job2.start_training()
+        job2.poll_for_completion()
+        job2.parse_results()
+    except Exception as e:  # noqa: BLE001
+        try:
+            job2.stop_training()
+        except Exception:  # noqa: BLE001
+            pass
+        pytest.fail(f"checkpoint resume phase failed: {e}")
+    finally:
+        try:
+            job2.stop_training()
+        except Exception:  # noqa: BLE001
+            pass
+
+    p2_steps = list(job2.step_metrics or [])
+    p2_log = getattr(job2, "raw_log", "") or ""
+
+    # Free the (large) checkpoint files now that both phases are done, unless the
+    # user asked to keep them (delete_ckpt_dir=false) for post-test inspection.
+    if getattr(cfg, "delete_ckpt_dir", True):
+        try:
+            orch.exec("bash -c " + shlex.quote(f"rm -rf {shlex.quote(ckpt_dir)} 2>/dev/null || true"))
+            log.info("[checkpoint] deleted checkpoint dir %s (delete_ckpt_dir=true)", ckpt_dir)
+        except Exception:  # noqa: BLE001
+            pass
+    else:
+        log.info("[checkpoint] keeping checkpoint dir %s (delete_ckpt_dir=false)", ckpt_dir)
+
+    # --- resume correctness ---
+    # A fresh (non-resumed) run logs step 0 first; a restored run starts at the
+    # checkpoint step. So a non-zero first step means the checkpoint (step +
+    # weights + optimizer) was restored.
+    resumed_step = p2_steps[0]["step"] if p2_steps else None
+    resume_ok = resumed_step is not None and resumed_step > 0
+
+    p1_last_loss = next((s["loss"] for s in reversed(p1_steps) if isinstance(s.get("loss"), (int, float))), None)
+    p2_first_loss = next((s["loss"] for s in p2_steps if isinstance(s.get("loss"), (int, float))), None)
+    loss_delta = (
+        abs(p2_first_loss - p1_last_loss) if (p1_last_loss is not None and p2_first_loss is not None) else None
+    )
+    loss_ok = loss_delta is not None and loss_delta <= cfg.loss_tolerance
+
+    # --- checkpoint I/O timings ---
+    save_seconds = extract_checkpoint_timings(p1_log).get("save_seconds")
+    if save_seconds is None:
+        # Fallback: with async_checkpointing=false the checkpoint step blocks, so
+        # it is the slow outlier -> save_seconds ~= max step time - median step time.
+        secs = sorted(s["seconds"] for s in p1_steps if isinstance(s.get("seconds"), (int, float)))
+        if len(secs) >= 3:
+            median = secs[len(secs) // 2]
+            delta = secs[-1] - median
+            save_seconds = delta if delta > 0 else None
+    load_seconds = extract_checkpoint_timings(p2_log).get("load_seconds")  # best-effort; None -> record-only
+
+    # --- record rows into the consolidated metric-results table (CKPT label) ---
+    rows = training_res_dict.setdefault("metric_rows", [])
+
+    def _io_row(metric_name, value, max_bound):
+        gated = bool(max_bound and max_bound > 0)
+        if value is None:
+            status = "N/A"
+        elif gated:
+            status = "PASS" if value <= max_bound else "FAIL"
+        else:
+            status = "RECORD"
+        rows.append(
+            {
+                "sweep": "CKPT",
+                "metric": metric_name,
+                "expected": (f"<= {max_bound}" if gated else "record"),
+                "actual": _format_value(value),
+                "unit": "s",
+                "status": status,
+            }
+        )
+        return status
+
+    save_status = _io_row("checkpoint_save_seconds", save_seconds, cfg.max_save_seconds)
+    load_status = _io_row("checkpoint_load_seconds", load_seconds, cfg.max_load_seconds)
+
+    # Stash the checkpoint I/O results in their own dict so print_results_table
+    # can render them as a separate section (after the per-sweep tables and loss
+    # curves) rather than mixing them into the perf-sweep metric tables.
+    training_res_dict["checkpoint_io"] = {
+        "resumed_step": resumed_step,
+        "loss_delta": loss_delta,
+        "loss_tolerance": cfg.loss_tolerance,
+        "save_seconds": save_seconds,
+        "save_max": cfg.max_save_seconds,
+        "save_status": save_status,
+        "load_seconds": load_seconds,
+        "load_max": cfg.max_load_seconds,
+        "load_status": load_status,
+    }
+
+    lifecycle.record(request.node.nodeid, "checkpoint_resume", time.monotonic() - t0)
+    log.info(
+        "[checkpoint] resumed_step=%s loss_delta=%s (tol=%s) | save=%ss (%s) load=%ss (%s)",
+        resumed_step, loss_delta, cfg.loss_tolerance, save_seconds, save_status, load_seconds, load_status,
+    )
+
+    # --- verdict: resume correctness (hard) + I/O gates (when configured) ---
+    failures = []
+    if not resume_ok:
+        failures.append(f"resume did not restore a checkpoint (phase-2 first step={resumed_step}, expected > 0)")
+    if not loss_ok:
+        failures.append(
+            f"loss discontinuity at resume: |{p2_first_loss} - {p1_last_loss}| = {loss_delta} > tol {cfg.loss_tolerance}"
+        )
+    if save_status == "FAIL":
+        failures.append(f"checkpoint save {save_seconds}s > max {cfg.max_save_seconds}s")
+    if load_status == "FAIL":
+        failures.append(f"checkpoint load {load_seconds}s > max {cfg.max_load_seconds}s")
+
+    if failures:
+        training_res_dict.setdefault("metric_failures", []).extend(f"[CKPT] {m}" for m in failures)
+        pytest.fail("; ".join(failures))
+    log.info("checkpoint_resume PASSED")
+
+
 def metric(sweep_name, metric, training_res_dict, variant_config, lifecycle, request):
     """One test (row) per (sweep, metric). Threshold-driven PASS/FAIL; logs
     `sweep | metric | expected | actual | status` and collects rows for the
@@ -534,6 +772,41 @@ def _print_sweep_tables(training_res_dict):
             )
 
 
+def _print_checkpoint_io(training_res_dict):
+    """Log the checkpoint save/load I/O results as a separate section, printed
+    after the per-sweep metric tables and loss curves. No-op when the (opt-in)
+    checkpoint_resume test did not run."""
+    io = training_res_dict.get("checkpoint_io")
+    if not io:
+        return
+    tol = io.get("loss_tolerance")
+
+    def _bound(mx):
+        return f"<= {mx}" if (mx and mx > 0) else "record"
+
+    rows = [
+        [
+            "checkpoint_save_seconds",
+            _format_value(io.get("save_seconds")),
+            _bound(io.get("save_max")),
+            io.get("save_status"),
+        ],
+        [
+            "checkpoint_load_seconds",
+            _format_value(io.get("load_seconds")),
+            _bound(io.get("load_max")),
+            io.get("load_status"),
+        ],
+    ]
+    log.info(
+        "\n[Checkpoint I/O]  resumed_step=%s  loss_delta=%s (tol=%s)\n%s",
+        io.get("resumed_step"),
+        _format_value(io.get("loss_delta")),
+        tol,
+        tabulate(rows, headers=["Metric", "Value (s)", "Threshold", "Status"], tablefmt="github"),
+    )
+
+
 def print_results_table(training_res_dict, request):
     """Summarize all sweeps: console tables, single metric-results HTML, and a
     consolidated PASS/FAIL summary recorded via globals.error_list for the pytest
@@ -543,6 +816,7 @@ def print_results_table(training_res_dict, request):
         return
 
     _print_sweep_tables(training_res_dict)
+    _print_checkpoint_io(training_res_dict)
     _write_metric_results_html(training_res_dict, request)
 
     failures = training_res_dict.get("metric_failures", [])

--- a/cvs/tests/training/jaxmaxtext/_common.py
+++ b/cvs/tests/training/jaxmaxtext/_common.py
@@ -453,6 +453,25 @@ def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecyc
     p1_steps = list(job1.step_metrics or [])
     p1_log = getattr(job1, "raw_log", "") or ""
 
+    # Phase 1 MUST have written a checkpoint, else Phase 2 has nothing to
+    # restore and the resume/loss checks are meaningless. This happens when
+    # checkpoint_period > steps_before_ckpt (no periodic save fires within
+    # Phase 1). Fail loudly here rather than silently continue into a Phase 2
+    # that cannot actually resume.
+    ckpt_step_path = _latest_checkpoint_step_path(orch, ckpt_dir)
+    if not ckpt_step_path:
+        pytest.fail(
+            f"Phase 1 wrote no checkpoint under {ckpt_dir}: checkpoint_period="
+            f"{cfg.checkpoint_period} likely exceeds steps_before_ckpt="
+            f"{cfg.steps_before_ckpt}. Set checkpoint_period <= steps_before_ckpt "
+            f"so a checkpoint is saved during Phase 1."
+        )
+    try:
+        checkpoint_step = int(str(ckpt_step_path).rstrip("/").rsplit("/", 1)[-1])
+    except (ValueError, IndexError):
+        checkpoint_step = None
+    log.info("[checkpoint] Phase 1 saved checkpoint at step %s (%s)", checkpoint_step, ckpt_step_path)
+
     # Phase 2: RESUME. Auto-restore Phase 1's latest checkpoint from the SAME
     # base_output_directory/run_name (both phases use the "CKPT" sweep + same
     # model, so out_dir/run_name are identical and MaxText auto-resumes the
@@ -463,12 +482,6 @@ def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecyc
     # push checkpoint_period beyond the total step count so no NEW periodic
     # checkpoint is written while we train the extra steps.
     total_steps = cfg.steps_before_ckpt + cfg.steps_after_resume
-    if not _latest_checkpoint_step_path(orch, ckpt_dir):
-        log.warning(
-            "[checkpoint] no saved checkpoint found under %s before Phase 2; "
-            "resume/loss-continuity checks will likely fail",
-            ckpt_dir,
-        )
     job2 = _mk_job(total_steps, {"checkpoint_period": total_steps + 1000}, True)
     try:
         job2.setup_training_env()
@@ -509,9 +522,31 @@ def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecyc
     resumed_step = p2_steps[0]["step"] if p2_steps else None
     resume_ok = resumed_step is not None and resumed_step > 0
 
-    p1_last_loss = next((s["loss"] for s in reversed(p1_steps) if isinstance(s.get("loss"), (int, float))), None)
-    p2_first_loss = next((s["loss"] for s in p2_steps if isinstance(s.get("loss"), (int, float))), None)
-    loss_delta = abs(p2_first_loss - p1_last_loss) if (p1_last_loss is not None and p2_first_loss is not None) else None
+    # --- loss continuity at the resume boundary ---
+    # Compare loss at the SAME step in both phases whenever they overlap: a
+    # correct restore reproduces Phase 1's loss at that step (delta ~ 0), so this
+    # is a true "state restored" check that does not depend on step alignment.
+    # Only when Phase 2 does NOT re-emit any Phase-1 step (it continued past the
+    # checkpoint without re-logging it) do we fall back to adjacent-boundary
+    # continuity (Phase 1's last loss vs Phase 2's first) -- looser, since those
+    # are one training step apart, but the best signal available.
+    p1_loss_by_step = {
+        s["step"]: s["loss"] for s in p1_steps if isinstance(s.get("loss"), (int, float)) and s.get("step") is not None
+    }
+    p2_loss_by_step = {
+        s["step"]: s["loss"] for s in p2_steps if isinstance(s.get("loss"), (int, float)) and s.get("step") is not None
+    }
+    common_steps = sorted(set(p1_loss_by_step) & set(p2_loss_by_step))
+    if common_steps:
+        cmp_step = common_steps[0]
+        p1_cmp_loss, p2_cmp_loss = p1_loss_by_step[cmp_step], p2_loss_by_step[cmp_step]
+        loss_basis = f"matched step {cmp_step}"
+    else:
+        cmp_step = None
+        p1_cmp_loss = next((s["loss"] for s in reversed(p1_steps) if isinstance(s.get("loss"), (int, float))), None)
+        p2_cmp_loss = next((s["loss"] for s in p2_steps if isinstance(s.get("loss"), (int, float))), None)
+        loss_basis = "adjacent boundary (no overlapping step; p1 last vs p2 first)"
+    loss_delta = abs(p2_cmp_loss - p1_cmp_loss) if (p1_cmp_loss is not None and p2_cmp_loss is not None) else None
     loss_ok = loss_delta is not None and loss_delta <= cfg.loss_tolerance
 
     # --- checkpoint I/O timings ---
@@ -569,10 +604,11 @@ def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecyc
 
     lifecycle.record(request.node.nodeid, "checkpoint_resume", time.monotonic() - t0)
     log.info(
-        "[checkpoint] resumed_step=%s loss_delta=%s (tol=%s) | save=%ss (%s) load=%ss (%s)",
+        "[checkpoint] resumed_step=%s loss_delta=%s (tol=%s, basis=%s) | save=%ss (%s) load=%ss (%s)",
         resumed_step,
         loss_delta,
         cfg.loss_tolerance,
+        loss_basis,
         save_seconds,
         save_status,
         load_seconds,
@@ -585,7 +621,8 @@ def checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecyc
         failures.append(f"resume did not restore a checkpoint (phase-2 first step={resumed_step}, expected > 0)")
     if not loss_ok:
         failures.append(
-            f"loss discontinuity at resume: |{p2_first_loss} - {p1_last_loss}| = {loss_delta} > tol {cfg.loss_tolerance}"
+            f"loss discontinuity at resume ({loss_basis}): |{p2_cmp_loss} - {p1_cmp_loss}| = "
+            f"{loss_delta} > tol {cfg.loss_tolerance}"
         )
     if save_status == "FAIL":
         failures.append(f"checkpoint save {save_seconds}s > max {cfg.max_save_seconds}s")

--- a/cvs/tests/training/jaxmaxtext/_common.py
+++ b/cvs/tests/training/jaxmaxtext/_common.py
@@ -22,6 +22,7 @@ import shlex
 import time
 import uuid as _uuid
 from pathlib import Path as _Path
+from types import SimpleNamespace
 
 import pytest
 from tabulate import tabulate
@@ -218,6 +219,73 @@ def setup_tokenizer(orch, variant_config, hf_token, lifecycle, request):
     job = MaxTextTrainingJob(orch, variant_config, hf_token)
     job.setup_tokenizer()
     lifecycle.record(request.node.nodeid, "tokenizer_setup", time.monotonic() - t)
+
+
+# Smoke test: smallest fixed run that confirms the model loads and trains a few
+# steps without hitting any error_patterns. Overrides only per_device_batch_size,
+# max_target_length, precision and step count; keeps the config's model_name +
+# tokenizer so the vocab/tokenizer stay consistent. No metric/threshold checks.
+_SMOKE_STEPS = 10
+_SMOKE_BATCH = 1
+_SMOKE_SEQLEN = 2048
+
+
+def smoke(orch, variant_config, hf_token, lifecycle, request):
+    """Smoke test: the model loads and runs _SMOKE_STEPS steps without any
+    error_pattern firing.
+
+    Runs one short training with small fixed per_device_batch_size / seqlen and
+    BF16, overriding the config for this run only. Completing the steps without an
+    error signature (scanned by poll_for_completion) is the only pass criterion --
+    there is no metric or threshold verification. A failure sets lifecycle.failed
+    so downstream stages skip.
+    """
+    if lifecycle.failed:
+        pytest.skip("a prior lifecycle stage failed")
+
+    # Isolated deep copy so the smoke run's tiny steps/overrides never leak into
+    # the real per-sweep training_run tests (they share the module-scoped config).
+    smoke_variant = variant_config.model_copy(deep=True)
+    smoke_variant.training.steps = _SMOKE_STEPS
+    smoke_sweep = SimpleNamespace(
+        name="SMOKE",
+        maxtext_overrides={
+            "per_device_batch_size": _SMOKE_BATCH,
+            "max_target_length": _SMOKE_SEQLEN,
+            "dtype": "bfloat16",
+            "weight_dtype": "bfloat16",
+            "quantization": "",
+        },
+    )
+
+    job = MaxTextTrainingJob(orch, smoke_variant, hf_token, sweep=smoke_sweep)
+    t = time.monotonic()
+    try:
+        job.setup_training_env()
+        job.build_training_cmd()
+        job.start_training()
+        # poll scans each node's log for error_patterns/NaN every iteration and
+        # raises on the first match or on timeout; returns cleanly once the run
+        # reaches step _SMOKE_STEPS-1.
+        job.poll_for_completion()
+    except Exception as e:  # noqa: BLE001
+        lifecycle.failed = True
+        pytest.fail(f"smoke test failed (model did not run {_SMOKE_STEPS} steps cleanly): {e}")
+    finally:
+        # Reap ranks so the smoke run leaves no orphan processes for the next stage.
+        try:
+            job.stop_training()
+        except Exception:  # noqa: BLE001
+            pass
+
+    lifecycle.record(request.node.nodeid, "smoke", time.monotonic() - t)
+    log.info(
+        "smoke PASSED | model=%s steps=%s batch=%s seqlen=%s",
+        smoke_variant.training.maxtext_config.get("model_name", "<base.yml default>"),
+        _SMOKE_STEPS,
+        _SMOKE_BATCH,
+        _SMOKE_SEQLEN,
+    )
 
 
 def training_run(orch, variant_config, hf_token, sweep_name, training_res_dict, lifecycle, request):

--- a/cvs/tests/training/jaxmaxtext/conftest.py
+++ b/cvs/tests/training/jaxmaxtext/conftest.py
@@ -176,8 +176,9 @@ def pytest_collection_modifyitems(items):
         "test_training_run": 4,
         "test_metric": 5,
         "test_loss_curve": 6,
-        "test_print_results_table": 7,
-        "test_teardown": 8,
+        "test_checkpoint_resume": 7,
+        "test_print_results_table": 8,
+        "test_teardown": 9,
     }
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
 

--- a/cvs/tests/training/jaxmaxtext/conftest.py
+++ b/cvs/tests/training/jaxmaxtext/conftest.py
@@ -172,11 +172,12 @@ def pytest_collection_modifyitems(items):
         "test_launch_container": 0,
         "test_setup_rdma": 1,
         "test_setup_tokenizer": 2,
-        "test_training_run": 3,
-        "test_metric": 4,
-        "test_loss_curve": 5,
-        "test_print_results_table": 6,
-        "test_teardown": 7,
+        "test_smoke": 3,
+        "test_training_run": 4,
+        "test_metric": 5,
+        "test_loss_curve": 6,
+        "test_print_results_table": 7,
+        "test_teardown": 8,
     }
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
 

--- a/cvs/tests/training/jaxmaxtext/jaxmaxtext_distributed.py
+++ b/cvs/tests/training/jaxmaxtext/jaxmaxtext_distributed.py
@@ -14,8 +14,10 @@ Tests performed (in order):
 5. test_training_run[sweep]   - Run MaxText training per sweep (e.g. BF16, FP8)
 6. test_metric[sweep-metric]  - Validate each metric against its threshold
 7. test_loss_curve[sweep]     - Render the loss curve and check it decreases
-8. test_print_results_table   - Console tables + metric-results HTML + summary
-9. test_teardown              - Tear the container down
+8. test_checkpoint_resume     - Opt-in: checkpoint save+resume correctness +
+                                checkpoint I/O timing (skipped unless enabled)
+9. test_print_results_table   - Console tables + metric-results HTML + summary
+10. test_teardown             - Tear the container down
 
 Metrics validated per sweep (namespace training.*): tflops_per_sec_per_gpu,
 tokens_per_sec_per_gpu, tokens_per_sec_total, scaling_efficiency_pct,
@@ -86,6 +88,14 @@ def test_loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, re
     not decreasing (least-squares slope check)."""
     log.info('Starting Testcase: loss curve [%s]', sweep_name)
     return _common.loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, request)
+
+
+def test_checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecycle, request):
+    """Opt-in (training.checkpoint_resume.enabled): save a checkpoint, resume from
+    it, and verify the restart restores step + loss (state), plus benchmark
+    checkpoint save/load I/O time. Skipped when disabled. No effect on the sweeps."""
+    log.info('Starting Testcase: checkpoint save+resume + I/O timing')
+    return _common.checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecycle, request)
 
 
 def test_print_results_table(training_res_dict, request):

--- a/cvs/tests/training/jaxmaxtext/jaxmaxtext_distributed.py
+++ b/cvs/tests/training/jaxmaxtext/jaxmaxtext_distributed.py
@@ -9,11 +9,13 @@ Tests performed (in order):
 2. test_setup_rdma            - Copy the RDMA lib into the container (thor2 NIC)
                                 and verify ibv_devinfo
 3. test_setup_tokenizer       - Download the HuggingFace tokenizer
-4. test_training_run[sweep]   - Run MaxText training per sweep (e.g. BF16, FP8)
-5. test_metric[sweep-metric]  - Validate each metric against its threshold
-6. test_loss_curve[sweep]     - Render the loss curve and check it decreases
-7. test_print_results_table   - Console tables + metric-results HTML + summary
-8. test_teardown              - Tear the container down
+4. test_smoke                 - Small fixed run: model loads + trains 10 steps
+                                without error_patterns (no metric checks)
+5. test_training_run[sweep]   - Run MaxText training per sweep (e.g. BF16, FP8)
+6. test_metric[sweep-metric]  - Validate each metric against its threshold
+7. test_loss_curve[sweep]     - Render the loss curve and check it decreases
+8. test_print_results_table   - Console tables + metric-results HTML + summary
+9. test_teardown              - Tear the container down
 
 Metrics validated per sweep (namespace training.*): tflops_per_sec_per_gpu,
 tokens_per_sec_per_gpu, tokens_per_sec_total, scaling_efficiency_pct,
@@ -33,21 +35,33 @@ Example usage:
 
 from cvs.tests.training.jaxmaxtext import _common
 
+log = _common.log
+
 
 def test_launch_container(orch, variant_config, lifecycle, request):
     """Launch and verify the MaxText training container is running."""
+    log.info('Starting Testcase: launch JAX containers')
     return _common.launch_container(orch, variant_config, lifecycle, request)
 
 
 def test_setup_rdma(orch, variant_config, hf_token, lifecycle, request):
     """Distributed-only: copy the host RDMA library into the container (thor2
     NIC workaround) and verify ibv_devinfo reports the expected HCA."""
+    log.info('Starting Testcase: setup RDMA library')
     return _common.setup_rdma(orch, variant_config, hf_token, lifecycle, request)
 
 
 def test_setup_tokenizer(orch, variant_config, hf_token, lifecycle, request):
     """Download the HuggingFace tokenizer for the model into the models dir."""
+    log.info('Starting Testcase: setup tokenizer')
     return _common.setup_tokenizer(orch, variant_config, hf_token, lifecycle, request)
+
+
+def test_smoke(orch, variant_config, hf_token, lifecycle, request):
+    """Smoke test: model loads and trains 10 steps (small fixed batch/seqlen,
+    BF16) without any error_pattern firing. No metric/threshold verification."""
+    log.info('Starting Testcase: smoke (model loads + runs 10 steps)')
+    return _common.smoke(orch, variant_config, hf_token, lifecycle, request)
 
 
 def test_training_run(orch, variant_config, hf_token, sweep_name, training_res_dict, lifecycle, request):
@@ -56,27 +70,32 @@ def test_training_run(orch, variant_config, hf_token, sweep_name, training_res_d
     Parametrized per sweep in conftest.py (e.g. BF16, FP8). A failure is isolated
     to this sweep's row so other sweeps still run.
     """
+    log.info('Starting Testcase: training run [%s]', sweep_name)
     return _common.training_run(orch, variant_config, hf_token, sweep_name, training_res_dict, lifecycle, request)
 
 
 def test_metric(sweep_name, metric, training_res_dict, variant_config, lifecycle, request):
     """One row per (sweep, metric): assert the parsed value against the sweep's
     threshold cell and record PASS / FAIL / N/A / RECORD."""
+    log.info('Starting Testcase: metric [%s - %s]', sweep_name, metric)
     return _common.metric(sweep_name, metric, training_res_dict, variant_config, lifecycle, request)
 
 
 def test_loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, request):
     """Sample the training loss, render a per-sweep PNG, and fail if the curve is
     not decreasing (least-squares slope check)."""
+    log.info('Starting Testcase: loss curve [%s]', sweep_name)
     return _common.loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, request)
 
 
 def test_print_results_table(training_res_dict, request):
     """Log per-sweep result tables, write the consolidated metric-results HTML,
     and record the aggregated failure summary for the pytest final summary."""
+    log.info('Starting Testcase: print results table')
     return _common.print_results_table(training_res_dict, request)
 
 
 def test_teardown(orch, lifecycle, request):
     """Tear the container down and verify it is gone."""
+    log.info('Starting Testcase: teardown JAX containers')
     return _common.teardown(orch, lifecycle, request)

--- a/cvs/tests/training/jaxmaxtext/jaxmaxtext_single.py
+++ b/cvs/tests/training/jaxmaxtext/jaxmaxtext_single.py
@@ -7,11 +7,13 @@ JAX MaxText Single-Node Training Validation Suite.
 Tests performed (in order):
 1. test_launch_container      - Launch the training container
 2. test_setup_tokenizer       - Download the HuggingFace tokenizer
-3. test_training_run[sweep]   - Run MaxText training per sweep (e.g. BF16, FP8)
-4. test_metric[sweep-metric]  - Validate each metric against its threshold
-5. test_loss_curve[sweep]     - Render the loss curve and check it decreases
-6. test_print_results_table   - Console tables + metric-results HTML + summary
-7. test_teardown              - Tear the container down
+3. test_smoke                 - Small fixed run: model loads + trains 10 steps
+                                without error_patterns (no metric checks)
+4. test_training_run[sweep]   - Run MaxText training per sweep (e.g. BF16, FP8)
+5. test_metric[sweep-metric]  - Validate each metric against its threshold
+6. test_loss_curve[sweep]     - Render the loss curve and check it decreases
+7. test_print_results_table   - Console tables + metric-results HTML + summary
+8. test_teardown              - Tear the container down
 
 Metrics validated per sweep (namespace training.*): tflops_per_sec_per_gpu,
 tokens_per_sec_per_gpu, tokens_per_sec_total, scaling_efficiency_pct,
@@ -30,15 +32,26 @@ Example usage:
 
 from cvs.tests.training.jaxmaxtext import _common
 
+log = _common.log
+
 
 def test_launch_container(orch, variant_config, lifecycle, request):
     """Launch and verify the MaxText training container is running."""
+    log.info('Starting Testcase: launch JAX containers')
     return _common.launch_container(orch, variant_config, lifecycle, request)
 
 
 def test_setup_tokenizer(orch, variant_config, hf_token, lifecycle, request):
     """Download the HuggingFace tokenizer for the model into the models dir."""
+    log.info('Starting Testcase: setup tokenizer')
     return _common.setup_tokenizer(orch, variant_config, hf_token, lifecycle, request)
+
+
+def test_smoke(orch, variant_config, hf_token, lifecycle, request):
+    """Smoke test: model loads and trains 10 steps (small fixed batch/seqlen,
+    BF16) without any error_pattern firing. No metric/threshold verification."""
+    log.info('Starting Testcase: smoke (model loads + runs 10 steps)')
+    return _common.smoke(orch, variant_config, hf_token, lifecycle, request)
 
 
 def test_training_run(orch, variant_config, hf_token, sweep_name, training_res_dict, lifecycle, request):
@@ -47,27 +60,32 @@ def test_training_run(orch, variant_config, hf_token, sweep_name, training_res_d
     Parametrized per sweep in conftest.py (e.g. BF16, FP8). A failure is isolated
     to this sweep's row so other sweeps still run.
     """
+    log.info('Starting Testcase: training run [%s]', sweep_name)
     return _common.training_run(orch, variant_config, hf_token, sweep_name, training_res_dict, lifecycle, request)
 
 
 def test_metric(sweep_name, metric, training_res_dict, variant_config, lifecycle, request):
     """One row per (sweep, metric): assert the parsed value against the sweep's
     threshold cell and record PASS / FAIL / N/A / RECORD."""
+    log.info('Starting Testcase: metric [%s - %s]', sweep_name, metric)
     return _common.metric(sweep_name, metric, training_res_dict, variant_config, lifecycle, request)
 
 
 def test_loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, request):
     """Sample the training loss, render a per-sweep PNG, and fail if the curve is
     not decreasing (least-squares slope check)."""
+    log.info('Starting Testcase: loss curve [%s]', sweep_name)
     return _common.loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, request)
 
 
 def test_print_results_table(training_res_dict, request):
     """Log per-sweep result tables, write the consolidated metric-results HTML,
     and record the aggregated failure summary for the pytest final summary."""
+    log.info('Starting Testcase: print results table')
     return _common.print_results_table(training_res_dict, request)
 
 
 def test_teardown(orch, lifecycle, request):
     """Tear the container down and verify it is gone."""
+    log.info('Starting Testcase: teardown JAX containers')
     return _common.teardown(orch, lifecycle, request)

--- a/cvs/tests/training/jaxmaxtext/jaxmaxtext_single.py
+++ b/cvs/tests/training/jaxmaxtext/jaxmaxtext_single.py
@@ -12,8 +12,10 @@ Tests performed (in order):
 4. test_training_run[sweep]   - Run MaxText training per sweep (e.g. BF16, FP8)
 5. test_metric[sweep-metric]  - Validate each metric against its threshold
 6. test_loss_curve[sweep]     - Render the loss curve and check it decreases
-7. test_print_results_table   - Console tables + metric-results HTML + summary
-8. test_teardown              - Tear the container down
+7. test_checkpoint_resume     - Opt-in: checkpoint save+resume correctness +
+                                checkpoint I/O timing (skipped unless enabled)
+8. test_print_results_table   - Console tables + metric-results HTML + summary
+9. test_teardown              - Tear the container down
 
 Metrics validated per sweep (namespace training.*): tflops_per_sec_per_gpu,
 tokens_per_sec_per_gpu, tokens_per_sec_total, scaling_efficiency_pct,
@@ -76,6 +78,14 @@ def test_loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, re
     not decreasing (least-squares slope check)."""
     log.info('Starting Testcase: loss curve [%s]', sweep_name)
     return _common.loss_curve(sweep_name, training_res_dict, variant_config, lifecycle, request)
+
+
+def test_checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecycle, request):
+    """Opt-in (training.checkpoint_resume.enabled): save a checkpoint, resume from
+    it, and verify the restart restores step + loss (state), plus benchmark
+    checkpoint save/load I/O time. Skipped when disabled. No effect on the sweeps."""
+    log.info('Starting Testcase: checkpoint save+resume + I/O timing')
+    return _common.checkpoint_resume(orch, variant_config, hf_token, training_res_dict, lifecycle, request)
 
 
 def test_print_results_table(training_res_dict, request):


### PR DESCRIPTION
## Summary
Extends the `jaxmaxtext_single` / `jaxmaxtext_distributed` training suites with new
model configs, a smoke test, a checkpoint save+resume (with I/O timing) test, and
fixes noisy poll logging. 6 commits on top of `origin/main`.
## Commits
### 1. `2e31e64` feat(JAX) Added more model configs and threshold files for jaxmaxtext
- New config + threshold pairs for **llama-3.1-8b**, **deepseek-v2-lite**, and
  **llama-3.1-405b** (MI300X/MI325X/MI355X as applicable).
- Config files aligned with the MAD repo reference (env vars, XLA flags, parallelism,
  MoE knobs).
### 2. `089c0d9` fix(JAX) Updated llama3.1-405b model config with BS and xla_autotune=0
- Tuned `per_device_batch_size` and set `xla_gpu_autotune_level=0` for the 405B config
  (+ matching threshold tweaks).
### 3. `ab6fe09` feat(JAX) Added Smoke Test for jaxmaxtext training
- New `test_smoke` stage (both suites): loads the model and runs 10 steps with a small
  fixed batch/seqlen in BF16. Pass = completes the steps with no error signature; no
  metric/threshold checks. A failure sets `lifecycle.failed` so downstream stages skip
  (early gate before the full sweeps).
### 4. `ec65b2d` feat(JAX) Added Checkpoint save and resume I/O timing metrics test
- New opt-in `test_checkpoint_resume` stage (`training.checkpoint_resume.enabled`):
  - **Phase 1** trains `steps_before_ckpt` with checkpointing on (saved at
    `checkpoint_period`); **Phase 2** resumes and trains `steps_after_resume` more.
  - Pass = Phase 2 restarts from the checkpoint step (non-zero first step) **and** the
    boundary loss matches Phase 1 within `loss_tolerance` (state restored, not
    reinitialized).
  - Benchmarks **checkpoint_save_seconds / checkpoint_load_seconds** (parsed from orbax
    logs), gated against `max_save_seconds` / `max_load_seconds` when > 0 (else
    record-only), rendered as a separate "Checkpoint I/O" section in the results.
  - `delete_ckpt_dir` (default true) cleans the checkpoint dir after the test.
- `checkpoint_resume` schema block added to all jaxmaxtext configs (default `enabled=false`).
> ⚠️ **Validation scope:** the checkpoint save+resume test has been validated **only with
> the small `llama3.1-8b` config on MI325X**. It has **not** yet been validated on the
> larger models (70B/405B/DeepSeek). Treat those as untested for this stage.
### 5. `94c1ffe` fix(exec_cmd_list) Exposed print_console arg to enable/disable
- Threaded a `print_console` argument through `ContainerOrchestrator.exec_cmd_list` and
  the Docker runtime (default `True`; pass `False` to fetch bulk output without
  re-echoing it to the console). Pssh already supported it.
### 6. `3522040` fix(JAX) Added logic to print training log incrementally
- `poll_for_completion()` no longer re-dumps a `tail -N` window every poll (which bloated
  `--log-file` with repeated content). It now **streams only the new node-0 log lines
  once** per poll (via a per-node line cursor), scans **all** nodes' new chunks for error
  signatures, and prints a compact `[poll]` heartbeat so polling remains visible.
- Fixed ruff fmt & lint.
## Test plan
- `make fmt-check` / `make lint` — clean on the changed files.
- Unit tests: `test_jaxmaxtext_training_lib`, `test_maxtext_parsing`,
  `test_training_config_loader` pass (incl. new smoke/checkpoint/drain coverage).
- Smoke + training + metric + loss-curve stages exercised on jaxmaxtext_distributed.
- Checkpoint save+resume validated end-to-end on **MI325X llama3.1-8b** (save/load
  timings captured, loss continuity within tolerance, resume from checkpoint step).