### PR TITLE
fix(report): import generate_rundeck from submodule directly

### DIFF
--- a/cvs/lib/report_plugins.py
+++ b/cvs/lib/report_plugins.py
@@ -617,7 +617,7 @@ class HtmlReportManager:
         if not self.is_enabled:
             return
 
-        from cvs.lib.report.rundeck import generate_rundeck
+        from cvs.lib.report.rundeck.generate_rundeck import generate_rundeck
 
         generate_rundeck(session, self)
 


### PR DESCRIPTION
Python resolves submodule names before invoking __getattr__, so `from cvs.lib.report.rundeck import generate_rundeck` returned the module object instead of the function, causing TypeError at session finish.


