### PR TITLE
feat(Megatron): Megatron checkpoint save and resume test, convergence tracking, and Primus factory dispatch

### DIFF
--- a/cvs/input/config_file/training/megatron/mi325x_megatron_deepseek-v2-lite_single.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_deepseek-v2-lite_single.json
@@ -11,7 +11,7 @@
   },
   "checkpoint": {
     "enforce": false,
-    "save_interval": 5,
+    "save_interval": 20,
     "save_iters": 21,
     "resume_iters": 25,
     "loss_rtol": 0.05

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_deepseek-v2-lite_single.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_deepseek-v2-lite_single.json
@@ -9,6 +9,13 @@
     "max_slope": 0.0,
     "enforce": true
   },
+  "checkpoint": {
+    "enforce": false,
+    "save_interval": 5,
+    "save_iters": 21,
+    "resume_iters": 25,
+    "loss_rtol": 0.05
+  },
   "threshold_json": "mi325x_megatron_deepseek-v2-lite_single_threshold.json",
   "config": {
     "hf_token_file": "/home/{user-id}/.hf_token",

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single.json
@@ -33,7 +33,7 @@
   },
   "checkpoint": {
     "enforce": false,
-    "save_interval": 5,
+    "save_interval": 20,
     "save_iters": 21,
     "resume_iters": 25,
     "loss_rtol": 0.05

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single.json
@@ -9,6 +9,10 @@
     "max_slope": 0.0,
     "enforce": true
   },
+  "convergence": {
+    "target_metric": "auto",
+    "target_value": 2.0
+  },
   "threshold_json": "mi325x_megatron_llama-3.1-8b_single_threshold.json",
   "config": {
     "hf_token_file": "/home/{user-id}/.hf_token",

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single.json
@@ -31,6 +31,13 @@
     "master_address": "127.0.0.1",
     "verify_network_errors": "False"
   },
+  "checkpoint": {
+    "enforce": false,
+    "save_interval": 5,
+    "save_iters": 21,
+    "resume_iters": 25,
+    "loss_rtol": 0.05
+  },
   "model_params": {
     "model_name": "llama3.1_8B",
     "tokenizer_model": "meta-llama/Llama-3.1-8B",

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single_threshold.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.1-8b_single_threshold.json
@@ -16,6 +16,14 @@
     "training.mem_usage": {
       "kind": "max",
       "value": 0.85
+    },
+    "training.steps_to_target": {
+      "kind": "info",
+      "value": 0
+    },
+    "training.time_to_target_seconds": {
+      "kind": "info",
+      "value": 0
     }
   },
   "MBS=4,GBS=128,PRECISION=BF16": {
@@ -34,6 +42,14 @@
     "training.mem_usage": {
       "kind": "max",
       "value": 0.85
+    },
+    "training.steps_to_target": {
+      "kind": "info",
+      "value": 0
+    },
+    "training.time_to_target_seconds": {
+      "kind": "info",
+      "value": 0
     }
   },
   "MBS=4,GBS=128,PRECISION=MXFP4": {
@@ -52,6 +68,14 @@
     "training.mem_usage": {
       "kind": "max",
       "value": 0.85
+    },
+    "training.steps_to_target": {
+      "kind": "info",
+      "value": 0
+    },
+    "training.time_to_target_seconds": {
+      "kind": "info",
+      "value": 0
     }
   },
   "MBS=4,GBS=128,PRECISION=MXFP8": {

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.3-70b_distributed.json
@@ -35,6 +35,14 @@
     "nccl_debug": "ERROR",
     "verify_network_errors": "True"
   },
+  "checkpoint": {
+    "enforce": false,
+    "save_interval": 5,
+    "save_iters": 21,
+    "resume_iters": 25,
+    "loss_rtol": 0.05,
+    "checkpoint_dir": "<changeme>"
+  },
   "model_params": {
     "model_name": "llama3.3_70B",
     "tokenizer_model": "meta-llama/Llama-3.3-70B-Instruct",
@@ -60,7 +68,8 @@
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
           "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
-          "/lib/libibverbs.d:/lib/libibverbs.d"
+          "/lib/libibverbs.d:/lib/libibverbs.d",
+          "<changeme>:<changeme>"
         ],
         "devices": [
           "/dev/kfd",

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.3-70b_distributed.json
@@ -37,7 +37,7 @@
   },
   "checkpoint": {
     "enforce": false,
-    "save_interval": 5,
+    "save_interval": 20,
     "save_iters": 21,
     "resume_iters": 25,
     "loss_rtol": 0.05,

--- a/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.3-70b_single.json
+++ b/cvs/input/config_file/training/megatron/mi325x_megatron_llama-3.3-70b_single.json
@@ -27,6 +27,13 @@
     "master_address": "127.0.0.1",
     "verify_network_errors": "False"
   },
+  "checkpoint": {
+    "enforce": false,
+    "save_interval": 20,
+    "save_iters": 21,
+    "resume_iters": 25,
+    "loss_rtol": 0.05
+  },
   "model_params": {
     "model_name": "llama3.3_70B",
     "tokenizer_model": "meta-llama/Llama-3.3-70B-Instruct",
@@ -80,3 +87,4 @@
     ]
   }
 }
+

--- a/cvs/lib/training/megatron/primus_lib.py
+++ b/cvs/lib/training/megatron/primus_lib.py
@@ -396,8 +396,8 @@ class PrimusTrainingJob:
             f'--global_batch_size {self.global_batch_size} '
             f'--train_iters {self.iterations}'
         )
-        if self.checkpoint_dir:
-            batch_args += f' --save {self.checkpoint_dir} --save_interval {self.save_interval or self.iterations}'
+        if self.checkpoint_dir and not self.load_checkpoint:
+            batch_args += f' --save_interval {self.save_interval or self.iterations}'
         if self.load_checkpoint and self.checkpoint_dir:
             batch_args += f' --load {self.checkpoint_dir}/checkpoints'
             if self.distributed_training:
@@ -421,9 +421,9 @@ class PrimusTrainingJob:
                     + f'-- train pretrain --config {exp_path} {batch_args} &'
                 )
                 script_cmd = (
-                    f'echo {shlex.quote(full_cmd)} > '
+                    f'umask 077; echo {shlex.quote(full_cmd)} > '
                     f'{self.scripts_dir}/distributed_wrapper_script_{i}.sh '
-                    f'&& chmod 777 {self.scripts_dir}/distributed_wrapper_script_{i}.sh'
+                    f'&& chmod 700 {self.scripts_dir}/distributed_wrapper_script_{i}.sh'
                 )
                 self.job_cmd_list.append(script_cmd)
         else:
@@ -481,8 +481,8 @@ class PrimusTrainingJob:
             )
         else:
             self.orch.all.exec(
-                f'echo {shlex.quote(self.job_cmd)} > {self.scripts_dir}/single_node_wrapper_script.sh '
-                f'&& chmod 777 {self.scripts_dir}/single_node_wrapper_script.sh'
+                f'umask 077; echo {shlex.quote(self.job_cmd)} > {self.scripts_dir}/single_node_wrapper_script.sh '
+                f'&& chmod 700 {self.scripts_dir}/single_node_wrapper_script.sh'
             )
             self.orch.exec(
                 f'nohup {self.scripts_dir}/single_node_wrapper_script.sh '

--- a/cvs/lib/training/megatron/primus_lib.py
+++ b/cvs/lib/training/megatron/primus_lib.py
@@ -385,6 +385,17 @@ class PrimusTrainingJob:
                 'export NVTE_CK_IS_V3_ATOMIC_FP32=1; '
             )
 
+        # PRIMUS_WORKSPACE controls where Primus writes checkpoints.
+        # With PRIMUS_TEAM/USER/EXP_NAME all empty the checkpoint lands at:
+        #   {PRIMUS_WORKSPACE}/checkpoints
+        if self.checkpoint_dir:
+            env_exports += (
+                f'export PRIMUS_WORKSPACE={self.checkpoint_dir}; '
+                f'export PRIMUS_TEAM=""; '
+                f'export PRIMUS_USER=""; '
+                f'export PRIMUS_EXP_NAME=""; '
+            )
+
         batch_args = (
             f'--micro_batch_size {self.micro_batch_size} '
             f'--global_batch_size {self.global_batch_size} '
@@ -396,7 +407,9 @@ class PrimusTrainingJob:
                 f' --save_interval {self.save_interval or self.iterations}'
             )
         if self.load_checkpoint and self.checkpoint_dir:
-            batch_args += f' --load {self.checkpoint_dir}'
+            batch_args += f' --load {self.checkpoint_dir}/checkpoints'
+            if self.distributed_training:
+                batch_args += ' --auto_detect_ckpt_format'
 
         if self.distributed_training:
             env_exports += (
@@ -482,16 +495,19 @@ class PrimusTrainingJob:
             )
         time.sleep(50)
 
-    def _read_last_node_log(self, tail_lines=0):
-        """Read training log from the last node."""
-        n = len(self.orch.hosts)
-        last_host = self.orch.hosts[-1]
+    def _read_node_log(self, node_idx: int, tail_lines: int = 0) -> str:
+        """Read training log from a specific node by index."""
+        host = self.orch.hosts[node_idx]
         tail_suffix = f' | tail -{tail_lines}' if tail_lines > 0 else ''
         out_dict = self.orch.exec(
-            f'cat {self.combo_log_dir}/out-node{n - 1}/training.log{tail_suffix}',
-            hosts=[last_host],
+            f'cat {self.combo_log_dir}/out-node{node_idx}/training.log{tail_suffix}',
+            hosts=[host],
         )
-        return out_dict.get(last_host) or ''
+        return out_dict.get(host) or ''
+
+    def _read_last_node_log(self, tail_lines=0):
+        """Read training log from the last node."""
+        return self._read_node_log(len(self.orch.hosts) - 1, tail_lines)
 
     def _get_training_results_dict(self):
         """Parse training log and extract Primus metrics."""

--- a/cvs/lib/training/megatron/primus_lib.py
+++ b/cvs/lib/training/megatron/primus_lib.py
@@ -64,6 +64,7 @@ PRIMUS_NAN_PATTERNS = [
     r'lm loss:\s+(?:NaN|Inf)',
 ]
 
+
 def _is_training_complete(output, total_iters):
     """Return True only when the final Primus iteration line is present.
 
@@ -119,6 +120,7 @@ def _parse_step_losses(log_text):
 # ---------------------------------------------------------------------------
 # PrimusTrainingJob
 # ---------------------------------------------------------------------------
+
 
 class PrimusTrainingJob:
     """Manages a single Primus-Megatron training run (single-node or distributed).
@@ -183,7 +185,8 @@ class PrimusTrainingJob:
         if int(self.nnodes) != len(orch.hosts):
             log.warning(
                 'config nnodes=%s does not match cluster host count=%d; using cluster host count',
-                self.nnodes, len(orch.hosts),
+                self.nnodes,
+                len(orch.hosts),
             )
             self.nnodes = str(len(orch.hosts))
 
@@ -307,8 +310,7 @@ class PrimusTrainingJob:
 
         if not self.training_results_dict:
             fail_test(
-                'Failed to populate training results, training_results_dict is empty'
-                ' - please check logs for failures'
+                'Failed to populate training results, training_results_dict is empty - please check logs for failures'
             )
             return
 
@@ -316,8 +318,7 @@ class PrimusTrainingJob:
             for val in result_vals:
                 if re.search('nan|inf', val, re.I):
                     fail_test(
-                        f'Failures seen in training_result dict for {result_key},'
-                        f' numbers are either NaN or Inf - {val}'
+                        f'Failures seen in training_result dict for {result_key}, numbers are either NaN or Inf - {val}'
                     )
 
         if self.distributed_training and self.verify_network_errors.lower() == 'true':
@@ -362,10 +363,7 @@ class PrimusTrainingJob:
 
     def _exp_config_path(self):
         """Return the Primus EXP YAML path relative to primus_root."""
-        return (
-            f'examples/megatron/configs/'
-            f'{self.gpu_arch}/{self.model_name}-{self.precision}-pretrain.yaml'
-        )
+        return f'examples/megatron/configs/{self.gpu_arch}/{self.model_name}-{self.precision}-pretrain.yaml'
 
     def _build_primus_cmd(self):
         """Build the primus-cli launch command per node."""
@@ -380,10 +378,7 @@ class PrimusTrainingJob:
         )
 
         if re.search(r'MI3(00|25)X', self.gpu_arch, re.I):
-            env_exports += (
-                'export PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32=1; '
-                'export NVTE_CK_IS_V3_ATOMIC_FP32=1; '
-            )
+            env_exports += 'export PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32=1; export NVTE_CK_IS_V3_ATOMIC_FP32=1; '
 
         # PRIMUS_WORKSPACE controls where Primus writes checkpoints.
         # With PRIMUS_TEAM/USER/EXP_NAME all empty the checkpoint lands at:
@@ -402,10 +397,7 @@ class PrimusTrainingJob:
             f'--train_iters {self.iterations}'
         )
         if self.checkpoint_dir:
-            batch_args += (
-                f' --save {self.checkpoint_dir}'
-                f' --save_interval {self.save_interval or self.iterations}'
-            )
+            batch_args += f' --save {self.checkpoint_dir} --save_interval {self.save_interval or self.iterations}'
         if self.load_checkpoint and self.checkpoint_dir:
             batch_args += f' --load {self.checkpoint_dir}/checkpoints'
             if self.distributed_training:
@@ -458,7 +450,8 @@ class PrimusTrainingJob:
             fallback_arch = 'MI300X'
             log.warning(
                 'EXP config not found for %s, retrying with fallback arch %s',
-                self.gpu_arch, fallback_arch,
+                self.gpu_arch,
+                fallback_arch,
             )
             self.gpu_arch = fallback_arch
             self.job_cmd = ''
@@ -479,11 +472,13 @@ class PrimusTrainingJob:
 
         if self.distributed_training:
             self.orch.all.exec_cmd_list(self.job_cmd_list)
-            self.orch.exec_cmd_list([
-                f'nohup {self.scripts_dir}/distributed_wrapper_script_{i}.sh '
-                f'>> {self.combo_log_dir}/out-node{i}/training.log 2>&1 &'
-                for i in range(n)
-            ])
+            self.orch.exec_cmd_list(
+                [
+                    f'nohup {self.scripts_dir}/distributed_wrapper_script_{i}.sh '
+                    f'>> {self.combo_log_dir}/out-node{i}/training.log 2>&1 &'
+                    for i in range(n)
+                ]
+            )
         else:
             self.orch.all.exec(
                 f'echo {shlex.quote(self.job_cmd)} > {self.scripts_dir}/single_node_wrapper_script.sh '

--- a/cvs/lib/training/megatron/primus_lib.py
+++ b/cvs/lib/training/megatron/primus_lib.py
@@ -1,0 +1,545 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+
+Primus-Megatron training job — standalone module for Primus-specific logic.
+
+PrimusTrainingJob has the same public interface as MegatronTrainingJob and can
+be used as a drop-in replacement when the container image is Primus-based:
+  build_training_job_cmd()
+  start_training_job()
+  poll_for_training_completion()
+  verify_training_results()
+  stop_training_processes()
+  download_tokenizer_model()   (always a no-op; Primus uses HF repo IDs)
+  _needs_local_tokenizer()     (always False)
+  _read_last_node_log()
+'''
+
+import os
+import re
+import shlex
+import time
+
+from cvs.lib import globals
+from cvs.lib import linux_utils
+from cvs.lib.utils_lib import fail_test
+from cvs.lib.verify_lib import verify_dmesg_for_errors
+
+log = globals.log
+
+# ---------------------------------------------------------------------------
+# Primus-Megatron log patterns
+# ---------------------------------------------------------------------------
+
+PRIMUS_RESULT_PATTERNS = {
+    'throughput_per_gpu': [
+        r'throughput per GPU \(TFLOP/s/GPU\):\s+[0-9.]+/([0-9.]+)',
+        r'throughput per GPU \(TFLOP/s/GPU\):\s+([0-9.]+)(?:\s|$|\|)',
+    ],
+    'tokens_per_gpu': [
+        r'tokens/s/GPU inst/harmonic mean:\s+[0-9.]+/([0-9.]+)',
+        r'tokens per GPU \(tokens/s/GPU\):\s+[0-9.]+/([0-9.]+)',
+    ],
+    'elapsed_time_per_iteration': [
+        r'elapsed time per iteration \(ms\):\s+[0-9.]+/([0-9.]+)',
+        r'elapsed time per iteration \(ms\):\s+([0-9.]+)(?:\s|$|\|)',
+    ],
+}
+
+PRIMUS_ITERATION_PATTERNS = {
+    'throughput_per_gpu': r'throughput per GPU \(TFLOP/s/GPU\):\s+[0-9.]+/([0-9.]+)',
+    'tokens_per_gpu': r'(?:tokens/s/GPU inst/harmonic mean|tokens per GPU \(tokens/s/GPU\)):\s+[0-9.]+/([0-9.]+)',
+    'elapsed_time_per_iteration': r'elapsed time per iteration \(ms\):\s+[0-9.]+/([0-9.]+)',
+    'lm_loss': r'lm loss:\s+([0-9.E+\-]+)',
+    'grad_norm': r'grad norm:\s+([0-9.]+)',
+    'hip_mem_usage_ratio': r'hip mem usage/free/total/usage_ratio:\s+[0-9.]+GB/[0-9.]+GB/[0-9.]+GB/([0-9.]+)%',
+    'rocm_mem_usage_ratio': r'rocm mem usage/free/total/usage_ratio:\s+[0-9.]+GB/[0-9.]+GB/[0-9.]+GB/([0-9.]+)%',
+}
+
+PRIMUS_NAN_PATTERNS = [
+    r'throughput per GPU \(TFLOP/s/GPU\):\s+[0-9.]+/(?:NaN|Inf)',
+    r'lm loss:\s+(?:NaN|Inf)',
+]
+
+def _is_training_complete(output, total_iters):
+    """Return True only when the final Primus iteration line is present.
+
+    Primus emits `iteration <cur>/<total>` on every step, so `<total>/<total>`
+    marks true completion.  The `torchrun finished successfully` line is a
+    secondary signal for runs where the iteration counter format differs.
+    Checking for any per-iteration throughput line instead would fire after
+    step 1 and cut slow runs short.
+    """
+    n = int(total_iters)
+    return bool(re.search(rf'iteration\s+{n}\s*/\s*{n}\b', output)) or bool(
+        re.search(r'torchrun finished successfully', output, re.I)
+    )
+
+
+_training_err_dict = {
+    'NCCL ERROR': 'NCCL ERROR|NCCL timeout|ncclRemoteError: A call failed possibly due to a network error|NCCL error:',
+    'GPU HW ERROR': 'HW Exception by GPU|GPU Hang|Uncorrectable error|GPU Reset',
+    'torch': 'torch.distributed.elastic.multiprocessing.errors',
+}
+
+_err_counters_pattern = 'err|retransmit|drop|discard|naks|invalid|oflow|out_of_buffer|reset|fail'
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_mean_from_iterations(log_text, pattern, skip_warmup=True):
+    """Parse per-iteration metric values and return their mean as a string."""
+    matches = re.findall(pattern, log_text, re.I)
+    if not matches:
+        return None
+    values = [float(m) for m in matches]
+    if skip_warmup and len(values) > 1:
+        values = values[1:]
+    return str(sum(values) / len(values))
+
+
+def _parse_step_losses(log_text):
+    """Return {step: lm_loss} from a Primus training log.
+
+    Each iteration line looks like:
+      iteration  42/  200 | ... | lm loss: 2.3456 | ...
+    """
+    result = {}
+    for m in re.finditer(r'iteration\s+(\d+)/\s*\d+.*?lm loss:\s+([0-9.E+\-]+)', log_text, re.I):
+        result[int(m.group(1))] = float(m.group(2))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# PrimusTrainingJob
+# ---------------------------------------------------------------------------
+
+class PrimusTrainingJob:
+    """Manages a single Primus-Megatron training run (single-node or distributed).
+
+    Provides the same public interface as MegatronTrainingJob so it can be used
+    interchangeably in test files.
+    """
+
+    def __init__(
+        self,
+        orch,
+        variant_config,
+        hf_token,
+        micro_batch_size,
+        global_batch_size,
+        precision=None,
+        distributed_training=False,
+        tune_model_params=False,
+        scripts_dir=None,
+        run_label=None,
+    ):
+        self.orch = orch
+        self.model_name = variant_config.model_params['model_name']
+        self.hf_token = hf_token
+        self.tune_model_params = tune_model_params
+        self.distributed_training = distributed_training
+
+        self.job_cmd = ''
+        self.job_cmd_list = []
+        self.training_results_dict = {}
+        self.local_tokenizer_path = None
+        self.rdma_stats_dict_before = {}
+        self.ethtool_stats_dict_before = {}
+        self.rdma_stats_dict_after = {}
+        self.ethtool_stats_dict_after = {}
+        self.training_start_time = self.orch.all.exec('date')
+        self.training_end_time = None
+
+        self.home_dir = os.path.expanduser('~')
+        tdict = dict(variant_config.config)
+        tdict.setdefault('training_iterations', 10)
+        tdict.setdefault('nnodes', '1')
+        tdict.setdefault('nccl_socket_ifname', 'ensf1np1')
+        tdict.setdefault('gloo_socket_ifname', 'ensf1np1')
+        tdict.setdefault('nccl_ib_hca_list', 'bnxt_re0,bnxt_re1,bnxt_re2,bnxt_re3,bnxt_re4,bnxt_re5,bnxt_re6,bnxt_re7')
+        tdict.setdefault('nccl_ib_gid_index', '3')
+        tdict.setdefault('nccl_debug', 'ERROR')
+        tdict.setdefault('data_cache_dir', f'{self.home_dir}/cache')
+        tdict.setdefault('log_dir', f'{self.home_dir}/LOGS')
+        tdict.setdefault('scripts_dir', f'{self.home_dir}/SCRIPTS')
+        tdict.setdefault('master_address', '127.0.0.1')
+        tdict.setdefault('verify_network_errors', 'False')
+        tdict.setdefault('primus_root', '/workspace/Primus')
+        tdict.setdefault('primus_cli', 'runner/primus-cli')
+
+        self.iterations = int(tdict['training_iterations'])
+        self.checkpoint_dir = None
+        self.save_interval = None
+        self.load_checkpoint = False
+
+        self.nnodes = str(tdict['nnodes'])
+        if int(self.nnodes) != len(orch.hosts):
+            log.warning(
+                'config nnodes=%s does not match cluster host count=%d; using cluster host count',
+                self.nnodes, len(orch.hosts),
+            )
+            self.nnodes = str(len(orch.hosts))
+
+        self.nccl_socket_ifname = tdict['nccl_socket_ifname']
+        self.gloo_socket_ifname = tdict['gloo_socket_ifname']
+        self.nccl_ib_hca_list = tdict['nccl_ib_hca_list']
+        self.nccl_ib_gid_index = tdict['nccl_ib_gid_index']
+        self.nccl_debug = tdict['nccl_debug']
+        self.data_cache_dir = tdict['data_cache_dir']
+        self.log_dir = tdict['log_dir']
+        self.scripts_dir = scripts_dir if scripts_dir is not None else tdict['scripts_dir']
+        self.master_address = tdict['master_address']
+        self.verify_network_errors = tdict['verify_network_errors']
+        self.primus_root = tdict['primus_root']
+        self.primus_cli = tdict['primus_cli']
+        self.gpu_arch = getattr(variant_config, 'gpu_arch', '')
+
+        pdict = dict(variant_config.model_params)
+        pdict['micro_batch_size'] = micro_batch_size
+        pdict['global_batch_size'] = global_batch_size
+        if precision:
+            pdict['precision'] = precision
+        pdict.pop('model_name', None)
+        pdict.setdefault('tokenizer_model', 'meta-llama/Llama-3.1-70B')
+        pdict.setdefault('precision', 'BF16')
+        pdict.setdefault('micro_batch_size', '2')
+        pdict.setdefault('global_batch_size', '128')
+
+        self.tokenizer_model = pdict['tokenizer_model']
+        self.precision = pdict['precision']
+        self.micro_batch_size = pdict['micro_batch_size']
+        self.global_batch_size = pdict['global_batch_size']
+
+        raw_label = run_label or f"{self.model_name}_mbs{micro_batch_size}_gbs{global_batch_size}_{self.precision}"
+        self.run_label = re.sub(r'[^A-Za-z0-9._-]', '_', str(raw_label))
+        self.combo_log_dir = f'{self.log_dir}/primus-logs/{self.run_label}'
+
+        self.orch.all.exec(f'rm -rf {self.scripts_dir}')
+        self.orch.all.exec(f'mkdir -p {self.scripts_dir}')
+        self.orch.all.exec(f'sudo chmod 700 {self.scripts_dir}')
+
+    # ------------------------------------------------------------------
+    # Interface required by test files
+    # ------------------------------------------------------------------
+
+    def _needs_local_tokenizer(self):
+        return False
+
+    def download_tokenizer_model(self):
+        """No-op: Primus accepts HF repo IDs directly."""
+
+    def build_training_job_cmd(self):
+        self._build_primus_cmd()
+
+    def start_training_job(self):
+        self._start_primus_job()
+
+    def stop_training_processes(self):
+        """Kill any GPU processes still holding VRAM after a training combo."""
+        log.info('Checking GPU memory state after training combo')
+        out_dict = self.orch.exec('rocm-smi --showpids 2>/dev/null')
+
+        has_pids = False
+        for node, output in (out_dict or {}).items():
+            if 'No KFD PIDs currently running' in (output or ''):
+                log.info('Node %s: VRAM already free', node)
+            else:
+                log.warning('Node %s: GPU processes still holding VRAM, will kill', node)
+                has_pids = True
+
+        if not has_pids:
+            return
+
+        self.orch.exec(
+            "rocm-smi --showpids 2>/dev/null "
+            "| awk '/^[0-9]+[[:space:]]/{print $1}' "
+            "| xargs -r kill -9 2>/dev/null || true; "
+            "sleep 10"
+        )
+
+        out_dict = self.orch.exec('rocm-smi --showpids 2>/dev/null')
+        for node, output in (out_dict or {}).items():
+            if 'No KFD PIDs currently running' in (output or ''):
+                log.info('Node %s: VRAM successfully freed', node)
+            else:
+                log.warning('Node %s: GPU processes may still be running after kill attempt', node)
+
+    def poll_for_training_completion(self, time_between_iters=120):
+        """Poll training logs until completion, NaN, or iteration budget exhausted."""
+        log.info('Poll for training completion ..')
+        time.sleep(80)
+
+        n = int(self.iterations)
+        for i in range(1, n + 10):
+            log.info('Starting Iteration %d', i)
+            if not self._scan_for_training_errors():
+                fail_test('Failures seen in training logs, Aborting!!!')
+                return
+            output = self._read_last_node_log()
+            complete = _is_training_complete(output, n)
+            if not complete:
+                log.info('Training still in progress')
+            else:
+                if any(re.search(p, output, re.I) for p in PRIMUS_NAN_PATTERNS):
+                    fail_test(f'ERROR - NaN or Inf values seen in training results {output}')
+                    return
+                time.sleep(30)
+                self.training_results_dict = self._get_training_results_dict()
+                log.info('Completed Training, returning !!!')
+                return
+            time.sleep(int(time_between_iters))
+
+    def verify_training_results(self):
+        """Validate training results and network health after a run."""
+        self.training_end_time = self.orch.all.exec('date')
+
+        log.info('#==================================================#')
+        log.info('\t\tTraining Results')
+        log.info('%s', self.training_results_dict)
+        log.info('#==================================================#')
+
+        if not self.training_results_dict:
+            fail_test(
+                'Failed to populate training results, training_results_dict is empty'
+                ' - please check logs for failures'
+            )
+            return
+
+        for result_key, result_vals in self.training_results_dict.items():
+            for val in result_vals:
+                if re.search('nan|inf', val, re.I):
+                    fail_test(
+                        f'Failures seen in training_result dict for {result_key},'
+                        f' numbers are either NaN or Inf - {val}'
+                    )
+
+        if self.distributed_training and self.verify_network_errors.lower() == 'true':
+            self.rdma_stats_dict_after = linux_utils.get_rdma_stats_dict(self.orch.all)
+            self.ethtool_stats_dict_after = linux_utils.get_nic_ethtool_stats_dict(self.orch.all)
+
+            for node, counters in self.rdma_stats_dict_after.items():
+                for name, val in counters.items():
+                    if re.search(_err_counters_pattern, name, re.I):
+                        before = int(self.rdma_stats_dict_before.get(node, {}).get(name, 0))
+                        if int(val) > before:
+                            fail_test(
+                                f'Error counter {name} has gone up after training on node {node} '
+                                f'Before = {before}, After = {val}'
+                            )
+
+            for node, counters in self.ethtool_stats_dict_after.items():
+                for name, val in counters.items():
+                    if re.search(_err_counters_pattern, name, re.I):
+                        before = int(self.ethtool_stats_dict_before.get(node, {}).get(name, 0))
+                        if int(val) > before:
+                            fail_test(
+                                f'Error counter {name} has gone up after training on node {node} '
+                                f'Before = {before}, After = {val}'
+                            )
+
+        verify_dmesg_for_errors(self.orch.all, self.training_start_time, self.training_end_time, till_end_flag=False)
+
+        log.info('^^^^^^^^^^^^^^^^^^^^')
+        log.info('training_results_dict')
+        log.info('^^^^^^^^^^^^^^^^^^^^')
+        log.info('%s', self.training_results_dict)
+
+    def run_pretraining_tasks(self):
+        if self.distributed_training:
+            self.rdma_stats_dict_before = linux_utils.get_rdma_stats_dict(self.orch.all)
+            self.ethtool_stats_dict_before = linux_utils.get_nic_ethtool_stats_dict(self.orch.all)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _exp_config_path(self):
+        """Return the Primus EXP YAML path relative to primus_root."""
+        return (
+            f'examples/megatron/configs/'
+            f'{self.gpu_arch}/{self.model_name}-{self.precision}-pretrain.yaml'
+        )
+
+    def _build_primus_cmd(self):
+        """Build the primus-cli launch command per node."""
+        exp_path = self._exp_config_path()
+        log.info('Primus EXP config path: %s', exp_path)
+
+        env_exports = (
+            f'export HF_TOKEN="{self.hf_token}"; '
+            f'export LOG_DIR={self.log_dir}; '
+            f'export NCCL_SOCKET_IFNAME={self.nccl_socket_ifname}; '
+            f'export GLOO_SOCKET_IFNAME={self.gloo_socket_ifname}; '
+        )
+
+        if re.search(r'MI3(00|25)X', self.gpu_arch, re.I):
+            env_exports += (
+                'export PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32=1; '
+                'export NVTE_CK_IS_V3_ATOMIC_FP32=1; '
+            )
+
+        batch_args = (
+            f'--micro_batch_size {self.micro_batch_size} '
+            f'--global_batch_size {self.global_batch_size} '
+            f'--train_iters {self.iterations}'
+        )
+        if self.checkpoint_dir:
+            batch_args += (
+                f' --save {self.checkpoint_dir}'
+                f' --save_interval {self.save_interval or self.iterations}'
+            )
+        if self.load_checkpoint and self.checkpoint_dir:
+            batch_args += f' --load {self.checkpoint_dir}'
+
+        if self.distributed_training:
+            env_exports += (
+                f'export NCCL_IB_HCA_LIST={self.nccl_ib_hca_list}; '
+                f'export NCCL_IB_HCA={self.nccl_ib_hca_list}; '
+                f'export NCCL_DEBUG={self.nccl_debug}; '
+                f'export NCCL_IB_GID_INDEX={self.nccl_ib_gid_index}; '
+            )
+            for i in range(len(self.orch.hosts)):
+                log_file = f'{self.combo_log_dir}/out-node{i}/training.log'
+                full_cmd = (
+                    env_exports
+                    + f'cd {self.primus_root} && '
+                    + f'NNODES={self.nnodes} NODE_RANK={i} MASTER_ADDR={self.master_address} '
+                    + f'nohup bash {self.primus_cli} direct '
+                    + f'--log_file {log_file} '
+                    + f'-- train pretrain --config {exp_path} {batch_args} &'
+                )
+                script_cmd = (
+                    f'echo {shlex.quote(full_cmd)} > '
+                    f'{self.scripts_dir}/distributed_wrapper_script_{i}.sh '
+                    f'&& chmod 777 {self.scripts_dir}/distributed_wrapper_script_{i}.sh'
+                )
+                self.job_cmd_list.append(script_cmd)
+        else:
+            log_file = f'{self.combo_log_dir}/out-node0/training.log'
+            self.job_cmd = (
+                env_exports
+                + f'cd {self.primus_root} && '
+                + f'nohup bash {self.primus_cli} direct '
+                + f'--log_file {log_file} '
+                + f'-- train pretrain --config {exp_path} {batch_args} &'
+            )
+
+    def _start_primus_job(self):
+        """Launch the Primus training job (distributed or single-node)."""
+        log.info('start primus training job')
+        log.info('%s', self.job_cmd_list)
+        log.info('%s', self.job_cmd)
+
+        exp_full_path = f'{self.primus_root}/{self._exp_config_path()}'
+        out_dict = self.orch.exec(f'test -f {exp_full_path} && echo EXISTS || echo MISSING')
+        output = list((out_dict or {}).values())[0] if out_dict else ''
+
+        if 'MISSING' in output and re.search(r'MI325X', self.gpu_arch, re.I):
+            fallback_arch = 'MI300X'
+            log.warning(
+                'EXP config not found for %s, retrying with fallback arch %s',
+                self.gpu_arch, fallback_arch,
+            )
+            self.gpu_arch = fallback_arch
+            self.job_cmd = ''
+            self.job_cmd_list = []
+            self._build_primus_cmd()
+            exp_full_path = f'{self.primus_root}/{self._exp_config_path()}'
+            out_dict = self.orch.exec(f'test -f {exp_full_path} && echo EXISTS || echo MISSING')
+            output = list((out_dict or {}).values())[0] if out_dict else ''
+
+        if 'MISSING' in output:
+            msg = f'Primus EXP config not found in container: {exp_full_path}'
+            log.error('Primus EXP config path: %s', exp_full_path)
+            fail_test(msg)
+            raise FileNotFoundError(msg)
+
+        n = len(self.orch.hosts)
+        self.orch.exec_cmd_list([f'mkdir -p {self.combo_log_dir}/out-node{i}' for i in range(n)])
+
+        if self.distributed_training:
+            self.orch.all.exec_cmd_list(self.job_cmd_list)
+            self.orch.exec_cmd_list([
+                f'nohup {self.scripts_dir}/distributed_wrapper_script_{i}.sh '
+                f'>> {self.combo_log_dir}/out-node{i}/training.log 2>&1 &'
+                for i in range(n)
+            ])
+        else:
+            self.orch.all.exec(
+                f'echo {shlex.quote(self.job_cmd)} > {self.scripts_dir}/single_node_wrapper_script.sh '
+                f'&& chmod 777 {self.scripts_dir}/single_node_wrapper_script.sh'
+            )
+            self.orch.exec(
+                f'nohup {self.scripts_dir}/single_node_wrapper_script.sh '
+                f'>> {self.combo_log_dir}/out-node0/training.log 2>&1 &'
+            )
+        time.sleep(50)
+
+    def _read_last_node_log(self, tail_lines=0):
+        """Read training log from the last node."""
+        n = len(self.orch.hosts)
+        last_host = self.orch.hosts[-1]
+        tail_suffix = f' | tail -{tail_lines}' if tail_lines > 0 else ''
+        out_dict = self.orch.exec(
+            f'cat {self.combo_log_dir}/out-node{n - 1}/training.log{tail_suffix}',
+            hosts=[last_host],
+        )
+        return out_dict.get(last_host) or ''
+
+    def _get_training_results_dict(self):
+        """Parse training log and extract Primus metrics."""
+        tail_output = self._read_last_node_log(tail_lines=15)
+
+        log.info('Extracting results from logs')
+        log.info('#===========================#')
+        log.info('%s', tail_output)
+        log.info('#===========================#')
+
+        full_log = self._read_last_node_log()
+        return self._parse_primus_results(tail_output, full_log)
+
+    def _parse_primus_results(self, output, full_log=None):
+        """Extract metrics from a Primus-Megatron training log.
+
+        For x/y format metrics (throughput, tokens, elapsed): search full_log and
+        take matches[-1] which is the final step's overall harmonic mean (y value).
+        For single-value metrics (lm_loss, grad_norm, mem): compute mean across all steps.
+        """
+        log_text = full_log if full_log is not None else output
+        out = {}
+        for metric, patterns in PRIMUS_RESULT_PATTERNS.items():
+            out[metric] = []
+            for pat in patterns:
+                matches = re.findall(pat, log_text, re.I)
+                if matches:
+                    out[metric] = [matches[-1]]
+                    break
+        for metric, pattern in PRIMUS_ITERATION_PATTERNS.items():
+            if not out.get(metric):
+                mean = _parse_mean_from_iterations(log_text, pattern, skip_warmup=True)
+                if mean:
+                    out[metric] = [mean]
+                    log.info('primus per-iteration mean: %s = %s', metric, mean)
+        return out
+
+    def _scan_for_training_errors(self):
+        """Scan training log for known error patterns.
+
+        Returns:
+            bool: True if no errors found.
+        """
+        output = self._read_last_node_log()
+        training_pass = True
+        for err_key, pattern in _training_err_dict.items():
+            if re.search(pattern, output):
+                fail_test(f'ERROR {pattern} seen in training logs ..')
+                log.error('Aborting training log polling')
+                training_pass = False
+        return training_pass

--- a/cvs/lib/training/megatron/utils/checkpoint_io.py
+++ b/cvs/lib/training/megatron/utils/checkpoint_io.py
@@ -94,9 +94,7 @@ def parse_checkpoint_io_seconds(
                 load_end_ts = datetime.strptime(outer_m.group(1), _TS_FMT_S)
 
     save_times = [
-        (itr, (save_ends[itr] - save_starts[itr]).total_seconds())
-        for itr in sorted(save_starts)
-        if itr in save_ends
+        (itr, (save_ends[itr] - save_starts[itr]).total_seconds()) for itr in sorted(save_starts) if itr in save_ends
     ]
 
     load_seconds = None
@@ -117,7 +115,8 @@ def log_checkpoint_io_times(
         avg_save = sum(e for _, e in save_times) / len(save_times)
         log.info(
             "checkpoint save I/O avg (across %d checkpoints): %.2fs",
-            len(save_times), avg_save,
+            len(save_times),
+            avg_save,
         )
     else:
         log.warning("checkpoint save I/O times could not be parsed from save log")

--- a/cvs/lib/training/megatron/utils/checkpoint_io.py
+++ b/cvs/lib/training/megatron/utils/checkpoint_io.py
@@ -1,0 +1,128 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Checkpoint I/O timing utilities for Primus-Megatron training logs.
+
+Parses save and load elapsed times directly from training log text so
+test_checkpoint can report checkpoint I/O performance without any external
+instrumentation.
+
+Save timing uses the embedded microsecond timestamps on save bracket lines:
+  [YYYY-MM-DD HH:MM:SS.ffffff] saving checkpoint at iteration N to ...
+  [YYYY-MM-DD HH:MM:SS.ffffff] successfully saved checkpoint from iteration N to ...
+
+Load timing uses the outer second-precision header timestamps:
+  [YYYYMMDD HH:MM:SS]... loading checkpoint from ...
+  [YYYYMMDD HH:MM:SS]... successfully loaded checkpoint from ...
+
+Both single-node and distributed runs emit these lines on the master node (rank-0).
+The caller is responsible for passing the node-0 log for distributed runs.
+'''
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from cvs.lib import globals
+
+log = globals.log
+
+# ---------------------------------------------------------------------------
+# Regex patterns (single-line, applied per line after splitlines())
+# ---------------------------------------------------------------------------
+
+_OUTER_TS_RE = re.compile(r'\[(\d{8} \d{2}:\d{2}:\d{2})\]')
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')
+_SAVE_START_RE = re.compile(
+    r'\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\]\s+saving checkpoint at iteration\s+(\d+)',
+)
+_SAVE_END_RE = re.compile(
+    r'\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\]\s+successfully saved checkpoint from iteration\s+(\d+)',
+)
+
+_TS_FMT_US = '%Y-%m-%d %H:%M:%S.%f'
+_TS_FMT_S = '%Y%m%d %H:%M:%S'
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_checkpoint_io_seconds(
+    log_text: str,
+) -> Tuple[List[Tuple[int, float]], Optional[float]]:
+    """Parse checkpoint save and load I/O times from a Primus training log.
+
+    Returns:
+        save_times  : list of (iteration, elapsed_seconds) for each checkpoint saved.
+        load_seconds: seconds to load the checkpoint, or None if not found.
+
+    Iterates line-by-line (via splitlines) so mixed line endings from SSH output
+    never interfere with the patterns.
+    """
+    save_starts: dict = {}
+    save_ends: dict = {}
+    load_start_ts = None
+    load_end_ts = None
+
+    for line in (_ANSI_RE.sub('', ln) for ln in log_text.splitlines()):
+        # Save start — embedded microsecond timestamp
+        m = _SAVE_START_RE.search(line)
+        if m:
+            save_starts[int(m.group(2))] = datetime.strptime(m.group(1), _TS_FMT_US)
+            continue
+
+        # Save end — embedded microsecond timestamp
+        m = _SAVE_END_RE.search(line)
+        if m:
+            save_ends[int(m.group(2))] = datetime.strptime(m.group(1), _TS_FMT_US)
+            continue
+
+        # Load start / end — keyword check first, then extract outer timestamp via
+        # search() (not match()) so any invisible prefix bytes don't block the match.
+        if 'loading checkpoint from' in line and 'successfully' not in line:
+            outer_m = _OUTER_TS_RE.search(line)
+            if outer_m:
+                load_start_ts = datetime.strptime(outer_m.group(1), _TS_FMT_S)
+        elif 'successfully loaded checkpoint from' in line:
+            outer_m = _OUTER_TS_RE.search(line)
+            if outer_m:
+                load_end_ts = datetime.strptime(outer_m.group(1), _TS_FMT_S)
+
+    save_times = [
+        (itr, (save_ends[itr] - save_starts[itr]).total_seconds())
+        for itr in sorted(save_starts)
+        if itr in save_ends
+    ]
+
+    load_seconds = None
+    if load_start_ts and load_end_ts:
+        load_seconds = (load_end_ts - load_start_ts).total_seconds()
+
+    return save_times, load_seconds
+
+
+def log_checkpoint_io_times(
+    save_times: List[Tuple[int, float]],
+    load_seconds: Optional[float],
+) -> None:
+    """Log checkpoint I/O timing results."""
+    if save_times:
+        for itr, elapsed in save_times:
+            log.info("checkpoint save I/O: iteration=%d time=%.2fs", itr, elapsed)
+        avg_save = sum(e for _, e in save_times) / len(save_times)
+        log.info(
+            "checkpoint save I/O avg (across %d checkpoints): %.2fs",
+            len(save_times), avg_save,
+        )
+    else:
+        log.warning("checkpoint save I/O times could not be parsed from save log")
+
+    if load_seconds is not None:
+        log.info("checkpoint load I/O time: %.2fs", load_seconds)
+    else:
+        log.warning("checkpoint load I/O time could not be parsed from resume log")

--- a/cvs/lib/training/megatron/utils/convergence.py
+++ b/cvs/lib/training/megatron/utils/convergence.py
@@ -11,7 +11,7 @@ compute_convergence — steps and wall-clock to reach a target loss
 from __future__ import annotations
 
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List
 
 
 def parse_step_metrics(log_text: str) -> List[Dict]:
@@ -39,11 +39,13 @@ def parse_step_metrics(log_text: str) -> List[Dict]:
         re.I,
     )
     for m in pattern.finditer(log_text):
-        results.append({
-            "step": int(m.group(1)),
-            "elapsed_time_ms": float(m.group(2)),
-            "loss": float(m.group(3)),
-        })
+        results.append(
+            {
+                "step": int(m.group(1)),
+                "elapsed_time_ms": float(m.group(2)),
+                "loss": float(m.group(3)),
+            }
+        )
     return results
 
 
@@ -102,4 +104,3 @@ def compute_convergence(step_metrics, eval_metrics, target_metric="auto", target
         time_to_target = max(prior) if prior else None
 
     return (target_step, time_to_target)
- 

--- a/cvs/lib/training/megatron/utils/convergence.py
+++ b/cvs/lib/training/megatron/utils/convergence.py
@@ -1,0 +1,105 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Convergence utilities for Megatron training log analysis.
+
+parse_step_metrics  — extract per-step (step, elapsed_time_ms, loss) from a training log
+compute_convergence — steps and wall-clock to reach a target loss
+'''
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional, Tuple
+
+
+def parse_step_metrics(log_text: str) -> List[Dict]:
+    """Extract per-step metrics from a full Megatron training log.
+
+    Each Megatron log line has the form:
+        iteration   <N>/  <total> | ... | elapsed time per iteration (ms): <X>[/<avg>] | ... | lm loss: <value> | ...
+
+    elapsed_time_ms captures the instantaneous per-step time (X, not the running
+    average). For warmup iterations the value is a single number; for steady-state
+    iterations it is X/Y — the regex captures X in both cases.
+
+    Args:
+        log_text: Full training log text.
+
+    Returns:
+        List of ``{"step": int, "elapsed_time_ms": float, "loss": float}`` dicts
+        in log order. Lines missing either elapsed time or lm loss are skipped.
+    """
+    results = []
+    pattern = re.compile(
+        r'iteration\s+(\d+)\s*/\s*\d+[^\n]*?'
+        r'elapsed time per iteration \(ms\):\s*([0-9.]+)(?:/[0-9.]+)?[^\n]*?'
+        r'\blm loss:\s*([0-9.eE+\-]+)',
+        re.I,
+    )
+    for m in pattern.finditer(log_text):
+        results.append({
+            "step": int(m.group(1)),
+            "elapsed_time_ms": float(m.group(2)),
+            "loss": float(m.group(3)),
+        })
+    return results
+
+
+def compute_convergence(step_metrics, eval_metrics, target_metric="auto", target_value=0.0):
+    """Steps and wall-clock to reach a target loss.
+
+    target_metric:
+      - "eval_loss":  converge on validation loss (eval_metrics points)
+      - "train_loss": converge on per-step training loss (step_metrics)
+      - "auto":       use eval_metrics when present, else training loss
+
+    A `target_value <= 0` disables the metric and returns (None, None) so an
+    uncalibrated target never gates or misleads.
+
+    Returns (steps_to_target, time_to_target_seconds), where the time is the
+    cumulative sum of per-step elapsed_time_ms (converted to seconds) up to and
+    including the target step. Returns (None, None) when disabled or the target
+    is never reached. Never raises.
+    """
+    if not target_value or target_value <= 0:
+        return (None, None)
+
+    use_eval = target_metric == "eval_loss" or (target_metric == "auto" and bool(eval_metrics))
+
+    # Cumulative training seconds indexed by step, derived from elapsed_time_ms.
+    cum = {}
+    running = 0.0
+    for s in step_metrics or []:
+        elapsed_ms = s.get("elapsed_time_ms")
+        if isinstance(elapsed_ms, (int, float)):
+            running += elapsed_ms / 1000.0
+        step = s.get("step")
+        if step is not None:
+            cum[step] = running
+
+    target_step = None
+    if use_eval:
+        for e in eval_metrics or []:
+            loss = e.get("eval_loss")
+            if loss is not None and e.get("step") is not None and loss <= target_value:
+                target_step = e.get("step")
+                break
+    else:
+        for s in step_metrics or []:
+            loss = s.get("loss")
+            if loss is not None and s.get("step") is not None and loss <= target_value:
+                target_step = s.get("step")
+                break
+
+    if target_step is None:
+        return (None, None)
+
+    time_to_target = cum.get(target_step)
+    if time_to_target is None and cum:
+        prior = [t for st, t in cum.items() if st <= target_step]
+        time_to_target = max(prior) if prior else None
+
+    return (target_step, time_to_target)
+ 

--- a/cvs/lib/training/megatron/utils/training_config_loader.py
+++ b/cvs/lib/training/megatron/utils/training_config_loader.py
@@ -135,6 +135,15 @@ class ConvergenceConfig(_Forbid):
     target_value: float = 0.0
 
 
+class CheckpointConfig(_Forbid):
+    enforce: bool = False      # if False, test_checkpoint is skipped entirely
+    save_interval: int = 5     # checkpoint written every N steps
+    save_iters: int = 21       # save phase total; last checkpoint = floor(save/interval)*interval
+    resume_iters: int = 25     # load phase total (must be > last_ckpt_step)
+    loss_rtol: float = 0.05    # max allowed fractional loss increase across boundary
+    checkpoint_dir: str = ""   # shared path for distributed; empty = derive from log_dir (single-node)
+
+
 class MegatronVariantConfig(_Forbid):
     schema_version: Literal[1]
     framework: Literal["megatron_single", "megatron_distributed"]
@@ -144,6 +153,7 @@ class MegatronVariantConfig(_Forbid):
     scaling_baseline: ScalingBaseline = Field(default_factory=ScalingBaseline)
     loss_curve: LossCurveConfig = Field(default_factory=LossCurveConfig)
     convergence: ConvergenceConfig = Field(default_factory=ConvergenceConfig)
+    checkpoint: CheckpointConfig = Field(default_factory=CheckpointConfig)
     config: Dict[str, Any]  # training knobs: megatron_root, nccl_*, nic_type, ...
     model_params: Dict[str, Any]  # model knobs: model_name, precision, tp, pp, ...
     container: ContainerSpec

--- a/cvs/lib/training/megatron/utils/training_config_loader.py
+++ b/cvs/lib/training/megatron/utils/training_config_loader.py
@@ -136,12 +136,12 @@ class ConvergenceConfig(_Forbid):
 
 
 class CheckpointConfig(_Forbid):
-    enforce: bool = False      # if False, test_checkpoint is skipped entirely
-    save_interval: int = 5     # checkpoint written every N steps
-    save_iters: int = 21       # save phase total; last checkpoint = floor(save/interval)*interval
-    resume_iters: int = 25     # load phase total (must be > last_ckpt_step)
-    loss_rtol: float = 0.05    # max allowed fractional loss increase across boundary
-    checkpoint_dir: str = ""   # shared path for distributed; empty = derive from log_dir (single-node)
+    enforce: bool = False  # if False, test_checkpoint is skipped entirely
+    save_interval: int = 5  # checkpoint written every N steps
+    save_iters: int = 21  # save phase total; last checkpoint = floor(save/interval)*interval
+    resume_iters: int = 25  # load phase total (must be > last_ckpt_step)
+    loss_rtol: float = 0.05  # max allowed fractional loss increase across boundary
+    checkpoint_dir: str = ""  # shared path for distributed; empty = derive from log_dir (single-node)
 
 
 class MegatronVariantConfig(_Forbid):

--- a/cvs/lib/training/megatron/utils/training_config_loader.py
+++ b/cvs/lib/training/megatron/utils/training_config_loader.py
@@ -137,7 +137,7 @@ class ConvergenceConfig(_Forbid):
 
 class CheckpointConfig(_Forbid):
     enforce: bool = False  # if False, test_checkpoint is skipped entirely
-    save_interval: int = 5  # checkpoint written every N steps
+    save_interval: int = 20  # checkpoint written every N steps
     save_iters: int = 21  # save phase total; last checkpoint = floor(save/interval)*interval
     resume_iters: int = 25  # load phase total (must be > last_ckpt_step)
     loss_rtol: float = 0.05  # max allowed fractional loss increase across boundary

--- a/cvs/lib/training/megatron/utils/training_config_loader.py
+++ b/cvs/lib/training/megatron/utils/training_config_loader.py
@@ -130,6 +130,11 @@ class LossCurveConfig(_Forbid):
     enforce: bool = True
 
 
+class ConvergenceConfig(_Forbid):
+    target_metric: Literal["auto", "train_loss", "eval_loss"] = "auto"
+    target_value: float = 0.0
+
+
 class MegatronVariantConfig(_Forbid):
     schema_version: Literal[1]
     framework: Literal["megatron_single", "megatron_distributed"]
@@ -138,6 +143,7 @@ class MegatronVariantConfig(_Forbid):
     threshold_json: str = ""
     scaling_baseline: ScalingBaseline = Field(default_factory=ScalingBaseline)
     loss_curve: LossCurveConfig = Field(default_factory=LossCurveConfig)
+    convergence: ConvergenceConfig = Field(default_factory=ConvergenceConfig)
     config: Dict[str, Any]  # training knobs: megatron_root, nccl_*, nic_type, ...
     model_params: Dict[str, Any]  # model knobs: model_name, precision, tp, pp, ...
     container: ContainerSpec

--- a/cvs/tests/training/megatron/conftest.py
+++ b/cvs/tests/training/megatron/conftest.py
@@ -121,10 +121,11 @@ def pytest_collection_modifyitems(items):
         "test_launch_container": 0,
         "test_download_tokenizer": 1,
         "test_smoke": 2,
-        "test_training": 3,
-        "test_metric": 4,
-        "test_loss_curve": 5,
-        "test_teardown": 6,
+        "test_checkpoint": 3,
+        "test_training": 4,
+        "test_metric": 5,
+        "test_loss_curve": 6,
+        "test_teardown": 7,
     }
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
 

--- a/cvs/tests/training/megatron/megatron_distributed.py
+++ b/cvs/tests/training/megatron/megatron_distributed.py
@@ -11,6 +11,7 @@ Topology is determined by the config file:
 Lifecycle (each stage is a separate test):
   test_launch_container  — launch the container once for all sweep combos
   test_smoke             — fixed small cell: model loads and runs N steps without error
+  test_checkpoint        — Primus-only: checkpoint save + resume correctness check
   test_training          — parametrized: one test per sweep combo; kills GPU
                            processes in finally so VRAM is free for the next combo
   test_metric            — parametrized: threshold check per combo via evaluate_all
@@ -27,7 +28,8 @@ import pytest
 
 from cvs.lib import globals
 from cvs.lib.training.megatron.megatron_lib import MegatronTrainingJob
-from cvs.lib.training.megatron.primus_lib import PrimusTrainingJob
+from cvs.lib.training.megatron.primus_lib import PrimusTrainingJob, _parse_step_losses
+from cvs.lib.training.megatron.utils.checkpoint_io import log_checkpoint_io_times, parse_checkpoint_io_seconds
 from cvs.lib.training.megatron.utils.convergence import (
     compute_convergence,
     parse_step_metrics,
@@ -190,6 +192,191 @@ def test_smoke(orch, variant_config, hf_token, lifecycle, request):
     update_test_result()
     lifecycle.record(request.node.nodeid, "smoke", time.monotonic() - t)
     log.info("smoke PASSED | iters=%s", _SMOKE_ITERS)
+
+
+def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
+    """Stage 2.5: checkpoint save + resume — verify step counter and loss continuity.
+
+    Two phases:
+      Phase 1 — Save : train checkpoint.save_iters steps, saving every checkpoint.save_interval.
+                       Last checkpoint lands at floor(save_iters/interval)*interval.
+      Phase 2 — Load : resume from that checkpoint with train_iters=checkpoint.resume_iters;
+                       Primus continues from last_ckpt_step+1 to resume_iters.
+
+    Asserts:
+      - First logged step of load phase == last_ckpt_step + 1 (step counter restored).
+      - resume_losses[last_ckpt_step+1] <= save_losses[last_ckpt_step] + tol (no loss spike).
+
+    Skipped if checkpoint.enforce=false or for non-Primus images.
+    """
+    if lifecycle.failed:
+        pytest.skip("a prior lifecycle stage failed")
+
+    ckpt_cfg = variant_config.checkpoint
+    if not ckpt_cfg.enforce:
+        pytest.skip("checkpoint.enforce=false in config; skipping test_checkpoint")
+
+    if not re.search(r'primus', orch.container_config.get("image", ""), re.I):
+        pytest.skip("checkpoint test is Primus-only")
+
+    # checkpoint_dir must be a shared path (e.g. NFS) visible on all nodes so
+    # every rank can read the checkpoint written by rank-0 in the save phase.
+    ckpt_dir = ckpt_cfg.checkpoint_dir
+    if not ckpt_dir:
+        pytest.fail(
+            "checkpoint.checkpoint_dir is required for distributed checkpoint test; "
+            "set it to a shared path (e.g. NFS) accessible from all nodes in the config"
+        )
+    orch.exec(f"mkdir -p {ckpt_dir}")
+
+    def _run(run_label, iters, checkpoint_dir=None, save_interval=None, load_checkpoint=False):
+        job = _make_training_job(
+            orch,
+            variant_config,
+            hf_token=hf_token,
+            micro_batch_size=_SMOKE_MBS,
+            global_batch_size=_SMOKE_GBS,
+            precision=_SMOKE_PRECISION,
+            distributed_training=True,
+            tune_model_params=False,
+            run_label=run_label,
+        )
+        job.iterations = iters
+        job.local_tokenizer_path = getattr(lifecycle, "tokenizer_path", None)
+        if checkpoint_dir:
+            job.checkpoint_dir = checkpoint_dir
+            job.save_interval = save_interval or iters
+        job.load_checkpoint = load_checkpoint
+        try:
+            job.build_training_job_cmd()
+            job.start_training_job()
+            job.poll_for_training_completion()
+        finally:
+            job.stop_training_processes()
+        # Losses are parsed from the last node; checkpoint timing lines are only
+        # emitted by rank-0 (master node), so return both logs.
+        return job._read_last_node_log(), job._read_node_log(0)
+
+    # Phase 1: save — train save_iters steps, writing checkpoint every save_interval steps.
+    # save_iters must not be an exact multiple of save_interval so the last checkpoint is
+    # not the final step (disable_last_saving=true in the YAML suppresses the last-iter save).
+    try:
+        save_log, save_log_node0 = _run(
+            "ckpt_save",
+            ckpt_cfg.save_iters,
+            checkpoint_dir=ckpt_dir,
+            save_interval=ckpt_cfg.save_interval,
+        )
+    except Exception:
+        raise
+
+    # Verify the checkpoint was written before attempting resume.
+    # With PRIMUS_TEAM/USER/EXP_NAME all empty, Primus writes to:
+    #   {PRIMUS_WORKSPACE}/checkpoints/latest_checkpointed_iteration.txt
+    ckpt_meta = f"{ckpt_dir}/checkpoints/latest_checkpointed_iteration.txt"
+    check = orch.exec(f"test -f {ckpt_meta} && echo FOUND || echo MISSING")
+    head_node = orch.hosts[0]
+    if "MISSING" in (check or {}).get(head_node, "MISSING"):
+        ls_out = orch.exec(f"ls -laR {ckpt_dir} 2>&1 || echo DIR_EMPTY")
+        log.error("checkpoint listing:\n%s", (ls_out or {}).get(head_node, ""))
+        pytest.fail(
+            f"checkpoint not written after save phase; expected: {ckpt_meta}\n"
+            f"Check that checkpoint_dir ({ckpt_dir}) is volume-mounted into the container."
+        )
+
+    # last_ckpt_step = floor(save_iters / interval) * interval
+    last_ckpt_step = (ckpt_cfg.save_iters // ckpt_cfg.save_interval) * ckpt_cfg.save_interval
+    expected_first = last_ckpt_step + 1
+
+    # Phase 2: load — resume from last checkpoint, train to resume_iters total.
+    # Primus reads the checkpoint and starts iterating from last_ckpt_step+1.
+    try:
+        resume_log, resume_log_node0 = _run(
+            "ckpt_resume",
+            ckpt_cfg.resume_iters,
+            checkpoint_dir=ckpt_dir,
+            load_checkpoint=True,
+        )
+    except Exception:
+        raise
+
+    save_losses = _parse_step_losses(save_log)
+    resume_losses = _parse_step_losses(resume_log)
+
+    log.info("checkpoint save steps  : %s", sorted(save_losses))
+    log.info("checkpoint resume steps: %s", sorted(resume_losses))
+
+    # Checkpoint I/O timing — save & load (seconds).
+    # Checkpoint timing lines are only emitted by rank-0, so parse from node-0 log.
+    save_io_times, _ = parse_checkpoint_io_seconds(save_log_node0)
+    _, load_io_seconds = parse_checkpoint_io_seconds(resume_log_node0)
+    log_checkpoint_io_times(save_io_times, load_io_seconds)
+
+    # Check 1: step counter restored — first logged step of resume == last_ckpt_step + 1
+    if not resume_losses:
+        pytest.fail("load phase produced no iteration logs; cannot verify step counter")
+
+    first_step = min(resume_losses)
+    log.info(
+        "CHECK 1 — step counter: last saved step in checkpoint=%d, "
+        "first step in load phase=%d",
+        last_ckpt_step, first_step,
+    )
+    if first_step != expected_first:
+        pytest.fail(
+            f"FAILED step counter check: last saved checkpoint step={last_ckpt_step}, "
+            f"expected load to start at step {expected_first}, got {first_step}"
+        )
+    log.info(
+        "CHECK 1 PASSED — step counter correctly restored: "
+        "last checkpoint step=%d, load phase started at step=%d",
+        last_ckpt_step, first_step,
+    )
+
+    # Check 2: loss must not spike — resume loss at first step <= save loss + tolerance
+    save_val = save_losses.get(last_ckpt_step)
+    resume_val = resume_losses.get(first_step)
+    if save_val is None or resume_val is None:
+        pytest.fail(
+            f"Cannot compare losses: "
+            f"save step {last_ckpt_step} loss={save_val}, "
+            f"resume step {first_step} loss={resume_val}"
+        )
+
+    tol = ckpt_cfg.loss_rtol * max(abs(save_val), 1e-9)
+    increase = resume_val - save_val
+    log.info(
+        "CHECK 2 — loss boundary: "
+        "loss at checkpoint step %d (save)=%.6f, "
+        "loss at step %d (load)=%.6f, increase=%.6f, allowed_increase=%.6f",
+        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+    )
+    if increase > tol:
+        pytest.fail(
+            f"FAILED loss boundary check: "
+            f"loss increased from save step {last_ckpt_step}={save_val:.6f} "
+            f"to load step {first_step}={resume_val:.6f} "
+            f"(increase={increase:.6f} exceeds tolerance {tol:.6f} [{ckpt_cfg.loss_rtol*100:.0f}%])"
+        )
+    log.info(
+        "CHECK 2 PASSED — loss did not increase beyond tolerance across checkpoint boundary: "
+        "save step %d loss=%.6f, load step %d loss=%.6f, increase=%.6f within tol=%.6f",
+        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+    )
+
+    avg_save_io = (
+        sum(e for _, e in save_io_times) / len(save_io_times) if save_io_times else None
+    )
+    log.info(
+        "test_checkpoint PASSED | "
+        "last_ckpt_step=%d first_resume_step=%d "
+        "save_loss=%.6f resume_loss=%.6f increase=%.6f | "
+        "save_io_avg=%s load_io=%s",
+        last_ckpt_step, first_step, save_val, resume_val, increase,
+        f"{avg_save_io:.2f}s" if avg_save_io is not None else "n/a",
+        f"{load_io_seconds:.2f}s" if load_io_seconds is not None else "n/a",
+    )
+    update_test_result()
 
 
 def test_training(

--- a/cvs/tests/training/megatron/megatron_distributed.py
+++ b/cvs/tests/training/megatron/megatron_distributed.py
@@ -26,6 +26,10 @@ import pytest
 
 from cvs.lib import globals
 from cvs.lib.training.megatron.megatron_lib import MegatronTrainingJob
+from cvs.lib.training.megatron.utils.convergence import (
+    compute_convergence,
+    parse_step_metrics,
+)
 from cvs.lib.training.megatron.utils.loss_curve import (
     parse_all_loss_points,
     sample_loss_curve,
@@ -246,6 +250,25 @@ def test_training(
         request.node.user_properties.append(("training_log_tail", tail))
     except Exception:
         pass
+
+    try:
+        conv = variant_config.convergence
+        log_text = mt_obj._read_last_node_log()
+        step_metrics = parse_step_metrics(log_text)
+        steps_to_target, time_to_target = compute_convergence(
+            step_metrics, [], conv.target_metric, conv.target_value
+        )
+        if steps_to_target is not None:
+            train_res_dict[combo_key]["steps_to_target"] = [str(steps_to_target)]
+        if time_to_target is not None:
+            train_res_dict[combo_key]["time_to_target_seconds"] = [str(time_to_target)]
+        log.info(
+            "convergence: steps_to_target=%s time_to_target_seconds=%s",
+            steps_to_target, time_to_target,
+        )
+    except Exception:
+        pass
+
     update_test_result()
 
 
@@ -255,8 +278,14 @@ def test_metric(variant_config, micro_batch_size, global_batch_size, precision, 
     if combo_key not in train_res_dict:
         pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run)")
 
+    actuals_raw = train_res_dict[combo_key]
+    request.node.user_properties.append(("training_log_tail", actuals_raw.get("_log_tail", "")))
+    actuals = {f"training.{k}": float(v[-1]) for k, v in actuals_raw.items() if v and not k.startswith("_")}
+
     if not variant_config.enforce_thresholds:
-        log.info("enforce_thresholds=false; skipping verdict for combo '%s'", combo_key)
+        log.info("enforce_thresholds=false; record-only for combo '%s'", combo_key)
+        for metric, value in actuals.items():
+            log.info("  RECORD  %s: actual=%s", metric, value)
         return
 
     cell = variant_config.cell_key(combo_key)
@@ -264,10 +293,6 @@ def test_metric(variant_config, micro_batch_size, global_batch_size, precision, 
     if not thresholds:
         log.warning("no thresholds defined for cell '%s'; skipping threshold checks", cell)
         return
-
-    actuals_raw = train_res_dict[combo_key]
-    request.node.user_properties.append(("training_log_tail", actuals_raw.get("_log_tail", "")))
-    actuals = {f"training.{k}": float(v[-1]) for k, v in actuals_raw.items() if v and not k.startswith("_")}
 
     log.info("--- Threshold check for combo '%s' ---", combo_key)
     violations = []

--- a/cvs/tests/training/megatron/megatron_distributed.py
+++ b/cvs/tests/training/megatron/megatron_distributed.py
@@ -20,12 +20,14 @@ Lifecycle (each stage is a separate test):
 
 import json
 import os
+import re
 import time
 
 import pytest
 
 from cvs.lib import globals
 from cvs.lib.training.megatron.megatron_lib import MegatronTrainingJob
+from cvs.lib.training.megatron.primus_lib import PrimusTrainingJob
 from cvs.lib.training.megatron.utils.convergence import (
     compute_convergence,
     parse_step_metrics,
@@ -41,6 +43,14 @@ from cvs.lib.utils.verdict import _check_one, ThresholdViolation
 from cvs.lib.utils_lib import update_test_result
 
 log = globals.log
+
+
+def _make_training_job(orch, variant_config, **kwargs):
+    """Return PrimusTrainingJob or MegatronTrainingJob based on the container image."""
+    if re.search(r'primus', orch.container_config.get("image", ""), re.I):
+        return PrimusTrainingJob(orch, variant_config, **kwargs)
+    return MegatronTrainingJob(orch, variant_config, **kwargs)
+
 
 # Smoke cell: smallest fixed parameters that confirm the model loads and trains.
 _SMOKE_MBS = "1"
@@ -107,7 +117,7 @@ def test_download_tokenizer(orch, variant_config, hf_token, lifecycle, request):
     if lifecycle.failed:
         pytest.skip("a prior lifecycle stage failed")
 
-    mt_obj = MegatronTrainingJob(
+    mt_obj = _make_training_job(
         orch,
         variant_config,
         hf_token=hf_token,
@@ -150,7 +160,7 @@ def test_smoke(orch, variant_config, hf_token, lifecycle, request):
 
     globals.error_list = []
 
-    mt_obj = MegatronTrainingJob(
+    mt_obj = _make_training_job(
         orch,
         variant_config,
         hf_token=hf_token,
@@ -196,7 +206,7 @@ def test_training(
     nodeid = request.node.nodeid
     combo_key = request.node.callspec.id
     globals.error_list = []
-    mt_obj = MegatronTrainingJob(
+    mt_obj = _make_training_job(
         orch,
         variant_config,
         hf_token=hf_token,
@@ -219,7 +229,7 @@ def test_training(
         mt_obj.verify_training_results()
         elapsed = time.monotonic() - t
     except Exception:
-        lifecycle.failed = True
+        train_res_dict[combo_key] = None
         raise
     finally:
         mt_obj.stop_training_processes()
@@ -274,9 +284,11 @@ def test_training(
 
 def test_metric(variant_config, micro_batch_size, global_batch_size, precision, train_res_dict, lifecycle, request):
     """Stage 4 (parametrized): compare each combo's metrics against thresholds."""
+    if lifecycle.failed:
+        pytest.skip("a prior lifecycle stage failed")
     combo_key = request.node.callspec.id
-    if combo_key not in train_res_dict:
-        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run)")
+    if not train_res_dict.get(combo_key):
+        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run or failed)")
 
     actuals_raw = train_res_dict[combo_key]
     request.node.user_properties.append(("training_log_tail", actuals_raw.get("_log_tail", "")))
@@ -335,8 +347,8 @@ def test_loss_curve(
         pytest.skip("a prior lifecycle stage failed")
 
     combo_key = request.node.callspec.id
-    if combo_key not in train_res_dict:
-        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run)")
+    if not train_res_dict.get(combo_key):
+        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run or failed)")
 
     combo_log_dir = train_res_dict[combo_key].get("_combo_log_dir")
     if not combo_log_dir:

--- a/cvs/tests/training/megatron/megatron_distributed.py
+++ b/cvs/tests/training/megatron/megatron_distributed.py
@@ -22,6 +22,7 @@ Lifecycle (each stage is a separate test):
 import json
 import os
 import re
+import shlex
 import time
 
 import pytest
@@ -389,6 +390,12 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
         f"{load_io_seconds:.2f}s" if load_io_seconds is not None else "n/a",
     )
     update_test_result()
+
+    ckpt_subdir = f"{ckpt_dir.rstrip('/')}/checkpoints"
+    if ckpt_dir and ckpt_dir.strip("/") and not request.node.session.testsfailed:
+        orch.exec(f"rm -rf {shlex.quote(ckpt_subdir)}")
+    else:
+        log.info("checkpoint dir retained for debugging: %s", ckpt_dir)
 
 
 def test_training(

--- a/cvs/tests/training/megatron/megatron_distributed.py
+++ b/cvs/tests/training/megatron/megatron_distributed.py
@@ -318,9 +318,9 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
 
     first_step = min(resume_losses)
     log.info(
-        "CHECK 1 — step counter: last saved step in checkpoint=%d, "
-        "first step in load phase=%d",
-        last_ckpt_step, first_step,
+        "CHECK 1 — step counter: last saved step in checkpoint=%d, first step in load phase=%d",
+        last_ckpt_step,
+        first_step,
     )
     if first_step != expected_first:
         pytest.fail(
@@ -328,9 +328,9 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
             f"expected load to start at step {expected_first}, got {first_step}"
         )
     log.info(
-        "CHECK 1 PASSED — step counter correctly restored: "
-        "last checkpoint step=%d, load phase started at step=%d",
-        last_ckpt_step, first_step,
+        "CHECK 1 PASSED — step counter correctly restored: last checkpoint step=%d, load phase started at step=%d",
+        last_ckpt_step,
+        first_step,
     )
 
     # Check 2: loss must not spike — resume loss at first step <= save loss + tolerance
@@ -349,30 +349,42 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
         "CHECK 2 — loss boundary: "
         "loss at checkpoint step %d (save)=%.6f, "
         "loss at step %d (load)=%.6f, increase=%.6f, allowed_increase=%.6f",
-        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+        last_ckpt_step,
+        save_val,
+        first_step,
+        resume_val,
+        increase,
+        tol,
     )
     if increase > tol:
         pytest.fail(
             f"FAILED loss boundary check: "
             f"loss increased from save step {last_ckpt_step}={save_val:.6f} "
             f"to load step {first_step}={resume_val:.6f} "
-            f"(increase={increase:.6f} exceeds tolerance {tol:.6f} [{ckpt_cfg.loss_rtol*100:.0f}%])"
+            f"(increase={increase:.6f} exceeds tolerance {tol:.6f} [{ckpt_cfg.loss_rtol * 100:.0f}%])"
         )
     log.info(
         "CHECK 2 PASSED — loss did not increase beyond tolerance across checkpoint boundary: "
         "save step %d loss=%.6f, load step %d loss=%.6f, increase=%.6f within tol=%.6f",
-        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+        last_ckpt_step,
+        save_val,
+        first_step,
+        resume_val,
+        increase,
+        tol,
     )
 
-    avg_save_io = (
-        sum(e for _, e in save_io_times) / len(save_io_times) if save_io_times else None
-    )
+    avg_save_io = sum(e for _, e in save_io_times) / len(save_io_times) if save_io_times else None
     log.info(
         "test_checkpoint PASSED | "
         "last_ckpt_step=%d first_resume_step=%d "
         "save_loss=%.6f resume_loss=%.6f increase=%.6f | "
         "save_io_avg=%s load_io=%s",
-        last_ckpt_step, first_step, save_val, resume_val, increase,
+        last_ckpt_step,
+        first_step,
+        save_val,
+        resume_val,
+        increase,
         f"{avg_save_io:.2f}s" if avg_save_io is not None else "n/a",
         f"{load_io_seconds:.2f}s" if load_io_seconds is not None else "n/a",
     )
@@ -452,16 +464,15 @@ def test_training(
         conv = variant_config.convergence
         log_text = mt_obj._read_last_node_log()
         step_metrics = parse_step_metrics(log_text)
-        steps_to_target, time_to_target = compute_convergence(
-            step_metrics, [], conv.target_metric, conv.target_value
-        )
+        steps_to_target, time_to_target = compute_convergence(step_metrics, [], conv.target_metric, conv.target_value)
         if steps_to_target is not None:
             train_res_dict[combo_key]["steps_to_target"] = [str(steps_to_target)]
         if time_to_target is not None:
             train_res_dict[combo_key]["time_to_target_seconds"] = [str(time_to_target)]
         log.info(
             "convergence: steps_to_target=%s time_to_target_seconds=%s",
-            steps_to_target, time_to_target,
+            steps_to_target,
+            time_to_target,
         )
     except Exception:
         pass

--- a/cvs/tests/training/megatron/megatron_single.py
+++ b/cvs/tests/training/megatron/megatron_single.py
@@ -312,9 +312,9 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
 
     first_step = min(resume_losses)
     log.info(
-        "CHECK 1 — step counter: last saved step in checkpoint=%d, "
-        "first step in load phase=%d",
-        last_ckpt_step, first_step,
+        "CHECK 1 — step counter: last saved step in checkpoint=%d, first step in load phase=%d",
+        last_ckpt_step,
+        first_step,
     )
     if first_step != expected_first:
         pytest.fail(
@@ -322,9 +322,9 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
             f"expected load to start at step {expected_first}, got {first_step}"
         )
     log.info(
-        "CHECK 1 PASSED — step counter correctly restored: "
-        "last checkpoint step=%d, load phase started at step=%d",
-        last_ckpt_step, first_step,
+        "CHECK 1 PASSED — step counter correctly restored: last checkpoint step=%d, load phase started at step=%d",
+        last_ckpt_step,
+        first_step,
     )
 
     # Check 2: loss continuity — save loss at last_ckpt_step ≈ resume loss at first_step
@@ -344,30 +344,42 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
         "CHECK 2 — loss boundary: "
         "loss at checkpoint step %d (save)=%.6f, "
         "loss at step %d (load)=%.6f, increase=%.6f, allowed_increase=%.6f",
-        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+        last_ckpt_step,
+        save_val,
+        first_step,
+        resume_val,
+        increase,
+        tol,
     )
     if increase > tol:
         pytest.fail(
             f"FAILED loss boundary check: "
             f"loss increased from save step {last_ckpt_step}={save_val:.6f} "
             f"to load step {first_step}={resume_val:.6f} "
-            f"(increase={increase:.6f} exceeds tolerance {tol:.6f} [{ckpt_cfg.loss_rtol*100:.0f}%])"
+            f"(increase={increase:.6f} exceeds tolerance {tol:.6f} [{ckpt_cfg.loss_rtol * 100:.0f}%])"
         )
     log.info(
         "CHECK 2 PASSED — loss did not increase beyond tolerance across checkpoint boundary: "
         "save step %d loss=%.6f, load step %d loss=%.6f, increase=%.6f within tol=%.6f",
-        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+        last_ckpt_step,
+        save_val,
+        first_step,
+        resume_val,
+        increase,
+        tol,
     )
 
-    avg_save_io = (
-        sum(e for _, e in save_io_times) / len(save_io_times) if save_io_times else None
-    )
+    avg_save_io = sum(e for _, e in save_io_times) / len(save_io_times) if save_io_times else None
     log.info(
         "test_checkpoint PASSED | "
         "last_ckpt_step=%d first_resume_step=%d "
         "save_loss=%.6f resume_loss=%.6f increase=%.6f | "
         "save_io_avg=%s load_io=%s",
-        last_ckpt_step, first_step, save_val, resume_val, increase,
+        last_ckpt_step,
+        first_step,
+        save_val,
+        resume_val,
+        increase,
         f"{avg_save_io:.2f}s" if avg_save_io is not None else "n/a",
         f"{load_io_seconds:.2f}s" if load_io_seconds is not None else "n/a",
     )
@@ -447,16 +459,15 @@ def test_training(
         conv = variant_config.convergence
         log_text = mt_obj._read_last_node_log()
         step_metrics = parse_step_metrics(log_text)
-        steps_to_target, time_to_target = compute_convergence(
-            step_metrics, [], conv.target_metric, conv.target_value
-        )
+        steps_to_target, time_to_target = compute_convergence(step_metrics, [], conv.target_metric, conv.target_value)
         if steps_to_target is not None:
             train_res_dict[combo_key]["steps_to_target"] = [str(steps_to_target)]
         if time_to_target is not None:
             train_res_dict[combo_key]["time_to_target_seconds"] = [str(time_to_target)]
         log.info(
             "convergence: steps_to_target=%s time_to_target_seconds=%s",
-            steps_to_target, time_to_target,
+            steps_to_target,
+            time_to_target,
         )
     except Exception:
         pass

--- a/cvs/tests/training/megatron/megatron_single.py
+++ b/cvs/tests/training/megatron/megatron_single.py
@@ -26,6 +26,10 @@ import pytest
 
 from cvs.lib import globals
 from cvs.lib.training.megatron.megatron_lib import MegatronTrainingJob
+from cvs.lib.training.megatron.utils.convergence import (
+    compute_convergence,
+    parse_step_metrics,
+)
 from cvs.lib.training.megatron.utils.loss_curve import (
     parse_all_loss_points,
     sample_loss_curve,
@@ -246,6 +250,25 @@ def test_training(
         request.node.user_properties.append(("training_log_tail", tail))
     except Exception:
         pass
+
+    try:
+        conv = variant_config.convergence
+        log_text = mt_obj._read_last_node_log()
+        step_metrics = parse_step_metrics(log_text)
+        steps_to_target, time_to_target = compute_convergence(
+            step_metrics, [], conv.target_metric, conv.target_value
+        )
+        if steps_to_target is not None:
+            train_res_dict[combo_key]["steps_to_target"] = [str(steps_to_target)]
+        if time_to_target is not None:
+            train_res_dict[combo_key]["time_to_target_seconds"] = [str(time_to_target)]
+        log.info(
+            "convergence: steps_to_target=%s time_to_target_seconds=%s",
+            steps_to_target, time_to_target,
+        )
+    except Exception:
+        pass
+
     update_test_result()
 
 
@@ -255,8 +278,14 @@ def test_metric(variant_config, micro_batch_size, global_batch_size, precision, 
     if combo_key not in train_res_dict:
         pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run)")
 
+    actuals_raw = train_res_dict[combo_key]
+    request.node.user_properties.append(("training_log_tail", actuals_raw.get("_log_tail", "")))
+    actuals = {f"training.{k}": float(v[-1]) for k, v in actuals_raw.items() if v and not k.startswith("_")}
+
     if not variant_config.enforce_thresholds:
-        log.info("enforce_thresholds=false; skipping verdict for combo '%s'", combo_key)
+        log.info("enforce_thresholds=false; record-only for combo '%s'", combo_key)
+        for metric, value in actuals.items():
+            log.info("  RECORD  %s: actual=%s", metric, value)
         return
 
     cell = variant_config.cell_key(combo_key)
@@ -264,10 +293,6 @@ def test_metric(variant_config, micro_batch_size, global_batch_size, precision, 
     if not thresholds:
         log.warning("no thresholds defined for cell '%s'; skipping threshold checks", cell)
         return
-
-    actuals_raw = train_res_dict[combo_key]
-    request.node.user_properties.append(("training_log_tail", actuals_raw.get("_log_tail", "")))
-    actuals = {f"training.{k}": float(v[-1]) for k, v in actuals_raw.items() if v and not k.startswith("_")}
 
     log.info("--- Threshold check for combo '%s' ---", combo_key)
     violations = []

--- a/cvs/tests/training/megatron/megatron_single.py
+++ b/cvs/tests/training/megatron/megatron_single.py
@@ -20,12 +20,14 @@ Lifecycle (each stage is a separate test):
 
 import json
 import os
+import re
 import time
 
 import pytest
 
 from cvs.lib import globals
 from cvs.lib.training.megatron.megatron_lib import MegatronTrainingJob
+from cvs.lib.training.megatron.primus_lib import PrimusTrainingJob
 from cvs.lib.training.megatron.utils.convergence import (
     compute_convergence,
     parse_step_metrics,
@@ -41,6 +43,14 @@ from cvs.lib.utils.verdict import _check_one, ThresholdViolation
 from cvs.lib.utils_lib import update_test_result
 
 log = globals.log
+
+
+def _make_training_job(orch, variant_config, **kwargs):
+    """Return PrimusTrainingJob or MegatronTrainingJob based on the container image."""
+    if re.search(r'primus', orch.container_config.get("image", ""), re.I):
+        return PrimusTrainingJob(orch, variant_config, **kwargs)
+    return MegatronTrainingJob(orch, variant_config, **kwargs)
+
 
 # Smoke cell: smallest fixed parameters that confirm the model loads and trains.
 _SMOKE_MBS = "1"
@@ -107,7 +117,7 @@ def test_download_tokenizer(orch, variant_config, hf_token, lifecycle, request):
     if lifecycle.failed:
         pytest.skip("a prior lifecycle stage failed")
 
-    mt_obj = MegatronTrainingJob(
+    mt_obj = _make_training_job(
         orch,
         variant_config,
         hf_token=hf_token,
@@ -150,7 +160,7 @@ def test_smoke(orch, variant_config, hf_token, lifecycle, request):
 
     globals.error_list = []
 
-    mt_obj = MegatronTrainingJob(
+    mt_obj = _make_training_job(
         orch,
         variant_config,
         hf_token=hf_token,
@@ -196,7 +206,7 @@ def test_training(
     nodeid = request.node.nodeid
     combo_key = request.node.callspec.id
     globals.error_list = []
-    mt_obj = MegatronTrainingJob(
+    mt_obj = _make_training_job(
         orch,
         variant_config,
         hf_token=hf_token,
@@ -219,7 +229,7 @@ def test_training(
         mt_obj.verify_training_results()
         elapsed = time.monotonic() - t
     except Exception:
-        lifecycle.failed = True
+        train_res_dict[combo_key] = None
         raise
     finally:
         mt_obj.stop_training_processes()
@@ -274,9 +284,11 @@ def test_training(
 
 def test_metric(variant_config, micro_batch_size, global_batch_size, precision, train_res_dict, lifecycle, request):
     """Stage 4 (parametrized): compare each combo's metrics against thresholds."""
+    if lifecycle.failed:
+        pytest.skip("a prior lifecycle stage failed")
     combo_key = request.node.callspec.id
-    if combo_key not in train_res_dict:
-        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run)")
+    if not train_res_dict.get(combo_key):
+        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run or failed)")
 
     actuals_raw = train_res_dict[combo_key]
     request.node.user_properties.append(("training_log_tail", actuals_raw.get("_log_tail", "")))
@@ -335,8 +347,8 @@ def test_loss_curve(
         pytest.skip("a prior lifecycle stage failed")
 
     combo_key = request.node.callspec.id
-    if combo_key not in train_res_dict:
-        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run)")
+    if not train_res_dict.get(combo_key):
+        pytest.skip(f"no recorded results for combo '{combo_key}' (training did not run or failed)")
 
     combo_log_dir = train_res_dict[combo_key].get("_combo_log_dir")
     if not combo_log_dir:

--- a/cvs/tests/training/megatron/megatron_single.py
+++ b/cvs/tests/training/megatron/megatron_single.py
@@ -21,6 +21,7 @@ Lifecycle (each stage is a separate test):
 import json
 import os
 import re
+import shlex
 import time
 
 import pytest
@@ -384,6 +385,11 @@ def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
         f"{load_io_seconds:.2f}s" if load_io_seconds is not None else "n/a",
     )
     update_test_result()
+
+    if not request.node.session.testsfailed:
+        orch.exec(f"rm -rf {shlex.quote(ckpt_dir)}")
+    else:
+        log.info("checkpoint dir retained for debugging: %s", ckpt_dir)
 
 
 def test_training(

--- a/cvs/tests/training/megatron/megatron_single.py
+++ b/cvs/tests/training/megatron/megatron_single.py
@@ -27,7 +27,8 @@ import pytest
 
 from cvs.lib import globals
 from cvs.lib.training.megatron.megatron_lib import MegatronTrainingJob
-from cvs.lib.training.megatron.primus_lib import PrimusTrainingJob
+from cvs.lib.training.megatron.primus_lib import PrimusTrainingJob, _parse_step_losses
+from cvs.lib.training.megatron.utils.checkpoint_io import log_checkpoint_io_times, parse_checkpoint_io_seconds
 from cvs.lib.training.megatron.utils.convergence import (
     compute_convergence,
     parse_step_metrics,
@@ -190,6 +191,187 @@ def test_smoke(orch, variant_config, hf_token, lifecycle, request):
     update_test_result()
     lifecycle.record(request.node.nodeid, "smoke", time.monotonic() - t)
     log.info("smoke PASSED | iters=%s", _SMOKE_ITERS)
+
+
+def test_checkpoint(orch, variant_config, hf_token, lifecycle, request):
+    """Stage 2.5: checkpoint save + resume — verify step counter and loss continuity.
+
+    Two phases:
+      Phase 1 — Save : train checkpoint.save_iters steps, saving every checkpoint.save_interval.
+                       Last checkpoint lands at floor(save_iters/interval)*interval.
+      Phase 2 — Load : resume from that checkpoint with train_iters=checkpoint.resume_iters;
+                       Primus continues from last_ckpt_step+1 to resume_iters.
+
+    Asserts:
+      - First logged step of load phase == last_ckpt_step + 1 (step counter restored).
+      - resume_losses[last_ckpt_step+1] <= save_losses[last_ckpt_step] + tol (no loss spike).
+
+    Skipped if checkpoint.enforce=false or for non-Primus images.
+    """
+    if lifecycle.failed:
+        pytest.skip("a prior lifecycle stage failed")
+
+    ckpt_cfg = variant_config.checkpoint
+    if not ckpt_cfg.enforce:
+        pytest.skip("checkpoint.enforce=false in config; skipping test_checkpoint")
+
+    if not re.search(r'primus', orch.container_config.get("image", ""), re.I):
+        pytest.skip("checkpoint test is Primus-only")
+
+    # PRIMUS_WORKSPACE must be on a host path already volume-mounted into the
+    # container so checkpoints survive container teardown.  log_dir is mounted
+    # at the same path on both host and container (runtime.args.volumes in the
+    # JSON config), so a subdirectory of log_dir satisfies that requirement.
+    log_dir = variant_config.config.get("log_dir", "/tmp")
+    ckpt_dir = f"{log_dir}/ckpt_primus"
+    orch.exec(f"mkdir -p {ckpt_dir}")
+
+    def _run(run_label, iters, checkpoint_dir=None, save_interval=None, load_checkpoint=False):
+        job = _make_training_job(
+            orch,
+            variant_config,
+            hf_token=hf_token,
+            micro_batch_size=_SMOKE_MBS,
+            global_batch_size=_SMOKE_GBS,
+            precision=_SMOKE_PRECISION,
+            distributed_training=False,
+            tune_model_params=False,
+            run_label=run_label,
+        )
+        job.iterations = iters
+        job.local_tokenizer_path = getattr(lifecycle, "tokenizer_path", None)
+        if checkpoint_dir:
+            job.checkpoint_dir = checkpoint_dir
+            job.save_interval = save_interval or iters
+        job.load_checkpoint = load_checkpoint
+        try:
+            job.build_training_job_cmd()
+            job.start_training_job()
+            job.poll_for_training_completion()
+        finally:
+            job.stop_training_processes()
+        return job._read_last_node_log()
+
+    # Phase 1: save — train save_iters steps, writing checkpoint every save_interval steps.
+    # save_iters must not be an exact multiple of save_interval so the last checkpoint is
+    # not the final step (disable_last_saving=true in the YAML suppresses the last-iter save).
+    try:
+        save_log = _run(
+            "ckpt_save",
+            ckpt_cfg.save_iters,
+            checkpoint_dir=ckpt_dir,
+            save_interval=ckpt_cfg.save_interval,
+        )
+    except Exception:
+        raise
+
+    # Verify the checkpoint was written before attempting resume.
+    # With PRIMUS_TEAM/USER/EXP_NAME all empty, Primus writes to:
+    #   {PRIMUS_WORKSPACE}/checkpoints/latest_checkpointed_iteration.txt
+    ckpt_meta = f"{ckpt_dir}/checkpoints/latest_checkpointed_iteration.txt"
+    check = orch.exec(f"test -f {ckpt_meta} && echo FOUND || echo MISSING")
+    head_node = orch.hosts[0]
+    if "MISSING" in (check or {}).get(head_node, "MISSING"):
+        ls_out = orch.exec(f"ls -laR {ckpt_dir} 2>&1 || echo DIR_EMPTY")
+        log.error("checkpoint listing:\n%s", (ls_out or {}).get(head_node, ""))
+        pytest.fail(
+            f"checkpoint not written after save phase; expected: {ckpt_meta}\n"
+            f"Check that log_dir ({log_dir}) is volume-mounted into the container."
+        )
+
+    # last_ckpt_step = floor(save_iters / interval) * interval
+    last_ckpt_step = (ckpt_cfg.save_iters // ckpt_cfg.save_interval) * ckpt_cfg.save_interval
+    expected_first = last_ckpt_step + 1
+
+    # Phase 2: load — resume from last checkpoint, train to resume_iters total.
+    # Primus reads the checkpoint and starts iterating from last_ckpt_step+1.
+    try:
+        resume_log = _run(
+            "ckpt_resume",
+            ckpt_cfg.resume_iters,
+            checkpoint_dir=ckpt_dir,
+            load_checkpoint=True,
+        )
+    except Exception:
+        raise
+
+    save_losses = _parse_step_losses(save_log)
+    resume_losses = _parse_step_losses(resume_log)
+
+    log.info("checkpoint save steps  : %s", sorted(save_losses))
+    log.info("checkpoint resume steps: %s", sorted(resume_losses))
+
+    # Checkpoint I/O timing — save & load (seconds).
+    save_io_times, _ = parse_checkpoint_io_seconds(save_log)
+    _, load_io_seconds = parse_checkpoint_io_seconds(resume_log)
+    log_checkpoint_io_times(save_io_times, load_io_seconds)
+
+    # Check 1: step counter restored — first logged step of resume == last_ckpt_step + 1
+    if not resume_losses:
+        pytest.fail("load phase produced no iteration logs; cannot verify step counter")
+
+    first_step = min(resume_losses)
+    log.info(
+        "CHECK 1 — step counter: last saved step in checkpoint=%d, "
+        "first step in load phase=%d",
+        last_ckpt_step, first_step,
+    )
+    if first_step != expected_first:
+        pytest.fail(
+            f"FAILED step counter check: last saved checkpoint step={last_ckpt_step}, "
+            f"expected load to start at step {expected_first}, got {first_step}"
+        )
+    log.info(
+        "CHECK 1 PASSED — step counter correctly restored: "
+        "last checkpoint step=%d, load phase started at step=%d",
+        last_ckpt_step, first_step,
+    )
+
+    # Check 2: loss continuity — save loss at last_ckpt_step ≈ resume loss at first_step
+    save_val = save_losses.get(last_ckpt_step)
+    resume_val = resume_losses.get(first_step)
+    if save_val is None or resume_val is None:
+        pytest.fail(
+            f"Cannot compare losses: "
+            f"save step {last_ckpt_step} loss={save_val}, "
+            f"resume step {first_step} loss={resume_val}"
+        )
+
+    tol = ckpt_cfg.loss_rtol * max(abs(save_val), 1e-9)
+    # Loss may decrease (training continues) but must not increase beyond tolerance.
+    increase = resume_val - save_val
+    log.info(
+        "CHECK 2 — loss boundary: "
+        "loss at checkpoint step %d (save)=%.6f, "
+        "loss at step %d (load)=%.6f, increase=%.6f, allowed_increase=%.6f",
+        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+    )
+    if increase > tol:
+        pytest.fail(
+            f"FAILED loss boundary check: "
+            f"loss increased from save step {last_ckpt_step}={save_val:.6f} "
+            f"to load step {first_step}={resume_val:.6f} "
+            f"(increase={increase:.6f} exceeds tolerance {tol:.6f} [{ckpt_cfg.loss_rtol*100:.0f}%])"
+        )
+    log.info(
+        "CHECK 2 PASSED — loss did not increase beyond tolerance across checkpoint boundary: "
+        "save step %d loss=%.6f, load step %d loss=%.6f, increase=%.6f within tol=%.6f",
+        last_ckpt_step, save_val, first_step, resume_val, increase, tol,
+    )
+
+    avg_save_io = (
+        sum(e for _, e in save_io_times) / len(save_io_times) if save_io_times else None
+    )
+    log.info(
+        "test_checkpoint PASSED | "
+        "last_ckpt_step=%d first_resume_step=%d "
+        "save_loss=%.6f resume_loss=%.6f increase=%.6f | "
+        "save_io_avg=%s load_io=%s",
+        last_ckpt_step, first_step, save_val, resume_val, increase,
+        f"{avg_save_io:.2f}s" if avg_save_io is not None else "n/a",
+        f"{load_io_seconds:.2f}s" if load_io_seconds is not None else "n/a",
+    )
+    update_test_result()
 
 
 def test_training(


### PR DESCRIPTION
 ## Summary

  **Commit 1 — Convergence tracking and steps/time-to-target thresholds**
  - Add `ConvergenceConfig` (`target_metric`, `target_value`) to `MegatronVariantConfig`
  - Add `convergence.py` utility (`parse_step_metrics`, `compute_convergence`)
  - Wire convergence computation into `test_training` in both single and distributed
  - Add convergence block and `steps_to_target` / `time_to_target_seconds` info
    thresholds to `mi325x_megatron_llama-3.1-8b` config and threshold file

**Commit 2 — Primus factory dispatch and training skip propagation fix**
  - Add `primus_lib.py` with `PrimusTrainingJob`, training completion detection,
    result/iteration/NaN patterns, and `_parse_step_losses` for checkpoint tests
  - Add `_make_training_job()` factory in both test files: returns `PrimusTrainingJob`
    when image contains `primus`, otherwise `MegatronTrainingJob`
  - Fix per-combo failure isolation: set `train_res_dict[combo_key] = None` on exception
    so `test_metric` / `test_loss_curve` skip correctly without blocking other combos

  **Commit 3 — Checkpoint save+resume test with I/O timing**
  - Add `CheckpointConfig` pydantic model (`enforce`, `save_interval`, `save_iters`,
    `resume_iters`, `loss_rtol`, `checkpoint_dir`) wired into `MegatronVariantConfig`
  - Add `test_checkpoint` to single and distributed: two-phase test that saves a
    checkpoint, resumes from it, and verifies step counter restoration and loss continuity
  - Add `checkpoint_io.py`: parses save/load I/O times from Primus logs using embedded
    microsecond timestamps; strips ANSI escape codes before matching
  - Distributed: reads node-0 log for timing (rank-0 only emits checkpoint lines),
    last-node log for losses; adds `--auto_detect_ckpt_format` on load; requires
    `checkpoint_dir` (shared NFS path) in config with volume mount entry
  - Add `_read_node_log(node_idx)` to `PrimusTrainingJob`
  - Add checkpoint block to `mi325x_megatron_llama-3.1-8b_single.json`,
    `mi325x_megatron_deepseek-v2-lite_single.json`, and
    `mi325x_megatron_llama-3.3-70b_distributed.json`
  - Insert `test_checkpoint` at stage 3 in conftest test ordering


  ## Test plan
  - [ ] Single-node: run `test_checkpoint` with `enforce=true` on a Primus image; verify save/load I/O times
  - Add `CheckpointConfig` pydantic model (`enforce`, `save_interval`, `save_iters`,
    `resume_iters`, `loss_rtol`, `checkpoint_dir`) wired into `MegatronVariantConfig`
  - Add `test_checkpoint` to single and distributed: two-phase test that saves a
    checkpoint, resumes from it, and verifies step counter restoration and loss continuity
  - Add `checkpoint_io.py`: parses save/load I/O times from Primus logs using embedded
    microsecond timestamps; strips ANSI escape codes before matching
  - Distributed: reads node-0 log for timing (rank-0 only emits checkpoint lines),
    last-node log for losses; adds `--auto_detect_ckpt_format` on load; requires
    `checkpoint_dir` (shared NFS path) in config with volume mount entry
  - Add `_read_node_log(node_idx)` to `PrimusTrainingJob`
  - Add checkpoint block to `mi325x_megatron_llama-3.1-8b_single.json`,
    `mi325x_megatron_deepseek-v2-lite_single.json`, and
    `mi325x_megatron_llama-3.3-70b_distributed.json`
  - Insert `test_checkpoint` at stage 3 in conftest test ordering