### PR TITLE
feat(inference): expand lm-eval accuracy configuration

### DIFF
--- a/cvs/lib/inference/unittests/test_accuracy_config.py
+++ b/cvs/lib/inference/unittests/test_accuracy_config.py
@@ -51,18 +51,23 @@ def _dupes_message(exc):
 
 
 class TestAccuracyTaskDefaults(unittest.TestCase):
-    """AC12, AC23, AC24: defaults, empty-string id, include_path (no I/O)."""
+    """Defaults mirror the pinned lm-eval 0.4.12 surface."""
 
     def test_defaults_on_minimal_task(self):
         t = AccuracyTask(id="a", task="gsm8k")
         self.assertEqual(t.id, "a")
         self.assertEqual(t.task, "gsm8k")
-        self.assertEqual(t.num_fewshot, 0)
+        self.assertEqual(t.tasks, "gsm8k")
+        self.assertIsNone(t.num_fewshot)
+        self.assertEqual(t.batch_size, "1")
+        self.assertEqual(t.device, "cuda:0")
         self.assertEqual(t.metadata, {})
-        self.assertEqual(t.include_path, "")
+        self.assertIsNone(t.include_path)
         self.assertEqual(t.num_concurrent, 8)
         self.assertIs(t.apply_chat_template, False)
         self.assertEqual(t.gen_kwargs, {})
+        self.assertEqual(t.seed, [0, 1234, 1234, 1234])
+        self.assertEqual(t.exec_timeout_sec, 4 * 60 * 60)
 
     def test_empty_string_id_is_valid(self):
         # AC23: "" is a valid id, not treated as missing.
@@ -80,6 +85,7 @@ class TestAccuracyTaskDefaults(unittest.TestCase):
         t2 = AccuracyTask(id="b", task="gsm8k")
         self.assertIsNot(t1.metadata, t2.metadata)
         self.assertIsNot(t1.gen_kwargs, t2.gen_kwargs)
+        self.assertIsNot(t1.seed, t2.seed)
 
 
 class TestAccuracyTaskRequiredFields(unittest.TestCase):
@@ -107,9 +113,7 @@ class TestAccuracyTaskExplicitNone(unittest.TestCase):
         for field in (
             "id",
             "task",
-            "num_fewshot",
             "metadata",
-            "include_path",
             "num_concurrent",
             "apply_chat_template",
             "gen_kwargs",
@@ -199,9 +203,9 @@ class TestAccuracyTaskBoolCoercion(unittest.TestCase):
         t = _task(apply_chat_template=False)
         self.assertIs(t.apply_chat_template, False)
 
-    def test_non_bool_word_raises(self):
-        with self.assertRaises(ValidationError):
-            _task(apply_chat_template="maybe")
+    def test_template_name_is_accepted(self):
+        task = _task(apply_chat_template="chatml")
+        self.assertEqual(task.apply_chat_template, "chatml")
 
 
 class TestAccuracyTaskStringTyping(unittest.TestCase):
@@ -227,6 +231,52 @@ class TestAccuracyTaskExtraForbid(unittest.TestCase):
     def test_unknown_field_raises(self):
         with self.assertRaises(ValidationError):
             AccuracyTask(id="a", task="gsm8k", extra_field=1)
+
+
+class TestAccuracyTaskLmEvalSurface(unittest.TestCase):
+    def test_accepts_every_exposed_lm_eval_0412_option(self):
+        task = AccuracyTask(
+            id="all",
+            tasks=["hellaswag", "gsm8k"],
+            backend="vllm",
+            lm_eval_model="local-completions",
+            extra_model_args="tokenizer_backend=huggingface",
+            num_fewshot=5,
+            batch_size="auto:4",
+            max_batch_size=8,
+            device="cuda:0",
+            gen_kwargs={"temperature": 0},
+            limit=100,
+            samples={"hellaswag": [0, 1]},
+            use_cache="/tmp/cache.db",
+            cache_requests="refresh",
+            check_integrity=True,
+            system_instruction="Answer concisely.",
+            apply_chat_template="chatml",
+            fewshot_as_multiturn=False,
+            include_path="/tmp/tasks",
+            predict_only=True,
+            seed=[1, None, 3, 4],
+            trust_remote_code=True,
+            confirm_run_unsafe_code=True,
+            metadata={"difficulty": "easy"},
+            exec_timeout_sec=7200,
+        )
+        self.assertEqual(task.task_names(), ["hellaswag", "gsm8k"])
+        self.assertEqual(task.task, "hellaswag,gsm8k")
+        self.assertEqual(task.resolved_lm_eval_model, "local-completions")
+
+    def test_task_is_accepted_as_legacy_alias(self):
+        task = AccuracyTask(id="a", task="gsm8k")
+        self.assertEqual(task.tasks, "gsm8k")
+
+    def test_task_and_tasks_must_agree(self):
+        with self.assertRaises(ValidationError):
+            AccuracyTask(id="a", task="gsm8k", tasks="hellaswag")
+
+    def test_rejects_invalid_seed_length(self):
+        with self.assertRaises(ValidationError):
+            AccuracyTask(id="a", task="gsm8k", seed=[1, 2, 3])
 
 
 class TestAccuracyConfigConstruction(unittest.TestCase):
@@ -463,16 +513,7 @@ class TestValidationPrecedence(unittest.TestCase):
         with self.assertRaises(ValidationError) as ctx:
             AccuracyConfig(tasks=[{"id": "a", "task": "gsm8k"}, {"id": "a"}])
         msg = str(ctx.exception)
-        # The missing required 'task' field on element index 1 is what surfaces.
-        # Assert the fully-qualified error location "tasks.1.task" rather than a
-        # bare "task": the parent field name "tasks" means a plain "task"
-        # substring would also match "tasks.1.id" (i.e. the *other* field being
-        # the one missing), so it cannot tell which required field failed.
-        self.assertIn("tasks.1.task", msg)
-        self.assertTrue(
-            ("Field required" in msg) or ("missing" in msg),
-            f"expected a missing-required-field marker, got: {msg}",
-        )
+        self.assertIn("one of tasks or task is required", msg)
         # ...and the duplicate-id validator must NOT have run.
         self.assertNotIn("duplicate task id(s):", msg)
 
@@ -486,13 +527,32 @@ class TestModelFieldMembership(unittest.TestCase):
             set(AccuracyTask.model_fields),
             {
                 "id",
+                "tasks",
                 "task",
+                "backend",
+                "lm_eval_model",
+                "extra_model_args",
                 "num_fewshot",
-                "metadata",
-                "include_path",
+                "batch_size",
+                "max_batch_size",
+                "device",
+                "limit",
+                "samples",
+                "use_cache",
+                "cache_requests",
+                "check_integrity",
+                "system_instruction",
                 "num_concurrent",
                 "apply_chat_template",
+                "fewshot_as_multiturn",
+                "include_path",
                 "gen_kwargs",
+                "predict_only",
+                "seed",
+                "trust_remote_code",
+                "confirm_run_unsafe_code",
+                "metadata",
+                "exec_timeout_sec",
             },
         )
 

--- a/cvs/lib/inference/unittests/test_accuracy_config.py
+++ b/cvs/lib/inference/unittests/test_accuracy_config.py
@@ -207,6 +207,10 @@ class TestAccuracyTaskBoolCoercion(unittest.TestCase):
         task = _task(apply_chat_template="chatml")
         self.assertEqual(task.apply_chat_template, "chatml")
 
+    def test_boolean_template_strings_keep_boolean_meaning(self):
+        self.assertIs(_task(apply_chat_template="false").apply_chat_template, False)
+        self.assertIs(_task(apply_chat_template="1").apply_chat_template, True)
+
 
 class TestAccuracyTaskStringTyping(unittest.TestCase):
     """AC22: id/task accept only str; non-str scalars are not auto-coerced."""
@@ -275,8 +279,14 @@ class TestAccuracyTaskLmEvalSurface(unittest.TestCase):
             AccuracyTask(id="a", task="gsm8k", tasks="hellaswag")
 
     def test_rejects_invalid_seed_length(self):
-        with self.assertRaises(ValidationError):
-            AccuracyTask(id="a", task="gsm8k", seed=[1, 2, 3])
+        for seed in ([1, 2], [1, 2, 3, 4, 5]):
+            with self.subTest(seed=seed):
+                with self.assertRaises(ValidationError):
+                    AccuracyTask(id="a", task="gsm8k", seed=seed)
+
+    def test_seed_accepts_upstream_single_and_three_value_forms(self):
+        self.assertEqual(AccuracyTask(id="a", task="gsm8k", seed=42).seed, [42, 42, 42, 42])
+        self.assertEqual(AccuracyTask(id="a", task="gsm8k", seed="1,None,3").seed, [1, None, 3, 1234])
 
 
 class TestAccuracyConfigConstruction(unittest.TestCase):

--- a/cvs/lib/inference/unittests/test_accuracy_config.py
+++ b/cvs/lib/inference/unittests/test_accuracy_config.py
@@ -60,7 +60,7 @@ class TestAccuracyTaskDefaults(unittest.TestCase):
         self.assertEqual(t.tasks, "gsm8k")
         self.assertIsNone(t.num_fewshot)
         self.assertEqual(t.batch_size, "1")
-        self.assertEqual(t.device, "cuda:0")
+        self.assertIsNone(t.device)
         self.assertEqual(t.metadata, {})
         self.assertIsNone(t.include_path)
         self.assertEqual(t.num_concurrent, 8)

--- a/cvs/lib/inference/unittests/test_lm_eval_job.py
+++ b/cvs/lib/inference/unittests/test_lm_eval_job.py
@@ -17,6 +17,7 @@ import unittest
 from cvs.lib.inference.utils.accuracy_config import AccuracyTask
 from cvs.lib.inference.utils.lm_eval_job import (
     LM_EVAL_INSTALL_CHECK_CMD,
+    LM_EVAL_VERSION,
     LmEvalCtx,
     build_lm_eval_cmd,
     normalize_client_base_url,
@@ -66,7 +67,10 @@ class TestBuildLmEvalCmd(unittest.TestCase):
             cmd,
         )
         self.assertIn("--tasks mmlu", cmd)
-        self.assertIn("--num_fewshot 0", cmd)
+        self.assertNotIn("--num_fewshot", cmd)
+        self.assertIn("--batch_size 1", cmd)
+        self.assertIn("--device cuda:0", cmd)
+        self.assertIn("--seed 0,1234,1234,1234", cmd)
         self.assertIn("--output_path /tmp/accuracy-out/mmlu", cmd)
         self.assertIn("--log_samples", cmd)
 
@@ -136,6 +140,59 @@ class TestBuildLmEvalCmd(unittest.TestCase):
         cmd = build_lm_eval_cmd(_task(gen_kwargs={}), _ctx())
         self.assertNotIn("--gen_kwargs", cmd)
 
+    def test_complete_lm_eval_surface_is_forwarded(self):
+        cmd = build_lm_eval_cmd(
+            _task(
+                tasks=["hellaswag", "gsm8k"],
+                task="hellaswag,gsm8k",
+                lm_eval_model="local-chat-completions",
+                extra_model_args="retry=5",
+                num_fewshot=5,
+                batch_size="auto:4",
+                max_batch_size=8,
+                device="cpu",
+                limit=100,
+                samples={"gsm8k": [0]},
+                use_cache="/tmp/cache.db",
+                cache_requests="refresh",
+                check_integrity=True,
+                system_instruction="Be concise",
+                apply_chat_template="chatml",
+                fewshot_as_multiturn=False,
+                include_path="/tmp/tasks",
+                predict_only=True,
+                seed=[1, None, 3, 4],
+                trust_remote_code=True,
+                confirm_run_unsafe_code=True,
+                metadata={"source": "test"},
+            ),
+            _ctx(),
+        )
+        for part in (
+            "--tasks hellaswag gsm8k",
+            "--batch_size auto:4",
+            "--max_batch_size 8",
+            "--device cpu",
+            "--limit 100.0",
+            "--use_cache /tmp/cache.db",
+            "--cache_requests refresh",
+            "--check_integrity",
+            "--system_instruction 'Be concise'",
+            "--apply_chat_template chatml",
+            "--fewshot_as_multiturn false",
+            "--include_path /tmp/tasks",
+            "--predict_only",
+            "--seed 1,None,3,4",
+            "--trust_remote_code",
+            "--confirm_run_unsafe_code",
+        ):
+            self.assertIn(part, cmd)
+        self.assertIn("retry=5", cmd)
+
+    def test_rejects_extra_model_arg_collision(self):
+        with self.assertRaisesRegex(ValueError, "CVS-owned"):
+            build_lm_eval_cmd(_task(extra_model_args="model=other"), _ctx())
+
     def test_shell_quoting_safety_for_special_characters(self):
         task = _task(
             id="weird id",
@@ -179,6 +236,9 @@ class TestInstallGuard(unittest.TestCase):
 
     def test_installs_math_extra(self):
         self.assertIn("lm-eval[api,math]", LM_EVAL_INSTALL_CHECK_CMD)
+
+    def test_pins_lm_eval_version(self):
+        self.assertIn(f"=={LM_EVAL_VERSION}", LM_EVAL_INSTALL_CHECK_CMD)
 
     def test_guard_probes_math_verify_import_not_just_lm_eval_presence(self):
         # A `pip list | grep lm_eval` guard short-circuits on an image that
@@ -330,6 +390,12 @@ class TestRunAccuracyTasks(unittest.TestCase):
         orch = FakeOrch(responses=["", "1700000000.0 /out/mmlu/model/results.json", json.dumps(payload)])
         run_accuracy_tasks(**self._run_kwargs(orch, [_task()]))
         self.assertTrue(orch.head_kwargs[0].get("detailed"))
+
+    def test_uses_task_specific_timeout(self):
+        payload = {"results": {"mmlu": {"acc,none": 0.5}}}
+        orch = FakeOrch(responses=["", "1700000000.0 /out/mmlu/model/results.json", json.dumps(payload)])
+        run_accuracy_tasks(**self._run_kwargs(orch, [_task(exec_timeout_sec=7200)]))
+        self.assertEqual(orch.head_kwargs[0]["timeout"], 7200)
 
     def test_zero_exit_code_with_dict_response_succeeds(self):
         payload = {"results": {"mmlu": {"acc,none": 0.5}}}

--- a/cvs/lib/inference/unittests/test_lm_eval_job.py
+++ b/cvs/lib/inference/unittests/test_lm_eval_job.py
@@ -193,6 +193,10 @@ class TestBuildLmEvalCmd(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "CVS-owned"):
             build_lm_eval_cmd(_task(extra_model_args="model=other"), _ctx())
 
+    def test_matching_extra_model_arg_is_idempotent(self):
+        cmd = build_lm_eval_cmd(_task(extra_model_args="tokenizer_backend=huggingface"), _ctx())
+        self.assertEqual(cmd.count("tokenizer_backend=huggingface"), 1)
+
     def test_shell_quoting_safety_for_special_characters(self):
         task = _task(
             id="weird id",

--- a/cvs/lib/inference/unittests/test_lm_eval_job.py
+++ b/cvs/lib/inference/unittests/test_lm_eval_job.py
@@ -12,6 +12,7 @@ cvs/lib/inference/unittests/test_vllm_job_server_reuse.py.
 
 import copy
 import json
+import shlex
 import unittest
 
 from cvs.lib.inference.utils.accuracy_config import AccuracyTask
@@ -69,10 +70,32 @@ class TestBuildLmEvalCmd(unittest.TestCase):
         self.assertIn("--tasks mmlu", cmd)
         self.assertNotIn("--num_fewshot", cmd)
         self.assertIn("--batch_size 1", cmd)
-        self.assertIn("--device cuda:0", cmd)
+        self.assertNotIn("--device", cmd)
         self.assertIn("--seed 0,1234,1234,1234", cmd)
         self.assertIn("--output_path /tmp/accuracy-out/mmlu", cmd)
         self.assertIn("--log_samples", cmd)
+
+    def test_list_tasks_emit_one_comma_joined_argv_value(self):
+        cmd = build_lm_eval_cmd(AccuracyTask(id="multi", tasks=["hellaswag", "gsm8k"]), _ctx())
+        argv = shlex.split(cmd)
+        tasks_index = argv.index("--tasks")
+        self.assertEqual(
+            argv[tasks_index : tasks_index + 3],
+            ["--tasks", "hellaswag,gsm8k", "--output_path"],
+        )
+        self.assertNotIn("hellaswag", argv)
+        self.assertNotIn("gsm8k", argv)
+
+    def test_legacy_task_emits_one_comma_joined_argv_value(self):
+        cmd = build_lm_eval_cmd(AccuracyTask(id="multi", task="hellaswag,gsm8k"), _ctx())
+        argv = shlex.split(cmd)
+        tasks_index = argv.index("--tasks")
+        self.assertEqual(
+            argv[tasks_index : tasks_index + 3],
+            ["--tasks", "hellaswag,gsm8k", "--output_path"],
+        )
+        self.assertNotIn("hellaswag", argv)
+        self.assertNotIn("gsm8k", argv)
 
     def test_trust_remote_code_always_present(self):
         # Models with custom tokenizer code (Qwen, ChatGLM, Phi, MPT, ...)
@@ -169,7 +192,7 @@ class TestBuildLmEvalCmd(unittest.TestCase):
             _ctx(),
         )
         for part in (
-            "--tasks hellaswag gsm8k",
+            "--tasks hellaswag,gsm8k",
             "--batch_size auto:4",
             "--max_batch_size 8",
             "--device cpu",
@@ -208,9 +231,7 @@ class TestBuildLmEvalCmd(unittest.TestCase):
         cmd = build_lm_eval_cmd(task, ctx)
         # Command must be shell-parseable without raising, and round-trip the
         # exact values through shlex (proves quoting, not just substring presence).
-        import shlex as _shlex
-
-        parts = _shlex.split(cmd)
+        parts = shlex.split(cmd)
         self.assertIn("weird task", parts)
         self.assertIn("/tmp/out dir/weird id", parts)
         self.assertIn("/path with spaces/tasks", parts)

--- a/cvs/lib/inference/utils/accuracy_config.py
+++ b/cvs/lib/inference/utils/accuracy_config.py
@@ -4,31 +4,104 @@ All rights reserved.
 
 Accuracy-evaluation config schema, shared across inference suites.
 
-`AccuracyTask`/`AccuracyConfig` define the `config.json`-side selection schema
-for lm-eval-harness based accuracy tasks (see cvs/lib/inference/utils/AGENTS.md
-for the broader accuracy-evaluation design). This module holds selection only
--- no threshold/gating values, which live in the sibling threshold.json file
-and are joined against `AccuracyConfig.tasks` at runtime by a later unit.
+`AccuracyTask` describes an lm-evaluation-harness 0.4.12 invocation against a
+live OpenAI-compatible server. CVS owns the live-server endpoint, model path,
+output path, and sample logging. Every other supported ``lm_eval run`` setting
+has an explicit field and its 0.4.12 default.
 '''
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import model_validator
+from pydantic import Field, field_validator, model_validator
 
 from cvs.lib.utils.config_loader import _Forbid
 
 
 class AccuracyTask(_Forbid):
     id: str
-    task: str
-    num_fewshot: int = 0
-    metadata: Dict[str, Any] = {}
-    include_path: str = ""
+    # ``task`` remains accepted so existing Atom and vLLM configs need no
+    # migration. ``tasks`` is the lm-eval 0.4.12 spelling and supports a
+    # comma-separated string or a list of task names.
+    tasks: Optional[Union[str, List[str]]] = None
+    task: Optional[str] = None
+
+    # CVS/OpenAI adapter selection. These are deliberately narrower than
+    # lm-eval's generic --model field because CVS always targets a live local
+    # OpenAI-compatible server.
+    backend: str = ""
+    lm_eval_model: Optional[Literal["local-completions", "local-chat-completions"]] = None
+    extra_model_args: str = ""
     num_concurrent: int = 8
-    apply_chat_template: bool = False
-    gen_kwargs: Dict[str, Any] = {}
+
+    # lm-eval 0.4.12 evaluation settings.
+    num_fewshot: Optional[int] = None
+    batch_size: str = "1"
+    max_batch_size: Optional[int] = None
+    device: Optional[str] = "cuda:0"
+    gen_kwargs: Dict[str, Any] = Field(default_factory=dict)
+    limit: Optional[float] = None
+    samples: Optional[Union[str, Dict[str, Any]]] = None
+    use_cache: Optional[str] = None
+    cache_requests: Optional[Literal["true", "refresh", "delete"]] = None
+    check_integrity: bool = False
+    system_instruction: Optional[str] = None
+    apply_chat_template: Union[bool, str] = False
+    fewshot_as_multiturn: Optional[bool] = None
+    include_path: Optional[str] = None
+    predict_only: bool = False
+    seed: List[Optional[int]] = Field(default_factory=lambda: [0, 1234, 1234, 1234])
+    trust_remote_code: bool = False
+    confirm_run_unsafe_code: bool = False
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    # CVS controls execution duration, not lm-eval.
+    exec_timeout_sec: int = 4 * 60 * 60
+
+    @field_validator("tasks", mode="before")
+    @classmethod
+    def _reject_empty_task_lists(cls, value):
+        if value == []:
+            raise ValueError("tasks must not be empty")
+        return value
+
+    @field_validator("seed")
+    @classmethod
+    def _validate_seed_count(cls, value):
+        if len(value) != 4:
+            raise ValueError("seed must contain exactly four values: python,numpy,torch,fewshot")
+        return value
+
+    @model_validator(mode="after")
+    def _resolve_legacy_task_alias(self):
+        if self.tasks is None and self.task is None:
+            raise ValueError("one of tasks or task is required")
+        if self.tasks is None:
+            self.tasks = self.task
+        elif self.task is not None and self.task_names() != self._split_task_string(self.task):
+            raise ValueError("task and tasks disagree")
+        # Preserve the historical public attribute for Atom and callers that
+        # consume a single comma-separated task selector.
+        task_names = self.task_names()
+        if not task_names:
+            raise ValueError("tasks must contain at least one task name")
+        self.task = ",".join(task_names)
+        return self
+
+    @staticmethod
+    def _split_task_string(value: str) -> List[str]:
+        return [item.strip() for item in value.split(",") if item.strip()]
+
+    def task_names(self) -> List[str]:
+        if isinstance(self.tasks, list):
+            return self.tasks
+        return self._split_task_string(self.tasks or "")
+
+    @property
+    def resolved_lm_eval_model(self) -> str:
+        if self.lm_eval_model:
+            return self.lm_eval_model
+        return "local-chat-completions" if self.apply_chat_template else "local-completions"
 
 
 class AccuracyConfig(_Forbid):

--- a/cvs/lib/inference/utils/accuracy_config.py
+++ b/cvs/lib/inference/utils/accuracy_config.py
@@ -58,6 +58,30 @@ class AccuracyTask(_Forbid):
     # CVS controls execution duration, not lm-eval.
     exec_timeout_sec: int = 4 * 60 * 60
 
+    @field_validator("apply_chat_template", mode="before")
+    @classmethod
+    def _coerce_boolean_template_values(cls, value):
+        if isinstance(value, str) and value.lower() in {"true", "false", "0", "1"}:
+            return value.lower() in {"true", "1"}
+        return value
+
+    @field_validator("seed", mode="before")
+    @classmethod
+    def _normalize_seed(cls, value):
+        defaults = [0, 1234, 1234, 1234]
+        if isinstance(value, int):
+            return [value] * 4
+        if isinstance(value, str):
+            value = value.split(",")
+        if isinstance(value, list):
+            normalized = [None if item is None or item == "None" else int(item) for item in value]
+            if len(normalized) == 1:
+                return normalized * 4
+            if len(normalized) == 3:
+                return [*normalized, defaults[3]]
+            return normalized
+        return value
+
     @field_validator("tasks", mode="before")
     @classmethod
     def _reject_empty_task_lists(cls, value):

--- a/cvs/lib/inference/utils/accuracy_config.py
+++ b/cvs/lib/inference/utils/accuracy_config.py
@@ -39,7 +39,7 @@ class AccuracyTask(_Forbid):
     num_fewshot: Optional[int] = None
     batch_size: str = "1"
     max_batch_size: Optional[int] = None
-    device: Optional[str] = "cuda:0"
+    device: Optional[str] = None
     gen_kwargs: Dict[str, Any] = Field(default_factory=dict)
     limit: Optional[float] = None
     samples: Optional[Union[str, Dict[str, Any]]] = None

--- a/cvs/lib/inference/utils/lm_eval_job.py
+++ b/cvs/lib/inference/utils/lm_eval_job.py
@@ -103,10 +103,10 @@ def build_lm_eval_cmd(task: AccuracyTask, ctx: LmEvalCtx) -> str:
         "trust_remote_code": "True",
     }
     extras = _split_model_args(task.extra_model_args)
-    collisions = sorted(set(model_args) & set(extras))
+    collisions = sorted(key for key, value in extras.items() if key in model_args and model_args[key] != value)
     if collisions:
         raise ValueError(f"extra_model_args cannot override CVS-owned model args: {collisions}")
-    model_args.update(extras)
+    model_args.update({key: value for key, value in extras.items() if key not in model_args})
     rendered_model_args = ",".join(f"{key}={value}" for key, value in model_args.items())
 
     args = [

--- a/cvs/lib/inference/utils/lm_eval_job.py
+++ b/cvs/lib/inference/utils/lm_eval_job.py
@@ -19,10 +19,12 @@ from typing import Any, Dict, List
 from cvs.lib.inference.utils.accuracy_config import AccuracyTask
 from cvs.lib.inference.utils.lm_eval_parsing import project
 
+LM_EVAL_VERSION = "0.4.12"
 LM_EVAL_INSTALL_CHECK_CMD = (
-    "python -c 'import lm_eval, math_verify' 2>/dev/null || pip install -q 'lm-eval[api,math]>=0.4.4'"
+    "python -c \"import importlib.metadata as m; import lm_eval, math_verify; "
+    f"assert m.version('lm-eval') == '{LM_EVAL_VERSION}'\" 2>/dev/null || "
+    f"pip install -q 'lm-eval[api,math]=={LM_EVAL_VERSION}'"
 )
-PER_TASK_TIMEOUT_S = 4 * 60 * 60
 
 
 @dataclass
@@ -38,40 +40,109 @@ def normalize_client_base_url(base_url: str) -> str:
     return base_url.replace("0.0.0.0", "127.0.0.1")
 
 
-def build_lm_eval_cmd(task: AccuracyTask, ctx: LmEvalCtx) -> str:
-    model_flag = "local-chat-completions" if task.apply_chat_template else "local-completions"
-    endpoint_path = "/v1/chat/completions" if task.apply_chat_template else "/v1/completions"
+def _split_model_args(value: str) -> Dict[str, str]:
+    """Parse comma-separated model args without splitting quoted JSON values."""
+    if not value:
+        return {}
 
-    model_args = ",".join(
-        [
-            f"base_url={ctx.base_url}{endpoint_path}",
-            f"model={ctx.model_id}",
-            f"tokenizer={ctx.model_path}",
-            "tokenizer_backend=huggingface",
-            f"num_concurrent={task.num_concurrent}",
-            "max_retries=3",
-            "tokenized_requests=False",
-            "trust_remote_code=True",
-        ]
-    )
+    fragments = []
+    start = 0
+    depth = 0
+    quote = None
+    escaped = False
+    for index, char in enumerate(value):
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+        elif char in "'\"":
+            quote = char
+        elif char in "[{(":
+            depth += 1
+        elif char in "]})":
+            depth -= 1
+            if depth < 0:
+                raise ValueError(f"invalid extra_model_args: {value!r}")
+        elif char == "," and depth == 0:
+            fragments.append(value[start:index])
+            start = index + 1
+    if quote or depth:
+        raise ValueError(f"invalid extra_model_args: {value!r}")
+    fragments.append(value[start:])
+
+    parsed = {}
+    for fragment in fragments:
+        key, separator, argument = fragment.strip().partition("=")
+        if not separator or not key:
+            raise ValueError(f"extra_model_args entries must be key=value, got: {fragment!r}")
+        if key in parsed:
+            raise ValueError(f"duplicate extra_model_args key: {key!r}")
+        parsed[key] = argument
+    return parsed
+
+
+def _optional_arg(args: List[str], name: str, value) -> None:
+    if value is not None:
+        args += [name, str(value)]
+
+
+def build_lm_eval_cmd(task: AccuracyTask, ctx: LmEvalCtx) -> str:
+    model_flag = task.resolved_lm_eval_model
+    endpoint_path = "/v1/chat/completions" if model_flag == "local-chat-completions" else "/v1/completions"
+    model_args = {
+        "base_url": f"{ctx.base_url}{endpoint_path}",
+        "model": ctx.model_id,
+        "tokenizer": ctx.model_path,
+        "tokenizer_backend": "huggingface",
+        "num_concurrent": str(task.num_concurrent),
+        "max_retries": "3",
+        "tokenized_requests": "False",
+        "trust_remote_code": "True",
+    }
+    extras = _split_model_args(task.extra_model_args)
+    collisions = sorted(set(model_args) & set(extras))
+    if collisions:
+        raise ValueError(f"extra_model_args cannot override CVS-owned model args: {collisions}")
+    model_args.update(extras)
+    rendered_model_args = ",".join(f"{key}={value}" for key, value in model_args.items())
 
     args = [
         "lm_eval",
         "--model",
         model_flag,
         "--model_args",
-        model_args,
+        rendered_model_args,
         "--tasks",
-        task.task,
-        "--num_fewshot",
-        str(task.num_fewshot),
+        *task.task_names(),
         "--output_path",
         f"{ctx.output_dir}/{task.id}",
         "--log_samples",
     ]
 
+    _optional_arg(args, "--num_fewshot", task.num_fewshot)
+    _optional_arg(args, "--batch_size", task.batch_size)
+    _optional_arg(args, "--max_batch_size", task.max_batch_size)
+    _optional_arg(args, "--device", task.device)
+    _optional_arg(args, "--limit", task.limit)
+    _optional_arg(args, "--use_cache", task.use_cache)
+    if task.samples is not None:
+        _optional_arg(args, "--samples", json.dumps(task.samples) if isinstance(task.samples, dict) else task.samples)
+    _optional_arg(args, "--cache_requests", task.cache_requests)
+
+    if task.check_integrity:
+        args.append("--check_integrity")
+    _optional_arg(args, "--system_instruction", task.system_instruction)
     if task.apply_chat_template:
         args.append("--apply_chat_template")
+        if isinstance(task.apply_chat_template, str):
+            args.append(task.apply_chat_template)
+    if task.fewshot_as_multiturn is not None:
+        args.append("--fewshot_as_multiturn")
+        if task.fewshot_as_multiturn is False:
+            args.append("false")
 
     if task.metadata:
         args += ["--metadata", json.dumps(task.metadata)]
@@ -82,6 +153,13 @@ def build_lm_eval_cmd(task: AccuracyTask, ctx: LmEvalCtx) -> str:
     if task.gen_kwargs:
         gen_kwargs = ",".join(f"{k}={v}" for k, v in task.gen_kwargs.items())
         args += ["--gen_kwargs", gen_kwargs]
+    if task.predict_only:
+        args.append("--predict_only")
+    _optional_arg(args, "--seed", ",".join("None" if value is None else str(value) for value in task.seed))
+    if task.trust_remote_code:
+        args.append("--trust_remote_code")
+    if task.confirm_run_unsafe_code:
+        args.append("--confirm_run_unsafe_code")
 
     lm_eval_cmd = " ".join(shlex.quote(str(a)) for a in args)
     return f"source /tmp/server_env_script.sh && {LM_EVAL_INSTALL_CHECK_CMD} && {lm_eval_cmd}"
@@ -106,7 +184,7 @@ def run_accuracy_tasks(
 
     for task in tasks:
         cmd = build_lm_eval_cmd(task, ctx)
-        out = orch.exec_on_head(cmd, timeout=PER_TASK_TIMEOUT_S, detailed=True)
+        out = orch.exec_on_head(cmd, timeout=task.exec_timeout_sec, detailed=True)
         try:
             (run_result,) = out.values()
         except ValueError as e:

--- a/cvs/lib/inference/utils/lm_eval_job.py
+++ b/cvs/lib/inference/utils/lm_eval_job.py
@@ -116,7 +116,7 @@ def build_lm_eval_cmd(task: AccuracyTask, ctx: LmEvalCtx) -> str:
         "--model_args",
         rendered_model_args,
         "--tasks",
-        *task.task_names(),
+        ",".join(task.task_names()),
         "--output_path",
         f"{ctx.output_dir}/{task.id}",
         "--log_samples",


### PR DESCRIPTION
## Summary
- Pin the runtime lm-eval dependency to 0.4.12 and expose its evaluation controls with defaults.
- Preserve existing Atom accuracy configuration through the legacy task alias and shared regression coverage.

## Test plan
- [x] make fmt-check
- [x] make lint
- [x] make ut

Made with [Cursor](https://cursor.com)