### PR TITLE
fix(preflight): remove hardcoded NIC/GPU count assumptions in health checks

### DIFF
--- a/cvs/lib/linux_utils.py
+++ b/cvs/lib/linux_utils.py
@@ -496,8 +496,9 @@ def get_nic_ethtool_stats_dict(phdl, vendor=None):
           }
 
     Important assumptions and behavior:
-        - Assumes each node in bck_nic_dict has the same number of backend RDMA NICs,
-          and that NICs are accessed by a consistent index across nodes when batching.
+        - Nodes may have different backend RDMA NIC counts (e.g. a downed link). Batches
+          are sized to the largest per-node count; nodes with fewer NICs run a no-op for
+          the extra rounds and are skipped when parsing results for those rounds.
         - Uses grep -v "[" to skip per-queue stats (bracketed) and focus on aggregate totals.
         - Prints warnings (stdout) for non-zero error-like counters; does not raise.
         - Values parsed from ethtool output are kept as strings to preserve the parser behavior.
@@ -511,10 +512,11 @@ def get_nic_ethtool_stats_dict(phdl, vendor=None):
 
     bck_nic_dict = get_backend_rdma_nic_dict(phdl)
 
-    # Derive node list and infer NIC count from the first node
+    # Derive node list. Nodes are not guaranteed to have the same NIC count
+    # (e.g. a downed link drops one node's backend NIC list by one), so the
+    # batch count below is driven by the largest per-node count rather than
+    # assuming every node matches node_list[0].
     node_list = list(bck_nic_dict.keys())
-    node_0 = node_list[0]
-    no_of_nics = len(bck_nic_dict[node_0])
 
     # Initialize the final per-node stats dict
     for node in node_list:
@@ -539,18 +541,28 @@ def get_nic_ethtool_stats_dict(phdl, vendor=None):
             intf_name = node_nic_dict[dev_name]['eth_device']
             eth_dev_dict[node].append(intf_name)
 
-    # For each NIC index, generate one command per node so they can be executed in parallel
+    no_of_nics = max((len(eth_dev_dict[node]) for node in node_list), default=0)
+
+    # For each NIC index, generate one command per node so they can be executed in parallel.
+    # exec_cmd_list pairs cmd_list[k] with the k-th reachable host positionally, so every
+    # batch needs exactly one entry per node even when a node has no interface at this
+    # index; give it a harmless no-op and skip its (nonexistent) result below.
     for i in range(0, no_of_nics):
         cmd_dict[i] = []
         for node in node_list:
-            intf_nam = eth_dev_dict[node][i]
-            cmd_dict[i].append(f'sudo ethtool -S {intf_nam} | grep -v "\[" --color=never')
+            if i < len(eth_dev_dict[node]):
+                intf_nam = eth_dev_dict[node][i]
+                cmd_dict[i].append(f'sudo ethtool -S {intf_nam} | grep -v "\[" --color=never')
+            else:
+                cmd_dict[i].append('true')
 
     # Execute each batch of commands and parse results into stats_dict
     for i in range(0, no_of_nics):
         cmd_list = cmd_dict[i]
         stats_dict_out = phdl.exec_cmd_list(cmd_list)
         for node in stats_dict_out:
+            if i >= len(eth_dev_dict[node]):
+                continue
             intf_nam = eth_dev_dict[node][i]
             stats_dict[node][intf_nam] = convert_ethtool_out_to_dict(stats_dict_out[node], vendor)
 

--- a/cvs/lib/unittests/test_linux_utils.py
+++ b/cvs/lib/unittests/test_linux_utils.py
@@ -1,6 +1,6 @@
 # cvs/lib/unittests/test_linux_utils.py
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import cvs.lib.linux_utils as linux_utils
 
 
@@ -132,6 +132,45 @@ link rdma1/1 state DOWN physical_state LINK_DOWN netdev tw_eth1"""
 
         # Verify non-ACTIVE device is excluded
         self.assertNotIn('rdma1', result['node1'])  # DOWN state
+
+
+class TestGetNicEthtoolStatsDict(unittest.TestCase):
+    def test_asymmetric_nic_counts_across_nodes(self):
+        """Nodes with different backend RDMA NIC counts (e.g. a downed link) must not
+        raise IndexError, and each node's stats must only contain its own interfaces."""
+        mock_phdl = MagicMock()
+
+        bck_nic_dict = {
+            'node1': {
+                'rdma0': {'eth_device': 'eth0'},
+                'rdma1': {'eth_device': 'eth1'},
+            },
+            'node2': {
+                'rdma0': {'eth_device': 'eth2'},
+            },
+        }
+
+        # Batch 0: both nodes have an interface at index 0.
+        # Batch 1: only node1 has a second interface; node2 ran the 'true' no-op.
+        mock_phdl.exec_cmd_list.side_effect = [
+            {'node1': 'rx_errors: 0', 'node2': 'rx_errors: 0'},
+            {'node1': 'rx_errors: 1', 'node2': ''},
+        ]
+
+        with patch.object(linux_utils, 'get_backend_rdma_nic_dict', return_value=bck_nic_dict):
+            result = linux_utils.get_nic_ethtool_stats_dict(mock_phdl)
+
+        self.assertEqual(mock_phdl.exec_cmd_list.call_count, 2)
+
+        self.assertEqual(set(result['node1'].keys()), {'eth0', 'eth1'})
+        self.assertEqual(result['node1']['eth1']['rx_errors'], '1')
+
+        # node2 must only have its single real interface, not a bogus entry
+        # from the 'true' no-op run in the second batch.
+        self.assertEqual(set(result['node2'].keys()), {'eth2'})
+
+        second_batch_cmds = mock_phdl.exec_cmd_list.call_args_list[1].args[0]
+        self.assertEqual(second_batch_cmds[1], 'true')
 
 
 if __name__ == '__main__':

--- a/cvs/lib/unittests/test_verify_lib.py
+++ b/cvs/lib/unittests/test_verify_lib.py
@@ -38,6 +38,43 @@ class TestVerifyGpuPcieBusWidth(unittest.TestCase):
         verify_lib.verify_gpu_pcie_bus_width(phdl, expected_cards=1)
         mock_fail_test.assert_called()
 
+    @patch("cvs.lib.verify_lib.get_gpu_pcie_bus_dict")
+    @patch("cvs.lib.verify_lib.fail_test")
+    def test_auto_detects_expected_cards_when_omitted(self, mock_fail_test, mock_get_bus_dict):
+        """Platforms with fewer than 8 GPUs per node (e.g. a 4-GPU Helios-R tray)
+        must not be judged against a hardcoded expectation when none is given."""
+        mock_get_bus_dict.return_value = {
+            "node1": {"card0": {"PCI Bus": "0000:01:00.0"}, "card1": {"PCI Bus": "0000:02:00.0"}},
+            "node2": {"card0": {"PCI Bus": "0000:03:00.0"}, "card1": {"PCI Bus": "0000:04:00.0"}},
+        }
+
+        phdl = MagicMock()
+        phdl.exec_cmd_list.return_value = {
+            "node1": "LnkSta: Speed 32GT/s, Width x16",
+            "node2": "LnkSta: Speed 32GT/s, Width x16",
+        }
+
+        result = verify_lib.verify_gpu_pcie_bus_width(phdl)
+        self.assertEqual(result, {"node1": [], "node2": []})
+        mock_fail_test.assert_not_called()
+
+    @patch("cvs.lib.verify_lib.get_gpu_pcie_bus_dict")
+    @patch("cvs.lib.verify_lib.fail_test")
+    def test_flags_node_disagreeing_with_auto_detected_count(self, mock_fail_test, mock_get_bus_dict):
+        mock_get_bus_dict.return_value = {
+            "node1": {"card0": {"PCI Bus": "0000:01:00.0"}, "card1": {"PCI Bus": "0000:02:00.0"}},
+            "node2": {"card0": {"PCI Bus": "0000:03:00.0"}},
+        }
+
+        phdl = MagicMock()
+        phdl.exec_cmd_list.return_value = {
+            "node1": "LnkSta: Speed 32GT/s, Width x16",
+            "node2": "LnkSta: Speed 32GT/s, Width x16",
+        }
+
+        verify_lib.verify_gpu_pcie_bus_width(phdl)
+        mock_fail_test.assert_any_call('ERROR !! Number of cards not matching expected no 2 on node node2')
+
 
 class TestVerifyGpuPcieErrors(unittest.TestCase):
     @patch("cvs.lib.verify_lib.get_gpu_metrics_dict")

--- a/cvs/lib/verify_lib.py
+++ b/cvs/lib/verify_lib.py
@@ -158,7 +158,7 @@ def _node_scraper_scan(output_dict, analysis_args=None, source_label='Dmesg'):
     return err_dict
 
 
-def verify_gpu_pcie_bus_width(phdl, expected_cards=8, gpu_pcie_speed=32, gpu_pcie_width=16):
+def verify_gpu_pcie_bus_width(phdl, expected_cards=None, gpu_pcie_speed=32, gpu_pcie_width=16):
     """
     Verify that all GPUs across nodes are operating at the expected PCIe link speed and width.
 
@@ -166,7 +166,11 @@ def verify_gpu_pcie_bus_width(phdl, expected_cards=8, gpu_pcie_speed=32, gpu_pci
       phdl: parallel ssh handle to execute on all nodes:
             - exec_cmd_list(list_of_shell_cmds) -> dict mapping node to command output.
               used when the commands to run can vary from node to node
-      expected_cards (int): Expected number of GPUs per node to validate.
+      expected_cards (int, optional): Expected number of GPUs per node to validate.
+              GPU count per node varies by platform (e.g. 4 on a Helios-R tray,
+              8 on other platforms), so this has no fixed default. If None,
+              it is auto-detected from the first node's actual GPU count and
+              every other node is checked for agreement with that count.
       gpu_pcie_speed (int): Expected PCIe link speed in GT/s (e.g., 32 for PCIe Gen5).
       gpu_pcie_width (int): Expected PCIe link width (e.g., 16 for x16).
 
@@ -201,6 +205,9 @@ def verify_gpu_pcie_bus_width(phdl, expected_cards=8, gpu_pcie_speed=32, gpu_pci
     # Use first node to derive an initial card list (structure validation)
     node_0 = list(out_dict.keys())[0]
     card_list = list(out_dict[node_0].keys())
+
+    if expected_cards is None:
+        expected_cards = len(card_list)
 
     # Check each node has the expected number of GPUs
     for node in out_dict.keys():

--- a/cvs/monitors/check_cluster_health.py
+++ b/cvs/monitors/check_cluster_health.py
@@ -69,12 +69,13 @@ def load_cluster_file(cluster_file_path):
 def general_health_checks(
     phdl,
     start_time_dict=None,
+    expected_gpu_count=None,
 ):
     health_dict = {}
     print('Verify General Health Checks')
     # Check PCIe Bus and Width
     try:
-        health_dict['gpu_pcie_link'] = verify_lib.verify_gpu_pcie_bus_width(phdl)
+        health_dict['gpu_pcie_link'] = verify_lib.verify_gpu_pcie_bus_width(phdl, expected_cards=expected_gpu_count)
     except Exception as e:
         print(f'ERROR running verify_gpu_pcie_bus_width, due to exception {e}')
     # Check Dmesg for errors
@@ -412,6 +413,17 @@ class CheckClusterHealthMonitor(MonitorPlugin):
         parser.add_argument("--key_file", help="SSH private key file (only valid with --hosts_file)")
         parser.add_argument("--iterations", type=int, default=2, help="Number of iterations to run the checks")
         parser.add_argument(
+            "--expected_gpu_count",
+            type=int,
+            default=None,
+            help=(
+                "Expected number of GPUs per node for the PCIe bus/width check. "
+                "GPU count varies by platform (e.g. 4 on a Helios-R tray, 8 on others); "
+                "if omitted, it is auto-detected from the first node and other nodes "
+                "are checked for agreement with that count."
+            ),
+        )
+        parser.add_argument(
             "--time_between_iters", type=int, default=60, help="Time duration to sleep between iterations"
         )
         parser.add_argument("--report_file", default="./cluster_report.html", help="Output HTML report file path")
@@ -482,7 +494,9 @@ class CheckClusterHealthMonitor(MonitorPlugin):
         start_time = phdl.exec('date +"%a %b %e %H:%M:%S"')
 
         # Run general health checks and scan historic errors
-        gen_health_dict = general_health_checks(phdl, start_time_dict=start_time)
+        gen_health_dict = general_health_checks(
+            phdl, start_time_dict=start_time, expected_gpu_count=args.expected_gpu_count
+        )
 
         # Take cluster metrics snapshot before iterations
         snapshot_dict_before = verify_lib.create_cluster_metrics_snapshot(phdl)


### PR DESCRIPTION
## Summary

Follow-up to #375, addressing the two other issues flagged during that review
(hardcoded NIC/GPU count assumptions in the cluster health checks).

- **`get_nic_ethtool_stats_dict()`** (`cvs/lib/linux_utils.py`) derived its
  per-node command batch size from the *first* node's backend RDMA NIC count
  and indexed every other node with it. A cluster where one node has fewer
  NICs than its peers (e.g. a downed link) hit `IndexError`. Batch size is
  now driven by the max count across nodes; nodes short an interface at a
  given index run a harmless `true` no-op for that round and are skipped
  when parsing results.

- **`verify_gpu_pcie_bus_width()`** (`cvs/lib/verify_lib.py`) defaulted
  `expected_cards=8`, and `check_cluster_health.py` always called it with no
  override, so the check unconditionally failed on any platform with a
  different GPU count per node (e.g. a 4-GPU Helios-R tray always reported
  "Number of cards not matching expected no 8"). The default now auto-detects
  the expected count from the first node's actual GPU count; `check_cluster_health`
  also gains an `--expected_gpu_count` flag for explicit override when strict
  enforcement of a known count is wanted.

## Testing

- New unit tests: `test_asymmetric_nic_counts_across_nodes` (linux_utils),
  `test_auto_detects_expected_cards_when_omitted` and
  `test_flags_node_disagreeing_with_auto_detected_count` (verify_lib).
- `make fmt-check` and `make lint` clean (pylint 10.00/10).
- Live-validated against a 2-node Helios-R cluster (4 GPUs/node, 9 backend
  RDMA NICs/node):
  - `verify_gpu_pcie_bus_width(phdl)` with no `expected_cards` now
    auto-detects 4 instead of failing against the hardcoded 8.
  - `get_nic_ethtool_stats_dict(phdl)` runs cleanly across both nodes with
    correct per-node interface sets; no regression on the normal (symmetric)
    path. Both nodes happened to have all links up during this test, so the
    exact asymmetric-count path itself is covered by the unit test rather
    than a live repro (didn't want to force a link down on shared hardware
    to manufacture one).

## Test plan
- [x] `make fmt-check`
- [x] `make lint`
- [x] `python -m unittest cvs.lib.unittests.test_linux_utils cvs.lib.unittests.test_verify_lib`
- [x] Live smoke test against a 2-node cluster (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)