### PR TITLE
Add cvs config command for browsing and copying

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ def test_example(orch, config_dict):
 
 ### Configuration References
 - [cvs/input/cluster_file/README.md](cvs/input/cluster_file/README.md) - Cluster configuration format
-- Sample configs: `cvs copy-config --list` for available templates
+- Sample configs: ``cvs config list-dirs`` and ``cvs config list`` for available templates
 
 ### AMD/ROCm Resources
 - [ROCm Documentation](https://rocm.docs.amd.com/) - ROCm platform documentation

--- a/cvs/cli_plugins/config_files.py
+++ b/cvs/cli_plugins/config_files.py
@@ -1,0 +1,198 @@
+import os
+import shutil
+
+from cvs.extension import ExtensionConfig
+
+CONFIG_EXTENSIONS = (".json", ".yaml", ".sh")
+KNOWN_ROOT_NAMES = ("config_file", "cluster_file", "env_file")
+
+
+def is_config_file(filename):
+    return filename.endswith(CONFIG_EXTENSIONS)
+
+
+def find_config_roots():
+    """
+    Find config directories from cvs and extension packages.
+
+    Searches core cvs input dirs first, then extension packages via extension.ini.
+    """
+    plugin_dir = os.path.dirname(__file__)
+    cvs_dir = os.path.dirname(plugin_dir)
+    roots = []
+
+    for name in KNOWN_ROOT_NAMES:
+        root = os.path.join(cvs_dir, "input", name)
+        if os.path.exists(root):
+            roots.append(root)
+
+    config = ExtensionConfig()
+    for input_dir in config.get_input_dirs():
+        for name in KNOWN_ROOT_NAMES:
+            root = os.path.join(input_dir, name)
+            if os.path.exists(root):
+                roots.append(root)
+
+    return roots
+
+
+def root_name(root_path):
+    return os.path.basename(root_path)
+
+
+def parse_scope(path):
+    """
+    Parse optional root prefix from a user path.
+
+    Returns (root_filter, subpath) where root_filter is None or one of KNOWN_ROOT_NAMES.
+    """
+    normalized = (path or "").strip("/")
+    if not normalized:
+        return None, ""
+
+    parts = normalized.split("/", 1)
+    if parts[0] in KNOWN_ROOT_NAMES:
+        return parts[0], parts[1] if len(parts) > 1 else ""
+    return None, normalized
+
+
+def filter_roots(roots, root_filter):
+    if root_filter is None:
+        return roots
+    return [root for root in roots if root_name(root) == root_filter]
+
+
+def list_config_files(root, subpath):
+    base = os.path.join(root, subpath) if subpath else root
+    if not os.path.exists(base):
+        return []
+
+    result = []
+    for dirpath, _dirs, files in os.walk(base):
+        for filename in files:
+            if is_config_file(filename):
+                rel = os.path.relpath(os.path.join(dirpath, filename), root)
+                result.append(rel)
+    return sorted(result)
+
+
+def find_config_file(roots, subpath):
+    for root in roots:
+        candidate = os.path.join(root, subpath)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def group_files_by_dir(files):
+    grouped = {}
+    for filepath in files:
+        parent = os.path.dirname(filepath)
+        grouped.setdefault(parent, []).append(filepath)
+    for parent in grouped:
+        grouped[parent] = sorted(grouped[parent])
+    return dict(sorted(grouped.items()))
+
+
+def collect_dir_entries(files):
+    """Return (dir_paths, root_level_files) relative to a config root."""
+    dirs = set()
+    root_files = []
+    for filepath in files:
+        parent = os.path.dirname(filepath)
+        if not parent:
+            root_files.append(filepath)
+        else:
+            dirs.add(parent)
+    return sorted(dirs), sorted(root_files)
+
+
+def group_dirs_by_first_segment(dir_paths):
+    groups = {}
+    for dir_path in dir_paths:
+        first = dir_path.split("/", 1)[0]
+        entry = f"{dir_path}/"
+        groups.setdefault(first, []).append(entry)
+    for first in groups:
+        groups[first] = sorted(groups[first])
+    return dict(sorted(groups.items()))
+
+
+def copy_all_configs(roots, output_dir, force=False):
+    if not output_dir:
+        print("Error: --output required when using --all")
+        return False
+
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+    except OSError as exc:
+        print(f"Error creating output directory {output_dir}: {exc}")
+        return False
+
+    copied_count = 0
+    for root in roots:
+        label = root_name(root)
+        configs = list_config_files(root, "")
+        for config in configs:
+            src = os.path.join(root, config)
+            dest = os.path.join(output_dir, label, config)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            if os.path.exists(dest) and not force:
+                print(f"Error: File {dest} already exists. Use --force to overwrite.")
+                return False
+            try:
+                shutil.copyfile(src, dest)
+                copied_count += 1
+            except OSError as exc:
+                print(f"Error copying {src} to {dest}: {exc}")
+                return False
+
+    print(f"Copied {copied_count} config files to {output_dir}")
+    return True
+
+
+def copy_single_config(roots, subpath, output, force=False):
+    if not subpath:
+        print("Error: path to config file required for copying")
+        return False
+
+    config_file = find_config_file(roots, subpath)
+    if not config_file:
+        print(f"Config file not found: {subpath}")
+        return False
+
+    if os.path.isdir(output):
+        dest = os.path.join(output, os.path.basename(config_file))
+    else:
+        dest = output
+
+    dest_dir = os.path.dirname(dest)
+    if dest_dir:
+        os.makedirs(dest_dir, exist_ok=True)
+
+    if os.path.exists(dest) and not force:
+        print(f"Error: File {dest} already exists. Use --force to overwrite.")
+        return False
+
+    try:
+        shutil.copyfile(config_file, dest)
+        print(f"Copied {config_file} to {dest}")
+        return True
+    except OSError as exc:
+        print(f"Error copying {config_file} to {dest}: {exc}")
+        return False
+
+
+def print_flat_config_list(roots, subpath):
+    found = False
+    for root in roots:
+        configs = list_config_files(root, subpath)
+        if configs:
+            display_path = os.path.join(root, subpath) if subpath else root
+            print(f"Configs under {display_path}:")
+            for config in configs:
+                print(f"  {config}")
+            found = True
+    if not found:
+        print("No config files found at the specified path.")
+    return found

--- a/cvs/cli_plugins/config_plugin.py
+++ b/cvs/cli_plugins/config_plugin.py
@@ -1,0 +1,209 @@
+import sys
+
+from .base import SubcommandPlugin
+from . import config_files
+
+CONFIG_COMMANDS = (
+    ("list", "List config files grouped by directory"),
+    ("list-dirs", "List config directories grouped by category"),
+    ("copy", "Copy bundled config file(s) to --output"),
+)
+
+
+class ConfigPlugin(SubcommandPlugin):
+    def get_name(self):
+        return "config"
+
+    def get_parser(self, subparsers):
+        parser = subparsers.add_parser(
+            "config",
+            help="Browse or copy bundled CVS config templates",
+        )
+        config_subparsers = parser.add_subparsers(dest="config_command")
+
+        config_subparsers.add_parser(
+            "list",
+            help=CONFIG_COMMANDS[0][1],
+        ).add_argument(
+            "path",
+            nargs="?",
+            default="",
+            help="Optional path scope (e.g. configDir1 or configDir1/configDir2)",
+        )
+
+        config_subparsers.add_parser(
+            "list-dirs",
+            help=CONFIG_COMMANDS[1][1],
+        ).add_argument(
+            "path",
+            nargs="?",
+            default="",
+            help="Optional path scope (e.g. configDir1 or rootName/configDir1)",
+        )
+
+        copy_parser = config_subparsers.add_parser(
+            "copy",
+            help=CONFIG_COMMANDS[2][1],
+        )
+        copy_parser.add_argument(
+            "path",
+            nargs="?",
+            help="Path to config file (required unless --all)",
+        )
+        copy_parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Copy all config files preserving directory structure",
+        )
+        copy_parser.add_argument(
+            "--output",
+            required=True,
+            help="Destination path to copy config file(s)",
+        )
+        copy_parser.add_argument("--force", action="store_true", help="Force overwrite of existing files")
+        copy_parser.prog = "cvs config copy"
+
+        self._copy_parser = copy_parser
+        parser.set_defaults(_plugin=self)
+        return parser
+
+    def get_epilog(self):
+        return """
+Config Commands:
+  cvs config                                           List available config commands
+  cvs config list-dirs                                 List config directories by category
+  cvs config list-dirs <configDir1>                    List directories under a category
+  cvs config list                                      List all config files grouped by directory
+  cvs config list <configDir1>/<configDir2>            List config files under a directory
+  cvs config copy --all --output <destDir>             Copy all bundled configs
+  cvs config copy <configPath> --output <dest>         Copy a specific config file
+  cvs config copy --all --output <destDir> --force     Copy all bundled configs, overwrite existing"""
+
+    def _print_command_catalog(self):
+        print("Available config commands:")
+        for name, description in CONFIG_COMMANDS:
+            print(f"  {name} - {description}")
+
+    def run(self, args):
+        command = getattr(args, "config_command", None)
+        if command == "list":
+            self._run_list(args.path or "")
+        elif command == "list-dirs":
+            self._run_list_dirs(args.path or "")
+        elif command == "copy":
+            self._run_copy(args)
+        else:
+            self._print_command_catalog()
+
+    def _scoped_roots(self, path):
+        root_filter, subpath = config_files.parse_scope(path)
+        roots = config_files.filter_roots(config_files.find_config_roots(), root_filter)
+        return roots, subpath, root_filter
+
+    def _is_scoped(self, path, root_filter):
+        return bool(path) and root_filter is None
+
+    def _run_list_dirs(self, path):
+        roots, subpath, root_filter = self._scoped_roots(path)
+        scoped = self._is_scoped(path, root_filter)
+        found = False
+        root_results = []
+
+        for root in roots:
+            files = config_files.list_config_files(root, subpath)
+            if not files:
+                continue
+
+            found = True
+            label = config_files.root_name(root)
+            dir_paths, root_files = config_files.collect_dir_entries(files)
+            root_results.append((label, dir_paths, root_files))
+
+        if not found:
+            print("No config directories found at the specified path.")
+            return
+
+        show_root_headers = not scoped or len(root_results) > 1
+
+        for root_idx, (label, dir_paths, root_files) in enumerate(root_results):
+            if root_idx > 0:
+                print()
+
+            if show_root_headers:
+                print(f"{label}_dirs:")
+
+            if dir_paths:
+                if scoped:
+                    for dir_path in dir_paths:
+                        prefix = "  " if show_root_headers else ""
+                        print(f"{prefix}{dir_path}/")
+                else:
+                    groups = config_files.group_dirs_by_first_segment(dir_paths)
+                    for group_idx, (group_name, entries) in enumerate(groups.items()):
+                        if group_idx > 0:
+                            print()
+                        print(f"  {group_name}:")
+                        for entry in entries:
+                            print(f"    {entry}")
+
+            if root_files:
+                prefix = "  " if show_root_headers or not scoped else ""
+                for entry in root_files:
+                    print(f"{prefix}{entry}")
+
+    def _run_list(self, path):
+        roots, subpath, root_filter = self._scoped_roots(path)
+        scoped = self._is_scoped(path, root_filter)
+        root_results = []
+
+        for root in roots:
+            files = config_files.list_config_files(root, subpath)
+            if not files:
+                continue
+
+            label = config_files.root_name(root)
+            grouped = config_files.group_files_by_dir(files)
+            root_results.append((label, grouped))
+
+        if not root_results:
+            print("No config files found at the specified path.")
+            return
+
+        show_root_headers = not scoped or len(root_results) > 1
+
+        for root_idx, (label, grouped) in enumerate(root_results):
+            if root_idx > 0:
+                print()
+
+            if show_root_headers:
+                print(f"{label}:")
+
+            for group_idx, (parent, filepaths) in enumerate(grouped.items()):
+                if group_idx > 0:
+                    print()
+
+                if not parent:
+                    for filepath in filepaths:
+                        prefix = "  " if show_root_headers or not scoped else ""
+                        print(f"{prefix}{filepath}")
+                else:
+                    prefix = "  " if show_root_headers or not scoped else ""
+                    print(f"{prefix}{parent}:")
+                    for filepath in filepaths:
+                        inner = "    " if show_root_headers or not scoped else "  "
+                        print(f"{inner}{filepath}")
+
+    def _run_copy(self, args):
+        path = args.path or ""
+
+        if not args.all and not path:
+            self._copy_parser.print_help()
+            sys.exit(2)
+
+        roots = config_files.find_config_roots()
+
+        if args.all:
+            config_files.copy_all_configs(roots, args.output, force=args.force)
+            return
+
+        config_files.copy_single_config(roots, path, args.output, force=args.force)

--- a/cvs/cli_plugins/copy_config_plugin.py
+++ b/cvs/cli_plugins/copy_config_plugin.py
@@ -1,7 +1,10 @@
+import sys
+import warnings
+
 from .base import SubcommandPlugin
-from cvs.extension import ExtensionConfig
-import os
-import shutil
+from . import config_files
+
+COPY_CONFIG_LIST_DEPRECATION = "copy-config --list is deprecated; use 'cvs config list' or 'cvs config list-dirs'"
 
 
 class CopyConfigPlugin(SubcommandPlugin):
@@ -15,7 +18,7 @@ class CopyConfigPlugin(SubcommandPlugin):
         parser.add_argument(
             "path",
             nargs="?",
-            help="Path to config file (e.g. training/jaxmaxtext/mi325x_jaxmaxtext_llama-3.1-405b_distributed.json)",
+            help="Path to config file (e.g. configDir1/config1.json)",
         )
         parser.add_argument("--all", action="store_true", help="Copy all config files preserving directory structure")
         parser.add_argument("--output", help="Destination path to copy config file(s)")
@@ -31,143 +34,32 @@ class CopyConfigPlugin(SubcommandPlugin):
     def get_epilog(self):
         return """
 Copy-Config Commands:
-  cvs copy-config                   List all available config files
-  cvs copy-config training          List configs in training directory
-  cvs copy-config training/jaxmaxtext   List configs in training/jaxmaxtext directory
-  cvs copy-config --list            Same as above (list all)
-  cvs copy-config training --list   Same as above (list training)
+  cvs copy-config                         List all available config files (deprecated: use cvs config list)
+  cvs copy-config <configDir1>            List configs in a directory
+  cvs copy-config --list                  Same as above (list all)
+  cvs copy-config <configDir1> --list     Same as above (list directory)
 
-  Note: --list is optional, same behavior without it
-  
-  cvs copy-config --all --output /tmp/cvs/input/                          Copy all config files preserving directory structure
-  cvs copy-config training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json --output ~/cfg.json   Copy specific config file
-  cvs copy-config --all --output /tmp/cvs/input/ --force                  Force overwrite existing files"""
+  Note: prefer cvs config list / cvs config list-dirs for browsing templates
 
-    def _find_config_root(self):
-        """
-        Find config directories from cvs and extension packages.
+  cvs copy-config --all --output <destDir>              Copy all config files preserving directory structure
+  cvs copy-config <configPath> --output <dest>          Copy a specific config file
+  cvs copy-config --all --output <destDir> --force        Force overwrite existing files"""
 
-        Searches for config directories in:
-        1. Core cvs package (cvs/input/config_file, cvs/input/cluster_file, cvs/input/env_file)
-        2. Extension packages configured via extension.ini (e.g., cvs_extension/input)
-        """
-        plugin_dir = os.path.dirname(__file__)
-        cvs_dir = os.path.dirname(plugin_dir)  # cvs/
-        config_root = os.path.join(cvs_dir, "input", "config_file")
-        cluster_root = os.path.join(cvs_dir, "input", "cluster_file")
-        env_root = os.path.join(cvs_dir, "input", "env_file")
-        roots = []
-
-        # Add core cvs config directories
-        if os.path.exists(config_root):
-            roots.append(config_root)
-        if os.path.exists(cluster_root):
-            roots.append(cluster_root)
-        if os.path.exists(env_root):
-            roots.append(env_root)
-
-        # Add extension config directories
-        config = ExtensionConfig()
-        for input_dir in config.get_input_dirs():
-            config_file_dir = os.path.join(input_dir, "config_file")
-            cluster_file_dir = os.path.join(input_dir, "cluster_file")
-            env_file_dir = os.path.join(input_dir, "env_file")
-
-            if os.path.exists(config_file_dir):
-                roots.append(config_file_dir)
-            if os.path.exists(cluster_file_dir):
-                roots.append(cluster_file_dir)
-            if os.path.exists(env_file_dir):
-                roots.append(env_file_dir)
-
-        return roots
-
-    def _list_configs(self, root, subpath):
-        base = os.path.join(root, subpath) if subpath else root
-        if not os.path.exists(base):
-            return []
-        result = []
-        for dirpath, dirs, files in os.walk(base):
-            for f in files:
-                if f.endswith(".json") or f.endswith(".yaml") or f.endswith(".sh"):
-                    rel = os.path.relpath(os.path.join(dirpath, f), root)
-                    result.append(rel)
-        return sorted(result)
-
-    def _find_config_file(self, roots, subpath):
-        for root in roots:
-            candidate = os.path.join(root, subpath)
-            if os.path.isfile(candidate):
-                return candidate
-        return None
+    def _warn_list_deprecated(self):
+        warnings.warn(COPY_CONFIG_LIST_DEPRECATION, DeprecationWarning, stacklevel=3)
+        print(COPY_CONFIG_LIST_DEPRECATION, file=sys.stderr)
 
     def run(self, args):
-        roots = self._find_config_root()
+        roots = config_files.find_config_roots()
         path = args.path or ""
 
         if args.all:
-            if not args.output:
-                print("Error: --output required when using --all")
-                return
-            # Create output directory if it doesn't exist
-            try:
-                os.makedirs(args.output, exist_ok=True)
-            except Exception as e:
-                print(f"Error creating output directory {args.output}: {e}")
-                return
-            copied_count = 0
-            for root in roots:
-                root_name = os.path.basename(root)
-                configs = self._list_configs(root, "")
-                for config in configs:
-                    src = os.path.join(root, config)
-                    dest = os.path.join(args.output, root_name, config)
-                    os.makedirs(os.path.dirname(dest), exist_ok=True)
-                    # Check for existing files
-                    if os.path.exists(dest) and not args.force:
-                        print(f"Error: File {dest} already exists. Use --force to overwrite.")
-                        return
-                    try:
-                        shutil.copyfile(src, dest)
-                        copied_count += 1
-                    except Exception as e:
-                        print(f"Error copying {src} to {dest}: {e}")
-            print(f"Copied {copied_count} config files to {args.output}")
+            config_files.copy_all_configs(roots, args.output, force=args.force)
             return
 
         if args.list or not args.output:
-            found = False
-            for root in roots:
-                configs = self._list_configs(root, path)
-                if configs:
-                    display_path = os.path.join(root, path) if path else root
-                    print(f"Configs under {display_path}:")
-                    for c in configs:
-                        print(f"  {c}")
-                    found = True
-            if not found:
-                print("No config files found at the specified path.")
+            self._warn_list_deprecated()
+            config_files.print_flat_config_list(roots, path)
             return
-        else:
-            if not path:
-                print("Error: path to config file required for copying")
-                return
 
-            config_file = self._find_config_file(roots, path)
-            if not config_file:
-                print(f"Config file not found: {path}")
-                return
-            if os.path.isdir(args.output):
-                dest = os.path.join(args.output, os.path.basename(config_file))
-            else:
-                dest = args.output
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
-            # Check for existing files
-            if os.path.exists(dest) and not args.force:
-                print(f"Error: File {dest} already exists. Use --force to overwrite.")
-                return
-            try:
-                shutil.copyfile(config_file, dest)
-                print(f"Copied {config_file} to {dest}")
-            except Exception as e:
-                print(f"Error copying {config_file} to {dest}: {e}")
+        config_files.copy_single_config(roots, path, args.output, force=args.force)

--- a/cvs/cli_plugins/unittests/test_config_files.py
+++ b/cvs/cli_plugins/unittests/test_config_files.py
@@ -1,0 +1,93 @@
+import os
+import tempfile
+import unittest
+
+from cvs.cli_plugins import config_files
+
+
+class TestConfigFiles(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import cvs
+
+        cvs_dir = os.path.dirname(cvs.__file__)
+        cls.expected_roots = [
+            os.path.join(cvs_dir, "input", "config_file"),
+            os.path.join(cvs_dir, "input", "cluster_file"),
+            os.path.join(cvs_dir, "input", "env_file"),
+        ]
+
+    def test_find_config_roots(self):
+        roots = config_files.find_config_roots()
+        self.assertEqual(sorted(roots), sorted(self.expected_roots))
+
+    def test_parse_scope_with_root_prefix(self):
+        root_filter, subpath = config_files.parse_scope("config_file/rccl")
+        self.assertEqual(root_filter, "config_file")
+        self.assertEqual(subpath, "rccl")
+
+    def test_parse_scope_without_root_prefix(self):
+        root_filter, subpath = config_files.parse_scope("training/torchtitan")
+        self.assertIsNone(root_filter)
+        self.assertEqual(subpath, "training/torchtitan")
+
+    def test_group_files_by_dir(self):
+        grouped = config_files.group_files_by_dir(
+            [
+                "training/jax/a.json",
+                "training/jax/b.json",
+                "cluster.json",
+            ]
+        )
+        self.assertEqual(grouped["training/jax"], ["training/jax/a.json", "training/jax/b.json"])
+        self.assertEqual(grouped[""], ["cluster.json"])
+
+    def test_group_dirs_by_first_segment(self):
+        groups = config_files.group_dirs_by_first_segment(["training/jax", "training/torchtitan", "inference/atom"])
+        self.assertEqual(
+            groups["training"],
+            ["training/jax/", "training/torchtitan/"],
+        )
+        self.assertEqual(groups["inference"], ["inference/atom/"])
+
+    def test_collect_dir_entries(self):
+        dirs, root_files = config_files.collect_dir_entries(["rccl/rccl_config.json", "cluster.json"])
+        self.assertEqual(dirs, ["rccl"])
+        self.assertEqual(root_files, ["cluster.json"])
+
+    def test_list_config_files_training_scope(self):
+        root = self.expected_roots[0]
+        files = config_files.list_config_files(root, "training/torchtitan")
+        self.assertTrue(files)
+        self.assertTrue(all(path.startswith("training/torchtitan/") for path in files))
+
+    def test_find_config_file(self):
+        found = config_files.find_config_file(
+            self.expected_roots,
+            "platform/host_config.json",
+        )
+        self.assertIsNotNone(found)
+        self.assertTrue(os.path.isfile(found))
+
+    def test_copy_single_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = os.path.join(tmpdir, "host_config.json")
+            ok = config_files.copy_single_config(
+                self.expected_roots,
+                "platform/host_config.json",
+                dest,
+            )
+            self.assertTrue(ok)
+            self.assertTrue(os.path.exists(dest))
+
+    def test_copy_all_configs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ok = config_files.copy_all_configs(self.expected_roots, tmpdir)
+            self.assertTrue(ok)
+            for root in self.expected_roots:
+                label = os.path.basename(root)
+                self.assertTrue(os.path.isdir(os.path.join(tmpdir, label)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/cli_plugins/unittests/test_config_plugin.py
+++ b/cvs/cli_plugins/unittests/test_config_plugin.py
@@ -1,0 +1,191 @@
+import argparse
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+import cvs.main as main
+from cvs.cli_plugins.config_plugin import ConfigPlugin
+
+
+class TestConfigPlugin(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import cvs
+
+        cvs_dir = os.path.dirname(cvs.__file__)
+        cls.expected_roots = [
+            os.path.join(cvs_dir, "input", "config_file"),
+            os.path.join(cvs_dir, "input", "cluster_file"),
+            os.path.join(cvs_dir, "input", "env_file"),
+        ]
+
+    def setUp(self):
+        self.plugin = ConfigPlugin()
+        subparsers = argparse.ArgumentParser().add_subparsers()
+        self.plugin.get_parser(subparsers)
+
+    def test_bare_config_shows_catalog(self):
+        captured = io.StringIO()
+        with redirect_stdout(captured):
+            self.plugin.run(argparse.Namespace(config_command=None))
+        output = captured.getvalue()
+        self.assertIn("Available config commands:", output)
+        self.assertIn("list - List config files grouped by directory", output)
+        self.assertIn("list-dirs - List config directories grouped by category", output)
+        self.assertIn("copy - Copy bundled config file(s) to --output", output)
+
+    def test_bare_config_copy_requires_output(self):
+        parser = main.build_arg_parser(main.discover_plugins())
+        with self.assertRaises(SystemExit) as exc:
+            with redirect_stdout(io.StringIO()):
+                parser.parse_args(["config", "copy"])
+        self.assertEqual(exc.exception.code, 2)
+
+    def test_config_copy_missing_path_shows_help(self):
+        captured = io.StringIO()
+        with redirect_stdout(captured):
+            with self.assertRaises(SystemExit) as exc:
+                self.plugin.run(
+                    argparse.Namespace(
+                        config_command="copy",
+                        path=None,
+                        output="/tmp/out",
+                        all=False,
+                        force=False,
+                    )
+                )
+        self.assertEqual(exc.exception.code, 2)
+        self.assertIn("usage: cvs config copy", captured.getvalue())
+        self.assertIn("--output OUTPUT", captured.getvalue())
+
+    def test_list_dirs_unscoped(self):
+        captured = io.StringIO()
+        with redirect_stdout(captured):
+            self.plugin.run(argparse.Namespace(config_command="list-dirs", path=""))
+        output = captured.getvalue()
+        self.assertIn("config_file_dirs:", output)
+        self.assertNotIn("config_file:\n", output)
+        self.assertIn("training/jaxmaxtext/", output)
+        self.assertIn("inference/atom/", output)
+        self.assertIn("cluster_file_dirs:", output)
+        self.assertIn("cluster.json", output)
+
+    def test_list_dirs_training_scoped(self):
+        captured = io.StringIO()
+        with redirect_stdout(captured):
+            self.plugin.run(argparse.Namespace(config_command="list-dirs", path="training"))
+        output = captured.getvalue()
+        self.assertIn("training/jaxmaxtext/", output)
+        self.assertIn("training/torchtitan/", output)
+        self.assertNotIn("inference/atom/", output)
+        self.assertNotIn("config_file_dirs:", output)
+
+    def test_list_dirs_rccl_shows_both_roots(self):
+        captured = io.StringIO()
+        with redirect_stdout(captured):
+            self.plugin.run(argparse.Namespace(config_command="list-dirs", path="rccl"))
+        output = captured.getvalue()
+        self.assertIn("config_file_dirs:", output)
+        self.assertIn("env_file_dirs:", output)
+        self.assertEqual(output.count("rccl/"), 2)
+
+    def test_list_torchtitan_scoped(self):
+        captured = io.StringIO()
+        with redirect_stdout(captured):
+            self.plugin.run(argparse.Namespace(config_command="list", path="training/torchtitan"))
+        output = captured.getvalue()
+        self.assertIn("training/torchtitan:", output)
+        self.assertIn("training/torchtitan/mi355x_torchtitan_llama-3.1-8b_single.json", output)
+        self.assertNotIn("inference/atom/", output)
+        self.assertNotIn("config_file:", output)
+
+    def test_copy_single_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = os.path.join(tmpdir, "host_config.json")
+            captured = io.StringIO()
+            with redirect_stdout(captured):
+                self.plugin.run(
+                    argparse.Namespace(
+                        config_command="copy",
+                        path="platform/host_config.json",
+                        output=dest,
+                        all=False,
+                        force=False,
+                    )
+                )
+            self.assertTrue(os.path.exists(dest))
+            self.assertIn("Copied", captured.getvalue())
+
+    def test_copy_all(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            captured = io.StringIO()
+            with redirect_stdout(captured):
+                self.plugin.run(
+                    argparse.Namespace(
+                        config_command="copy",
+                        path=None,
+                        output=tmpdir,
+                        all=True,
+                        force=False,
+                    )
+                )
+            for expected_root in self.expected_roots:
+                label = os.path.basename(expected_root)
+                self.assertTrue(os.path.isdir(os.path.join(tmpdir, label)))
+            self.assertIn("Copied", captured.getvalue())
+
+    def test_copy_all_without_output_errors(self):
+        parser = main.build_arg_parser(main.discover_plugins())
+        with self.assertRaises(SystemExit) as exc:
+            with redirect_stdout(io.StringIO()):
+                parser.parse_args(["config", "copy", "--all"])
+        self.assertEqual(exc.exception.code, 2)
+
+    def test_copy_overwrite_requires_force(self):
+        test_config_path = "training/jaxmaxtext/mi300x_jaxmaxtext_llama-3.3-70b_distributed.json"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dest = os.path.join(tmpdir, "cfg.json")
+            self.plugin.run(
+                argparse.Namespace(
+                    config_command="copy",
+                    path=test_config_path,
+                    output=dest,
+                    all=False,
+                    force=False,
+                )
+            )
+            with open(dest, "w", encoding="utf-8") as handle:
+                handle.write('{"modified": true}')
+
+            captured = io.StringIO()
+            with redirect_stdout(captured):
+                self.plugin.run(
+                    argparse.Namespace(
+                        config_command="copy",
+                        path=test_config_path,
+                        output=dest,
+                        all=False,
+                        force=False,
+                    )
+                )
+            self.assertIn("already exists", captured.getvalue())
+
+            with redirect_stdout(io.StringIO()):
+                self.plugin.run(
+                    argparse.Namespace(
+                        config_command="copy",
+                        path=test_config_path,
+                        output=dest,
+                        all=False,
+                        force=True,
+                    )
+                )
+            with open(dest, encoding="utf-8") as handle:
+                content = handle.read()
+            self.assertNotIn('"modified": true', content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/cli_plugins/unittests/test_copy_config_plugin.py
+++ b/cvs/cli_plugins/unittests/test_copy_config_plugin.py
@@ -1,12 +1,13 @@
 import unittest
-from unittest.mock import patch
+import warnings
 import os
 import tempfile
 import argparse
 import io
-from contextlib import redirect_stdout
+from contextlib import redirect_stdout, redirect_stderr
 
 from cvs.cli_plugins.copy_config_plugin import CopyConfigPlugin
+from cvs.cli_plugins import config_files
 
 
 class TestCopyConfigPlugin(unittest.TestCase):
@@ -27,13 +28,12 @@ class TestCopyConfigPlugin(unittest.TestCase):
 
     def test_find_config_root(self):
         """Test finding config root directories"""
-        roots = self.plugin._find_config_root()
+        roots = config_files.find_config_roots()
 
         # Should match the expected roots
         self.assertEqual(sorted(roots), sorted(self.expected_roots))
 
-    @patch("builtins.print")
-    def test_run_list_mode(self, mock_print):
+    def test_run_list_mode(self):
         """Test listing configs when no output specified"""
         args = argparse.Namespace()
         args.output = None
@@ -42,10 +42,17 @@ class TestCopyConfigPlugin(unittest.TestCase):
         args.all = False
         args.force = False
 
-        self.plugin.run(args)
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with redirect_stdout(captured_out), redirect_stderr(captured_err):
+                self.plugin.run(args)
 
-        # Should print configs
-        mock_print.assert_called()
+        self.assertIn("Configs under", captured_out.getvalue())
+        self.assertIn("deprecated", captured_err.getvalue())
+        self.assertEqual(len(caught), 1)
+        self.assertIs(caught[0].category, DeprecationWarning)
 
     def test_run_copy_all_success(self):
         """Test successful copy of all configs"""
@@ -54,6 +61,8 @@ class TestCopyConfigPlugin(unittest.TestCase):
             args.output = temp_dir
             args.path = None
             args.all = True
+            args.force = False
+            args.list = False
 
             self.plugin.run(args)
 
@@ -242,9 +251,8 @@ class TestCopyConfigPluginExtension(unittest.TestCase):
     """Test copy-config plugin finds core config roots"""
 
     def test_find_config_root_returns_list(self):
-        """Test that _find_config_root returns a list of directories"""
-        plugin = CopyConfigPlugin()
-        roots = plugin._find_config_root()
+        """Test that find_config_roots returns a list of directories"""
+        roots = config_files.find_config_roots()
 
         # Should return a list
         self.assertIsInstance(roots, list)
@@ -256,11 +264,10 @@ class TestCopyConfigPluginExtension(unittest.TestCase):
 
     def test_find_config_file_in_core_package(self):
         """Test finding config files from core cvs package"""
-        plugin = CopyConfigPlugin()
-        roots = plugin._find_config_root()
+        roots = config_files.find_config_roots()
 
         # Should be able to find a file that exists in core package
-        found_file = plugin._find_config_file(roots, "platform/host_config.json")
+        found_file = config_files.find_config_file(roots, "platform/host_config.json")
         self.assertIsNotNone(found_file)
         self.assertTrue(os.path.exists(found_file))
 

--- a/cvs/unittests/test_main.py
+++ b/cvs/unittests/test_main.py
@@ -15,7 +15,7 @@ class TestMain(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up shared test data"""
-        cls.expected_ordered_plugins = ["copy-config", "generate", "list", "run", "scp", "monitor", "exec"]
+        cls.expected_ordered_plugins = ["config", "copy-config", "generate", "list", "run", "scp", "monitor", "exec"]
 
     def test_get_version_success(self):
         """Test successful version retrieval"""


### PR DESCRIPTION
config templates

Currently with many config templates avaialble in the cvs repo, users can only list all the config files, which is cluttered and not user friendly. if there is a way to list the config files by directory/category, user will get sub set of relavent config file templates.

Introduce list, list-dirs, and copy subcommands with grouped directory output, shared config_files helpers, and generate-style help for bare invocations. Deprecate copy-config --list while keeping copy-config copy behavior for backward compatibility.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
