### PR TITLE
fix(preflight): handle amd-smi builds that emit concatenated JSON documents

### DIFF
--- a/cvs/lib/preflight/scaleup_fabric.py
+++ b/cvs/lib/preflight/scaleup_fabric.py
@@ -90,14 +90,33 @@ def _walk_dicts(value: Any, inherited_bdf: Optional[str] = None) -> Iterable[Tup
             yield from _walk_dicts(child, inherited_bdf)
 
 
-def _parse_json(output: str, command_name: str) -> Tuple[Optional[Any], List[str]]:
+def _parse_json(output: str, command_name: str) -> Tuple[List[Any], List[str]]:
+    """Decode one or more whitespace-separated top-level JSON documents.
+
+    Some amd-smi builds print multiple JSON documents back-to-back for a
+    single ``list --json`` invocation (e.g. a GPU array followed by an
+    AI-NIC array), which a plain ``json.loads`` rejects as trailing data.
+    """
     raw = (output or "").strip()
     if not raw:
-        return None, [f"{command_name} returned empty output"]
-    try:
-        return json.loads(raw), []
-    except json.JSONDecodeError as exc:
-        return None, [f"{command_name} did not return valid JSON: {exc.msg}"]
+        return [], [f"{command_name} returned empty output"]
+    decoder = json.JSONDecoder()
+    documents: List[Any] = []
+    index = 0
+    length = len(raw)
+    while index < length:
+        while index < length and raw[index].isspace():
+            index += 1
+        if index >= length:
+            break
+        try:
+            document, index = decoder.raw_decode(raw, index)
+        except json.JSONDecodeError as exc:
+            return [], [f"{command_name} did not return valid JSON: {exc.msg}"]
+        documents.append(document)
+    if not documents:
+        return [], [f"{command_name} returned empty output"]
+    return documents, []
 
 
 def parse_afmctl_device_json(output: str) -> Tuple[List[Dict[str, Any]], List[str]]:
@@ -112,27 +131,33 @@ def parse_afmctl_device_json(output: str) -> Tuple[List[Dict[str, Any]], List[st
 
 
 def parse_amd_smi_gpu_json(output: str) -> Tuple[List[Dict[str, Any]], List[str]]:
-    """Return a de-duplicated GPU inventory from ``amd-smi list --json``."""
-    document, errors = _parse_json(output, "amd-smi list --json")
+    """Return a de-duplicated GPU inventory from ``amd-smi list --json``.
+
+    Some amd-smi builds emit the GPU list followed by other device
+    families (e.g. AI-NIC) as a second concatenated JSON document; only
+    records carrying a GPU identifier are counted as GPUs.
+    """
+    documents, errors = _parse_json(output, "amd-smi list --json")
     if errors:
         return [], errors
 
     gpus: List[Dict[str, Any]] = []
     seen = set()
-    for record, inherited_bdf in _walk_dicts(document):
-        flattened = _flatten_values(record)
-        bdf = _normalize_bdf(_first_value(flattened, _BDF_KEYS)) or inherited_bdf
-        gpu_id = _first_value(flattened, _GPU_ID_KEYS)
-        if bdf is None and gpu_id is None:
-            continue
-        # AFM/IFoE BDFs are function .1; AMD-SMI lists GPU function .0.
-        if bdf and not bdf.endswith(".0"):
-            continue
-        identity = bdf or f"gpu:{gpu_id}"
-        if identity in seen:
-            continue
-        seen.add(identity)
-        gpus.append({"bdf": bdf, "gpu_id": gpu_id})
+    for document in documents:
+        for record, inherited_bdf in _walk_dicts(document):
+            flattened = _flatten_values(record)
+            gpu_id = _first_value(flattened, _GPU_ID_KEYS)
+            if gpu_id is None:
+                continue
+            bdf = _normalize_bdf(_first_value(flattened, _BDF_KEYS)) or inherited_bdf
+            # AFM/IFoE BDFs are function .1; AMD-SMI lists GPU function .0.
+            if bdf and not bdf.endswith(".0"):
+                continue
+            identity = bdf or f"gpu:{gpu_id}"
+            if identity in seen:
+                continue
+            seen.add(identity)
+            gpus.append({"bdf": bdf, "gpu_id": gpu_id})
     if not gpus:
         errors.append("amd-smi list JSON contained no GPU descriptors")
     return gpus, errors

--- a/cvs/lib/preflight/unittests/test_scaleup_fabric.py
+++ b/cvs/lib/preflight/unittests/test_scaleup_fabric.py
@@ -125,6 +125,30 @@ class TestMi4xxParsers(unittest.TestCase):
         self.assertEqual(gpus, [])
         self.assertTrue(errors)
 
+    def test_amd_smi_gpu_inventory_ignores_concatenated_ai_nic_document(self):
+        # Some amd-smi builds print the GPU array and an AI-NIC array as two
+        # back-to-back JSON documents on one `list --json` call. The NIC
+        # record has a function-.0 BDF but no GPU identifier and must not be
+        # counted as a 5th GPU.
+        gpu_json = json.dumps(_gpu_inventory()["gpus"])
+        ai_nic_json = json.dumps(
+            [
+                {
+                    "ai_nic": 0,
+                    "bdf": "0005:01:00.0",
+                    "permanent_address": "04:90:81:ad:bd:b8",
+                    "product_name": "Salina 2x400G QSFP112",
+                    "part_number": "DSC3-2Q400-64S64E64P",
+                    "serial_number": "FPK260701BCEC0V2",
+                    "vendor_name": "AMD Pensando Systems, Inc.",
+                }
+            ]
+        )
+        gpus, errors = parse_amd_smi_gpu_json(f"{gpu_json}\n{ai_nic_json}")
+        self.assertEqual(errors, [])
+        self.assertEqual(len(gpus), 4)
+        self.assertEqual({gpu["bdf"] for gpu in gpus}, {f"0000:{i + 1:02x}:00.0" for i in range(4)})
+
     def test_afm_device_json_preserves_accelerator_zero_and_vpod(self):
         devices, errors = parse_afmctl_device_json(json.dumps(_afm_devices()))
         self.assertEqual(errors, [])


### PR DESCRIPTION
## Summary
- On amd-smi 27.0.0 (the build with AI-NIC/Pensando integration), `amd-smi list --json` prints **two concatenated top-level JSON documents** from one call — a GPU array, then an AI-NIC array. `_parse_json()` called plain `json.loads()`, which rejects the trailing document, so `node_health` fails on every node with `did not return valid JSON: Extra data` even though the GPUs are healthy and node-health is a mandatory gate, so this cascades into `ifoe_l2_connectivity`, `transferbench_smoke`, and `rdma_connectivity` all being marked `BLOCKED`.
- Fix has two parts, both in `cvs/lib/preflight/scaleup_fabric.py`:
  1. `_parse_json()` decodes a stream of concatenated documents via `json.JSONDecoder().raw_decode()` in a loop, returning `List[Any]` instead of a single document.
  2. `parse_amd_smi_gpu_json()` skips records with no GPU identifier (`gpu_id is None`) **before** the BDF check. This matters because the AI-NIC record's BDF ends in `.0` — identical in form to a GPU BDF — so it would otherwise pass the existing `.0` filter and be miscounted as an extra GPU (e.g. 5 "GPUs" reported on a 4-GPU node instead of the correct 4).

## Verification
Reproduced on a real 4-GPU Helios-R node (amd-smi `27.0.0+920e5a8a`, ROCm 10.0.0, gfx1250):

```
BEFORE: ['amd-smi list --json did not return valid JSON: Extra data']
AFTER : 4 GPUs, errors=[]
```

End-to-end `preflight_checks`: `1 failed, 10 passed` → `11 passed`.

Single-document output (older amd-smi builds) is unaffected — the loop simply yields one document, and the pre-existing test `test_amd_smi_gpu_inventory_requires_four_descriptors` (single doc, 4 GPUs) still passes unchanged.

## Test plan
- [x] Added regression test `test_amd_smi_gpu_inventory_ignores_concatenated_ai_nic_document` — feeds a GPU array plus a concatenated AI-NIC array, asserts exactly 4 GPUs with the NIC excluded
- [x] Full `cvs/lib/preflight/unittests/test_scaleup_fabric.py` module: 24/24 tests pass
- [x] `make fmt-check` clean