### PR TITLE
AIMVT-302: Implement HTTP Agent to serve exec, exec_cmd_list etc

### DIFF
--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -7,6 +7,7 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 
 import asyncio
 import hmac
+import os
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,10 +16,24 @@ from fastapi import Depends, FastAPI, HTTPException, Request, status
 
 from . import messages
 
+FILE_MODE_PREVIEW_LINES = 20
+
 
 def _read_secret(file_path: Path) -> str:
     with open(file_path) as file:
         return file.readline().strip()
+
+
+async def _write_text(path: Path, content: str) -> None:
+    await asyncio.to_thread(path.write_text, content)
+
+
+def _tail_lines(text: str, max_lines: int) -> list[str]:
+    return text.splitlines()[-max_lines:]
+
+
+def _merged_env(overrides: dict[str, str]) -> dict[str, str]:
+    return {**os.environ, **overrides}
 
 
 @dataclass
@@ -33,7 +48,7 @@ class AgentRegistry:
     def __init__(self, expected_count: int) -> None:
         self._agents: dict[int, AgentInfo] = {}
         self._lock = asyncio.Lock()
-        self._expected_count = expected_count
+        self._expected_count: int = expected_count
         self._all_registered = asyncio.Event()
 
     async def register(self, rank: int, hostname: str, port: int) -> None:
@@ -49,6 +64,46 @@ class AgentRegistry:
     async def wait_until_ready(self, timeout: float | None = None) -> dict[int, AgentInfo]:
         await asyncio.wait_for(self._all_registered.wait(), timeout=timeout)
         return self.snapshot()
+
+
+class ProcessRegistry:
+    '''In-memory record of processes spawned via /v1/exec, keyed by cmd_id. Every rank's own agent has one,
+    since a spawned process only exists in that rank's local kernel process table.'''
+
+    def __init__(self) -> None:
+        self._processes: dict[str, asyncio.subprocess.Process] = {}
+        self._lock = asyncio.Lock()
+
+    async def register(self, cmd_id: str, process: asyncio.subprocess.Process) -> None:
+        async with self._lock:
+            self._processes[cmd_id] = process
+
+    async def unregister(self, cmd_id: str) -> None:
+        async with self._lock:
+            self._processes.pop(cmd_id, None)
+
+    def snapshot(self) -> dict[str, asyncio.subprocess.Process]:
+        return dict(self._processes)
+
+
+async def _spawn_process(
+    request: messages.ExecRequest,
+    registry: ProcessRegistry,
+    stdout: int,
+    stderr: int,
+) -> asyncio.subprocess.Process:
+    # start_new_session detaches the child into its own process group so a future kill can target
+    # the whole group (via os.killpg) without also signaling this agent process itself.
+    process = await asyncio.create_subprocess_shell(
+        request.cmd,
+        stdout=stdout,
+        stderr=stderr,
+        cwd=request.cwd,
+        env=_merged_env(request.env),
+        start_new_session=True,
+    )
+    await registry.register(request.cmd_id, process)
+    return process
 
 
 def _extract_bearer_token(header_value: str | None) -> str | None:
@@ -75,6 +130,7 @@ def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> Fas
     app = FastAPI(lifespan=lifespan, dependencies=[Depends(verify_auth)])
     app.state.own_rank = own_rank
     app.state.registry = AgentRegistry(expected_agent_count)
+    app.state.process_registry = ProcessRegistry()
 
     @app.post(messages.REGISTER_PATH)
     async def register_agent(request: messages.RegisterRequest, http_request: Request) -> messages.RegisterResponse:
@@ -89,14 +145,56 @@ def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> Fas
         '''Return status of agent connection health'''
         return messages.HealthResponse(ok=True)
 
+    @app.post(messages.EXEC_PATH)
+    async def run_cmd(request: messages.ExecRequest, http_request: Request) -> messages.ExecResponse:
+        '''Run cmd on host'''
+        registry: ProcessRegistry = http_request.app.state.process_registry
+
+        if request.output_mode == messages.ExecOutputMode.EXIT_CODE_ONLY:
+            process = await _spawn_process(
+                request, registry, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+            )
+            try:
+                await process.wait()
+            finally:
+                await registry.unregister(request.cmd_id)
+            return messages.ExecResponse(
+                exit_code=process.returncode,
+                stdout=None,
+                stderr=None,
+                stdout_path=None,
+                stderr_path=None,
+                truncated=None,
+            )
+
+        if request.output_mode == messages.ExecOutputMode.FILE:
+            process = await _spawn_process(
+                request, registry, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+            )
+            try:
+                stdout_bytes, stderr_bytes = await process.communicate()
+            finally:
+                await registry.unregister(request.cmd_id)
+            stdout_text = stdout_bytes.decode(errors="replace")
+            stderr_text = stderr_bytes.decode(errors="replace")
+            stdout_path = request.out_path / f"{request.cmd_id}.stdout"
+            stderr_path = request.out_path / f"{request.cmd_id}.stderr"
+            await _write_text(stdout_path, stdout_text)
+            await _write_text(stderr_path, stderr_text)
+            return messages.ExecResponse(
+                exit_code=process.returncode,
+                stdout=_tail_lines(stdout_text, FILE_MODE_PREVIEW_LINES),
+                stderr=_tail_lines(stderr_text, FILE_MODE_PREVIEW_LINES),
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+                truncated=None,
+            )
+
+        raise NotImplementedError(f"output_mode {request.output_mode} is not yet implemented")
+
     @app.post(messages.SHUTDOWN_PATH)
     async def run_shutdown() -> messages.ShutdownResponse:
         '''Initiate graceful shutdown'''
-        ...
-
-    @app.post(messages.EXEC_PATH)
-    async def run_cmd() -> messages.ExecResponse:
-        '''Run cmd on host'''
         ...
 
     return app

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -34,6 +34,12 @@ def _tail_lines(text: str, max_lines: int) -> list[str]:
     return text.splitlines()[-max_lines:]
 
 
+def _truncate_tail(data: bytes, max_bytes: int) -> tuple[bytes, bool]:
+    if len(data) <= max_bytes:
+        return data, False
+    return data[-max_bytes:], True
+
+
 def _merged_env(overrides: dict[str, str]) -> dict[str, str]:
     return {**os.environ, **overrides}
 
@@ -139,6 +145,25 @@ async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> 
             stdout_path=None,
             stderr_path=None,
             truncated=None,
+        )
+
+    if request.output_mode == messages.ExecOutputMode.INLINE:
+        process = await _spawn_process(
+            request, registry, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        try:
+            stdout_bytes, stderr_bytes = await process.communicate()
+        finally:
+            await registry.unregister(request.cmd_id)
+        stdout_bytes, stdout_truncated = _truncate_tail(stdout_bytes, messages.MAX_INLINE_RESPONSE_BYTES)
+        stderr_bytes, stderr_truncated = _truncate_tail(stderr_bytes, messages.MAX_INLINE_RESPONSE_BYTES)
+        return messages.ExecResponse(
+            exit_code=process.returncode,
+            stdout=stdout_bytes.decode(errors="replace").splitlines(),
+            stderr=stderr_bytes.decode(errors="replace").splitlines(),
+            stdout_path=None,
+            stderr_path=None,
+            truncated=stdout_truncated or stderr_truncated,
         )
 
     if request.output_mode == messages.ExecOutputMode.FILE:

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -53,17 +53,17 @@ class AgentInfo:
 class AgentRegistry:
     '''In-memory record of registered agents, keyed by rank. Lives on rank 0 only.'''
 
-    def __init__(self, expected_count: int) -> None:
+    def __init__(self, world_size: int) -> None:
         self._agents: dict[int, AgentInfo] = {}
         self._lock = asyncio.Lock()
-        self._expected_count: int = expected_count
+        self._world_size: int = world_size
         self._all_registered = asyncio.Event()
 
     async def register(self, rank: int, hostname: str, port: int) -> None:
         async with self._lock:
             # last write wins: a re-registering rank (e.g. restarted with a new port) replaces its old entry
             self._agents[rank] = AgentInfo(hostname, port)
-            if len(self._agents) >= self._expected_count:
+            if len(self._agents) == self._world_size:
                 self._all_registered.set()
 
     def snapshot(self) -> dict[int, AgentInfo]:
@@ -109,44 +109,52 @@ async def _terminate_process_group(process: asyncio.subprocess.Process, grace_pe
         await process.wait()
 
 
-async def _read_stream_with_inactivity_timeout(
-    stream: asyncio.StreamReader, chunks: list[bytes], inactivity_timeout: float | None
-) -> None:
+async def _read_stream(stream: asyncio.StreamReader, chunks: list[bytes], activity: asyncio.Event) -> None:
     # chunks is a caller-owned accumulator (not a local) so partial output survives if this task is
-    # cancelled mid-read, e.g. because the sibling stream or the overall timeout fired first.
+    # cancelled mid-read, e.g. because a sibling task or the overall timeout fired first.
     while True:
-        if inactivity_timeout is None:
-            chunk = await stream.read(65536)
-        else:
-            # wait_for re-arms on every call, so the deadline measures time since the last chunk, not
-            # total elapsed time - exactly the "no output for N seconds" semantics inactivity_timeout wants.
-            chunk = await asyncio.wait_for(stream.read(65536), timeout=inactivity_timeout)
+        chunk = await stream.read(65536)
         if not chunk:
             return
         chunks.append(chunk)
+        activity.set()
+
+
+async def _watch_inactivity(activity: asyncio.Event, inactivity_timeout: float) -> None:
+    # Activity is watched combined across both streams, not per-stream: a process that only ever
+    # writes to one of stdout/stderr must not have the other stream's silence mistaken for a hang.
+    while True:
+        activity.clear()
+        await asyncio.wait_for(activity.wait(), timeout=inactivity_timeout)
 
 
 async def _communicate_with_timeouts(
     process: asyncio.subprocess.Process, timeout: float | None, inactivity_timeout: float | None
 ) -> tuple[bytes, bytes, bool]:
     '''Like process.communicate(), but kills the process and reports timed_out if it runs longer than
-    timeout or falls silent on both streams for longer than inactivity_timeout.'''
+    timeout, or if stdout and stderr are both silent for longer than inactivity_timeout.'''
     stdout_chunks: list[bytes] = []
     stderr_chunks: list[bytes] = []
-    tasks = [
-        asyncio.ensure_future(_read_stream_with_inactivity_timeout(process.stdout, stdout_chunks, inactivity_timeout)),
-        asyncio.ensure_future(_read_stream_with_inactivity_timeout(process.stderr, stderr_chunks, inactivity_timeout)),
-        asyncio.ensure_future(process.wait()),
-    ]
+    activity = asyncio.Event()
+    work = asyncio.ensure_future(
+        asyncio.gather(
+            _read_stream(process.stdout, stdout_chunks, activity),
+            _read_stream(process.stderr, stderr_chunks, activity),
+            process.wait(),
+        )
+    )
+    watchdog = asyncio.ensure_future(_watch_inactivity(activity, inactivity_timeout)) if inactivity_timeout else None
+    racers = [work, watchdog] if watchdog else [work]
     try:
-        await asyncio.wait_for(asyncio.gather(*tasks), timeout=timeout)
-        timed_out = False
-    except asyncio.TimeoutError:
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        done, _ = await asyncio.wait(racers, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
+        timed_out = work not in done
+    finally:
+        work.cancel()
+        if watchdog is not None:
+            watchdog.cancel()
+        await asyncio.gather(work, *([watchdog] if watchdog else []), return_exceptions=True)
+    if timed_out:
         await _terminate_process_group(process, TERMINATE_GRACE_PERIOD_SECONDS)
-        timed_out = True
     return b"".join(stdout_chunks), b"".join(stderr_chunks), timed_out
 
 
@@ -261,24 +269,38 @@ async def verify_auth(request: Request) -> None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="invalid or missing bearer token")
 
 
-def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> FastAPI:
-    '''Build a FastAPI app for one rank's agent process. own_rank gates /v1/register to rank 0 only.'''
+def create_app(
+    agent_dir: Path,
+    world_rank: int,
+    world_size: int,
+    own_hostname: str | None = None,
+    own_port: int | None = None,
+    register_timeout: float | None = None,
+) -> FastAPI:
+    '''Build a FastAPI app for one rank's agent process. world_rank gates /v1/register to rank 0 only.
+    Rank 0 additionally self-registers under own_hostname/own_port during startup and blocks until every
+    rank has registered, or register_timeout elapses.'''
+    if world_rank == 0 and (own_hostname is None or own_port is None):
+        raise ValueError("own_hostname and own_port are required for rank 0 to self-register")
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         app.state.auth_token = _read_secret(agent_dir / messages.AUTH_TOKEN_FILENAME)
+        if world_rank == 0:
+            await app.state.registry.register(world_rank, own_hostname, own_port)
+            await app.state.registry.wait_until_ready(timeout=register_timeout)
         yield
 
     app = FastAPI(lifespan=lifespan, dependencies=[Depends(verify_auth)])
-    app.state.own_rank = own_rank
-    app.state.registry = AgentRegistry(expected_agent_count)
+    app.state.world_rank = world_rank
+    app.state.registry = AgentRegistry(world_size)
     app.state.process_registry = ProcessRegistry()
     app.state.exec_busy = False
 
     @app.post(messages.REGISTER_PATH)
     async def register_agent(request: messages.RegisterRequest, http_request: Request) -> messages.RegisterResponse:
         '''Record that a worker rank has started and is reachable at hostname:port'''
-        if http_request.app.state.own_rank != 0:
+        if http_request.app.state.world_rank != 0:
             raise HTTPException(status.HTTP_403_FORBIDDEN, detail="only rank 0 accepts registrations")
         await http_request.app.state.registry.register(request.rank, request.hostname, request.port)
         return messages.RegisterResponse(ok=True)

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -123,6 +123,53 @@ async def _spawn_process(
     return process
 
 
+async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> messages.ExecResponse:
+    if request.output_mode == messages.ExecOutputMode.EXIT_CODE_ONLY:
+        process = await _spawn_process(
+            request, registry, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+        )
+        try:
+            await process.wait()
+        finally:
+            await registry.unregister(request.cmd_id)
+        return messages.ExecResponse(
+            exit_code=process.returncode,
+            stdout=None,
+            stderr=None,
+            stdout_path=None,
+            stderr_path=None,
+            truncated=None,
+        )
+
+    if request.output_mode == messages.ExecOutputMode.FILE:
+        process = await _spawn_process(
+            request, registry, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        try:
+            stdout_bytes, stderr_bytes = await process.communicate()
+        finally:
+            await registry.unregister(request.cmd_id)
+        stdout_text = stdout_bytes.decode(errors="replace")
+        stderr_text = stderr_bytes.decode(errors="replace")
+        stdout_path = None
+        stderr_path = None
+        if request.out_path:
+            stdout_path = request.out_path / f"{request.cmd_id}.stdout"
+            stderr_path = request.out_path / f"{request.cmd_id}.stderr"
+            await _write_text(stdout_path, stdout_text)
+            await _write_text(stderr_path, stderr_text)
+        return messages.ExecResponse(
+            exit_code=process.returncode,
+            stdout=_tail_lines(stdout_text, FILE_MODE_PREVIEW_LINES),
+            stderr=_tail_lines(stderr_text, FILE_MODE_PREVIEW_LINES),
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+            truncated=None,
+        )
+
+    raise NotImplementedError(f"output_mode {request.output_mode} is not yet implemented")
+
+
 def _extract_bearer_token(header_value: str | None) -> str | None:
     if not header_value:
         return None
@@ -148,6 +195,7 @@ def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> Fas
     app.state.own_rank = own_rank
     app.state.registry = AgentRegistry(expected_agent_count)
     app.state.process_registry = ProcessRegistry()
+    app.state.exec_busy = False
 
     @app.post(messages.REGISTER_PATH)
     async def register_agent(request: messages.RegisterRequest, http_request: Request) -> messages.RegisterResponse:
@@ -165,52 +213,15 @@ def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> Fas
     @app.post(messages.EXEC_PATH)
     async def run_cmd(request: messages.ExecRequest, http_request: Request) -> messages.ExecResponse:
         '''Run cmd on host'''
-        registry: ProcessRegistry = http_request.app.state.process_registry
-
-        if request.output_mode == messages.ExecOutputMode.EXIT_CODE_ONLY:
-            process = await _spawn_process(
-                request, registry, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
-            )
-            try:
-                await process.wait()
-            finally:
-                await registry.unregister(request.cmd_id)
-            return messages.ExecResponse(
-                exit_code=process.returncode,
-                stdout=None,
-                stderr=None,
-                stdout_path=None,
-                stderr_path=None,
-                truncated=None,
-            )
-
-        if request.output_mode == messages.ExecOutputMode.FILE:
-            process = await _spawn_process(
-                request, registry, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-            )
-            try:
-                stdout_bytes, stderr_bytes = await process.communicate()
-            finally:
-                await registry.unregister(request.cmd_id)
-            stdout_text = stdout_bytes.decode(errors="replace")
-            stderr_text = stderr_bytes.decode(errors="replace")
-            stdout_path = None
-            stderr_path = None
-            if request.out_path:
-                stdout_path = request.out_path / f"{request.cmd_id}.stdout"
-                stderr_path = request.out_path / f"{request.cmd_id}.stderr"
-                await _write_text(stdout_path, stdout_text)
-                await _write_text(stderr_path, stderr_text)
-            return messages.ExecResponse(
-                exit_code=process.returncode,
-                stdout=_tail_lines(stdout_text, FILE_MODE_PREVIEW_LINES),
-                stderr=_tail_lines(stderr_text, FILE_MODE_PREVIEW_LINES),
-                stdout_path=stdout_path,
-                stderr_path=stderr_path,
-                truncated=None,
-            )
-
-        raise NotImplementedError(f"output_mode {request.output_mode} is not yet implemented")
+        # Checked and set with no `await` in between: the event loop can't switch to another
+        # request's coroutine mid-way, so this is race-free without needing an explicit lock.
+        if http_request.app.state.exec_busy:
+            raise HTTPException(status.HTTP_409_CONFLICT, detail="an exec is already in progress on this agent")
+        http_request.app.state.exec_busy = True
+        try:
+            return await _run_cmd(request, http_request.app.state.process_registry)
+        finally:
+            http_request.app.state.exec_busy = False
 
     @app.post(messages.SHUTDOWN_PATH)
     async def run_shutdown(http_request: Request) -> messages.ShutdownResponse:

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -1,0 +1,102 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+import asyncio
+import hmac
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+
+from . import messages
+
+
+def _read_secret(file_path: Path) -> str:
+    with open(file_path) as file:
+        return file.readline().strip()
+
+
+@dataclass
+class AgentInfo:
+    hostname: str
+    port: int
+
+
+class AgentRegistry:
+    '''In-memory record of registered agents, keyed by rank. Lives on rank 0 only.'''
+
+    def __init__(self, expected_count: int) -> None:
+        self._agents: dict[int, AgentInfo] = {}
+        self._lock = asyncio.Lock()
+        self._expected_count = expected_count
+        self._all_registered = asyncio.Event()
+
+    async def register(self, rank: int, hostname: str, port: int) -> None:
+        async with self._lock:
+            # last write wins: a re-registering rank (e.g. restarted with a new port) replaces its old entry
+            self._agents[rank] = AgentInfo(hostname, port)
+            if len(self._agents) >= self._expected_count:
+                self._all_registered.set()
+
+    def snapshot(self) -> dict[int, AgentInfo]:
+        return dict(self._agents)
+
+    async def wait_until_ready(self, timeout: float | None = None) -> dict[int, AgentInfo]:
+        await asyncio.wait_for(self._all_registered.wait(), timeout=timeout)
+        return self.snapshot()
+
+
+def _extract_bearer_token(header_value: str | None) -> str | None:
+    if not header_value:
+        return None
+    scheme, _, token = header_value.partition(" ")
+    return token if scheme == messages.AUTH_SCHEME and token else None
+
+
+async def verify_auth(request: Request) -> None:
+    provided = _extract_bearer_token(request.headers.get(messages.AUTH_HEADER))
+    if provided is None or not hmac.compare_digest(provided, request.app.state.auth_token):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="invalid or missing bearer token")
+
+
+def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> FastAPI:
+    '''Build a FastAPI app for one rank's agent process. own_rank gates /v1/register to rank 0 only.'''
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.auth_token = _read_secret(agent_dir / messages.AUTH_TOKEN_FILENAME)
+        yield
+
+    app = FastAPI(lifespan=lifespan, dependencies=[Depends(verify_auth)])
+    app.state.own_rank = own_rank
+    app.state.registry = AgentRegistry(expected_agent_count)
+
+    @app.post(messages.REGISTER_PATH)
+    async def register_agent(request: messages.RegisterRequest, http_request: Request) -> messages.RegisterResponse:
+        '''Record that a worker rank has started and is reachable at hostname:port'''
+        if http_request.app.state.own_rank != 0:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, detail="only rank 0 accepts registrations")
+        await http_request.app.state.registry.register(request.rank, request.hostname, request.port)
+        return messages.RegisterResponse(ok=True)
+
+    @app.get(messages.HEALTH_PATH)
+    async def get_health_status() -> messages.HealthResponse:
+        '''Return status of agent connection health'''
+        return messages.HealthResponse(ok=True)
+
+    @app.post(messages.SHUTDOWN_PATH)
+    async def run_shutdown() -> messages.ShutdownResponse:
+        '''Initiate graceful shutdown'''
+        ...
+
+    @app.post(messages.EXEC_PATH)
+    async def run_cmd() -> messages.ExecResponse:
+        '''Run cmd on host'''
+        ...
+
+    return app

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -8,6 +8,7 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 import asyncio
 import hmac
 import os
+import signal
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +18,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, status
 from . import messages
 
 FILE_MODE_PREVIEW_LINES = 20
+SHUTDOWN_GRACE_PERIOD_SECONDS = 10.0
 
 
 def _read_secret(file_path: Path) -> str:
@@ -84,6 +86,21 @@ class ProcessRegistry:
 
     def snapshot(self) -> dict[str, asyncio.subprocess.Process]:
         return dict(self._processes)
+
+
+async def _terminate_process_group(process: asyncio.subprocess.Process, grace_period: float) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return  # already exited (e.g. its own /v1/exec call completed concurrently)
+    try:
+        await asyncio.wait_for(process.wait(), timeout=grace_period)
+    except asyncio.TimeoutError:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        await process.wait()
 
 
 async def _spawn_process(
@@ -177,10 +194,13 @@ def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> Fas
                 await registry.unregister(request.cmd_id)
             stdout_text = stdout_bytes.decode(errors="replace")
             stderr_text = stderr_bytes.decode(errors="replace")
-            stdout_path = request.out_path / f"{request.cmd_id}.stdout"
-            stderr_path = request.out_path / f"{request.cmd_id}.stderr"
-            await _write_text(stdout_path, stdout_text)
-            await _write_text(stderr_path, stderr_text)
+            stdout_path = None
+            stderr_path = None
+            if request.out_path:
+                stdout_path = request.out_path / f"{request.cmd_id}.stdout"
+                stderr_path = request.out_path / f"{request.cmd_id}.stderr"
+                await _write_text(stdout_path, stdout_text)
+                await _write_text(stderr_path, stderr_text)
             return messages.ExecResponse(
                 exit_code=process.returncode,
                 stdout=_tail_lines(stdout_text, FILE_MODE_PREVIEW_LINES),
@@ -193,8 +213,16 @@ def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> Fas
         raise NotImplementedError(f"output_mode {request.output_mode} is not yet implemented")
 
     @app.post(messages.SHUTDOWN_PATH)
-    async def run_shutdown() -> messages.ShutdownResponse:
-        '''Initiate graceful shutdown'''
-        ...
+    async def run_shutdown(http_request: Request) -> messages.ShutdownResponse:
+        '''Terminate every process this agent has spawned, then exit the agent itself'''
+        registry: ProcessRegistry = http_request.app.state.process_registry
+        processes = registry.snapshot()
+        await asyncio.gather(
+            *(_terminate_process_group(process, SHUTDOWN_GRACE_PERIOD_SECONDS) for process in processes.values())
+        )
+        # Self-signal rather than depending on a Server reference: uvicorn installs a SIGTERM
+        # handler that drains in-flight requests (this one included) before exiting.
+        os.kill(os.getpid(), signal.SIGTERM)
+        return messages.ShutdownResponse(ok=True)
 
     return app

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -18,7 +18,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, status
 from . import messages
 
 FILE_MODE_PREVIEW_LINES = 20
-SHUTDOWN_GRACE_PERIOD_SECONDS = 10.0
+TERMINATE_GRACE_PERIOD_SECONDS = 10.0
 
 
 def _read_secret(file_path: Path) -> str:
@@ -109,6 +109,47 @@ async def _terminate_process_group(process: asyncio.subprocess.Process, grace_pe
         await process.wait()
 
 
+async def _read_stream_with_inactivity_timeout(
+    stream: asyncio.StreamReader, chunks: list[bytes], inactivity_timeout: float | None
+) -> None:
+    # chunks is a caller-owned accumulator (not a local) so partial output survives if this task is
+    # cancelled mid-read, e.g. because the sibling stream or the overall timeout fired first.
+    while True:
+        if inactivity_timeout is None:
+            chunk = await stream.read(65536)
+        else:
+            # wait_for re-arms on every call, so the deadline measures time since the last chunk, not
+            # total elapsed time - exactly the "no output for N seconds" semantics inactivity_timeout wants.
+            chunk = await asyncio.wait_for(stream.read(65536), timeout=inactivity_timeout)
+        if not chunk:
+            return
+        chunks.append(chunk)
+
+
+async def _communicate_with_timeouts(
+    process: asyncio.subprocess.Process, timeout: float | None, inactivity_timeout: float | None
+) -> tuple[bytes, bytes, bool]:
+    '''Like process.communicate(), but kills the process and reports timed_out if it runs longer than
+    timeout or falls silent on both streams for longer than inactivity_timeout.'''
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    tasks = [
+        asyncio.ensure_future(_read_stream_with_inactivity_timeout(process.stdout, stdout_chunks, inactivity_timeout)),
+        asyncio.ensure_future(_read_stream_with_inactivity_timeout(process.stderr, stderr_chunks, inactivity_timeout)),
+        asyncio.ensure_future(process.wait()),
+    ]
+    try:
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=timeout)
+        timed_out = False
+    except asyncio.TimeoutError:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await _terminate_process_group(process, TERMINATE_GRACE_PERIOD_SECONDS)
+        timed_out = True
+    return b"".join(stdout_chunks), b"".join(stderr_chunks), timed_out
+
+
 async def _spawn_process(
     request: messages.ExecRequest,
     registry: ProcessRegistry,
@@ -135,7 +176,12 @@ async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> 
             request, registry, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
         )
         try:
-            await process.wait()
+            timed_out = False
+            try:
+                await asyncio.wait_for(process.wait(), timeout=request.timeout)
+            except asyncio.TimeoutError:
+                await _terminate_process_group(process, TERMINATE_GRACE_PERIOD_SECONDS)
+                timed_out = True
         finally:
             await registry.unregister(request.cmd_id)
         return messages.ExecResponse(
@@ -145,6 +191,7 @@ async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> 
             stdout_path=None,
             stderr_path=None,
             truncated=None,
+            timed_out=timed_out,
         )
 
     if request.output_mode == messages.ExecOutputMode.INLINE:
@@ -152,7 +199,9 @@ async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> 
             request, registry, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )
         try:
-            stdout_bytes, stderr_bytes = await process.communicate()
+            stdout_bytes, stderr_bytes, timed_out = await _communicate_with_timeouts(
+                process, request.timeout, request.inactivity_timeout
+            )
         finally:
             await registry.unregister(request.cmd_id)
         stdout_bytes, stdout_truncated = _truncate_tail(stdout_bytes, messages.MAX_INLINE_RESPONSE_BYTES)
@@ -164,6 +213,7 @@ async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> 
             stdout_path=None,
             stderr_path=None,
             truncated=stdout_truncated or stderr_truncated,
+            timed_out=timed_out,
         )
 
     if request.output_mode == messages.ExecOutputMode.FILE:
@@ -171,7 +221,9 @@ async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> 
             request, registry, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )
         try:
-            stdout_bytes, stderr_bytes = await process.communicate()
+            stdout_bytes, stderr_bytes, timed_out = await _communicate_with_timeouts(
+                process, request.timeout, request.inactivity_timeout
+            )
         finally:
             await registry.unregister(request.cmd_id)
         stdout_text = stdout_bytes.decode(errors="replace")
@@ -190,6 +242,7 @@ async def _run_cmd(request: messages.ExecRequest, registry: ProcessRegistry) -> 
             stdout_path=stdout_path,
             stderr_path=stderr_path,
             truncated=None,
+            timed_out=timed_out,
         )
 
     raise NotImplementedError(f"output_mode {request.output_mode} is not yet implemented")
@@ -254,7 +307,7 @@ def create_app(agent_dir: Path, own_rank: int, expected_agent_count: int) -> Fas
         registry: ProcessRegistry = http_request.app.state.process_registry
         processes = registry.snapshot()
         await asyncio.gather(
-            *(_terminate_process_group(process, SHUTDOWN_GRACE_PERIOD_SECONDS) for process in processes.values())
+            *(_terminate_process_group(process, TERMINATE_GRACE_PERIOD_SECONDS) for process in processes.values())
         )
         # Self-signal rather than depending on a Server reference: uvicorn installs a SIGTERM
         # handler that drains in-flight requests (this one included) before exiting.

--- a/cvs/core/agent/messages.py
+++ b/cvs/core/agent/messages.py
@@ -77,7 +77,7 @@ class ExecResponse(BaseModel):
       EXIT_CODE_ONLY: only exit_code is set, every other field is None
     '''
 
-    exit_code: int
+    exit_code: int | None  # asyncio.create_subprocess_exec return returncode int | None
     stdout: list[str] | None
     stderr: list[str] | None
     stdout_path: Path | None

--- a/cvs/core/agent/messages.py
+++ b/cvs/core/agent/messages.py
@@ -67,6 +67,15 @@ class ExecRequest(BaseModel):
             raise ValueError("out_path is required when output_mode is FILE")
         return self
 
+    @model_validator(mode="after")
+    def _inactivity_timeout_requires_captured_output(self):
+        if self.inactivity_timeout is not None and self.output_mode == ExecOutputMode.EXIT_CODE_ONLY:
+            raise ValueError(
+                "inactivity_timeout requires output_mode INLINE or FILE "
+                "(EXIT_CODE_ONLY discards output, so activity can't be observed)"
+            )
+        return self
+
 
 class ExecResponse(BaseModel):
     '''
@@ -75,6 +84,9 @@ class ExecResponse(BaseModel):
       INLINE: stdout/stderr hold the full captured output; truncated reflects MAX_INLINE_RESPONSE_BYTES
       FILE: stdout/stderr hold a trailing preview only; stdout_path/stderr_path hold the full output on shared FS
       EXIT_CODE_ONLY: only exit_code is set, every other field is None
+    timed_out is set whenever the process was killed for exceeding timeout or inactivity_timeout; when
+    True, exit_code reflects the kill signal (negative) and stdout/stderr (if applicable) hold only
+    whatever output was captured before the process was killed.
     '''
 
     exit_code: int | None  # asyncio.create_subprocess_exec return returncode int | None
@@ -83,6 +95,7 @@ class ExecResponse(BaseModel):
     stdout_path: Path | None
     stderr_path: Path | None
     truncated: bool | None  # set for INLINE mode only; None when not applicable
+    timed_out: bool
 
 
 class ErrorResponse(BaseModel):

--- a/cvs/core/agent/messages.py
+++ b/cvs/core/agent/messages.py
@@ -33,6 +33,7 @@ class RegisterRequest(BaseModel):
     '''Data model for a agent to register itself with the server'''
 
     rank: int = Field(ge=0)
+    hostname: str
     port: int = Field(gt=0, le=65535)
 
 

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -1,0 +1,103 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+# Unit tests for cvs/core/agent/http_agent.py: AgentRegistry bookkeeping/readiness,
+# the bearer-token auth dependency, and the /v1/register, /v1/health route behavior.
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from cvs.core.agent import messages
+from cvs.core.agent.http_agent import AgentInfo, AgentRegistry, create_app
+
+
+class TestAgentRegistry(unittest.IsolatedAsyncioTestCase):
+    async def test_register_stores_agent_info(self):
+        registry = AgentRegistry(expected_count=2)
+        await registry.register(rank=1, hostname="node1", port=9000)
+        self.assertEqual(registry.snapshot(), {1: AgentInfo(hostname="node1", port=9000)})
+
+    async def test_reregistering_rank_overwrites_previous_entry(self):
+        registry = AgentRegistry(expected_count=1)
+        await registry.register(rank=1, hostname="node1", port=9000)
+        await registry.register(rank=1, hostname="node1", port=9001)
+        self.assertEqual(registry.snapshot(), {1: AgentInfo(hostname="node1", port=9001)})
+
+    async def test_wait_until_ready_returns_once_expected_count_reached(self):
+        registry = AgentRegistry(expected_count=2)
+        await registry.register(rank=1, hostname="node1", port=9000)
+        await registry.register(rank=2, hostname="node2", port=9000)
+        snapshot = await registry.wait_until_ready(timeout=1)
+        self.assertEqual(len(snapshot), 2)
+
+    async def test_wait_until_ready_times_out_when_short(self):
+        registry = AgentRegistry(expected_count=2)
+        await registry.register(rank=1, hostname="node1", port=9000)
+        with self.assertRaises(asyncio.TimeoutError):
+            await registry.wait_until_ready(timeout=0.05)
+
+
+class HttpAgentTestBase(unittest.TestCase):
+    TOKEN = "test-token-123"
+
+    def _make_client(self, own_rank: int, expected_agent_count: int = 1) -> TestClient:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        agent_dir = Path(tmp_dir.name)
+        (agent_dir / messages.AUTH_TOKEN_FILENAME).write_text(self.TOKEN + "\n")
+        app = create_app(agent_dir=agent_dir, own_rank=own_rank, expected_agent_count=expected_agent_count)
+        client = TestClient(app)
+        client.__enter__()  # runs the app's lifespan startup so app.state.auth_token is populated
+        self.addCleanup(client.__exit__, None, None, None)
+        return client
+
+    def _auth_headers(self, token: str | None = None) -> dict[str, str]:
+        return {
+            messages.AUTH_HEADER: f"{messages.AUTH_SCHEME} {token if token is not None else self.TOKEN}",
+            "content-type": "application/json",
+        }
+
+
+class TestAuth(HttpAgentTestBase):
+    def test_missing_authorization_header_is_rejected(self):
+        client = self._make_client(own_rank=0)
+        response = client.get(messages.HEALTH_PATH)
+        self.assertEqual(response.status_code, 401)
+
+    def test_wrong_token_is_rejected(self):
+        client = self._make_client(own_rank=0)
+        response = client.get(messages.HEALTH_PATH, headers=self._auth_headers(token="wrong-token"))
+        self.assertEqual(response.status_code, 401)
+
+    def test_correct_token_is_accepted(self):
+        client = self._make_client(own_rank=0)
+        response = client.get(messages.HEALTH_PATH, headers=self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(messages.HealthResponse(**response.json()).ok)
+
+
+class TestRegisterAgent(HttpAgentTestBase):
+    def test_rank0_accepts_registration(self):
+        client = self._make_client(own_rank=0)
+        req = messages.RegisterRequest(rank=1, hostname="node1", port=9000)
+        response = client.post(messages.REGISTER_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(messages.RegisterResponse(**response.json()).ok)
+
+    def test_non_rank0_rejects_registration(self):
+        client = self._make_client(own_rank=1)
+        req = messages.RegisterRequest(rank=2, hostname="node2", port=9000)
+        response = client.post(messages.REGISTER_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        self.assertEqual(response.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -26,25 +26,25 @@ from cvs.core.agent.http_agent import AgentInfo, AgentRegistry, create_app, _ter
 
 class TestAgentRegistry(unittest.IsolatedAsyncioTestCase):
     async def test_register_stores_agent_info(self):
-        registry = AgentRegistry(expected_count=2)
+        registry = AgentRegistry(world_size=2)
         await registry.register(rank=1, hostname="node1", port=9000)
         self.assertEqual(registry.snapshot(), {1: AgentInfo(hostname="node1", port=9000)})
 
     async def test_reregistering_rank_overwrites_previous_entry(self):
-        registry = AgentRegistry(expected_count=1)
+        registry = AgentRegistry(world_size=1)
         await registry.register(rank=1, hostname="node1", port=9000)
         await registry.register(rank=1, hostname="node1", port=9001)
         self.assertEqual(registry.snapshot(), {1: AgentInfo(hostname="node1", port=9001)})
 
     async def test_wait_until_ready_returns_once_expected_count_reached(self):
-        registry = AgentRegistry(expected_count=2)
+        registry = AgentRegistry(world_size=2)
         await registry.register(rank=1, hostname="node1", port=9000)
         await registry.register(rank=2, hostname="node2", port=9000)
         snapshot = await registry.wait_until_ready(timeout=1)
         self.assertEqual(len(snapshot), 2)
 
     async def test_wait_until_ready_times_out_when_short(self):
-        registry = AgentRegistry(expected_count=2)
+        registry = AgentRegistry(world_size=2)
         await registry.register(rank=1, hostname="node1", port=9000)
         with self.assertRaises(asyncio.TimeoutError):
             await registry.wait_until_ready(timeout=0.05)
@@ -73,12 +73,19 @@ class TestTerminateProcessGroup(unittest.IsolatedAsyncioTestCase):
 class HttpAgentTestBase(unittest.TestCase):
     TOKEN = "test-token-123"
 
-    def _make_client(self, own_rank: int, expected_agent_count: int = 1) -> TestClient:
+    def _make_client(self, world_rank: int, world_size: int = 1) -> TestClient:
         tmp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(tmp_dir.cleanup)
         agent_dir = Path(tmp_dir.name)
         (agent_dir / messages.AUTH_TOKEN_FILENAME).write_text(self.TOKEN + "\n")
-        app = create_app(agent_dir=agent_dir, own_rank=own_rank, expected_agent_count=expected_agent_count)
+        app = create_app(
+            agent_dir=agent_dir,
+            world_rank=world_rank,
+            world_size=world_size,
+            own_hostname="rank0-host" if world_rank == 0 else None,
+            own_port=9000 if world_rank == 0 else None,
+            register_timeout=5.0 if world_rank == 0 else None,
+        )
         client = TestClient(app)
         client.__enter__()  # runs the app's lifespan startup so app.state.auth_token is populated
         self.addCleanup(client.__exit__, None, None, None)
@@ -93,17 +100,17 @@ class HttpAgentTestBase(unittest.TestCase):
 
 class TestAuth(HttpAgentTestBase):
     def test_missing_authorization_header_is_rejected(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         response = client.get(messages.HEALTH_PATH)
         self.assertEqual(response.status_code, 401)
 
     def test_wrong_token_is_rejected(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         response = client.get(messages.HEALTH_PATH, headers=self._auth_headers(token="wrong-token"))
         self.assertEqual(response.status_code, 401)
 
     def test_correct_token_is_accepted(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         response = client.get(messages.HEALTH_PATH, headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         self.assertTrue(messages.HealthResponse(**response.json()).ok)
@@ -111,17 +118,58 @@ class TestAuth(HttpAgentTestBase):
 
 class TestRegisterAgent(HttpAgentTestBase):
     def test_rank0_accepts_registration(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = messages.RegisterRequest(rank=1, hostname="node1", port=9000)
         response = client.post(messages.REGISTER_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         self.assertTrue(messages.RegisterResponse(**response.json()).ok)
 
     def test_non_rank0_rejects_registration(self):
-        client = self._make_client(own_rank=1)
+        client = self._make_client(world_rank=1)
         req = messages.RegisterRequest(rank=2, hostname="node2", port=9000)
         response = client.post(messages.REGISTER_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         self.assertEqual(response.status_code, 403)
+
+
+class TestRankZeroSelfRegistration(HttpAgentTestBase):
+    def _agent_dir(self) -> Path:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        agent_dir = Path(tmp_dir.name)
+        (agent_dir / messages.AUTH_TOKEN_FILENAME).write_text(self.TOKEN + "\n")
+        return agent_dir
+
+    def test_rank0_requires_own_hostname_and_port(self):
+        with self.assertRaises(ValueError):
+            create_app(agent_dir=self._agent_dir(), world_rank=0, world_size=1)
+
+    def test_non_rank0_does_not_require_own_hostname_and_port(self):
+        create_app(agent_dir=self._agent_dir(), world_rank=1, world_size=1)
+
+    def test_rank0_self_registers_and_becomes_ready_when_world_size_is_one(self):
+        app = create_app(
+            agent_dir=self._agent_dir(),
+            world_rank=0,
+            world_size=1,
+            own_hostname="rank0-host",
+            own_port=9000,
+            register_timeout=1,
+        )
+        with TestClient(app):
+            self.assertEqual(app.state.registry.snapshot(), {0: AgentInfo(hostname="rank0-host", port=9000)})
+
+    def test_rank0_startup_blocks_until_register_timeout_when_other_ranks_never_register(self):
+        app = create_app(
+            agent_dir=self._agent_dir(),
+            world_rank=0,
+            world_size=2,
+            own_hostname="rank0-host",
+            own_port=9000,
+            register_timeout=0.05,
+        )
+        with self.assertRaises(asyncio.TimeoutError):
+            with TestClient(app):
+                pass
 
 
 class TestExec(HttpAgentTestBase):
@@ -140,7 +188,7 @@ class TestExec(HttpAgentTestBase):
         return messages.ExecRequest(**kwargs)
 
     def test_exit_code_only_reports_success(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="true")
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
@@ -150,7 +198,7 @@ class TestExec(HttpAgentTestBase):
         self.assertIsNone(exec_response.stdout_path)
 
     def test_exit_code_only_reports_failure(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="false")
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
@@ -158,14 +206,14 @@ class TestExec(HttpAgentTestBase):
         self.assertEqual(exec_response.exit_code, 1)
 
     def test_exit_code_only_does_not_deadlock_on_large_output(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="head -c 1000000 /dev/zero | tr '\\0' 'a'")
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(messages.ExecResponse(**response.json()).exit_code, 0)
 
     def test_file_mode_writes_output_and_returns_preview(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         with tempfile.TemporaryDirectory() as out_dir:
             out_path = Path(out_dir)
             req = self._exec_request(
@@ -184,7 +232,7 @@ class TestExec(HttpAgentTestBase):
             self.assertEqual((out_path / "cmd-file.stderr").read_text(), "world\n")
 
     def test_file_mode_previews_only_trailing_lines(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         with tempfile.TemporaryDirectory() as out_dir:
             out_path = Path(out_dir)
             req = self._exec_request(
@@ -199,7 +247,7 @@ class TestExec(HttpAgentTestBase):
             self.assertEqual((out_path / "cmd-tail.stdout").read_text(), "\n".join(str(n) for n in range(1, 31)) + "\n")
 
     def test_env_is_passed_to_command(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         with tempfile.TemporaryDirectory() as out_dir:
             out_path = Path(out_dir)
             req = self._exec_request(
@@ -214,7 +262,7 @@ class TestExec(HttpAgentTestBase):
             self.assertEqual(exec_response.stdout, ["hello-env"])
 
     def test_cwd_is_passed_to_command(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         with tempfile.TemporaryDirectory() as cwd_dir, tempfile.TemporaryDirectory() as out_dir:
             req = self._exec_request(
                 cmd="pwd",
@@ -244,7 +292,7 @@ class TestExecTimeouts(HttpAgentTestBase):
         return messages.ExecRequest(**kwargs)
 
     def test_exit_code_only_completes_normally_within_timeout(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="true", timeout=5)
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         exec_response = messages.ExecResponse(**response.json())
@@ -252,7 +300,7 @@ class TestExecTimeouts(HttpAgentTestBase):
         self.assertEqual(exec_response.exit_code, 0)
 
     def test_exit_code_only_is_killed_when_timeout_exceeded(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="sleep 30", timeout=1)
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         exec_response = messages.ExecResponse(**response.json())
@@ -260,7 +308,7 @@ class TestExecTimeouts(HttpAgentTestBase):
         self.assertEqual(exec_response.exit_code, -signal.SIGTERM)
 
     def test_inline_mode_captures_partial_output_when_timeout_exceeded(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(
             cmd="echo partial; sleep 30",
             timeout=1,
@@ -273,7 +321,7 @@ class TestExecTimeouts(HttpAgentTestBase):
         self.assertEqual(exec_response.exit_code, -signal.SIGTERM)
 
     def test_inline_mode_is_killed_after_falling_silent(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(
             cmd="echo first; sleep 30",
             inactivity_timeout=1,
@@ -286,7 +334,7 @@ class TestExecTimeouts(HttpAgentTestBase):
         self.assertEqual(exec_response.exit_code, -signal.SIGTERM)
 
     def test_inline_mode_does_not_time_out_on_output_that_arrives_within_inactivity_window(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(
             cmd="echo a; sleep 0.3; echo b",
             inactivity_timeout=5,
@@ -296,6 +344,23 @@ class TestExecTimeouts(HttpAgentTestBase):
         exec_response = messages.ExecResponse(**response.json())
         self.assertFalse(exec_response.timed_out)
         self.assertEqual(exec_response.stdout, ["a", "b"])
+        self.assertEqual(exec_response.exit_code, 0)
+
+    def test_inline_mode_does_not_time_out_when_only_one_stream_stays_active(self):
+        # stderr never writes anything, but stdout keeps producing within the inactivity window -
+        # inactivity must be judged on combined stream activity, not on each stream independently,
+        # or a permanently silent stderr would falsely trigger a kill.
+        client = self._make_client(world_rank=0)
+        req = self._exec_request(
+            cmd="for i in 1 2 3; do echo tick; sleep 0.3; done",
+            inactivity_timeout=1,
+            output_mode=messages.ExecOutputMode.INLINE,
+        )
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertFalse(exec_response.timed_out)
+        self.assertEqual(exec_response.stdout, ["tick", "tick", "tick"])
+        self.assertEqual(exec_response.stderr, [])
         self.assertEqual(exec_response.exit_code, 0)
 
 
@@ -315,7 +380,7 @@ class TestInlineExec(HttpAgentTestBase):
         return messages.ExecRequest(**kwargs)
 
     def test_reports_full_stdout_and_stderr_untruncated(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="seq 1 30; echo err 1>&2")
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
@@ -328,14 +393,14 @@ class TestInlineExec(HttpAgentTestBase):
         self.assertFalse(exec_response.truncated)
 
     def test_reports_nonzero_exit_code(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="false")
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         exec_response = messages.ExecResponse(**response.json())
         self.assertEqual(exec_response.exit_code, 1)
 
     def test_output_beyond_byte_cap_is_tail_truncated(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         with patch("cvs.core.agent.http_agent.messages.MAX_INLINE_RESPONSE_BYTES", 10):
             req = self._exec_request(cmd="printf '0123456789abcdefghij'")
             response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
@@ -344,7 +409,7 @@ class TestInlineExec(HttpAgentTestBase):
         self.assertTrue(exec_response.truncated)
 
     def test_does_not_deadlock_on_large_output(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         req = self._exec_request(cmd="head -c 1000000 /dev/zero | tr '\\0' 'a'")
         response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
@@ -367,7 +432,7 @@ class TestExecConcurrency(HttpAgentTestBase):
         return messages.ExecRequest(**kwargs)
 
     def test_concurrent_exec_is_rejected_with_409_and_flag_resets_after(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         with tempfile.TemporaryDirectory() as marker_dir:
             # the marker file is only written once /v1/exec has spawned the process, which happens
             # strictly after exec_busy is set, so waiting for it rules out a race against the second request
@@ -406,7 +471,7 @@ class TestExecConcurrency(HttpAgentTestBase):
 
 class TestShutdown(HttpAgentTestBase):
     def test_shutdown_with_no_running_processes_signals_self_and_returns_ok(self):
-        client = self._make_client(own_rank=0)
+        client = self._make_client(world_rank=0)
         with patch("cvs.core.agent.http_agent.os.kill") as mock_kill:
             response = client.post(
                 messages.SHUTDOWN_PATH,

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -228,6 +228,58 @@ class TestExec(HttpAgentTestBase):
             self.assertEqual(exec_response.stdout, [cwd_dir])
 
 
+class TestInlineExec(HttpAgentTestBase):
+    def _exec_request(self, **overrides) -> messages.ExecRequest:
+        kwargs = dict(
+            cmd="true",
+            env={},
+            cwd=Path("/tmp"),
+            timeout=None,
+            inactivity_timeout=None,
+            cmd_id="cmd-inline",
+            out_path=None,
+            output_mode=messages.ExecOutputMode.INLINE,
+        )
+        kwargs.update(overrides)
+        return messages.ExecRequest(**kwargs)
+
+    def test_reports_full_stdout_and_stderr_untruncated(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="seq 1 30; echo err 1>&2")
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertEqual(exec_response.exit_code, 0)
+        self.assertEqual(exec_response.stdout, [str(n) for n in range(1, 31)])
+        self.assertEqual(exec_response.stderr, ["err"])
+        self.assertIsNone(exec_response.stdout_path)
+        self.assertIsNone(exec_response.stderr_path)
+        self.assertFalse(exec_response.truncated)
+
+    def test_reports_nonzero_exit_code(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="false")
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertEqual(exec_response.exit_code, 1)
+
+    def test_output_beyond_byte_cap_is_tail_truncated(self):
+        client = self._make_client(own_rank=0)
+        with patch("cvs.core.agent.http_agent.messages.MAX_INLINE_RESPONSE_BYTES", 10):
+            req = self._exec_request(cmd="printf '0123456789abcdefghij'")
+            response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertEqual(exec_response.stdout, ["abcdefghij"])
+        self.assertTrue(exec_response.truncated)
+
+    def test_does_not_deadlock_on_large_output(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="head -c 1000000 /dev/zero | tr '\\0' 'a'")
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(messages.ExecResponse(**response.json()).exit_code, 0)
+
+
 class TestExecConcurrency(HttpAgentTestBase):
     def _exec_request(self, **overrides) -> messages.ExecRequest:
         kwargs = dict(

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -12,6 +12,8 @@ import asyncio
 import os
 import signal
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -224,6 +226,59 @@ class TestExec(HttpAgentTestBase):
             response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
             exec_response = messages.ExecResponse(**response.json())
             self.assertEqual(exec_response.stdout, [cwd_dir])
+
+
+class TestExecConcurrency(HttpAgentTestBase):
+    def _exec_request(self, **overrides) -> messages.ExecRequest:
+        kwargs = dict(
+            cmd="true",
+            env={},
+            cwd=Path("/tmp"),
+            timeout=None,
+            inactivity_timeout=None,
+            cmd_id="cmd-1",
+            out_path=None,
+            output_mode=messages.ExecOutputMode.EXIT_CODE_ONLY,
+        )
+        kwargs.update(overrides)
+        return messages.ExecRequest(**kwargs)
+
+    def test_concurrent_exec_is_rejected_with_409_and_flag_resets_after(self):
+        client = self._make_client(own_rank=0)
+        with tempfile.TemporaryDirectory() as marker_dir:
+            # the marker file is only written once /v1/exec has spawned the process, which happens
+            # strictly after exec_busy is set, so waiting for it rules out a race against the second request
+            marker_path = Path(marker_dir) / "started"
+            first_req = self._exec_request(cmd=f"touch {marker_path}; sleep 1", cmd_id="cmd-slow")
+            responses = {}
+
+            def run_first():
+                responses["first"] = client.post(
+                    messages.EXEC_PATH, content=first_req.model_dump_json(), headers=self._auth_headers()
+                )
+
+            first_thread = threading.Thread(target=run_first)
+            first_thread.start()
+            deadline = time.monotonic() + 5
+            while not marker_path.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertTrue(marker_path.exists(), "first exec never started")
+
+            second_req = self._exec_request(cmd="true", cmd_id="cmd-second")
+            second_response = client.post(
+                messages.EXEC_PATH, content=second_req.model_dump_json(), headers=self._auth_headers()
+            )
+            self.assertEqual(second_response.status_code, 409)
+
+            first_thread.join(timeout=5)
+            self.assertEqual(responses["first"].status_code, 200)
+            self.assertEqual(messages.ExecResponse(**responses["first"].json()).exit_code, 0)
+
+            third_req = self._exec_request(cmd="true", cmd_id="cmd-third")
+            third_response = client.post(
+                messages.EXEC_PATH, content=third_req.model_dump_json(), headers=self._auth_headers()
+            )
+            self.assertEqual(third_response.status_code, 200)
 
 
 class TestShutdown(HttpAgentTestBase):

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -99,5 +99,109 @@ class TestRegisterAgent(HttpAgentTestBase):
         self.assertEqual(response.status_code, 403)
 
 
+class TestExec(HttpAgentTestBase):
+    def _exec_request(self, **overrides) -> messages.ExecRequest:
+        kwargs = dict(
+            cmd="true",
+            env={},
+            cwd=Path("/tmp"),
+            timeout=None,
+            inactivity_timeout=None,
+            cmd_id="cmd-1",
+            out_path=None,
+            output_mode=messages.ExecOutputMode.EXIT_CODE_ONLY,
+        )
+        kwargs.update(overrides)
+        return messages.ExecRequest(**kwargs)
+
+    def test_exit_code_only_reports_success(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="true")
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertEqual(exec_response.exit_code, 0)
+        self.assertIsNone(exec_response.stdout)
+        self.assertIsNone(exec_response.stdout_path)
+
+    def test_exit_code_only_reports_failure(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="false")
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertEqual(exec_response.exit_code, 1)
+
+    def test_exit_code_only_does_not_deadlock_on_large_output(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="head -c 1000000 /dev/zero | tr '\\0' 'a'")
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(messages.ExecResponse(**response.json()).exit_code, 0)
+
+    def test_file_mode_writes_output_and_returns_preview(self):
+        client = self._make_client(own_rank=0)
+        with tempfile.TemporaryDirectory() as out_dir:
+            out_path = Path(out_dir)
+            req = self._exec_request(
+                cmd="echo hello; echo world 1>&2",
+                cmd_id="cmd-file",
+                out_path=out_path,
+                output_mode=messages.ExecOutputMode.FILE,
+            )
+            response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+            self.assertEqual(response.status_code, 200)
+            exec_response = messages.ExecResponse(**response.json())
+            self.assertEqual(exec_response.exit_code, 0)
+            self.assertEqual(exec_response.stdout, ["hello"])
+            self.assertEqual(exec_response.stderr, ["world"])
+            self.assertEqual((out_path / "cmd-file.stdout").read_text(), "hello\n")
+            self.assertEqual((out_path / "cmd-file.stderr").read_text(), "world\n")
+
+    def test_file_mode_previews_only_trailing_lines(self):
+        client = self._make_client(own_rank=0)
+        with tempfile.TemporaryDirectory() as out_dir:
+            out_path = Path(out_dir)
+            req = self._exec_request(
+                cmd="seq 1 30",
+                cmd_id="cmd-tail",
+                out_path=out_path,
+                output_mode=messages.ExecOutputMode.FILE,
+            )
+            response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+            exec_response = messages.ExecResponse(**response.json())
+            self.assertEqual(exec_response.stdout, [str(n) for n in range(11, 31)])
+            self.assertEqual((out_path / "cmd-tail.stdout").read_text(), "\n".join(str(n) for n in range(1, 31)) + "\n")
+
+    def test_env_is_passed_to_command(self):
+        client = self._make_client(own_rank=0)
+        with tempfile.TemporaryDirectory() as out_dir:
+            out_path = Path(out_dir)
+            req = self._exec_request(
+                cmd="echo $MY_TEST_VAR",
+                cmd_id="cmd-env",
+                out_path=out_path,
+                output_mode=messages.ExecOutputMode.FILE,
+                env={"MY_TEST_VAR": "hello-env"},
+            )
+            response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+            exec_response = messages.ExecResponse(**response.json())
+            self.assertEqual(exec_response.stdout, ["hello-env"])
+
+    def test_cwd_is_passed_to_command(self):
+        client = self._make_client(own_rank=0)
+        with tempfile.TemporaryDirectory() as cwd_dir, tempfile.TemporaryDirectory() as out_dir:
+            req = self._exec_request(
+                cmd="pwd",
+                cmd_id="cmd-cwd",
+                cwd=Path(cwd_dir),
+                out_path=Path(out_dir),
+                output_mode=messages.ExecOutputMode.FILE,
+            )
+            response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+            exec_response = messages.ExecResponse(**response.json())
+            self.assertEqual(exec_response.stdout, [cwd_dir])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -9,14 +9,17 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 # the bearer-token auth dependency, and the /v1/register, /v1/health route behavior.
 
 import asyncio
+import os
+import signal
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from cvs.core.agent import messages
-from cvs.core.agent.http_agent import AgentInfo, AgentRegistry, create_app
+from cvs.core.agent.http_agent import AgentInfo, AgentRegistry, create_app, _terminate_process_group
 
 
 class TestAgentRegistry(unittest.IsolatedAsyncioTestCase):
@@ -43,6 +46,26 @@ class TestAgentRegistry(unittest.IsolatedAsyncioTestCase):
         await registry.register(rank=1, hostname="node1", port=9000)
         with self.assertRaises(asyncio.TimeoutError):
             await registry.wait_until_ready(timeout=0.05)
+
+
+class TestTerminateProcessGroup(unittest.IsolatedAsyncioTestCase):
+    async def test_sends_sigterm_and_awaits_exit(self):
+        process = await asyncio.create_subprocess_shell("sleep 30", start_new_session=True)
+        await _terminate_process_group(process, grace_period=5)
+        self.assertEqual(process.returncode, -signal.SIGTERM)
+
+    async def test_escalates_to_sigkill_when_process_ignores_sigterm(self):
+        process = await asyncio.create_subprocess_shell(
+            "trap '' TERM; echo ready; sleep 30", stdout=asyncio.subprocess.PIPE, start_new_session=True
+        )
+        await process.stdout.readline()  # ensures the trap is installed before we signal the group
+        await _terminate_process_group(process, grace_period=0.2)
+        self.assertEqual(process.returncode, -signal.SIGKILL)
+
+    async def test_no_error_when_process_already_exited(self):
+        process = await asyncio.create_subprocess_shell("true", start_new_session=True)
+        await process.wait()
+        await _terminate_process_group(process, grace_period=1)
 
 
 class HttpAgentTestBase(unittest.TestCase):
@@ -201,6 +224,20 @@ class TestExec(HttpAgentTestBase):
             response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
             exec_response = messages.ExecResponse(**response.json())
             self.assertEqual(exec_response.stdout, [cwd_dir])
+
+
+class TestShutdown(HttpAgentTestBase):
+    def test_shutdown_with_no_running_processes_signals_self_and_returns_ok(self):
+        client = self._make_client(own_rank=0)
+        with patch("cvs.core.agent.http_agent.os.kill") as mock_kill:
+            response = client.post(
+                messages.SHUTDOWN_PATH,
+                content=messages.ShutdownRequest().model_dump_json(),
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(messages.ShutdownResponse(**response.json()).ok)
+        mock_kill.assert_called_once_with(os.getpid(), signal.SIGTERM)
 
 
 if __name__ == "__main__":

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -228,6 +228,77 @@ class TestExec(HttpAgentTestBase):
             self.assertEqual(exec_response.stdout, [cwd_dir])
 
 
+class TestExecTimeouts(HttpAgentTestBase):
+    def _exec_request(self, **overrides) -> messages.ExecRequest:
+        kwargs = dict(
+            cmd="true",
+            env={},
+            cwd=Path("/tmp"),
+            timeout=None,
+            inactivity_timeout=None,
+            cmd_id="cmd-timeout",
+            out_path=None,
+            output_mode=messages.ExecOutputMode.EXIT_CODE_ONLY,
+        )
+        kwargs.update(overrides)
+        return messages.ExecRequest(**kwargs)
+
+    def test_exit_code_only_completes_normally_within_timeout(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="true", timeout=5)
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertFalse(exec_response.timed_out)
+        self.assertEqual(exec_response.exit_code, 0)
+
+    def test_exit_code_only_is_killed_when_timeout_exceeded(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(cmd="sleep 30", timeout=1)
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertTrue(exec_response.timed_out)
+        self.assertEqual(exec_response.exit_code, -signal.SIGTERM)
+
+    def test_inline_mode_captures_partial_output_when_timeout_exceeded(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(
+            cmd="echo partial; sleep 30",
+            timeout=1,
+            output_mode=messages.ExecOutputMode.INLINE,
+        )
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertTrue(exec_response.timed_out)
+        self.assertEqual(exec_response.stdout, ["partial"])
+        self.assertEqual(exec_response.exit_code, -signal.SIGTERM)
+
+    def test_inline_mode_is_killed_after_falling_silent(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(
+            cmd="echo first; sleep 30",
+            inactivity_timeout=1,
+            output_mode=messages.ExecOutputMode.INLINE,
+        )
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertTrue(exec_response.timed_out)
+        self.assertEqual(exec_response.stdout, ["first"])
+        self.assertEqual(exec_response.exit_code, -signal.SIGTERM)
+
+    def test_inline_mode_does_not_time_out_on_output_that_arrives_within_inactivity_window(self):
+        client = self._make_client(own_rank=0)
+        req = self._exec_request(
+            cmd="echo a; sleep 0.3; echo b",
+            inactivity_timeout=5,
+            output_mode=messages.ExecOutputMode.INLINE,
+        )
+        response = client.post(messages.EXEC_PATH, content=req.model_dump_json(), headers=self._auth_headers())
+        exec_response = messages.ExecResponse(**response.json())
+        self.assertFalse(exec_response.timed_out)
+        self.assertEqual(exec_response.stdout, ["a", "b"])
+        self.assertEqual(exec_response.exit_code, 0)
+
+
 class TestInlineExec(HttpAgentTestBase):
     def _exec_request(self, **overrides) -> messages.ExecRequest:
         kwargs = dict(

--- a/cvs/core/agent/unittests/test_messages.py
+++ b/cvs/core/agent/unittests/test_messages.py
@@ -89,6 +89,14 @@ class TestExecRequest(unittest.TestCase):
         restored = parse_message(ExecRequest, req.model_dump_json())
         self.assertEqual(req, restored)
 
+    def test_exit_code_only_mode_rejects_inactivity_timeout(self):
+        with self.assertRaises(ValidationError):
+            ExecRequest(**self._base_kwargs(output_mode=ExecOutputMode.EXIT_CODE_ONLY, inactivity_timeout=10))
+
+    def test_inline_mode_accepts_inactivity_timeout(self):
+        req = ExecRequest(**self._base_kwargs(output_mode=ExecOutputMode.INLINE, inactivity_timeout=10))
+        self.assertEqual(req.inactivity_timeout, 10)
+
 
 class TestExecResponse(unittest.TestCase):
     def test_inline_mode_response(self):
@@ -99,6 +107,7 @@ class TestExecResponse(unittest.TestCase):
             stdout_path=None,
             stderr_path=None,
             truncated=False,
+            timed_out=False,
         )
         self.assertEqual(resp.stdout, ["hi"])
         self.assertIsNone(resp.stdout_path)
@@ -111,6 +120,7 @@ class TestExecResponse(unittest.TestCase):
             stdout_path=Path("/tmp/out/abc123.stdout"),
             stderr_path=Path("/tmp/out/abc123.stderr"),
             truncated=None,
+            timed_out=False,
         )
         self.assertEqual(resp.stdout_path, Path("/tmp/out/abc123.stdout"))
 
@@ -122,6 +132,7 @@ class TestExecResponse(unittest.TestCase):
             stdout_path=None,
             stderr_path=None,
             truncated=None,
+            timed_out=False,
         )
         self.assertEqual(resp.exit_code, 1)
         self.assertIsNone(resp.stdout)

--- a/cvs/core/agent/unittests/test_messages.py
+++ b/cvs/core/agent/unittests/test_messages.py
@@ -29,17 +29,18 @@ from cvs.core.agent.messages import (
 
 class TestRegisterRequest(unittest.TestCase):
     def test_accepts_valid_rank_and_port(self):
-        req = RegisterRequest(rank=1, port=8080)
+        req = RegisterRequest(rank=1, hostname="node1", port=8080)
         self.assertEqual(req.rank, 1)
+        self.assertEqual(req.hostname, "node1")
         self.assertEqual(req.port, 8080)
 
     def test_rejects_negative_rank(self):
         with self.assertRaises(ValidationError):
-            RegisterRequest(rank=-1, port=8080)
+            RegisterRequest(rank=-1, hostname="node1", port=8080)
 
     def test_rejects_out_of_range_port(self):
         with self.assertRaises(ValidationError):
-            RegisterRequest(rank=0, port=70000)
+            RegisterRequest(rank=0, hostname="node1", port=70000)
 
 
 class TestExecRequest(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,5 @@ matplotlib
 
 # scheduler integration
 fastapi>=0.115.0
-uvicorn[standard]>=0.30.0
-httpx >= 0.28.1
+httpx >= 0.28.1  # required by fastapi.testclient.TestClient, used in cvs/core/agent/unittests/test_http_agent.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,9 @@ jinja2
 
 # Headless plotting for training loss-curve PNGs (Agg backend; see cvs/lib/training/jaxmaxtext/utils/loss_curve.py)
 matplotlib
+
+# scheduler integration
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
+httpx >= 0.28.1
+


### PR DESCRIPTION
## Summary
- Implements the per-node HTTP agent (`cvs/core/agent/http_agent.py`) using FastAPI/asyncio, with rank registration, an `/v1/exec` endpoint supporting inline and file-backed output modes, and a shutdown endpoint.
- Adds `ProcessRegistry`/`AgentRegistry` to track spawned processes and registered agents per host, with process-group based termination.
- Adds `timeout` and `inactivity_timeout` handling for exec requests, killing the process group when either fires.
- Updates `cvs/core/agent/messages.py` request/response schemas to support the above.

Jira: [AIMVT-302](https://amd-hub.atlassian.net/browse/AIMVT-302)

## Test plan
- [x] `cvs/core/agent/unittests/test_http_agent.py` covers registration, exec (inline/file modes), timeout/inactivity-timeout, and shutdown paths
- [x] `cvs/core/agent/unittests/test_messages.py` updated for schema changes