### PR TITLE
Config update with RDMA lib mounts + fixes

### DIFF
--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -115,7 +116,7 @@
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -111,7 +112,7 @@
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -34,7 +34,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -119,7 +120,7 @@
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -115,7 +116,7 @@
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -35,7 +35,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -119,7 +120,7 @@
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -111,7 +112,7 @@
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -118,7 +119,7 @@
       "HSA_NO_SCRATCH_RECLAIM": "1",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_deepseek-v2-lite_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -115,7 +116,7 @@
       "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-405b_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -117,7 +118,7 @@
       "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.1-8b_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -112,7 +113,7 @@
       "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed.json
+++ b/cvs/input/config_file/training/jaxmaxtext/mi355x_jaxmaxtext_llama-3.3-70b_distributed.json
@@ -33,7 +33,8 @@
         "volumes": [
           "/home/{user-id}:/home/{user-id}",
           "/dev/infiniband:/dev/infiniband",
-          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.host",
+          "/usr/local/lib/libbnxt_re-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so:ro",
+          "/usr/lib/x86_64-linux-gnu/libibverbs.so.1:/usr/lib/x86_64-linux-gnu/libibverbs.so.1:ro",
           "/lib/libibverbs.d:/lib/libibverbs.d",
           "/tmp/{user-id}/jax/TRAINING_LOGS:/workspace/maxtext/output"
         ]
@@ -119,7 +120,7 @@
       "RCCL_WARP_SPEED_AUTO": "0",
       "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.97",
       "NCCL_DEBUG": "VERSION",
-      "NCCL_IB_DISABLE": "1",
+      "NCCL_IB_DISABLE": "0",
       "NCCL_PROTO": "Simple",
       "NCCL_IB_TC": "41",
       "NCCL_IB_SL": "0",

--- a/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/jaxmaxtext_training_lib.py
@@ -56,7 +56,16 @@ _TRAINING_ERR_PATTERNS = {
     'segfault': r'Segmentation fault|SIGSEGV|signal 11|core dumped',
 }
 
-_NAN_INF_RE = re.compile(r'(TFLOP/s/device|Tokens/s/device):\s*(NaN|Inf|-Inf)', re.I)
+# NaN/Inf in any reported training metric -- loss/lm_loss/perplexity go NaN while
+# the throughput fields (TFLOP/s/device, Tokens/s/device) stay numeric, so those
+# alone are NOT enough; MaxText also emits an explicit abort line. NOTE: the
+# TensorBoard "NaN or Inf found in input tensor" writer warning is intentionally
+# NOT matched -- it also fires on healthy steps (false positive).
+_NAN_INF_RE = re.compile(
+    r'(?:TFLOP/s/device|Tokens/s/device|loss|lm_loss|perplexity)\s*[:=]\s*(?:nan|[+-]?inf)\b'
+    r'|Aborting training due to NaN',
+    re.I,
+)
 
 
 def _sanitize(name):
@@ -273,7 +282,16 @@ class MaxTextTrainingJob:
         if not rdma.container_mount_file or not rdma.container_dest_file:
             log.info("rdma_lib paths not configured, skipping")
             return
-        cmd = f"sudo cp {shlex.quote(rdma.container_mount_file)} {shlex.quote(rdma.container_dest_file)}"
+        # Only copy when the mount source actually exists. Newer configs mount the
+        # host RDMA lib directly onto the container's real .so path (read-only), so
+        # the legacy ".host" copy source is absent -- skip the cp instead of
+        # emitting a spurious error (the ibv_devinfo check below is the real gate).
+        src = shlex.quote(rdma.container_mount_file)
+        dst = shlex.quote(rdma.container_dest_file)
+        cmd = (
+            f"if [ -f {src} ]; then sudo cp {src} {dst}; "
+            f"else echo 'rdma_lib: source {rdma.container_mount_file} not present, skipping cp'; fi"
+        )
         out = self.orch.exec(cmd)
         for host, output in (out or {}).items():
             log.info("[rdma_lib %s] %s", host, (output or "")[:200])
@@ -449,16 +467,26 @@ class MaxTextTrainingJob:
         return True
 
     def _scan_chunk_for_errors(self, host, i, text):
-        """Raise on the first known error signature (or NaN/Inf) in `text`."""
+        """Raise on the first known error signature (or NaN/Inf) in `text`.
+
+        Before raising, log the FULL offending chunk so the failure cause (e.g. a
+        compile traceback) is always visible in the console/--log-file -- the
+        exception message alone is truncated (text[-500:]) and can miss the root
+        line, and the chunk is otherwise not streamed for non-node-0 nodes.
+        """
         if not text:
             return
+        hit = None
         if _NAN_INF_RE.search(text):
-            raise RuntimeError(f"NaN/Inf in training metrics on {host} (node {i}): {text[-500:]}")
-        for err_name, err_pattern in self.error_patterns.items():
-            if not err_pattern:
-                continue
-            if re.search(err_pattern, text, re.I):
-                raise RuntimeError(f"Training error '{err_name}' on {host} (node {i}): {text[-500:]}")
+            hit = "NaN/Inf in training metrics"
+        else:
+            for err_name, err_pattern in self.error_patterns.items():
+                if err_pattern and re.search(err_pattern, text, re.I):
+                    hit = f"error '{err_name}'"
+                    break
+        if hit:
+            log.error("[train node%s] FAILURE chunk (node %s / %s):\n%s", i, i, host, text.rstrip())
+            raise RuntimeError(f"Training {hit} on {host} (node {i}): {text[-500:]}")
 
     def _drain_new_log_lines(self):
         """Fetch training-log lines written since the last poll, on every node,
@@ -509,28 +537,31 @@ class MaxTextTrainingJob:
 
             new_by_node = self._drain_new_log_lines()
 
-            # Scan every node's new chunk for errors (raises on the first match).
-            for i, text in new_by_node.items():
-                self._scan_chunk_for_errors(self.orch.hosts[i], i, text)
-
-            # Stream node 0's (coordinator) new lines to the console once.
+            # Stream node 0's (coordinator) new lines to the console FIRST, so the
+            # chunk reaches the log even when the scan below raises on this same
+            # chunk (e.g. a compile traceback in the final drained lines).
             node0_new = (new_by_node.get(0) or "").rstrip()
             if node0_new:
                 log.info("[train node0]\n%s", node0_new)
+
+            # Then scan every node's new chunk for errors (raises on the first
+            # match; the scanner logs the offending chunk before raising).
+            for i, text in new_by_node.items():
+                self._scan_chunk_for_errors(self.orch.hosts[i], i, text)
 
             if self.is_complete():
                 # Flush the tail lines written between the drain above and this
                 # completion check -- the final "completed step" marker, and
                 # anything after it (a shutdown traceback or a last-step NaN),
-                # land here. Scan EVERY node's final chunk for error signatures
-                # before declaring success (dropping non-0 nodes would hide a
-                # worker-only failure in this window), then stream node 0.
+                # land here. Stream node 0 FIRST, then scan EVERY node's final
+                # chunk (dropping non-0 nodes would hide a worker-only failure in
+                # this window; the scanner logs the offending chunk before raising).
                 tail = self._drain_new_log_lines()
-                for i, text in tail.items():
-                    self._scan_chunk_for_errors(self.orch.hosts[i], i, text)
                 node0_tail = (tail.get(0) or "").rstrip()
                 if node0_tail:
                     log.info("[train node0]\n%s", node0_tail)
+                for i, text in tail.items():
+                    self._scan_chunk_for_errors(self.orch.hosts[i], i, text)
                 log.info("training complete (poll iter=%d, %.0fs elapsed)", it, elapsed)
                 return
 

--- a/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_jaxmaxtext_training_lib.py
@@ -172,6 +172,47 @@ class ScanForErrorsTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             job._scan_chunk_for_errors("h0", 0, "completed step: 1, TFLOP/s/device: NaN\n")
 
+    def test_nan_loss_raises_even_when_throughput_numeric(self):
+        # Real failure signature: loss/lm_loss/perplexity go NaN while
+        # TFLOP/s/device and Tokens/s/device stay numeric.
+        job, _ = _make_job(hosts=["h0"])
+        line = (
+            "completed step: 3, seconds: 6.783, TFLOP/s/device: 39.268, "
+            "Tokens/s/device: 301.929, total_weights: 65536, loss: nan, "
+            "lm_loss: nan, perplexity: nan, moe_lb_loss: 0.000\n"
+        )
+        with self.assertRaises(RuntimeError):
+            job._scan_chunk_for_errors("h0", 0, line)
+
+    def test_aborting_nan_loss_line_raises(self):
+        job, _ = _make_job(hosts=["h0"])
+        with self.assertRaises(RuntimeError):
+            job._scan_chunk_for_errors("h0", 0, "metric_logger.py:270] Aborting training due to NaN loss.\n")
+
+    def test_failure_chunk_is_logged_before_raising(self):
+        # The offending chunk (e.g. a compile traceback) must be logged so it
+        # reaches the console/--log-file -- the truncated exception message alone
+        # can miss the root cause, and non-node-0 chunks are not otherwise streamed.
+        job, _ = _make_job(hosts=["h0", "h1"])
+        chunk = "some log\nValueError: Compiler params for platform tpu cannot be used for gpu lowering.\ngrpc tail\n"
+        with patch("cvs.lib.training.jaxmaxtext.jaxmaxtext_training_lib.log") as mock_log:
+            with self.assertRaises(RuntimeError):
+                job._scan_chunk_for_errors("h1", 1, chunk)
+        logged = " ".join(str(c) for c in mock_log.error.call_args_list)
+        self.assertIn("FAILURE chunk", logged)
+        self.assertIn("Compiler params for platform tpu", logged)
+
+    def test_healthy_step_with_large_perplexity_no_raise(self):
+        # Regression guard: valid numeric metrics (incl. a big perplexity) must
+        # NOT trip the NaN detector.
+        job, _ = _make_job(hosts=["h0"])
+        job._scan_chunk_for_errors(
+            "h0",
+            0,
+            "completed step: 2, TFLOP/s/device: 38.530, Tokens/s/device: 296.258, "
+            "loss: 11.267, lm_loss: 11.267, perplexity: 78210.594, moe_lb_loss: 0.000\n",
+        )
+
     def test_config_error_patterns_replace_defaults(self):
         # A config-provided error_patterns set fully REPLACES the built-in defaults.
         job, _ = _make_job(hosts=["h0"], error_patterns={"custom": "MY_CUSTOM_ERR"})
@@ -255,6 +296,16 @@ class SetupRdmaLibTests(unittest.TestCase):
         job, orch = _make_job(rdma_lib=SimpleNamespace(container_mount_file="/src.so", container_dest_file="/dst.so"))
         orch.exec.return_value = {"h0": "hca_id: bnxt_re0\n"}
         job.setup_rdma_lib()  # should not raise
+
+    def test_cp_is_guarded_by_source_existence(self):
+        # With a direct read-only mount the legacy ".host" source is absent, so
+        # the copy must be guarded ([ -f <src> ]) rather than failing.
+        job, orch = _make_job(rdma_lib=SimpleNamespace(container_mount_file="/src.so", container_dest_file="/dst.so"))
+        orch.exec.return_value = {"h0": "hca_id: bnxt_re0\n"}
+        job.setup_rdma_lib()
+        cp_cmd = orch.exec.call_args_list[0].args[0]  # first exec == the guarded copy
+        self.assertIn("[ -f /src.so ]", cp_cmd)
+        self.assertIn("cp /src.so /dst.so", cp_cmd)
 
 
 class SetupTokenizerTests(unittest.TestCase):

--- a/cvs/lib/training/jaxmaxtext/unittests/test_training_config_loader.py
+++ b/cvs/lib/training/jaxmaxtext/unittests/test_training_config_loader.py
@@ -17,6 +17,7 @@ from cvs.lib.training.jaxmaxtext.utils.training_config_loader import (
     Convergence,
     LossCurve,
     ScalingBaseline,
+    SmokeTest,
     load_training_variant,
     validate_thresholds_cover_training,
 )
@@ -44,6 +45,13 @@ class SchemaDefaultsTests(unittest.TestCase):
         self.assertEqual(lc.milestone_steps, [100, 500, 1000, 5000])
         self.assertEqual(lc.max_slope, 0.0)
         self.assertTrue(lc.enforce)
+
+    def test_smoke_defaults(self):
+        s = SmokeTest()
+        self.assertTrue(s.enabled)  # opt-OUT: on by default
+        self.assertEqual(s.steps, 5)
+        self.assertEqual(s.per_device_batch_size, 1)
+        self.assertEqual(s.max_target_length, 2048)
 
     def test_checkpoint_resume_defaults(self):
         cr = CheckpointResume()

--- a/cvs/lib/training/jaxmaxtext/utils/training_config_loader.py
+++ b/cvs/lib/training/jaxmaxtext/utils/training_config_loader.py
@@ -120,6 +120,23 @@ class LossCurve(_Allow):
     enforce: bool = True
 
 
+class SmokeTest(_Allow):
+    """Smoke test (ENABLED by default). Loads the model and runs `steps` steps
+    with a small fixed batch/seqlen in BF16, passing only if no error signature
+    fires (no metric/threshold checks). A failure gates the rest of the suite.
+
+    Set `enabled=false` to SKIP it -- e.g. during iterative experiments where you
+    don't want the smoke run every time (mirrors checkpoint_resume, but opt-OUT
+    rather than opt-in). `steps`/`per_device_batch_size`/`max_target_length` tune
+    the smoke run itself.
+    """
+
+    enabled: bool = True
+    steps: int = 5
+    per_device_batch_size: int = 1
+    max_target_length: int = 2048
+
+
 class CheckpointResume(_Allow):
     """Checkpoint save + resume test (opt-in; off by default).
 
@@ -202,6 +219,7 @@ class TrainingConfig(_Allow):
     scaling_baseline: ScalingBaseline = ScalingBaseline()
     convergence: Convergence = Convergence()
     loss_curve: LossCurve = LossCurve()
+    smoke: SmokeTest = SmokeTest()
     checkpoint_resume: CheckpointResume = CheckpointResume()
     sweeps: List[Sweep] = []
     enabled_sweep_list: List[str] = []

--- a/cvs/tests/training/jaxmaxtext/_common.py
+++ b/cvs/tests/training/jaxmaxtext/_common.py
@@ -226,7 +226,7 @@ def setup_tokenizer(orch, variant_config, hf_token, lifecycle, request):
 # steps without hitting any error_patterns. Overrides only per_device_batch_size,
 # max_target_length, precision and step count; keeps the config's model_name +
 # tokenizer so the vocab/tokenizer stay consistent. No metric/threshold checks.
-_SMOKE_STEPS = 10
+_SMOKE_STEPS = 5
 _SMOKE_BATCH = 1
 _SMOKE_SEQLEN = 2048
 
@@ -240,19 +240,29 @@ def smoke(orch, variant_config, hf_token, lifecycle, request):
     error signature (scanned by poll_for_completion) is the only pass criterion --
     there is no metric or threshold verification. A failure sets lifecycle.failed
     so downstream stages skip.
+
+    Enabled by default; skipped when training.smoke.enabled=false (opt-OUT, e.g.
+    during iterative experiments). steps/batch/seqlen come from training.smoke.
     """
+    cfg = variant_config.training.smoke
+    if not getattr(cfg, "enabled", True):
+        pytest.skip("smoke test disabled (training.smoke.enabled=false)")
     if lifecycle.failed:
         pytest.skip("a prior lifecycle stage failed")
+
+    steps = getattr(cfg, "steps", _SMOKE_STEPS)
+    batch = getattr(cfg, "per_device_batch_size", _SMOKE_BATCH)
+    seqlen = getattr(cfg, "max_target_length", _SMOKE_SEQLEN)
 
     # Isolated deep copy so the smoke run's tiny steps/overrides never leak into
     # the real per-sweep training_run tests (they share the module-scoped config).
     smoke_variant = variant_config.model_copy(deep=True)
-    smoke_variant.training.steps = _SMOKE_STEPS
+    smoke_variant.training.steps = steps
     smoke_sweep = SimpleNamespace(
         name="SMOKE",
         maxtext_overrides={
-            "per_device_batch_size": _SMOKE_BATCH,
-            "max_target_length": _SMOKE_SEQLEN,
+            "per_device_batch_size": batch,
+            "max_target_length": seqlen,
             "dtype": "bfloat16",
             "weight_dtype": "bfloat16",
             "quantization": "",
@@ -267,11 +277,11 @@ def smoke(orch, variant_config, hf_token, lifecycle, request):
         job.start_training()
         # poll scans each node's log for error_patterns/NaN every iteration and
         # raises on the first match or on timeout; returns cleanly once the run
-        # reaches step _SMOKE_STEPS-1.
+        # reaches step steps-1.
         job.poll_for_completion()
     except Exception as e:  # noqa: BLE001
         lifecycle.failed = True
-        pytest.fail(f"smoke test failed (model did not run {_SMOKE_STEPS} steps cleanly): {e}")
+        pytest.fail(f"smoke test failed (model did not run {steps} steps cleanly): {e}")
     finally:
         # Reap ranks so the smoke run leaves no orphan processes for the next stage.
         try:
@@ -283,9 +293,9 @@ def smoke(orch, variant_config, hf_token, lifecycle, request):
     log.info(
         "smoke PASSED | model=%s steps=%s batch=%s seqlen=%s",
         smoke_variant.training.maxtext_config.get("model_name", "<base.yml default>"),
-        _SMOKE_STEPS,
-        _SMOKE_BATCH,
-        _SMOKE_SEQLEN,
+        steps,
+        batch,
+        seqlen,
     )
 
 

--- a/cvs/tests/training/jaxmaxtext/conftest.py
+++ b/cvs/tests/training/jaxmaxtext/conftest.py
@@ -188,6 +188,22 @@ def pytest_runtest_makereport(item, call):
     """Attach THIS test's recorded rows to its HTML report detail panel."""
     outcome = yield
     report = outcome.get_result()
+
+    # Log each test's final outcome (PASS/FAIL/SKIP) to the console + --log-file,
+    # mirroring the "Starting Testcase:" line. Log at 'call', plus at 'setup' when
+    # the test was skipped/failed before its body ran (so nothing is missed) --
+    # this avoids double-logging (a passed setup logs only later, at 'call').
+    if report.when == "call" or (report.when == "setup" and report.outcome != "passed"):
+        name = item.name  # includes params, e.g. test_metric[BF16-...-tflops]
+        if report.outcome == "skipped":
+            lr = report.longrepr
+            reason = lr[2] if isinstance(lr, tuple) and len(lr) == 3 else (str(lr) if lr is not None else "")
+            log.info("Testcase %s: SKIPPED (%s)", name, reason)
+        elif report.outcome == "failed":
+            log.error("Testcase %s: FAILED", name)
+        else:
+            log.info("Testcase %s: PASSED", name)
+
     if report.when != "call":
         return
     try:
@@ -201,9 +217,12 @@ def pytest_runtest_makereport(item, call):
 
     # Each metric row gets an EXTRA "Metric Results" link to the single shared
     # metric-results HTML file (written by test_print_results_table), in addition
-    # to its own per-test "Full Log" link (kept as-is). Two links per metric row.
+    # to its own per-test "Full Log" link (kept as-is). Skip the link for SKIPPED
+    # metric rows: when an earlier stage (e.g. smoke) fails, the metric tests are
+    # skipped and test_print_results_table writes no metric_results.html, so the
+    # link would point at empty/missing content.
     metric_link = None
-    if (item.originalname or "") == "test_metric":
+    if (item.originalname or "") == "test_metric" and report.outcome != "skipped":
         mgr = getattr(item.config, "_html_report_manager", None)
         if mgr is not None and getattr(mgr, "is_enabled", False):
             metric_link = f"{mgr._test_html_dir}/metric_results.html"


### PR DESCRIPTION
    config(JAX) Fix bnxt_re RDMA lib mounts + enable IB across jaxmaxtext configs

    1. RDMA lib volume mount fix in all distributed jaxmaxtext configs
       (mi300x/mi325x/mi355x x llama-3.1-8b / llama-3.3-70b / llama-3.1-405b /
       deepseek-v2-lite): mount the host libbnxt_re-rdmav34.so directly onto the
       container's real .so path read-only (":ro") instead of the ".so.host"
       indirection, and add a read-only /usr/lib/x86_64-linux-gnu/libibverbs.so.1
       mount.
    2. Flip NCCL_IB_DISABLE "1" -> "0" in those configs to enable IB/RoCE over
       bnxt_re (was pinned to the TCP fallback).

    Signed-off-by: Saravanan Solaiyappan <saravanan.solaiyappan@amd.com>


    fix(JAX) Harden jaxmaxtext poller/error-detection + add opt-out smoke test

    1. Broaden NaN/Inf detection to match loss/lm_loss/perplexity going NaN (not
       just the throughput fields, which stay numeric) and MaxText's explicit
       "Aborting training due to NaN loss" line; ignore the false-positive-prone
       TensorBoard "NaN or Inf found in input tensor" warning.
    2. Stream each poll's new node-0 log lines BEFORE scanning, and log the full
       offending chunk before raising, so failure tracebacks reach the console /
       --log-file (previously the scan raised first and only the truncated
       text[-500:] survived).
    3. Add an opt-OUT smoke test config block (training.smoke, enabled by default,
       with steps/per_device_batch_size/max_target_length); smoke() skips when
       smoke.enabled=false, for iterative experiments.
    4. Log every test's final PASS/FAIL/SKIP (with skip reason) to the console /
       --log-file, mirroring the "Starting Testcase:" line.
    5. Drop the per-row "Metric Results" HTML link for SKIPPED metric tests, so it
       no longer points at an empty/missing metric_results.html when an earlier
       stage (e.g. smoke) fails.
    6. Unit tests for the NaN-loss/abort signatures, the failure-chunk logging, and
       the smoke schema defaults.

    Signed-off-by: Saravanan Solaiyappan <saravanan.solaiyappan@amd.com>
