### PR TITLE
AIMVT-301: Enable managed HTTP agent mode

### DIFF
--- a/cvs/cli_plugins/run_plugin.py
+++ b/cvs/cli_plugins/run_plugin.py
@@ -3,7 +3,9 @@ import sys
 import os
 import json
 
+from cvs.core.agent.lifecycle import REGISTRATION_TIMEOUT_SECONDS, managed_rank, run_worker, start_rank0
 from cvs.core.run_layout import RunLayout
+from cvs.core.scheduler import is_managed_compute
 
 from .list_plugin import ListPlugin
 
@@ -101,12 +103,12 @@ Run Commands:
         test_file = self._resolve_test_file(args.test)
 
         try:
-            RunLayout.get(args.workspace)
+            layout = RunLayout.get(args.workspace)
         except RuntimeError as e:
             print(f"Error: {e}")
             sys.exit(1)
 
-        self.run_test(
+        test_args = (
             test_file,
             args.function,
             args.cluster_file,
@@ -118,6 +120,27 @@ Run Commands:
             args.capture,
             getattr(args, "extra_pytest_args", []),
         )
+        if not is_managed_compute():
+            return sys.exit(self.run_test(*test_args))
+
+        try:
+            rank, world_size = managed_rank()
+        except RuntimeError as e:
+            print(f"Error: {e}")
+            return sys.exit(1)
+        if rank != 0:
+            return sys.exit(run_worker(layout.agent_dir, rank, world_size))
+
+        coordinator = start_rank0(layout.agent_dir, world_size)
+        try:
+            try:
+                coordinator.wait_for_registrations(REGISTRATION_TIMEOUT_SECONDS)
+            except TimeoutError:
+                print("Warning: registration timeout expired; continuing with available ranks.")
+            exit_code = self.run_test(*test_args)
+        finally:
+            coordinator.close()
+        return sys.exit(exit_code)
 
     def _resolve_test_file(self, test_name):
         """Map a suite name to the file pytest should collect."""
@@ -198,5 +221,4 @@ Run Commands:
         pytest_args.extend(extra_pytest_args)
 
         # Run pytest normally
-        exit_code = pytest.main(pytest_args)
-        sys.exit(exit_code)
+        return pytest.main(pytest_args)

--- a/cvs/cli_plugins/run_plugin.py
+++ b/cvs/cli_plugins/run_plugin.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import sys
 import os
@@ -135,7 +136,7 @@ Run Commands:
         try:
             try:
                 coordinator.wait_for_registrations(REGISTRATION_TIMEOUT_SECONDS)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 print("Warning: registration timeout expired; continuing with available ranks.")
             exit_code = self.run_test(*test_args)
         finally:

--- a/cvs/cli_plugins/unittests/test_run_plugin.py
+++ b/cvs/cli_plugins/unittests/test_run_plugin.py
@@ -290,6 +290,61 @@ class TestRunPluginWorkspace(unittest.TestCase):
         self.assertIn("workspace is not writable", printed)
 
 
+class TestManagedRunPlugin(unittest.TestCase):
+    def setUp(self):
+        self.plugin = RunPlugin()
+        self.args = argparse.Namespace(
+            test="health",
+            function=[],
+            cluster_file="/path/to/cluster.json",
+            config_file="/path/to/config.json",
+            html=None,
+            self_contained_html=False,
+            log_file=None,
+            log_level=None,
+            capture=None,
+            extra_pytest_args=[],
+            workspace="/shared/workspace",
+        )
+
+    def _prepare_run(self):
+        return (
+            patch.object(self.plugin, "_validate_json_config"),
+            patch.object(self.plugin, "_resolve_test_file", return_value="/mock/path/test.py"),
+        )
+
+    @patch("cvs.cli_plugins.run_plugin.sys.exit")
+    @patch("cvs.cli_plugins.run_plugin.run_worker", return_value=0)
+    @patch("cvs.cli_plugins.run_plugin.managed_rank", return_value=(1, 2))
+    @patch("cvs.cli_plugins.run_plugin.is_managed_compute", return_value=True)
+    @patch("cvs.cli_plugins.run_plugin.RunLayout")
+    def test_worker_never_enters_pytest(self, mock_layout, _managed, _rank, mock_worker, mock_exit):
+        mock_layout.get.return_value.agent_dir = "/shared/workspace/agent"
+        validate, resolve = self._prepare_run()
+        with validate, resolve, patch.object(self.plugin, "run_test") as mock_run_test:
+            self.plugin.run(self.args)
+        mock_worker.assert_called_once_with("/shared/workspace/agent", 1, 2)
+        mock_run_test.assert_not_called()
+        mock_exit.assert_called_once_with(0)
+
+    @patch("cvs.cli_plugins.run_plugin.sys.exit")
+    @patch("cvs.cli_plugins.run_plugin.start_rank0")
+    @patch("cvs.cli_plugins.run_plugin.managed_rank", return_value=(0, 2))
+    @patch("cvs.cli_plugins.run_plugin.is_managed_compute", return_value=True)
+    @patch("cvs.cli_plugins.run_plugin.RunLayout")
+    def test_rank0_continues_after_registration_timeout(
+        self, mock_layout, _managed, _rank, mock_start_rank0, mock_exit
+    ):
+        coordinator = mock_start_rank0.return_value
+        coordinator.wait_for_registrations.side_effect = TimeoutError
+        validate, resolve = self._prepare_run()
+        with validate, resolve, patch.object(self.plugin, "run_test", return_value=5) as mock_run_test:
+            self.plugin.run(self.args)
+        mock_run_test.assert_called_once()
+        coordinator.close.assert_called_once()
+        mock_exit.assert_called_once_with(5)
+
+
 class TestResolveTestFunctionNames(unittest.TestCase):
     def setUp(self):
         self.plugin = RunPlugin()

--- a/cvs/cli_plugins/unittests/test_run_plugin.py
+++ b/cvs/cli_plugins/unittests/test_run_plugin.py
@@ -344,6 +344,42 @@ class TestManagedRunPlugin(unittest.TestCase):
         coordinator.close.assert_called_once()
         mock_exit.assert_called_once_with(5)
 
+    @patch("cvs.cli_plugins.run_plugin.sys.exit")
+    @patch("cvs.cli_plugins.run_plugin.start_rank0")
+    @patch("cvs.cli_plugins.run_plugin.managed_rank", return_value=(0, 2))
+    @patch("cvs.cli_plugins.run_plugin.is_managed_compute", return_value=True)
+    @patch("cvs.cli_plugins.run_plugin.RunLayout")
+    def test_rank0_continues_after_legacy_asyncio_timeout(
+        self, mock_layout, _managed, _rank, mock_start_rank0, mock_exit
+    ):
+        class LegacyAsyncioTimeout(Exception):
+            pass
+
+        coordinator = mock_start_rank0.return_value
+        coordinator.wait_for_registrations.side_effect = LegacyAsyncioTimeout
+        validate, resolve = self._prepare_run()
+        with patch("cvs.cli_plugins.run_plugin.asyncio.TimeoutError", LegacyAsyncioTimeout):
+            with validate, resolve, patch.object(self.plugin, "run_test", return_value=0) as mock_run_test:
+                self.plugin.run(self.args)
+        mock_run_test.assert_called_once()
+        coordinator.close.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+    @patch("cvs.cli_plugins.run_plugin.sys.exit")
+    @patch("cvs.cli_plugins.run_plugin.start_rank0")
+    @patch("cvs.cli_plugins.run_plugin.managed_rank", return_value=(0, 2))
+    @patch("cvs.cli_plugins.run_plugin.is_managed_compute", return_value=True)
+    @patch("cvs.cli_plugins.run_plugin.RunLayout")
+    def test_rank0_runs_after_successful_registration(self, mock_layout, _managed, _rank, mock_start_rank0, mock_exit):
+        validate, resolve = self._prepare_run()
+        with validate, resolve, patch.object(self.plugin, "run_test", return_value=7) as mock_run_test:
+            self.plugin.run(self.args)
+        coordinator = mock_start_rank0.return_value
+        coordinator.wait_for_registrations.assert_called_once_with(60)
+        mock_run_test.assert_called_once()
+        coordinator.close.assert_called_once()
+        mock_exit.assert_called_once_with(7)
+
 
 class TestResolveTestFunctionNames(unittest.TestCase):
     def setUp(self):

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -275,7 +275,6 @@ def create_app(
     world_size: int,
     own_hostname: str | None = None,
     own_port: int | None = None,
-    register_timeout: float | None = None,
 ) -> FastAPI:
     '''Build the agent app without blocking startup on rank registration.'''
     if world_rank == 0 and (own_hostname is None or own_port is None):

--- a/cvs/core/agent/http_agent.py
+++ b/cvs/core/agent/http_agent.py
@@ -277,9 +277,7 @@ def create_app(
     own_port: int | None = None,
     register_timeout: float | None = None,
 ) -> FastAPI:
-    '''Build a FastAPI app for one rank's agent process. world_rank gates /v1/register to rank 0 only.
-    Rank 0 additionally self-registers under own_hostname/own_port during startup and blocks until every
-    rank has registered, or register_timeout elapses.'''
+    '''Build the agent app without blocking startup on rank registration.'''
     if world_rank == 0 and (own_hostname is None or own_port is None):
         raise ValueError("own_hostname and own_port are required for rank 0 to self-register")
 
@@ -288,7 +286,6 @@ def create_app(
         app.state.auth_token = _read_secret(agent_dir / messages.AUTH_TOKEN_FILENAME)
         if world_rank == 0:
             await app.state.registry.register(world_rank, own_hostname, own_port)
-            await app.state.registry.wait_until_ready(timeout=register_timeout)
         yield
 
     app = FastAPI(lifespan=lifespan, dependencies=[Depends(verify_auth)])

--- a/cvs/core/agent/lifecycle.py
+++ b/cvs/core/agent/lifecycle.py
@@ -1,0 +1,303 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+import atexit
+import asyncio
+import os
+import secrets
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import uvicorn
+
+from . import messages
+from .http_agent import AgentInfo, create_app
+
+RANK0_HOST_FILENAME = "rank0.host"
+RANK0_PORT_FILENAME = "rank0.port"
+RANK0_ALIVE_FILENAME = "rank0.alive"
+RANK0_HEARTBEAT_INTERVAL_FILENAME = "rank0.heartbeat_interval"
+RANK0_DONE_FILENAME = "rank0.done"
+STARTUP_TIMEOUT_SECONDS = 30
+BOOTSTRAP_TIMEOUT_SECONDS = 60
+REGISTRATION_TIMEOUT_SECONDS = 60
+HEARTBEAT_INTERVAL_SECONDS = 10
+POLL_INTERVAL_SECONDS = 1
+
+
+def _write_file(path: Path, value: str, mode: int = 0o644) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_path = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(value)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary_path, mode)
+        os.replace(temporary_path, path)
+    except OSError:
+        try:
+            os.unlink(temporary_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_file(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def managed_rank() -> tuple[int, int]:
+    try:
+        rank = int(os.environ["SLURM_PROCID"])
+        world_size = int(os.environ["SLURM_NTASKS"])
+    except (KeyError, ValueError) as exc:
+        raise RuntimeError("managed CVS run requires SLURM_PROCID and SLURM_NTASKS") from exc
+    if not 0 <= rank < world_size:
+        raise RuntimeError(f"invalid managed rank {rank} for world size {world_size}")
+    return rank, world_size
+
+
+def clear_rank0_markers(agent_dir: Path) -> None:
+    for filename in (
+        messages.AUTH_TOKEN_FILENAME,
+        RANK0_HOST_FILENAME,
+        RANK0_PORT_FILENAME,
+        RANK0_ALIVE_FILENAME,
+        RANK0_HEARTBEAT_INTERVAL_FILENAME,
+        RANK0_DONE_FILENAME,
+    ):
+        (agent_dir / filename).unlink(missing_ok=True)
+
+
+def write_auth_token(agent_dir: Path) -> None:
+    _write_file(agent_dir / messages.AUTH_TOKEN_FILENAME, f"{secrets.token_hex(32)}\n", mode=0o600)
+
+
+def publish_rank0(agent_dir: Path, host: str, port: int, heartbeat_interval: float) -> None:
+    _write_file(agent_dir / RANK0_HOST_FILENAME, f"{host}\n")
+    _write_file(agent_dir / RANK0_HEARTBEAT_INTERVAL_FILENAME, f"{heartbeat_interval}\n")
+    _write_file(agent_dir / RANK0_PORT_FILENAME, f"{port}\n")
+    touch_alive(agent_dir)
+
+
+def read_rank0_rendezvous(agent_dir: Path) -> tuple[str, int, float]:
+    host = _read_file(agent_dir / RANK0_HOST_FILENAME)
+    port = int(_read_file(agent_dir / RANK0_PORT_FILENAME))
+    heartbeat_interval = float(_read_file(agent_dir / RANK0_HEARTBEAT_INTERVAL_FILENAME))
+    if not host or not 0 < port <= 65535 or heartbeat_interval <= 0:
+        raise ValueError("invalid rank-0 rendezvous")
+    return host, port, heartbeat_interval
+
+
+def touch_alive(agent_dir: Path) -> None:
+    (agent_dir / RANK0_ALIVE_FILENAME).touch()
+
+
+def mark_done(agent_dir: Path) -> None:
+    _write_file(agent_dir / RANK0_DONE_FILENAME, "\n")
+
+
+class Heartbeat:
+    def __init__(self, agent_dir: Path, interval: float):
+        self._agent_dir = agent_dir
+        self._interval = interval
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._thread.join(timeout=self._interval + 1)
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._interval):
+            touch_alive(self._agent_dir)
+
+
+class AgentRunner:
+    '''Run the AIMVT-302 application in the background for one scheduler rank.'''
+
+    def __init__(self, agent_dir: Path, rank: int, world_size: int, host: str | None = None):
+        self.host = host or socket.gethostname()
+        self._socket = socket.socket()
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.bind(("0.0.0.0", 0))
+        self._socket.listen(2048)
+        self.port = self._socket.getsockname()[1]
+        self._app = create_app(
+            agent_dir,
+            rank,
+            world_size,
+            own_hostname=self.host if rank == 0 else None,
+            own_port=self.port if rank == 0 else None,
+        )
+        self._server = uvicorn.Server(uvicorn.Config(self._app, log_level="warning"))
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._event_loop = None
+
+    def _run(self) -> None:
+        asyncio.run(self._serve())
+
+    async def _serve(self) -> None:
+        self._event_loop = asyncio.get_running_loop()
+        await self._server.serve(sockets=[self._socket])
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def wait_until_ready(self, timeout: float) -> int:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._server.started and self._event_loop is not None:
+                return self.port
+            if not self._thread.is_alive():
+                raise RuntimeError("HTTP agent stopped before becoming ready")
+            time.sleep(0.01)
+        raise TimeoutError("HTTP agent did not become ready")
+
+    def wait_for_registrations(self, timeout: float) -> dict[int, AgentInfo]:
+        future = asyncio.run_coroutine_threadsafe(self._app.state.registry.wait_until_ready(timeout), self._event_loop)
+        return future.result(timeout=timeout + 1)
+
+    def stop(self) -> None:
+        self._server.should_exit = True
+        if self._thread.is_alive():
+            self._thread.join(timeout=5)
+        else:
+            self._socket.close()
+
+
+class Rank0Coordinator:
+    def __init__(self, agent_dir: Path, agent: AgentRunner, heartbeat: Heartbeat):
+        self._agent_dir = agent_dir
+        self._agent = agent
+        self._heartbeat = heartbeat
+        self._closed = False
+
+    def wait_for_registrations(self, timeout: float) -> dict:
+        return self._agent.wait_for_registrations(timeout)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._heartbeat.stop()
+        mark_done(self._agent_dir)
+        self._agent.stop()
+
+
+def start_rank0(
+    agent_dir: Path,
+    world_size: int,
+    *,
+    agent_factory=AgentRunner,
+    heartbeat_interval: float = HEARTBEAT_INTERVAL_SECONDS,
+    startup_timeout: float = STARTUP_TIMEOUT_SECONDS,
+) -> Rank0Coordinator:
+    clear_rank0_markers(agent_dir)
+    write_auth_token(agent_dir)
+    agent = agent_factory(agent_dir, 0, world_size)
+    try:
+        agent.start()
+        port = agent.wait_until_ready(startup_timeout)
+        publish_rank0(agent_dir, agent.host, port, heartbeat_interval)
+        heartbeat = Heartbeat(agent_dir, heartbeat_interval)
+        heartbeat.start()
+        coordinator = Rank0Coordinator(agent_dir, agent, heartbeat)
+        atexit.register(coordinator.close)
+        return coordinator
+    except Exception:
+        mark_done(agent_dir)
+        agent.stop()
+        raise
+
+
+def register_worker(endpoint: str, token: str, rank: int, host: str, port: int, timeout: float) -> None:
+    request = messages.RegisterRequest(rank=rank, hostname=host, port=port)
+    deadline = time.monotonic() + timeout
+    headers = {messages.AUTH_HEADER: f"{messages.AUTH_SCHEME} {token}"}
+    with httpx.Client(headers=headers) as client:
+        while (remaining := deadline - time.monotonic()) > 0:
+            try:
+                response = client.post(
+                    f"{endpoint}{messages.REGISTER_PATH}",
+                    json=request.model_dump(),
+                    timeout=min(STARTUP_TIMEOUT_SECONDS, remaining),
+                )
+                response.raise_for_status()
+                return
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code < 500:
+                    raise
+            except httpx.TransportError:
+                pass
+            time.sleep(min(POLL_INTERVAL_SECONDS, max(0, deadline - time.monotonic())))
+    raise TimeoutError("could not register with rank-0 HTTP agent")
+
+
+def wait_for_rendezvous(agent_dir: Path, timeout: float) -> tuple[str, int, float, str]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            host, port, heartbeat_interval = read_rank0_rendezvous(agent_dir)
+            return host, port, heartbeat_interval, _read_file(agent_dir / messages.AUTH_TOKEN_FILENAME)
+        except (OSError, ValueError):
+            time.sleep(POLL_INTERVAL_SECONDS)
+    raise TimeoutError("rank-0 rendezvous did not appear")
+
+
+def watch_rank0(agent_dir: Path, heartbeat_interval: float) -> int:
+    last_progress = time.monotonic()
+    last_mtime_ns = None
+    while True:
+        if (agent_dir / RANK0_DONE_FILENAME).exists():
+            return 0
+        try:
+            mtime_ns = (agent_dir / RANK0_ALIVE_FILENAME).stat().st_mtime_ns
+        except OSError:
+            mtime_ns = None
+        if mtime_ns is not None and mtime_ns != last_mtime_ns:
+            last_mtime_ns = mtime_ns
+            last_progress = time.monotonic()
+        if time.monotonic() - last_progress >= 3 * heartbeat_interval:
+            return 1
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def run_worker(
+    agent_dir: Path,
+    rank: int,
+    world_size: int,
+    *,
+    agent_factory=AgentRunner,
+    bootstrap_timeout: float = BOOTSTRAP_TIMEOUT_SECONDS,
+    startup_timeout: float = STARTUP_TIMEOUT_SECONDS,
+    registration_timeout: float = REGISTRATION_TIMEOUT_SECONDS,
+) -> int:
+    host, rank0_port, heartbeat_interval, token = wait_for_rendezvous(agent_dir, bootstrap_timeout)
+    agent = agent_factory(agent_dir, rank, world_size)
+    try:
+        agent.start()
+        port = agent.wait_until_ready(startup_timeout)
+        register_worker(
+            f"http://{host}:{rank0_port}",
+            token,
+            rank,
+            agent.host,
+            port,
+            registration_timeout,
+        )
+        return watch_rank0(agent_dir, heartbeat_interval)
+    finally:
+        agent.stop()

--- a/cvs/core/agent/lifecycle.py
+++ b/cvs/core/agent/lifecycle.py
@@ -126,10 +126,12 @@ class Heartbeat:
 
 
 class AgentRunner:
-    '''Run the AIMVT-302 application in the background for one scheduler rank.'''
+    '''Run the HTTP agent application in the background for one scheduler rank.'''
 
     def __init__(self, agent_dir: Path, rank: int, world_size: int, host: str | None = None):
-        self.host = host or socket.gethostname()
+        self.host = (
+            host or os.environ.get("SLURM_NODENAME") or os.environ.get("SLURMD_NODENAME") or socket.gethostname()
+        )
         self._socket = socket.socket()
         self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self._socket.bind(("0.0.0.0", 0))

--- a/cvs/core/agent/lifecycle.py
+++ b/cvs/core/agent/lifecycle.py
@@ -1,0 +1,54 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved. This notice is intended as a precaution against inadvertent publication and does not imply publication or any waiver of confidentiality.
+The year included in the foregoing notice is the year of creation of the work.
+All code contained here is Property of Advanced Micro Devices, Inc.
+'''
+
+import os
+import tempfile
+from enum import Enum
+from pathlib import Path
+
+
+STATE_FILENAME = "rank0.state"
+
+
+class Rank0State(str, Enum):
+    STARTING = "STARTING"
+    WAITING_FOR_RANKS = "WAITING_FOR_RANKS"
+    RUNNING = "RUNNING"
+    STOPPING = "STOPPING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+class Rank0StateStore:
+    '''Shared-filesystem query and update API for rank-0 state.'''
+
+    def __init__(self, agent_dir: Path):
+        self.path = agent_dir / STATE_FILENAME
+
+    def get_state(self) -> Rank0State:
+        try:
+            return Rank0State(self.path.read_text(encoding="utf-8").strip())
+        except OSError as exc:
+            raise RuntimeError(f"cannot read rank-0 state: {exc}") from exc
+        except ValueError as exc:
+            raise RuntimeError(f"invalid rank-0 state in {self.path}") from exc
+
+    def update_state(self, state: Rank0State) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary_path = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                stream.write(f"{state.value}\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary_path, self.path)
+        except OSError:
+            try:
+                os.unlink(temporary_path)
+            except OSError:
+                pass
+            raise

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -84,7 +84,6 @@ class HttpAgentTestBase(unittest.TestCase):
             world_size=world_size,
             own_hostname="rank0-host" if world_rank == 0 else None,
             own_port=9000 if world_rank == 0 else None,
-            register_timeout=5.0 if world_rank == 0 else None,
         )
         client = TestClient(app)
         client.__enter__()  # runs the app's lifespan startup so app.state.auth_token is populated
@@ -153,7 +152,6 @@ class TestRankZeroSelfRegistration(HttpAgentTestBase):
             world_size=1,
             own_hostname="rank0-host",
             own_port=9000,
-            register_timeout=1,
         )
         with TestClient(app):
             self.assertEqual(app.state.registry.snapshot(), {0: AgentInfo(hostname="rank0-host", port=9000)})
@@ -165,7 +163,6 @@ class TestRankZeroSelfRegistration(HttpAgentTestBase):
             world_size=2,
             own_hostname="rank0-host",
             own_port=9000,
-            register_timeout=0.05,
         )
         with TestClient(app):
             self.assertEqual(app.state.registry.snapshot(), {0: AgentInfo(hostname="rank0-host", port=9000)})

--- a/cvs/core/agent/unittests/test_http_agent.py
+++ b/cvs/core/agent/unittests/test_http_agent.py
@@ -158,7 +158,7 @@ class TestRankZeroSelfRegistration(HttpAgentTestBase):
         with TestClient(app):
             self.assertEqual(app.state.registry.snapshot(), {0: AgentInfo(hostname="rank0-host", port=9000)})
 
-    def test_rank0_startup_blocks_until_register_timeout_when_other_ranks_never_register(self):
+    def test_rank0_startup_does_not_wait_for_workers(self):
         app = create_app(
             agent_dir=self._agent_dir(),
             world_rank=0,
@@ -167,9 +167,8 @@ class TestRankZeroSelfRegistration(HttpAgentTestBase):
             own_port=9000,
             register_timeout=0.05,
         )
-        with self.assertRaises(asyncio.TimeoutError):
-            with TestClient(app):
-                pass
+        with TestClient(app):
+            self.assertEqual(app.state.registry.snapshot(), {0: AgentInfo(hostname="rank0-host", port=9000)})
 
 
 class TestExec(HttpAgentTestBase):

--- a/cvs/core/agent/unittests/test_lifecycle.py
+++ b/cvs/core/agent/unittests/test_lifecycle.py
@@ -1,0 +1,78 @@
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cvs.core.agent import lifecycle
+
+
+class FakeAgent:
+    def __init__(self, _agent_dir, _rank, _world_size):
+        self.host = "rank0"
+
+    def start(self):
+        pass
+
+    def wait_until_ready(self, _timeout):
+        return 9000
+
+    def wait_for_registrations(self, _timeout):
+        raise TimeoutError
+
+    def stop(self):
+        pass
+
+
+class TestLifecycle(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.agent_dir = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_managed_rank_reads_scheduler_environment(self):
+        with patch.dict(os.environ, {"SLURM_PROCID": "1", "SLURM_NTASKS": "2"}, clear=True):
+            self.assertEqual(lifecycle.managed_rank(), (1, 2))
+
+    def test_rank0_publishes_rendezvous_and_secret(self):
+        coordinator = lifecycle.start_rank0(
+            self.agent_dir,
+            1,
+            agent_factory=FakeAgent,
+            heartbeat_interval=60,
+        )
+        self.addCleanup(coordinator.close)
+        self.assertEqual(lifecycle.read_rank0_rendezvous(self.agent_dir), ("rank0", 9000, 60.0))
+        self.assertEqual(len((self.agent_dir / "secret").read_text(encoding="utf-8").strip()), 64)
+        self.assertEqual(stat.S_IMODE((self.agent_dir / "secret").stat().st_mode), 0o600)
+        coordinator.close()
+        self.assertTrue((self.agent_dir / lifecycle.RANK0_DONE_FILENAME).exists())
+
+    def test_agent_runner_starts_and_registers_rank0(self):
+        lifecycle.write_auth_token(self.agent_dir)
+        agent = lifecycle.AgentRunner(self.agent_dir, rank=0, world_size=1, host="localhost")
+        self.addCleanup(agent.stop)
+        agent.start()
+        self.assertEqual(agent.wait_until_ready(timeout=5), agent.port)
+        self.assertIn(0, agent.wait_for_registrations(timeout=1))
+
+    @patch("cvs.core.agent.lifecycle.httpx.Client")
+    def test_worker_registration_uses_bearer_token(self, mock_client_class):
+        client = mock_client_class.return_value.__enter__.return_value
+        lifecycle.register_worker("http://rank0:9000", "token", 1, "worker1", 9001, timeout=1)
+        mock_client_class.assert_called_once_with(headers={"Authorization": "Bearer token"})
+        self.assertTrue(client.post.call_args.args[0].endswith("/v1/register"))
+        client.post.return_value.raise_for_status.assert_called_once()
+
+    def test_worker_watcher_stops_for_done_or_stale_heartbeat(self):
+        lifecycle.mark_done(self.agent_dir)
+        self.assertEqual(lifecycle.watch_rank0(self.agent_dir, heartbeat_interval=1), 0)
+        (self.agent_dir / lifecycle.RANK0_DONE_FILENAME).unlink()
+        self.assertEqual(lifecycle.watch_rank0(self.agent_dir, heartbeat_interval=0), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/core/agent/unittests/test_lifecycle.py
+++ b/cvs/core/agent/unittests/test_lifecycle.py
@@ -1,0 +1,31 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from cvs.core.agent.lifecycle import Rank0State, Rank0StateStore
+
+
+class TestRank0StateStore(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.store = Rank0StateStore(Path(self.temp_dir.name))
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_update_and_get_state(self):
+        self.store.update_state(Rank0State.STARTING)
+        self.assertEqual(self.store.get_state(), Rank0State.STARTING)
+
+        self.store.update_state(Rank0State.RUNNING)
+        self.assertEqual(self.store.get_state(), Rank0State.RUNNING)
+
+    def test_get_state_rejects_unknown_value(self):
+        self.store.path.write_text("UNKNOWN\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(RuntimeError, "invalid rank-0 state"):
+            self.store.get_state()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/core/agent/unittests/test_lifecycle.py
+++ b/cvs/core/agent/unittests/test_lifecycle.py
@@ -3,7 +3,9 @@ import stat
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import httpx
 
 from cvs.core.agent import lifecycle
 
@@ -59,6 +61,14 @@ class TestLifecycle(unittest.TestCase):
         self.assertEqual(agent.wait_until_ready(timeout=5), agent.port)
         self.assertIn(0, agent.wait_for_registrations(timeout=1))
 
+    @patch("cvs.core.agent.lifecycle.socket.socket")
+    def test_agent_runner_prefers_scheduler_hostname(self, mock_socket):
+        mock_socket.return_value.getsockname.return_value = ("0.0.0.0", 9000)
+        with patch.dict(os.environ, {"SLURM_NODENAME": "scheduler-host"}, clear=True):
+            agent = lifecycle.AgentRunner(self.agent_dir, rank=1, world_size=2)
+        self.addCleanup(agent.stop)
+        self.assertEqual(agent.host, "scheduler-host")
+
     @patch("cvs.core.agent.lifecycle.httpx.Client")
     def test_worker_registration_uses_bearer_token(self, mock_client_class):
         client = mock_client_class.return_value.__enter__.return_value
@@ -66,6 +76,70 @@ class TestLifecycle(unittest.TestCase):
         mock_client_class.assert_called_once_with(headers={"Authorization": "Bearer token"})
         self.assertTrue(client.post.call_args.args[0].endswith("/v1/register"))
         client.post.return_value.raise_for_status.assert_called_once()
+
+    @patch("cvs.core.agent.lifecycle.httpx.Client")
+    @patch("cvs.core.agent.lifecycle.time.sleep")
+    @patch("cvs.core.agent.lifecycle.time.monotonic", return_value=0)
+    def test_worker_registration_retries_transient_failure(self, _monotonic, mock_sleep, mock_client_class):
+        client = mock_client_class.return_value.__enter__.return_value
+        response = MagicMock()
+        response.raise_for_status.side_effect = [
+            httpx.HTTPStatusError("unavailable", request=MagicMock(), response=httpx.Response(503)),
+            None,
+        ]
+        client.post.return_value = response
+
+        lifecycle.register_worker("http://rank0:9000", "token", 1, "worker1", 9001, timeout=1)
+
+        self.assertEqual(client.post.call_count, 2)
+        mock_sleep.assert_called_once_with(lifecycle.POLL_INTERVAL_SECONDS)
+
+    @patch("cvs.core.agent.lifecycle.httpx.Client")
+    @patch("cvs.core.agent.lifecycle.time.sleep")
+    @patch("cvs.core.agent.lifecycle.time.monotonic", return_value=0)
+    def test_worker_registration_retries_connection_failure(self, _monotonic, mock_sleep, mock_client_class):
+        client = mock_client_class.return_value.__enter__.return_value
+        client.post.side_effect = [httpx.ConnectError("down", request=MagicMock()), MagicMock()]
+
+        lifecycle.register_worker("http://rank0:9000", "token", 1, "worker1", 9001, timeout=1)
+
+        self.assertEqual(client.post.call_count, 2)
+        mock_sleep.assert_called_once_with(lifecycle.POLL_INTERVAL_SECONDS)
+
+    @patch("cvs.core.agent.lifecycle.read_rank0_rendezvous", side_effect=[ValueError, ("rank0", 9000, 10)])
+    @patch("cvs.core.agent.lifecycle.time.sleep")
+    @patch("cvs.core.agent.lifecycle.time.monotonic", return_value=0)
+    def test_wait_for_rendezvous_retries_then_succeeds(self, _monotonic, mock_sleep, mock_rendezvous):
+        (self.agent_dir / "secret").write_text("token\n")
+
+        actual = lifecycle.wait_for_rendezvous(self.agent_dir, timeout=1)
+
+        self.assertEqual(actual, ("rank0", 9000, 10, "token"))
+        self.assertEqual(mock_rendezvous.call_count, 2)
+        mock_sleep.assert_called_once_with(lifecycle.POLL_INTERVAL_SECONDS)
+
+    @patch("cvs.core.agent.lifecycle.read_rank0_rendezvous", side_effect=FileNotFoundError)
+    @patch("cvs.core.agent.lifecycle.time.sleep")
+    @patch("cvs.core.agent.lifecycle.time.monotonic", side_effect=[0, 0, 1])
+    def test_wait_for_rendezvous_times_out(self, _monotonic, mock_sleep, _mock_rendezvous):
+        with self.assertRaisesRegex(TimeoutError, "rank-0 rendezvous did not appear"):
+            lifecycle.wait_for_rendezvous(self.agent_dir, timeout=1)
+        mock_sleep.assert_called_once_with(lifecycle.POLL_INTERVAL_SECONDS)
+
+    @patch("cvs.core.agent.lifecycle.watch_rank0", return_value=0)
+    @patch("cvs.core.agent.lifecycle.register_worker")
+    @patch("cvs.core.agent.lifecycle.wait_for_rendezvous", return_value=("rank0", 9000, 10, "token"))
+    def test_worker_starts_registers_and_stops(self, mock_rendezvous, mock_register, mock_watch):
+        agent = MagicMock(host="worker1")
+        agent.wait_until_ready.return_value = 9001
+
+        status = lifecycle.run_worker(self.agent_dir, 1, 2, agent_factory=MagicMock(return_value=agent))
+
+        self.assertEqual(status, 0)
+        mock_rendezvous.assert_called_once_with(self.agent_dir, lifecycle.BOOTSTRAP_TIMEOUT_SECONDS)
+        mock_register.assert_called_once_with("http://rank0:9000", "token", 1, "worker1", 9001, 60)
+        mock_watch.assert_called_once_with(self.agent_dir, 10)
+        agent.stop.assert_called_once()
 
     def test_worker_watcher_stops_for_done_or_stale_heartbeat(self):
         lifecycle.mark_done(self.agent_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,5 @@ matplotlib
 # scheduler integration
 fastapi>=0.115.0
 httpx >= 0.28.1  # required by fastapi.testclient.TestClient, used in cvs/core/agent/unittests/test_http_agent.py
+uvicorn[standard]>=0.30.0
 


### PR DESCRIPTION
## Summary
- route managed `cvs run` ranks into rank-0 coordinator and worker-agent paths
- publish shared authentication, endpoint, heartbeat, and completion markers; workers register and monitor rank 0
- adjust AIMVT-302 `create_app()` so registration waiting no longer blocks FastAPI startup; AIMVT-301 performs that wait after HTTP readiness

## Test plan
- [x] 68 focused tests
- [x] `make fmt-check`
- [x] `make lint`
- [x] `make ut` (1583 passed, 1 skipped)

Jira: [AIMVT-301](https://amd-hub.atlassian.net/browse/AIMVT-301)