### PR TITLE
feat(vllm): report threshold gates as metric subtests

### DIFF
--- a/cvs/lib/inference/unittests/test_vllm_deck_profile.py
+++ b/cvs/lib/inference/unittests/test_vllm_deck_profile.py
@@ -76,7 +76,7 @@ class TestVllmDeckProfile(unittest.TestCase):
         cfg = build_inference_config_from_profile(profile)
         self.assertEqual(cfg.suite_id, "vllm")
         self.assertEqual(cfg.inference_test_substring, "test_vllm_inference")
-        self.assertEqual(cfg.row_card_test_names, ("test_metric", "test_gpu_metric", "test_prom_metric"))
+        self.assertEqual(cfg.row_card_test_names, ("test_verify_cell_metrics",))
 
     def test_vllm_profile_lifecycle_labels_match_what_suite_records(self):
         profile = load_json_profile("vllm")

--- a/cvs/lib/inference/utils/unittests/test_vllm_verification.py
+++ b/cvs/lib/inference/utils/unittests/test_vllm_verification.py
@@ -2,7 +2,12 @@
 
 import unittest
 
-from cvs.lib.inference.utils.vllm_verification import active_metric_specs, evaluate_metric_verdicts, metric_definitions
+from cvs.lib.inference.utils.vllm_verification import (
+    active_metric_specs,
+    evaluate_metric_verdicts,
+    metric_definitions,
+    reportable_metric_specs,
+)
 
 
 class TestMetricDefinitions(unittest.TestCase):
@@ -15,18 +20,60 @@ class TestMetricDefinitions(unittest.TestCase):
 
 
 class TestActiveMetricSpecs(unittest.TestCase):
-    def test_record_only_and_info_specs_are_not_active(self):
+    def test_reportable_specs_are_separate_from_active_gates(self):
         thresholds = {
             'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
             'client.goodput': {'kind': 'info', 'value': 0},
         }
 
         self.assertEqual(active_metric_specs(thresholds, enforce_thresholds=False), ())
+        self.assertEqual(
+            [item['metric'] for item in reportable_metric_specs(thresholds)],
+            ['client.goodput', 'client.output_throughput'],
+        )
         active = active_metric_specs(thresholds, enforce_thresholds=True)
         self.assertEqual([item['metric'] for item in active], ['client.output_throughput'])
 
 
 class TestEvaluateMetricVerdicts(unittest.TestCase):
+    def test_record_only_reports_configured_specs_without_asserted_passes(self):
+        thresholds = {
+            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
+            'gpu.gpu_compute_util_pct': {'kind': 'min', 'value': 80},
+        }
+        actuals = {
+            'head': {
+                'client.output_throughput': 99,
+                'client.mean_ttft_ms': 40,
+                'gpu.gpu_compute_util_pct': None,
+            }
+        }
+
+        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=False)
+
+        self.assertEqual(
+            [(item['metric'], item['status'], item['enforced']) for item in verdicts],
+            [
+                ('client.output_throughput', 'record', False),
+                ('gpu.gpu_compute_util_pct', 'record', False),
+            ],
+        )
+        self.assertNotIn('client.mean_ttft_ms', {item['metric'] for item in verdicts})
+        self.assertIn('metric unavailable', verdicts[1]['reason'])
+        self.assertTrue(all('no threshold asserted' in item['reason'] for item in verdicts))
+
+    def test_info_spec_remains_record_only_when_other_gates_are_enforced(self):
+        thresholds = {
+            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
+            'client.goodput': {'kind': 'info', 'value': 0},
+        }
+        actuals = {'head': {'client.output_throughput': 100, 'client.goodput': 10}}
+
+        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
+
+        self.assertEqual([item['status'] for item in verdicts], ['record', 'pass'])
+        self.assertEqual([item['enforced'] for item in verdicts], [False, True])
+
     def test_evaluates_sibling_metrics_after_failure(self):
         thresholds = {
             'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},

--- a/cvs/lib/inference/utils/unittests/test_vllm_verification.py
+++ b/cvs/lib/inference/utils/unittests/test_vllm_verification.py
@@ -1,0 +1,97 @@
+'''Unit tests for vLLM metric verification verdicts.'''
+
+import unittest
+
+from cvs.lib.inference.utils.vllm_verification import active_metric_specs, evaluate_metric_verdicts, metric_definitions
+
+
+class TestMetricDefinitions(unittest.TestCase):
+    def test_definitions_cover_all_metric_families(self):
+        definitions = {item['metric']: item for item in metric_definitions()}
+
+        self.assertEqual(definitions['client.output_throughput']['unit'], 'tok/s')
+        self.assertEqual(definitions['gpu.gpu_compute_util_pct']['missing_status'], 'skip')
+        self.assertEqual(definitions['prom.queue_time_p95_ms']['missing_status'], 'skip')
+
+
+class TestActiveMetricSpecs(unittest.TestCase):
+    def test_record_only_and_info_specs_are_not_active(self):
+        thresholds = {
+            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
+            'client.goodput': {'kind': 'info', 'value': 0},
+        }
+
+        self.assertEqual(active_metric_specs(thresholds, enforce_thresholds=False), ())
+        active = active_metric_specs(thresholds, enforce_thresholds=True)
+        self.assertEqual([item['metric'] for item in active], ['client.output_throughput'])
+
+
+class TestEvaluateMetricVerdicts(unittest.TestCase):
+    def test_evaluates_sibling_metrics_after_failure(self):
+        thresholds = {
+            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
+            'client.mean_ttft_ms': {'kind': 'max_ms', 'value': 50},
+        }
+        actuals = {
+            'head': {
+                'client.output_throughput': 99,
+                'client.mean_ttft_ms': 40,
+            }
+        }
+
+        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
+
+        self.assertEqual([item['status'] for item in verdicts], ['fail', 'pass'])
+        self.assertIn('actual 99.0 tok/s < min 100.0 tok/s', verdicts[0]['reason'])
+
+    def test_missing_client_fails_and_missing_gpu_prom_skip(self):
+        thresholds = {
+            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
+            'gpu.gpu_compute_util_pct': {'kind': 'min', 'value': 80},
+            'prom.queue_time_p95_ms': {'kind': 'max_ms', 'value': 50},
+        }
+
+        verdicts = evaluate_metric_verdicts({'head': {}}, thresholds, enforce_thresholds=True)
+
+        self.assertEqual(
+            {item['metric']: item['status'] for item in verdicts},
+            {
+                'client.output_throughput': 'fail',
+                'gpu.gpu_compute_util_pct': 'skip',
+                'prom.queue_time_p95_ms': 'skip',
+            },
+        )
+
+    def test_min_ratio_uses_complete_actuals(self):
+        thresholds = {
+            'client.output_throughput': {
+                'kind': 'min_ratio',
+                'reference': 'client.total_token_throughput',
+                'value': 0.5,
+            }
+        }
+        actuals = {
+            'head': {
+                'client.output_throughput': 60,
+                'client.total_token_throughput': 100,
+            }
+        }
+
+        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
+
+        self.assertEqual(verdicts[0]['status'], 'pass')
+
+    def test_keeps_one_verdict_per_host(self):
+        thresholds = {'client.output_throughput': {'kind': 'min_tok_s', 'value': 100}}
+        actuals = {
+            'head': {'client.output_throughput': 100},
+            'worker': {'client.output_throughput': 200},
+        }
+
+        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
+
+        self.assertEqual([verdict['node'] for verdict in verdicts], ['head', 'worker'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/lib/inference/utils/vllm_verification.py
+++ b/cvs/lib/inference/utils/vllm_verification.py
@@ -1,0 +1,91 @@
+'''Threshold verdict helpers for vLLM metric verification subtests.'''
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from cvs.lib.inference.utils.vllm_parsing import CLIENT_METRICS
+from cvs.lib.inference.utils.vllm_server_metrics import PROM_METRICS
+from cvs.lib.utils.gpu import GPU_METRICS
+from cvs.lib.utils.verdict import ThresholdViolation, evaluate_all
+
+
+def metric_definitions() -> tuple[dict[str, str], ...]:
+    '''Return ordered vLLM metric metadata keyed by fully qualified names.'''
+    definitions = []
+    for prefix, metrics, missing_status in (
+        ('client.', CLIENT_METRICS, 'fail'),
+        ('gpu.', GPU_METRICS, 'skip'),
+        ('prom.', PROM_METRICS, 'skip'),
+    ):
+        for short_name, unit in metrics:
+            definitions.append(
+                {
+                    'metric': f'{prefix}{short_name}',
+                    'unit': unit,
+                    'missing_status': missing_status,
+                }
+            )
+    return tuple(definitions)
+
+
+def report_metric_units() -> dict[str, str]:
+    '''Return units for fully qualified metrics and vLLM's client shorthand.'''
+    units = {definition['metric']: definition['unit'] for definition in metric_definitions()}
+    units.update(
+        {metric.removeprefix('client.'): unit for metric, unit in units.items() if metric.startswith('client.')}
+    )
+    return units
+
+
+def active_metric_specs(
+    thresholds: Mapping[str, Mapping[str, Any]],
+    *,
+    enforce_thresholds: bool,
+) -> tuple[dict[str, Any], ...]:
+    '''Return configured, enforced, non-informational metric specs in display order.'''
+    if not enforce_thresholds:
+        return ()
+
+    specs = []
+    for definition in metric_definitions():
+        spec = thresholds.get(definition['metric'])
+        if not isinstance(spec, Mapping) or spec.get('kind') == 'info':
+            continue
+        specs.append({**definition, 'spec': dict(spec)})
+    return tuple(specs)
+
+
+def evaluate_metric_verdicts(
+    actuals_by_host: Mapping[str, Mapping[str, Any]],
+    thresholds: Mapping[str, Mapping[str, Any]],
+    *,
+    enforce_thresholds: bool,
+) -> list[dict[str, Any]]:
+    '''Evaluate all active vLLM metric specs without stopping after a failure.'''
+    verdicts = []
+    active_specs = active_metric_specs(thresholds, enforce_thresholds=enforce_thresholds)
+    for host, actuals in actuals_by_host.items():
+        for definition in active_specs:
+            metric = definition['metric']
+            value = actuals.get(metric)
+            verdict = {
+                'node': str(host),
+                'metric': metric,
+                'unit': definition['unit'],
+                'actual': value,
+                'spec': definition['spec'],
+                'status': 'pass',
+                'reason': '',
+            }
+            if value is None:
+                verdict['status'] = definition['missing_status']
+                verdict['reason'] = f'{metric}: value is None (metric unavailable for this run)'
+            else:
+                try:
+                    evaluate_all(actuals, {metric: definition['spec']})
+                except ThresholdViolation as exc:
+                    verdict['status'] = 'fail'
+                    verdict['reason'] = str(exc)
+            verdicts.append(verdict)
+    return verdicts

--- a/cvs/lib/inference/utils/vllm_verification.py
+++ b/cvs/lib/inference/utils/vllm_verification.py
@@ -47,10 +47,19 @@ def active_metric_specs(
     if not enforce_thresholds:
         return ()
 
+    return tuple(
+        definition for definition in reportable_metric_specs(thresholds) if definition['spec'].get('kind') != 'info'
+    )
+
+
+def reportable_metric_specs(
+    thresholds: Mapping[str, Mapping[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    '''Return configured metric specs in display order, whether enforced or not.'''
     specs = []
     for definition in metric_definitions():
         spec = thresholds.get(definition['metric'])
-        if not isinstance(spec, Mapping) or spec.get('kind') == 'info':
+        if not isinstance(spec, Mapping):
             continue
         specs.append({**definition, 'spec': dict(spec)})
     return tuple(specs)
@@ -62,26 +71,37 @@ def evaluate_metric_verdicts(
     *,
     enforce_thresholds: bool,
 ) -> list[dict[str, Any]]:
-    '''Evaluate all active vLLM metric specs without stopping after a failure.'''
+    '''Build report rows and evaluate only enforced vLLM metric gates.'''
     verdicts = []
-    active_specs = active_metric_specs(thresholds, enforce_thresholds=enforce_thresholds)
+    reportable_specs = reportable_metric_specs(thresholds)
     for host, actuals in actuals_by_host.items():
-        for definition in active_specs:
+        for definition in reportable_specs:
             metric = definition['metric']
             value = actuals.get(metric)
+            enforced = enforce_thresholds and definition['spec'].get('kind') != 'info'
+            record_reason = (
+                'threshold enforcement disabled; no threshold asserted'
+                if not enforce_thresholds
+                else 'informational metric; no threshold asserted'
+            )
             verdict = {
                 'node': str(host),
                 'metric': metric,
                 'unit': definition['unit'],
                 'actual': value,
                 'spec': definition['spec'],
-                'status': 'pass',
-                'reason': '',
+                'enforced': enforced,
+                'status': 'pass' if enforced else 'record',
+                'reason': '' if enforced else record_reason,
             }
             if value is None:
-                verdict['status'] = definition['missing_status']
-                verdict['reason'] = f'{metric}: value is None (metric unavailable for this run)'
-            else:
+                unavailable = f'{metric}: value is None (metric unavailable for this run)'
+                if enforced:
+                    verdict['status'] = definition['missing_status']
+                    verdict['reason'] = unavailable
+                else:
+                    verdict['reason'] = f'{unavailable}; no threshold asserted'
+            elif enforced:
                 try:
                     evaluate_all(actuals, {metric: definition['spec']})
                 except ThresholdViolation as exc:

--- a/cvs/lib/report/benchmark_metric_registry.py
+++ b/cvs/lib/report/benchmark_metric_registry.py
@@ -30,7 +30,7 @@ DEFAULT_BENCHMARK_TEST_NAME = 'test_run_performance_benchmark_test'
 
 _ROWS_BY_NODEID: dict[str, list[dict[str, Any]]] = {}
 _COLUMNS_BY_NODEID: dict[str, Sequence[MetricColumn]] = {}
-_SUBTEST_SUMMARY = {'failed': 0, 'passed': 0}
+_SUBTEST_SUMMARY = {'failed': 0, 'passed': 0, 'skipped': 0}
 _SUBTEST_SUMMARY_COUNTED: set[str] = set()
 
 
@@ -87,16 +87,20 @@ def record_benchmark_metric_summary(nodeid: str, rows: list[dict[str, Any]]) -> 
         return
     _SUBTEST_SUMMARY_COUNTED.add(nodeid)
     for row in dedupe_metric_rows(rows):
-        if str(row.get('status') or '').lower() == 'pass':
+        status = str(row.get('status') or '').lower()
+        if status == 'pass':
             _SUBTEST_SUMMARY['passed'] += 1
+        elif status == 'skip':
+            _SUBTEST_SUMMARY['skipped'] += 1
         else:
             _SUBTEST_SUMMARY['failed'] += 1
 
 
-def benchmark_subtest_summary() -> tuple[int, int, int]:
+def benchmark_subtest_summary() -> tuple[int, int, int, int]:
     failed = _SUBTEST_SUMMARY['failed']
     passed = _SUBTEST_SUMMARY['passed']
-    return failed + passed, failed, passed
+    skipped = _SUBTEST_SUMMARY['skipped']
+    return failed + passed + skipped, failed, passed, skipped
 
 
 def benchmark_metrics_extra(
@@ -164,7 +168,6 @@ def _apply_benchmark_entry_patch(
     *,
     columns: Sequence[MetricColumn] = (),
 ) -> None:
-    metrics_extra = benchmark_metrics_extra(rows, columns=columns)
     extras: list[dict[str, Any]] = []
     for extra in entry.get('extras') or []:
         if _is_full_log_extra(extra):
@@ -172,7 +175,7 @@ def _apply_benchmark_entry_patch(
         elif is_benchmark_metrics_extra(extra):
             extras.append(extra)
     if not any(is_benchmark_metrics_extra(e) for e in extras):
-        extras.append(metrics_extra)
+        extras.append(benchmark_metrics_extra(rows, columns=columns))
     entry['extras'] = extras
     entry['log'] = ''
 
@@ -181,32 +184,58 @@ def _apply_benchmark_entry_patch(
         entry['resultsTableRow'][0] = _mark_collapsible_result_cell(result_cell)
 
 
-def _dedupe_benchmark_call_entries(entries: list[dict[str, Any]], nodeid: str) -> tuple[list[dict[str, Any]], int]:
+def _dedupe_benchmark_call_entries(
+    entries: list[dict[str, Any]],
+    nodeid: str,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
     main_calls = [entry for entry in entries if _is_main_call_entry(entry, nodeid)]
     if len(main_calls) <= 1:
-        return entries, 0
+        return entries, {}
 
     failed = [entry for entry in main_calls if _entry_outcome(entry) == 'failed']
     passed = [entry for entry in main_calls if _entry_outcome(entry) == 'passed']
-    if failed and passed:
-        drop = set(map(id, passed))
-        return [entry for entry in entries if id(entry) not in drop], len(passed)
-    return entries, 0
+    skipped = [entry for entry in main_calls if _entry_outcome(entry) == 'skipped']
+    retained = failed[:1] or passed[:1] or skipped[:1] or main_calls[:1]
+    retained_ids = set(map(id, retained))
+    dropped = [entry for entry in main_calls if id(entry) not in retained_ids]
+    if not dropped:
+        return entries, {}
+    dropped_ids = set(map(id, dropped))
+    counts = {}
+    for entry in dropped:
+        outcome = _entry_outcome(entry)
+        counts[outcome] = counts.get(outcome, 0) + 1
+    return [entry for entry in entries if id(entry) not in dropped_ids], counts
 
 
-def _adjust_passed_outcome_in_html(content: str, decrement: int) -> str:
-    """Drop phantom Passed counts left by pytest-html subtest call reports."""
-    if decrement <= 0:
+def _adjust_outcome_counts_in_html(content: str, decrements: dict[str, int]) -> str:
+    """Drop report counts for subtest rows removed from pytest-html's result data."""
+    total = sum(decrements.values())
+    if total <= 0:
         return content
 
-    def _dec_passed(match: re.Match[str]) -> str:
-        value = max(0, int(match.group(1)) - decrement)
-        return f'<span class="passed">{value} Passed,</span>'
+    for outcome, label in (
+        ('passed', 'Passed'),
+        ('failed', 'Failed'),
+        ('skipped', 'Skipped'),
+    ):
+        decrement = decrements.get(outcome, 0)
+        if decrement <= 0:
+            continue
 
-    content = re.sub(r'<span class="passed">(\d+) Passed,</span>', _dec_passed, content, count=1)
+        def _decrement(match: re.Match[str], decrement: int = decrement, label: str = label) -> str:
+            value = max(0, int(match.group(1)) - decrement)
+            return f'<span class="{outcome}">{value} {label},</span>'
+
+        content = re.sub(
+            rf'<span class="{outcome}">(\d+) {label},</span>',
+            _decrement,
+            content,
+            count=1,
+        )
 
     def _dec_run_count(match: re.Match[str]) -> str:
-        value = max(0, int(match.group(1)) - decrement)
+        value = max(0, int(match.group(1)) - total)
         label = 'tests' if value != 1 else 'test'
         return f'<p class="run-count">{value} {label} took {match.group(3)}</p>'
 
@@ -218,14 +247,16 @@ def _adjust_passed_outcome_in_html(content: str, decrement: int) -> str:
     )
 
 
-def _subtests_filter_summary_html(total: int, failed: int, passed: int) -> str:
+def _subtests_filter_summary_html(total: int, failed: int, passed: int, skipped: int) -> str:
     failed_cls = 'failed' if failed else 'filter'
     passed_cls = 'passed' if passed else 'filter'
+    skipped_cls = 'skipped' if skipped else 'filter'
     return (
         '<span class="filter"> | </span>'
         f'<span class="filter cvs-subtests-count">{total} subtests,</span>'
         f'<span class="{failed_cls}"> {failed} Failed,</span>'
-        f'<span class="{passed_cls}"> {passed} Passed</span>'
+        f'<span class="{passed_cls}"> {passed} Passed,</span>'
+        f'<span class="{skipped_cls}"> {skipped} Skipped</span>'
     )
 
 
@@ -250,9 +281,9 @@ def _strip_legacy_subtest_summary(content: str) -> str:
     return content
 
 
-def _inject_subtest_summary_into_filters(content: str, total: int, failed: int, passed: int) -> str:
+def _inject_subtest_summary_into_filters(content: str, total: int, failed: int, passed: int, skipped: int) -> str:
     content = _strip_legacy_subtest_summary(content)
-    summary_html = _subtests_filter_summary_html(total, failed, passed)
+    summary_html = _subtests_filter_summary_html(total, failed, passed, skipped)
     filters_match = re.search(r'(<div class="filters">.*?)(</div>\s*<div class="collapse">)', content, re.DOTALL)
     if not filters_match:
         return content
@@ -263,6 +294,10 @@ def _inject_subtest_summary_into_filters(content: str, total: int, failed: int, 
 
 def _strip_filter_metrics_summary(content: str) -> str:
     return _strip_legacy_subtest_summary(content)
+
+
+def _nodeid_test_name(nodeid: str) -> str:
+    return nodeid.rsplit('::', 1)[-1].split('[', 1)[0]
 
 
 def patch_benchmark_metrics_into_html(
@@ -284,18 +319,19 @@ def patch_benchmark_metrics_into_html(
     data = json.loads(html.unescape(match.group(1)))
     tests: dict[str, list[dict[str, Any]]] = data.get('tests') or {}
     patched = False
-    phantom_passed = 0
+    dropped_outcomes: dict[str, int] = {}
 
     for nodeid, rows in all_benchmark_metric_rows().items():
-        if benchmark_test_name not in nodeid:
+        if _nodeid_test_name(nodeid) != benchmark_test_name:
             continue
         entries = tests.get(nodeid)
         if not entries:
             continue
 
         record_benchmark_metric_summary(nodeid, rows)
-        entries, dropped_passed = _dedupe_benchmark_call_entries(entries, nodeid)
-        phantom_passed += dropped_passed
+        entries, counts = _dedupe_benchmark_call_entries(entries, nodeid)
+        for outcome, count in counts.items():
+            dropped_outcomes[outcome] = dropped_outcomes.get(outcome, 0) + count
         tests[nodeid] = entries
 
         for entry in entries:
@@ -309,13 +345,13 @@ def patch_benchmark_metrics_into_html(
             patched = True
 
     data['tests'] = tests
-    total, failed, passed = benchmark_subtest_summary()
+    total, failed, passed, skipped = benchmark_subtest_summary()
     if total:
-        content = _inject_subtest_summary_into_filters(content, total, failed, passed)
+        content = _inject_subtest_summary_into_filters(content, total, failed, passed, skipped)
         patched = True
 
-    if phantom_passed:
-        content = _adjust_passed_outcome_in_html(content, phantom_passed)
+    if dropped_outcomes:
+        content = _adjust_outcome_counts_in_html(content, dropped_outcomes)
         patched = True
 
     if not patched:

--- a/cvs/lib/report/benchmark_metric_registry.py
+++ b/cvs/lib/report/benchmark_metric_registry.py
@@ -30,7 +30,7 @@ DEFAULT_BENCHMARK_TEST_NAME = 'test_run_performance_benchmark_test'
 
 _ROWS_BY_NODEID: dict[str, list[dict[str, Any]]] = {}
 _COLUMNS_BY_NODEID: dict[str, Sequence[MetricColumn]] = {}
-_SUBTEST_SUMMARY = {'failed': 0, 'passed': 0, 'skipped': 0}
+_SUBTEST_SUMMARY = {'failed': 0, 'passed': 0, 'skipped': 0, 'recorded': 0}
 _SUBTEST_SUMMARY_COUNTED: set[str] = set()
 
 
@@ -92,15 +92,18 @@ def record_benchmark_metric_summary(nodeid: str, rows: list[dict[str, Any]]) -> 
             _SUBTEST_SUMMARY['passed'] += 1
         elif status == 'skip':
             _SUBTEST_SUMMARY['skipped'] += 1
+        elif status == 'record':
+            _SUBTEST_SUMMARY['recorded'] += 1
         else:
             _SUBTEST_SUMMARY['failed'] += 1
 
 
-def benchmark_subtest_summary() -> tuple[int, int, int, int]:
+def benchmark_subtest_summary() -> tuple[int, int, int, int, int]:
     failed = _SUBTEST_SUMMARY['failed']
     passed = _SUBTEST_SUMMARY['passed']
     skipped = _SUBTEST_SUMMARY['skipped']
-    return failed + passed + skipped, failed, passed, skipped
+    recorded = _SUBTEST_SUMMARY['recorded']
+    return failed + passed + skipped + recorded, failed, passed, skipped, recorded
 
 
 def benchmark_metrics_extra(
@@ -169,12 +172,16 @@ def _apply_benchmark_entry_patch(
     columns: Sequence[MetricColumn] = (),
 ) -> None:
     extras: list[dict[str, Any]] = []
+    has_full_log = False
+    has_metric_table = False
     for extra in entry.get('extras') or []:
-        if _is_full_log_extra(extra):
+        if _is_full_log_extra(extra) and not has_full_log:
             extras.append(extra)
-        elif is_benchmark_metrics_extra(extra):
+            has_full_log = True
+        elif is_benchmark_metrics_extra(extra) and not has_metric_table:
             extras.append(extra)
-    if not any(is_benchmark_metrics_extra(e) for e in extras):
+            has_metric_table = True
+    if not has_metric_table:
         extras.append(benchmark_metrics_extra(rows, columns=columns))
     entry['extras'] = extras
     entry['log'] = ''
@@ -247,20 +254,33 @@ def _adjust_outcome_counts_in_html(content: str, decrements: dict[str, int]) -> 
     )
 
 
-def _subtests_filter_summary_html(total: int, failed: int, passed: int, skipped: int) -> str:
+def _subtests_filter_summary_html(total: int, failed: int, passed: int, skipped: int, recorded: int) -> str:
     failed_cls = 'failed' if failed else 'filter'
     passed_cls = 'passed' if passed else 'filter'
     skipped_cls = 'skipped' if skipped else 'filter'
+    count_label = 'metrics' if recorded else 'subtests'
+    recorded_html = f'<span class="filter cvs-recorded-count"> {recorded} Recorded</span>' if recorded else ''
     return (
         '<span class="filter"> | </span>'
-        f'<span class="filter cvs-subtests-count">{total} subtests,</span>'
+        f'<span class="filter cvs-subtests-count">{total} {count_label},</span>'
         f'<span class="{failed_cls}"> {failed} Failed,</span>'
         f'<span class="{passed_cls}"> {passed} Passed,</span>'
         f'<span class="{skipped_cls}"> {skipped} Skipped</span>'
+        f'{recorded_html}'
     )
 
 
 def _strip_legacy_subtest_summary(content: str) -> str:
+    content = re.sub(
+        r'<span class="filter"> \| </span>\s*'
+        r'<span class="filter cvs-subtests-count">.*?</span>\s*'
+        r'<span class="[^"]+">\s*\d+ Failed,</span>\s*'
+        r'<span class="[^"]+">\s*\d+ Passed,</span>\s*'
+        r'<span class="[^"]+">\s*\d+ Skipped</span>\s*'
+        r'(?:<span class="filter cvs-recorded-count">\s*\d+ Recorded</span>)?',
+        '',
+        content,
+    )
     content = re.sub(
         r'<span class="filter"> \| \d+ subtests ran</span>.*?passed</span>',
         '',
@@ -281,9 +301,16 @@ def _strip_legacy_subtest_summary(content: str) -> str:
     return content
 
 
-def _inject_subtest_summary_into_filters(content: str, total: int, failed: int, passed: int, skipped: int) -> str:
+def _inject_subtest_summary_into_filters(
+    content: str,
+    total: int,
+    failed: int,
+    passed: int,
+    skipped: int,
+    recorded: int,
+) -> str:
     content = _strip_legacy_subtest_summary(content)
-    summary_html = _subtests_filter_summary_html(total, failed, passed, skipped)
+    summary_html = _subtests_filter_summary_html(total, failed, passed, skipped, recorded)
     filters_match = re.search(r'(<div class="filters">.*?)(</div>\s*<div class="collapse">)', content, re.DOTALL)
     if not filters_match:
         return content
@@ -345,9 +372,9 @@ def patch_benchmark_metrics_into_html(
             patched = True
 
     data['tests'] = tests
-    total, failed, passed, skipped = benchmark_subtest_summary()
+    total, failed, passed, skipped, recorded = benchmark_subtest_summary()
     if total:
-        content = _inject_subtest_summary_into_filters(content, total, failed, passed, skipped)
+        content = _inject_subtest_summary_into_filters(content, total, failed, passed, skipped, recorded)
         patched = True
 
     if dropped_outcomes:

--- a/cvs/lib/report/cell_build.py
+++ b/cvs/lib/report/cell_build.py
@@ -82,6 +82,14 @@ class CellRecordBuilder:
         conc_suffix = f"-{concurrency}]"
         inference_nid = ""
         metrics_nid = ""
+        metric_test_priority = {
+            "test_verify_cell_metrics": 0,
+            "test_cell_metrics": 1,
+            "test_metric": 2,
+            "test_gpu_metric": 3,
+            "test_prom_metric": 4,
+        }
+        metrics_priority = len(metric_test_priority)
         for nodeid in self._lifecycle_report():
             if cell_id and f"[{cell_id}" not in nodeid:
                 continue
@@ -89,9 +97,11 @@ class CellRecordBuilder:
                 continue
             if self.config.inference_test_substring in nodeid:
                 inference_nid = inference_nid or nodeid
-            if "test_cell_metrics" in nodeid or "test_metric" in nodeid:
-                if not metrics_nid or "test_cell_metrics" in nodeid:
-                    metrics_nid = nodeid
+            test_name = nodeid.rsplit("::", 1)[-1].split("[", 1)[0]
+            priority = metric_test_priority.get(test_name)
+            if priority is not None and priority < metrics_priority:
+                metrics_nid = nodeid
+                metrics_priority = priority
         return {
             "pytest_inference_nodeid": inference_nid,
             "pytest_metrics_nodeid": metrics_nid,

--- a/cvs/lib/report/profiles/vllm.json
+++ b/cvs/lib/report/profiles/vllm.json
@@ -74,7 +74,7 @@
   "behavior": {
     "inference_test_substring": "test_vllm_inference",
     "row_card_extras": true,
-    "row_card_test_names": ["test_metric", "test_gpu_metric", "test_prom_metric"]
+    "row_card_test_names": ["test_verify_cell_metrics"]
   },
   "viewer": {
     "interactivity": {

--- a/cvs/lib/report/render/perf_metric_table.py
+++ b/cvs/lib/report/render/perf_metric_table.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import html
 from typing import Any, Mapping, Sequence
 
+from cvs.lib.report.formatting import fmt_num
+
 _BENCHMARK_METRICS_WRAP = 'cvs-benchmark-metrics-wrap'
 
 MetricColumn = tuple[str, str | None]
@@ -23,7 +25,7 @@ def metric_display_label(
 
 
 def dedupe_metric_rows(rows: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
-    """Keep one pass/fail row per (node, metric) pair."""
+    """Keep one metric verdict row per (node, metric) pair."""
     seen: set[tuple[str, str]] = set()
     out: list[Mapping[str, Any]] = []
     for row in rows:
@@ -40,24 +42,48 @@ def render_benchmark_metrics_html(
     *,
     columns: Sequence[MetricColumn] = (),
 ) -> str:
-    """Table rows aligned with pytest-html Result / Test / Duration / Links columns."""
+    """Render a collapsible pass/fail/skip metric-verdict table."""
+
+    def _display_value(value: Any, unit: Any) -> str:
+        if value is None:
+            return '—'
+        suffix = f' {unit}' if unit and unit != '-' else ''
+        return f'{fmt_num(value)}{suffix}'
+
+    def _display_gate(spec: Any) -> str:
+        if not isinstance(spec, Mapping):
+            return '—'
+        kind = spec.get('kind', '')
+        value = spec.get('value')
+        return str(kind) if value is None else f'{kind} {fmt_num(value)}'
+
     body_rows = []
     for row in dedupe_metric_rows(rows):
         status = str(row.get('status') or '').lower()
-        passed = status == 'pass'
-        label = html.escape(metric_display_label(str(row.get('metric') or ''), columns))
-        outcome = 'Passed' if passed else 'Failed'
-        outcome_cls = 'passed' if passed else 'failed'
+        outcome, outcome_cls = {
+            'pass': ('Passed', 'passed'),
+            'skip': ('Skipped', 'skipped'),
+        }.get(status, ('Failed', 'failed'))
+        label = str(row.get('label') or metric_display_label(str(row.get('metric') or ''), columns))
+        node = row.get('node') or row.get('host')
+        if node:
+            label = f'{node}: {label}'
+        label = html.escape(label)
+        actual = html.escape(_display_value(row.get('actual'), row.get('unit')))
+        gate = html.escape(_display_gate(row.get('spec')))
+        reason = html.escape(str(row.get('reason') or ''))
         body_rows.append(
             f"<tr class='cvs-benchmark-metric-row cvs-benchmark-metric-{outcome_cls} {outcome_cls}'>"
             f"<td class='col-result'>{outcome}</td>"
             f"<td class='col-testId'>{label}</td>"
-            f"<td class='col-duration'></td>"
-            f"<td class='col-links'></td>"
+            f"<td class='col-actual'>{actual}</td>"
+            f"<td class='col-gate'>{gate}</td>"
+            f"<td class='col-reason'>{reason}</td>"
             f'</tr>'
         )
     return (
         f"<table class='cvs-benchmark-metrics-table {_BENCHMARK_METRICS_WRAP}'>"
+        "<thead><tr><th>Result</th><th>Metric</th><th>Actual</th><th>Gate</th><th>Note</th></tr></thead>"
         f"<tbody>{''.join(body_rows)}</tbody></table>"
     )
 

--- a/cvs/lib/report/render/perf_metric_table.py
+++ b/cvs/lib/report/render/perf_metric_table.py
@@ -42,7 +42,7 @@ def render_benchmark_metrics_html(
     *,
     columns: Sequence[MetricColumn] = (),
 ) -> str:
-    """Render a collapsible pass/fail/skip metric-verdict table."""
+    """Render a collapsible pass/fail/skip/record metric-verdict table."""
 
     def _display_value(value: Any, unit: Any) -> str:
         if value is None:
@@ -50,12 +50,13 @@ def render_benchmark_metrics_html(
         suffix = f' {unit}' if unit and unit != '-' else ''
         return f'{fmt_num(value)}{suffix}'
 
-    def _display_gate(spec: Any) -> str:
+    def _display_gate(spec: Any, *, enforced: bool) -> str:
         if not isinstance(spec, Mapping):
             return '—'
         kind = spec.get('kind', '')
         value = spec.get('value')
-        return str(kind) if value is None else f'{kind} {fmt_num(value)}'
+        rendered = str(kind) if value is None else f'{kind} {fmt_num(value)}'
+        return rendered if enforced else f'reference: {rendered}'
 
     body_rows = []
     for row in dedupe_metric_rows(rows):
@@ -63,6 +64,7 @@ def render_benchmark_metrics_html(
         outcome, outcome_cls = {
             'pass': ('Passed', 'passed'),
             'skip': ('Skipped', 'skipped'),
+            'record': ('Recorded', 'record'),
         }.get(status, ('Failed', 'failed'))
         label = str(row.get('label') or metric_display_label(str(row.get('metric') or ''), columns))
         node = row.get('node') or row.get('host')
@@ -70,7 +72,7 @@ def render_benchmark_metrics_html(
             label = f'{node}: {label}'
         label = html.escape(label)
         actual = html.escape(_display_value(row.get('actual'), row.get('unit')))
-        gate = html.escape(_display_gate(row.get('spec')))
+        gate = html.escape(_display_gate(row.get('spec'), enforced=bool(row.get('enforced', status != 'record'))))
         reason = html.escape(str(row.get('reason') or ''))
         body_rows.append(
             f"<tr class='cvs-benchmark-metric-row cvs-benchmark-metric-{outcome_cls} {outcome_cls}'>"
@@ -83,7 +85,7 @@ def render_benchmark_metrics_html(
         )
     return (
         f"<table class='cvs-benchmark-metrics-table {_BENCHMARK_METRICS_WRAP}'>"
-        "<thead><tr><th>Result</th><th>Metric</th><th>Actual</th><th>Gate</th><th>Note</th></tr></thead>"
+        "<thead><tr><th>Result</th><th>Metric</th><th>Actual</th><th>Gate / reference</th><th>Note</th></tr></thead>"
         f"<tbody>{''.join(body_rows)}</tbody></table>"
     )
 

--- a/cvs/lib/report/unittests/test_benchmark_metric_registry.py
+++ b/cvs/lib/report/unittests/test_benchmark_metric_registry.py
@@ -22,6 +22,7 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
         registry._SUBTEST_SUMMARY_COUNTED.clear()
         registry._SUBTEST_SUMMARY['failed'] = 0
         registry._SUBTEST_SUMMARY['passed'] = 0
+        registry._SUBTEST_SUMMARY['skipped'] = 0
 
     def test_record_and_fetch_benchmark_metric_rows(self):
         node = SimpleNamespace(
@@ -66,13 +67,15 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
         rows = [
             {'node': 'n1', 'metric': 'mean_ttft_ms', 'status': 'pass'},
             {'node': 'n1', 'metric': 'goodput', 'status': 'fail'},
+            {'node': 'n1', 'metric': 'queue_time_p95_ms', 'status': 'skip'},
         ]
         registry.record_benchmark_metric_summary(nodeid, rows)
         registry.record_benchmark_metric_summary(nodeid, rows)
-        total, failed, passed = registry.benchmark_subtest_summary()
-        self.assertEqual(total, 2)
+        total, failed, passed, skipped = registry.benchmark_subtest_summary()
+        self.assertEqual(total, 3)
         self.assertEqual(failed, 1)
         self.assertEqual(passed, 1)
+        self.assertEqual(skipped, 1)
 
     def test_mark_collapsible_result_cell_adds_class(self):
         cell = '<td class="col-result">Passed</td>'
@@ -115,6 +118,41 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
             self.assertIn('cvs-benchmark-metrics-table', updated)
             self.assertIn('Mean TTFT (ms)', updated)
             self.assertIn('cvs-subtests-count', updated)
+
+    def test_patch_accepts_vllm_verification_parent(self):
+        nodeid = 'cvs/tests/inference/vllm/vllm_single.py::test_verify_cell_metrics[1k1k-conc16]'
+        registry._ROWS_BY_NODEID[nodeid] = [
+            {'node': 'n1', 'metric': 'gpu.gpu_compute_util_pct', 'status': 'skip', 'reason': 'unavailable'}
+        ]
+        payload = {
+            'tests': {
+                nodeid: [
+                    {
+                        'resultsTableRow': [
+                            '<td class="col-result">Skipped</td>',
+                            f'<td class="col-testId">{html.escape(nodeid)}</td>',
+                        ],
+                        'extras': [],
+                        'log': '',
+                    }
+                ]
+            }
+        }
+        blob = html.escape(json.dumps(payload), quote=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            html_path = Path(tmp) / 'report.html'
+            html_path.write_text(
+                '<html><body><div class="filters"></div><div class="collapse"></div>'
+                f'<div data-jsonblob="{blob}"></div></body></html>',
+                encoding='utf-8',
+            )
+            self.assertTrue(
+                registry.patch_benchmark_metrics_into_html(
+                    html_path,
+                    benchmark_test_name='test_verify_cell_metrics',
+                )
+            )
+            self.assertIn('Skipped', html_path.read_text(encoding='utf-8'))
 
 
 if __name__ == '__main__':

--- a/cvs/lib/report/unittests/test_benchmark_metric_registry.py
+++ b/cvs/lib/report/unittests/test_benchmark_metric_registry.py
@@ -2,6 +2,7 @@
 
 import html
 import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -23,6 +24,7 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
         registry._SUBTEST_SUMMARY['failed'] = 0
         registry._SUBTEST_SUMMARY['passed'] = 0
         registry._SUBTEST_SUMMARY['skipped'] = 0
+        registry._SUBTEST_SUMMARY['recorded'] = 0
 
     def test_record_and_fetch_benchmark_metric_rows(self):
         node = SimpleNamespace(
@@ -68,14 +70,16 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
             {'node': 'n1', 'metric': 'mean_ttft_ms', 'status': 'pass'},
             {'node': 'n1', 'metric': 'goodput', 'status': 'fail'},
             {'node': 'n1', 'metric': 'queue_time_p95_ms', 'status': 'skip'},
+            {'node': 'n1', 'metric': 'output_throughput', 'status': 'record'},
         ]
         registry.record_benchmark_metric_summary(nodeid, rows)
         registry.record_benchmark_metric_summary(nodeid, rows)
-        total, failed, passed, skipped = registry.benchmark_subtest_summary()
-        self.assertEqual(total, 3)
+        total, failed, passed, skipped, recorded = registry.benchmark_subtest_summary()
+        self.assertEqual(total, 4)
         self.assertEqual(failed, 1)
         self.assertEqual(passed, 1)
         self.assertEqual(skipped, 1)
+        self.assertEqual(recorded, 1)
 
     def test_mark_collapsible_result_cell_adds_class(self):
         cell = '<td class="col-result">Passed</td>'
@@ -122,8 +126,16 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
     def test_patch_accepts_vllm_verification_parent(self):
         nodeid = 'cvs/tests/inference/vllm/vllm_single.py::test_verify_cell_metrics[1k1k-conc16]'
         registry._ROWS_BY_NODEID[nodeid] = [
-            {'node': 'n1', 'metric': 'gpu.gpu_compute_util_pct', 'status': 'skip', 'reason': 'unavailable'}
+            {
+                'node': 'n1',
+                'metric': 'client.output_throughput',
+                'status': 'record',
+                'actual': 99,
+                'spec': {'kind': 'min_tok_s', 'value': 100},
+                'enforced': False,
+            }
         ]
+        full_log = {'format_type': 'url', 'name': 'Full Log', 'content': 'test_html/full.html'}
         payload = {
             'tests': {
                 nodeid: [
@@ -132,8 +144,8 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
                             '<td class="col-result">Skipped</td>',
                             f'<td class="col-testId">{html.escape(nodeid)}</td>',
                         ],
-                        'extras': [],
-                        'log': '',
+                        'extras': [full_log, dict(full_log)],
+                        'log': 'raw log',
                     }
                 ]
             }
@@ -152,7 +164,31 @@ class TestBenchmarkMetricRegistry(unittest.TestCase):
                     benchmark_test_name='test_verify_cell_metrics',
                 )
             )
-            self.assertIn('Skipped', html_path.read_text(encoding='utf-8'))
+            self.assertTrue(
+                registry.patch_benchmark_metrics_into_html(
+                    html_path,
+                    benchmark_test_name='test_verify_cell_metrics',
+                )
+            )
+            updated = html_path.read_text(encoding='utf-8')
+            self.assertIn('Recorded', updated)
+            self.assertIn('0 Failed', updated)
+            self.assertIn('1 Recorded', updated)
+            self.assertIn('cvs-subtests-count', updated)
+            self.assertEqual(updated.count('cvs-subtests-count'), 1)
+
+            match = re.search(r'data-jsonblob="([^"]*)"', updated)
+            patched_payload = json.loads(html.unescape(match.group(1)))
+            entry = patched_payload['tests'][nodeid][0]
+            self.assertEqual(entry['log'], '')
+            self.assertEqual(
+                sum(extra.get('name') == 'Full Log' for extra in entry['extras']),
+                1,
+            )
+            self.assertEqual(
+                sum(registry.is_benchmark_metrics_extra(extra) for extra in entry['extras']),
+                1,
+            )
 
 
 if __name__ == '__main__':

--- a/cvs/lib/report/unittests/test_cell_build.py
+++ b/cvs/lib/report/unittests/test_cell_build.py
@@ -45,6 +45,19 @@ class TestCellBuild(unittest.TestCase):
         self.assertIn("test_inference", ids["pytest_inference_nodeid"])
         self.assertIn("test_cell_metrics", ids["pytest_metrics_nodeid"])
 
+    def test_resolve_pytest_nodeids_prefers_vllm_verification_parent(self):
+        config = generic_inference_report_config()
+        parent = "cvs/tests/inference/vllm/vllm_single.py::test_verify_cell_metrics[combo-128]"
+        lifecycle = {
+            "cvs/tests/inference/vllm/vllm_single.py::test_vllm_inference[combo-128]": [],
+            "cvs/tests/inference/vllm/vllm_single.py::test_metric[output-128]": [],
+            parent: [],
+        }
+
+        ids = resolve_pytest_nodeids_for_cell(config, lifecycle, 128)
+
+        self.assertEqual(ids["pytest_metrics_nodeid"], parent)
+
     def test_pytest_row_href_encodes_nodeid(self):
         href = pytest_row_href("run.html", "cvs/tests/x.py::test_metric[a-128]")
         self.assertTrue(href.startswith("run.html#"))

--- a/cvs/lib/report/unittests/test_perf_metric_table.py
+++ b/cvs/lib/report/unittests/test_perf_metric_table.py
@@ -36,7 +36,7 @@ class TestPerfMetricTable(unittest.TestCase):
     def test_metric_display_label_prettifies_unknown_keys(self):
         self.assertEqual(metric_display_label('goodput'), 'Goodput')
 
-    def test_render_benchmark_metrics_html_includes_tri_state_rows(self):
+    def test_render_benchmark_metrics_html_includes_metric_statuses(self):
         columns = (('Mean TTFT (ms)', 'mean_ttft_ms'), ('Goodput', 'goodput'))
         html_out = render_benchmark_metrics_html(
             [
@@ -49,6 +49,15 @@ class TestPerfMetricTable(unittest.TestCase):
                     'actual': None,
                     'reason': 'metric unavailable',
                 },
+                {
+                    'node': 'n1',
+                    'metric': 'client.output_throughput',
+                    'status': 'record',
+                    'actual': 99,
+                    'spec': {'kind': 'min_tok_s', 'value': 100},
+                    'enforced': False,
+                    'reason': 'threshold enforcement disabled; no threshold asserted',
+                },
             ],
             columns=columns,
         )
@@ -57,6 +66,8 @@ class TestPerfMetricTable(unittest.TestCase):
         self.assertIn('Passed', html_out)
         self.assertIn('Failed', html_out)
         self.assertIn('Skipped', html_out)
+        self.assertIn('Recorded', html_out)
+        self.assertIn('reference: min_tok_s 100', html_out)
         self.assertIn('metric unavailable', html_out)
 
     def test_is_benchmark_metrics_extra_detects_wrapped_table(self):

--- a/cvs/lib/report/unittests/test_perf_metric_table.py
+++ b/cvs/lib/report/unittests/test_perf_metric_table.py
@@ -21,6 +21,14 @@ class TestPerfMetricTable(unittest.TestCase):
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0]['status'], 'pass')
 
+    def test_dedupe_metric_rows_keeps_same_metric_from_multiple_nodes(self):
+        rows = [
+            {'node': 'head', 'metric': 'client.output_throughput', 'status': 'pass'},
+            {'node': 'worker', 'metric': 'client.output_throughput', 'status': 'pass'},
+        ]
+
+        self.assertEqual(len(dedupe_metric_rows(rows)), 2)
+
     def test_metric_display_label_uses_columns_when_provided(self):
         columns = (('Mean TTFT (ms)', 'mean_ttft_ms'),)
         self.assertEqual(metric_display_label('mean_ttft_ms', columns), 'Mean TTFT (ms)')
@@ -28,12 +36,19 @@ class TestPerfMetricTable(unittest.TestCase):
     def test_metric_display_label_prettifies_unknown_keys(self):
         self.assertEqual(metric_display_label('goodput'), 'Goodput')
 
-    def test_render_benchmark_metrics_html_includes_pass_and_fail_rows(self):
+    def test_render_benchmark_metrics_html_includes_tri_state_rows(self):
         columns = (('Mean TTFT (ms)', 'mean_ttft_ms'), ('Goodput', 'goodput'))
         html_out = render_benchmark_metrics_html(
             [
                 {'node': 'n1', 'metric': 'mean_ttft_ms', 'status': 'pass'},
                 {'node': 'n1', 'metric': 'goodput', 'status': 'fail'},
+                {
+                    'node': 'n1',
+                    'metric': 'gpu.gpu_compute_util_pct',
+                    'status': 'skip',
+                    'actual': None,
+                    'reason': 'metric unavailable',
+                },
             ],
             columns=columns,
         )
@@ -41,6 +56,8 @@ class TestPerfMetricTable(unittest.TestCase):
         self.assertIn('Mean TTFT (ms)', html_out)
         self.assertIn('Passed', html_out)
         self.assertIn('Failed', html_out)
+        self.assertIn('Skipped', html_out)
+        self.assertIn('metric unavailable', html_out)
 
     def test_is_benchmark_metrics_extra_detects_wrapped_table(self):
         html_out = render_benchmark_metrics_html([{'node': 'n1', 'metric': 'goodput', 'status': 'pass'}])

--- a/cvs/tests/inference/vllm/_common.py
+++ b/cvs/tests/inference/vllm/_common.py
@@ -9,18 +9,17 @@ import pytest
 from cvs.lib import globals
 from cvs.lib.inference.utils.inference_suite_lifecycle import test_accuracy_eval  # noqa: F401
 from cvs.lib.inference.utils.vllm_config_loader import load_variant
-from cvs.lib.inference.utils.vllm_parsing import CLIENT_METRICS, CLIENT_METRIC_UNITS
-from cvs.lib.inference.utils.vllm_server_metrics import PROM_METRICS, PROM_METRIC_UNITS, to_prom_metrics
+from cvs.lib.inference.utils.vllm_parsing import VLLM_RESULTS_COLUMNS
+from cvs.lib.inference.utils.vllm_server_metrics import to_prom_metrics
+from cvs.lib.inference.utils.vllm_verification import evaluate_metric_verdicts
 from cvs.lib.inference.vllm_job import VllmJob, scrape_vllm_metrics
 from cvs.lib.utils.gpu import (
-    GPU_METRICS,
-    GPU_METRIC_UNITS,
     agg_readings,
     capture_gpu_metrics,
     start_gpu_poller,
     stop_and_collect_gpu_poller,
 )
-from cvs.lib.utils.verdict import evaluate_all
+from cvs.lib.report.benchmark_metric_registry import record_benchmark_metric_rows
 
 from ._shared import test_print_results_table  # noqa: F401
 
@@ -40,28 +39,7 @@ def pytest_generate_tests(metafunc):
     variant = load_variant(config_file, {})
     runs = variant.resolved_runs()
     ids = [run.cell.key for run in runs]
-    if "metric" in metafunc.fixturenames and runs:
-        params = [(run, metric) for run in runs for metric, _ in CLIENT_METRICS]
-        metafunc.parametrize(
-            "run,metric",
-            params,
-            ids=[f"{case_id}-{metric}" for case_id in ids for metric, _ in CLIENT_METRICS],
-        )
-    elif "gpu_metric" in metafunc.fixturenames and runs:
-        params = [(run, metric) for run in runs for metric, _ in GPU_METRICS]
-        metafunc.parametrize(
-            "run,gpu_metric",
-            params,
-            ids=[f"{case_id}-{metric}" for case_id in ids for metric, _ in GPU_METRICS],
-        )
-    elif "prom_metric" in metafunc.fixturenames and runs:
-        params = [(run, metric) for run in runs for metric, _ in PROM_METRICS]
-        metafunc.parametrize(
-            "run,prom_metric",
-            params,
-            ids=[f"{case_id}-{metric}" for case_id in ids for metric, _ in PROM_METRICS],
-        )
-    elif "accuracy_task" in metafunc.fixturenames:
+    if "accuracy_task" in metafunc.fixturenames:
         tasks = [task.id for task in variant.accuracy.tasks]
         metafunc.parametrize("accuracy_task", tasks, ids=tasks)
     elif "run" in metafunc.fixturenames and runs:
@@ -271,67 +249,31 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
     inf_res_dict[_cell_result_key(variant_config, run)] = results
 
 
-def _test_metric(run, metric, prefix, units, inf_res_dict, variant_config, vllm_targets, lifecycle, request):
-    if lifecycle.failed:
-        pytest.skip("a prior lifecycle stage failed")
+def test_verify_cell_metrics(run, inf_res_dict, variant_config, lifecycle, request, subtests):
+    """Verify one collected cell's active threshold gates as pytest subtests."""
     key = _cell_result_key(variant_config, run)
     host_dict = inf_res_dict.get(key)
     if not host_dict:
-        pytest.skip(f"no recorded results for {key!r}")
-    full = prefix + metric
-    _host, actuals = next(iter(host_dict.items()))
-    value = actuals.get(full)
-    request.node.user_properties.append(("metric_value", value))
-    request.node.user_properties.append(("metric_unit", units.get(metric, "-")))
-    if prefix != "client." and value is None:
-        pytest.skip(f"{full}: no value recorded")
-    cell = run.cell.key
-    spec = (variant_config.thresholds.get(cell) or {}).get(full)
-    if not variant_config.enforce_thresholds or spec is None:
-        return
-    evaluate_all(actuals, {full: spec})
+        pytest.skip(f"no recorded inference result for {key!r}")
 
-
-def test_metric(run, metric, inf_res_dict, variant_config, vllm_targets, lifecycle, request):
-    _test_metric(
-        run,
-        metric,
-        "client.",
-        CLIENT_METRIC_UNITS,
-        inf_res_dict,
-        variant_config,
-        vllm_targets,
-        lifecycle,
-        request,
+    verdicts = evaluate_metric_verdicts(
+        host_dict,
+        variant_config.thresholds.get(run.cell.key) or {},
+        enforce_thresholds=variant_config.enforce_thresholds,
     )
+    if not verdicts:
+        pytest.skip(f"no active threshold gates for {run.cell.key}")
 
-
-def test_gpu_metric(run, gpu_metric, inf_res_dict, variant_config, vllm_targets, lifecycle, request):
-    _test_metric(
-        run,
-        gpu_metric,
-        "gpu.",
-        GPU_METRIC_UNITS,
-        inf_res_dict,
-        variant_config,
-        vllm_targets,
-        lifecycle,
-        request,
-    )
-
-
-def test_prom_metric(run, prom_metric, inf_res_dict, variant_config, vllm_targets, lifecycle, request):
-    _test_metric(
-        run,
-        prom_metric,
-        "prom.",
-        PROM_METRIC_UNITS,
-        inf_res_dict,
-        variant_config,
-        vllm_targets,
-        lifecycle,
-        request,
-    )
+    record_benchmark_metric_rows(request.node, verdicts, columns=VLLM_RESULTS_COLUMNS)
+    started = time.monotonic()
+    for verdict in verdicts:
+        with subtests.test(node=verdict["node"], metric=verdict["metric"]):
+            if verdict["status"] == "skip":
+                pytest.skip(verdict["reason"])
+            assert verdict["status"] == "pass", verdict["reason"]
+    lifecycle.record(request.node.nodeid, "metric_verification", time.monotonic() - started)
+    if all(verdict["status"] == "skip" for verdict in verdicts):
+        pytest.skip(f"all active metrics were unavailable for {run.cell.key}")
 
 
 def test_teardown(orch, lifecycle, request):

--- a/cvs/tests/inference/vllm/_common.py
+++ b/cvs/tests/inference/vllm/_common.py
@@ -250,7 +250,7 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
 
 
 def test_verify_cell_metrics(run, inf_res_dict, variant_config, lifecycle, request, subtests):
-    """Verify one collected cell's active threshold gates as pytest subtests."""
+    """Report configured metrics and verify active gates as pytest subtests."""
     key = _cell_result_key(variant_config, run)
     host_dict = inf_res_dict.get(key)
     if not host_dict:
@@ -262,17 +262,20 @@ def test_verify_cell_metrics(run, inf_res_dict, variant_config, lifecycle, reque
         enforce_thresholds=variant_config.enforce_thresholds,
     )
     if not verdicts:
-        pytest.skip(f"no active threshold gates for {run.cell.key}")
+        pytest.skip(f"no configured metric specs for {run.cell.key}")
 
     record_benchmark_metric_rows(request.node, verdicts, columns=VLLM_RESULTS_COLUMNS)
+    asserted_verdicts = [verdict for verdict in verdicts if verdict["enforced"]]
     started = time.monotonic()
-    for verdict in verdicts:
+    for verdict in asserted_verdicts:
         with subtests.test(node=verdict["node"], metric=verdict["metric"]):
             if verdict["status"] == "skip":
                 pytest.skip(verdict["reason"])
             assert verdict["status"] == "pass", verdict["reason"]
     lifecycle.record(request.node.nodeid, "metric_verification", time.monotonic() - started)
-    if all(verdict["status"] == "skip" for verdict in verdicts):
+    if not asserted_verdicts:
+        pytest.skip(f"metrics recorded without active threshold gates for {run.cell.key}")
+    if all(verdict["status"] == "skip" for verdict in asserted_verdicts):
         pytest.skip(f"all active metrics were unavailable for {run.cell.key}")
 
 

--- a/cvs/tests/inference/vllm/_shared.py
+++ b/cvs/tests/inference/vllm/_shared.py
@@ -9,12 +9,24 @@ after `test_vllm_inference`.
 '''
 
 from tabulate import tabulate
+import pytest
 
 from cvs.lib import globals
 
 log = globals.log
 
-__all__ = ["test_print_results_table"]
+__all__ = ["test_print_results_table", "validate_vllm_execution_mode"]
+
+
+def validate_vllm_execution_mode(pytestconfig):
+    """Reject execution modes that split or overwrite process-local cell results."""
+    workers = pytestconfig.getoption("numprocesses", default=0)
+    if workers not in (None, 0, "0"):
+        raise pytest.UsageError("vLLM suites require serial pytest execution; xdist is unsupported")
+
+    repeat_count = pytestconfig.getoption("count", default=1)
+    if repeat_count not in (None, 1, "1"):
+        raise pytest.UsageError("vLLM suites do not support pytest-repeat counts above one")
 
 
 def _cell(m, key):

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -5,16 +5,74 @@ All rights reserved.
 
 import json
 import os
+from pathlib import Path
 
 import pytest
+
+try:
+    from _pytest.subtests import SubtestReport as _BuiltinSubtestReport
+except ImportError:
+    _BuiltinSubtestReport = None
+try:
+    from pytest_subtests.plugin import SubTestReport as _PluginSubtestReport
+except ImportError:
+    _PluginSubtestReport = None
 
 from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFactory
 from cvs.lib import globals
 from cvs.lib.inference.vllm_topology import resolve_vllm_topology, scope_vllm_cluster
 from cvs.lib.inference.utils.vllm_config_loader import load_variant
+from cvs.lib.inference.utils.vllm_parsing import VLLM_RESULTS_COLUMNS
+from cvs.lib.report.benchmark_metric_registry import (
+    benchmark_metric_columns_for_nodeid,
+    benchmark_metric_rows_from_report,
+    mark_collapsible_result_cell,
+    patch_benchmark_metrics_into_html,
+    stamp_benchmark_metric_rows_on_report,
+)
+from cvs.lib.report.render.perf_metric_table import (
+    is_benchmark_metrics_extra,
+    render_benchmark_metrics_html,
+)
 from cvs.lib.utils_lib import resolve_cluster_config_placeholders
+from cvs.tests.inference.vllm._shared import validate_vllm_execution_mode
 
 log = globals.log
+VLLM_METRIC_VERIFICATION_TEST = 'test_verify_cell_metrics'
+
+
+def _is_subtest_report(report) -> bool:
+    if _BuiltinSubtestReport is not None and isinstance(report, _BuiltinSubtestReport):
+        return True
+    if _PluginSubtestReport is not None and isinstance(report, _PluginSubtestReport):
+        return True
+    return False
+
+
+def _is_verification_report(report) -> bool:
+    test_name = report.nodeid.rsplit('::', 1)[-1].split('[', 1)[0]
+    return report.when == 'call' and test_name == VLLM_METRIC_VERIFICATION_TEST and not _is_subtest_report(report)
+
+
+def _is_full_log_extra(extra: object) -> bool:
+    return isinstance(extra, dict) and extra.get('format_type') == 'url' and extra.get('name') == 'Full Log'
+
+
+def _attach_metric_panel(report, rows) -> None:
+    try:
+        import pytest_html
+    except ImportError:
+        return
+
+    extras = []
+    for extra in getattr(report, 'extras', []) or []:
+        if _is_full_log_extra(extra) or is_benchmark_metrics_extra(extra):
+            extras.append(extra)
+    if not any(is_benchmark_metrics_extra(extra) for extra in extras):
+        columns = benchmark_metric_columns_for_nodeid(report.nodeid) or VLLM_RESULTS_COLUMNS
+        extras.append(pytest_html.extras.html(render_benchmark_metrics_html(rows, columns=columns)))
+    report.extras = extras
+    stamp_benchmark_metric_rows_on_report(report, rows)
 
 
 def _deep_merge(base, override):
@@ -149,7 +207,7 @@ def inf_res_dict():
     return {}
 
 
-def pytest_collection_modifyitems(items):
+def pytest_collection_modifyitems(config, items):
     """Pin the lifecycle order explicitly instead of relying on definition order.
 
     `test_print_results_table` is an imported function (its source line points
@@ -158,6 +216,7 @@ def pytest_collection_modifyitems(items):
     the benchmark cells, the results table, then teardown last. Items from other
     modules keep their relative order.
     """
+    validate_vllm_execution_mode(config)
     rank = {
         "test_launch_container": 0,
         "test_setup_sshd": 1,
@@ -165,9 +224,7 @@ def pytest_collection_modifyitems(items):
         "test_model_fetch": 3,
         "test_openai_compatible_smoke": 4,
         "test_vllm_inference": 5,
-        "test_metric": 6,
-        "test_gpu_metric": 6,
-        "test_prom_metric": 6,
+        VLLM_METRIC_VERIFICATION_TEST: 6,
         "test_accuracy_eval": 7,
         "test_print_results_table": 8,
         "test_teardown": 9,
@@ -175,29 +232,30 @@ def pytest_collection_modifyitems(items):
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
 
 
-# def pytest_html_results_table_header(cells):
-#     """Add Value + Unit columns just before the trailing Links column.
-#
-#     Populated for test_metric rows; blank for lifecycle/inference rows (they
-#     record no metric_value user-property). Scoped to this suite's conftest, so
-#     other suites' result tables are unaffected.
-#     """
-#     cells.insert(-1, "<th>Value</th>")
-#     cells.insert(-1, "<th>Unit</th>")
-#
-#
-# def pytest_html_results_table_row(report, cells):
-#     props = dict(report.user_properties)
-#     has = "metric_value" in props
-#     val = props.get("metric_value")
-#     unit = props.get("metric_unit", "") if has else ""
-#     if not has:
-#         shown = ""
-#     elif val is None:
-#         shown = "-"
-#     elif isinstance(val, float):
-#         shown = f"{val:.3f}"
-#     else:
-#         shown = str(val)
-#     cells.insert(-1, f"<td>{shown}</td>")
-#     cells.insert(-1, f"<td>{unit}</td>")
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_runtest_logreport(report):
+    yield
+    if _is_verification_report(report):
+        rows = benchmark_metric_rows_from_report(report)
+        if rows:
+            _attach_metric_panel(report, rows)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_html_results_table_html(report, data):
+    if _is_verification_report(report) and benchmark_metric_rows_from_report(report):
+        del data[:]
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_html_results_table_row(report, cells):
+    if _is_verification_report(report) and benchmark_metric_rows_from_report(report):
+        cells[0] = mark_collapsible_result_cell(str(cells[0]))
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    yield
+    htmlpath = getattr(session.config.option, 'htmlpath', None)
+    if htmlpath:
+        patch_benchmark_metrics_into_html(Path(htmlpath), benchmark_test_name=VLLM_METRIC_VERIFICATION_TEST)

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -25,6 +25,7 @@ from cvs.lib.inference.utils.vllm_config_loader import load_variant
 from cvs.lib.inference.utils.vllm_parsing import VLLM_RESULTS_COLUMNS
 from cvs.lib.report.benchmark_metric_registry import (
     benchmark_metric_columns_for_nodeid,
+    benchmark_metric_rows_from_item,
     benchmark_metric_rows_from_report,
     mark_collapsible_result_cell,
     patch_benchmark_metrics_into_html,
@@ -59,18 +60,27 @@ def _is_full_log_extra(extra: object) -> bool:
 
 
 def _attach_metric_panel(report, rows) -> None:
+    if not rows:
+        return
+
     try:
-        import pytest_html
+        from pytest_html import extras as pytest_html_extras
     except ImportError:
         return
 
     extras = []
+    has_full_log = False
+    has_metric_table = False
     for extra in getattr(report, 'extras', []) or []:
-        if _is_full_log_extra(extra) or is_benchmark_metrics_extra(extra):
+        if _is_full_log_extra(extra) and not has_full_log:
             extras.append(extra)
-    if not any(is_benchmark_metrics_extra(extra) for extra in extras):
+            has_full_log = True
+        elif is_benchmark_metrics_extra(extra) and not has_metric_table:
+            extras.append(extra)
+            has_metric_table = True
+    if not has_metric_table:
         columns = benchmark_metric_columns_for_nodeid(report.nodeid) or VLLM_RESULTS_COLUMNS
-        extras.append(pytest_html.extras.html(render_benchmark_metrics_html(rows, columns=columns)))
+        extras.append(pytest_html_extras.html(render_benchmark_metrics_html(rows, columns=columns)))
     report.extras = extras
     stamp_benchmark_metric_rows_on_report(report, rows)
 
@@ -230,6 +240,16 @@ def pytest_collection_modifyitems(config, items):
         "test_teardown": 9,
     }
     items.sort(key=lambda it: rank.get(it.originalname or it.name.split("[")[0], 99))
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_runtest_makereport(item, call):
+    """Attach metric rows before pytest-html consumes the parent call report."""
+    outcome = yield
+    report = outcome.get_result()
+    if not _is_verification_report(report):
+        return
+    _attach_metric_panel(report, benchmark_metric_rows_from_item(item))
 
 
 @pytest.hookimpl(hookwrapper=True, trylast=True)

--- a/cvs/tests/inference/vllm/unittests/test_common.py
+++ b/cvs/tests/inference/vllm/unittests/test_common.py
@@ -1,0 +1,72 @@
+'''Unit tests for shared vLLM metric verification stages.'''
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from _pytest.outcomes import Skipped
+
+from cvs.lib.report import benchmark_metric_registry as registry
+from cvs.tests.inference.vllm import _common
+
+
+class _FakeStash(dict):
+    pass
+
+
+class TestVerifyCellMetrics(unittest.TestCase):
+    def setUp(self):
+        registry._ROWS_BY_NODEID.clear()
+        registry._COLUMNS_BY_NODEID.clear()
+
+    def test_record_only_cell_registers_rows_without_running_assertions(self):
+        cell = SimpleNamespace(
+            key='ISL=1024,OSL=1024,TP=8,PP=1,CONC=16',
+            isl=1024,
+            osl=1024,
+            concurrency=16,
+        )
+        run = SimpleNamespace(cell=cell)
+        variant = SimpleNamespace(
+            model_id='org/model',
+            thresholds={
+                cell.key: {
+                    'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
+                }
+            },
+            enforce_thresholds=False,
+        )
+        result_key = _common._cell_result_key(variant, run)
+        inf_res_dict = {
+            result_key: {
+                'head': {
+                    'client.output_throughput': 99,
+                    'client.mean_ttft_ms': 40,
+                }
+            }
+        }
+        node = SimpleNamespace(
+            nodeid='cvs/tests/inference/vllm/vllm_single.py::test_verify_cell_metrics[cell]',
+            stash=_FakeStash(),
+        )
+        lifecycle = SimpleNamespace(record=mock.Mock())
+        subtests = SimpleNamespace(test=mock.Mock())
+
+        with self.assertRaises(Skipped):
+            _common.test_verify_cell_metrics(
+                run,
+                inf_res_dict,
+                variant,
+                lifecycle,
+                SimpleNamespace(node=node),
+                subtests,
+            )
+
+        rows = registry.benchmark_metric_rows_for_nodeid(node.nodeid)
+        self.assertEqual([(row['metric'], row['status']) for row in rows], [('client.output_throughput', 'record')])
+        subtests.test.assert_not_called()
+        lifecycle.record.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/tests/inference/vllm/unittests/test_conftest.py
+++ b/cvs/tests/inference/vllm/unittests/test_conftest.py
@@ -1,0 +1,65 @@
+'''Unit tests for vLLM pytest-html metric hooks.'''
+
+import unittest
+from types import SimpleNamespace
+
+from cvs.lib.report import benchmark_metric_registry as registry
+from cvs.lib.report.render.perf_metric_table import is_benchmark_metrics_extra
+from cvs.tests.inference.vllm import conftest as vllm_conftest
+
+
+class _FakeStash(dict):
+    def get(self, key, default=None):
+        return super().get(key, default)
+
+
+class _Outcome:
+    def __init__(self, report):
+        self.report = report
+
+    def get_result(self):
+        return self.report
+
+
+class TestVllmMetricReportHook(unittest.TestCase):
+    def setUp(self):
+        registry._ROWS_BY_NODEID.clear()
+        registry._COLUMNS_BY_NODEID.clear()
+
+    def test_makereport_attaches_and_stamps_metric_panel(self):
+        nodeid = 'cvs/tests/inference/vllm/vllm_single.py::test_verify_cell_metrics[cell]'
+        item = SimpleNamespace(nodeid=nodeid, stash=_FakeStash())
+        rows = [
+            {
+                'node': 'head',
+                'metric': 'client.output_throughput',
+                'status': 'record',
+                'actual': 99,
+                'spec': {'kind': 'min_tok_s', 'value': 100},
+                'enforced': False,
+            }
+        ]
+        registry.record_benchmark_metric_rows(item, rows)
+        full_log = {'format_type': 'url', 'name': 'Full Log', 'content': 'test_html/full.html'}
+        report = SimpleNamespace(
+            nodeid=nodeid,
+            when='call',
+            extras=[full_log, dict(full_log)],
+            user_properties=[],
+        )
+
+        hook = vllm_conftest.pytest_runtest_makereport(item, None)
+        next(hook)
+        with self.assertRaises(StopIteration):
+            hook.send(_Outcome(report))
+
+        self.assertEqual(sum(is_benchmark_metrics_extra(extra) for extra in report.extras), 1)
+        self.assertEqual(sum(extra.get('name') == 'Full Log' for extra in report.extras), 1)
+        self.assertEqual(
+            dict(report.user_properties)[registry.BENCHMARK_METRIC_ROWS_USER_PROPERTY],
+            rows,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cvs/tests/inference/vllm/unittests/test_shared.py
+++ b/cvs/tests/inference/vllm/unittests/test_shared.py
@@ -6,6 +6,8 @@ All rights reserved.
 import unittest
 from unittest import mock
 
+import pytest
+
 from cvs.tests.inference.vllm import _shared
 
 
@@ -17,6 +19,26 @@ class TestPrintResultsTable(unittest.TestCase):
             _shared.test_print_results_table(results)
 
         log_info.assert_called_once()
+
+
+class TestExecutionMode(unittest.TestCase):
+    class _Config:
+        def __init__(self, **options):
+            self.options = options
+
+        def getoption(self, name, default=None):
+            return self.options.get(name, default)
+
+    def test_serial_single_run_is_allowed(self):
+        _shared.validate_vllm_execution_mode(self._Config(numprocesses=0, count=1))
+
+    def test_xdist_is_rejected(self):
+        with self.assertRaisesRegex(pytest.UsageError, "xdist"):
+            _shared.validate_vllm_execution_mode(self._Config(numprocesses=2, count=1))
+
+    def test_repeat_is_rejected(self):
+        with self.assertRaisesRegex(pytest.UsageError, "pytest-repeat"):
+            _shared.validate_vllm_execution_mode(self._Config(numprocesses=0, count=2))
 
 
 if __name__ == "__main__":

--- a/cvs/tests/inference/vllm/vllm_distributed.py
+++ b/cvs/tests/inference/vllm/vllm_distributed.py
@@ -5,14 +5,12 @@ from cvs.tests.inference.vllm._common import (
     pytest_generate_tests,
     test_accuracy_eval,
     test_discover_topology,
-    test_gpu_metric,
     test_launch_container,
-    test_metric,
     test_model_fetch,
     test_openai_compatible_smoke,
-    test_prom_metric,
     test_setup_sshd,
     test_teardown,
+    test_verify_cell_metrics,
     test_vllm_inference,
 )  # noqa: F401
 from cvs.tests.inference.vllm._shared import test_print_results_table  # noqa: F401

--- a/cvs/tests/inference/vllm/vllm_single.py
+++ b/cvs/tests/inference/vllm/vllm_single.py
@@ -5,14 +5,12 @@ from cvs.tests.inference.vllm._common import (
     pytest_generate_tests,
     test_accuracy_eval,
     test_discover_topology,
-    test_gpu_metric,
     test_launch_container,
-    test_metric,
     test_model_fetch,
     test_openai_compatible_smoke,
-    test_prom_metric,
     test_setup_sshd,
     test_teardown,
+    test_verify_cell_metrics,
     test_vllm_inference,
 )  # noqa: F401
 from cvs.tests.inference.vllm._shared import test_print_results_table  # noqa: F401

--- a/docs/how-to/test-suites/inference/vllm.rst
+++ b/docs/how-to/test-suites/inference/vllm.rst
@@ -122,12 +122,12 @@ Use ``vllm_distributed`` for one distributed service across a two-host cluster:
 Step 4: Read the results
 ========================
 
-Open the HTML report. Each lifecycle stage and each metric is its own row:
+Open the HTML report. Each lifecycle stage, benchmark cell, and verification phase is its own row:
 
 - **Lifecycle rows** — container launch, topology discovery, model fetch, the OpenAI-compatible smoke test, then teardown. These tell you *how far* the run got.
 - **Inference rows** — one per sweep cell, labelled ``<combo>-conc<N>``.
-- **Metric rows** — one per metric per cell. A metric that could not be measured is skipped rather than failed.
-- **Results table** — the summary near the end, also printed to the console. This is where you read the measured numbers.
+- **Verification rows** — one per cell. Expand the row to see its active threshold metric subtests. Unavailable GPU and Prometheus metrics are skipped; unavailable client metrics with active thresholds fail.
+- **Results table** — the summary is also printed to the console. Use the per-cell logs for record-only client, GPU, and Prometheus values.
 
 Per-cell logs land under your configured ``log_dir``::
 
@@ -219,7 +219,7 @@ Common pitfalls
 
 **A threshold fails with "missing from actuals".** The threshold gates a metric this run did not produce. The suite owns benchmark percentile collection; do not add percentile controls to workload config.
 
-**Every metric row skips.** The benchmark produced no parseable results. Check ``client.log`` and the server log for the cell.
+**A verification row skips.** Either the benchmark produced no parseable result for that cell, threshold enforcement is disabled, or the cell has no active metric gates. Check ``client.log`` and the server log for collection failures.
 
 **The sweep is slower than expected.** Cells that differ only in concurrency reuse the running server; changing ISL, OSL, TP, PP, or any server argument forces a restart and a weight reload. Ordering ``runs`` so concurrency varies fastest avoids needless reloads.
 

--- a/docs/reference/configuration-files/inference/vllm.rst
+++ b/docs/reference/configuration-files/inference/vllm.rst
@@ -52,8 +52,8 @@ Each stage of the run is an independent test, so every stage becomes its own tim
      - ``test_vllm_inference``
      - Run one benchmark cell (parametrized per sweep run)
    * - 6
-     - ``test_metric``, ``test_gpu_metric``, ``test_prom_metric``
-     - One row per metric, per cell
+     - ``test_verify_cell_metrics``
+     - One verification parent per cell; configured threshold gates are listed as subtests
    * - 7
      - ``test_accuracy_eval``
      - lm-eval accuracy tasks, if any are configured
@@ -67,6 +67,12 @@ Each stage of the run is an independent test, so every stage becomes its own tim
 .. note::
 
   ``test_setup_sshd`` always skips in this suite. vLLM uses ``--distributed-executor-backend mp`` with NCCL over the host network, so no inter-container sshd is needed. A skipped row here is expected, not a problem.
+
+.. note::
+
+  vLLM suite execution is serial and single-pass. Do not use xdist workers or
+  ``pytest-repeat`` counts above one: the verification phase consumes results
+  collected earlier in the same pytest process.
 
 If a stage fails, later stages are skipped rather than cascading into confusing downstream errors. The container is still torn down by a leak-guard even when a mid-sweep test fails.
 
@@ -788,8 +794,11 @@ Threshold kinds
    * - ``min_ratio``
      - ``reference``
      - ``actual / <reference metric>`` is less than ``value``
+   * - ``info``
+     - —
+     - Never. The value is recorded, but no verification subtest is emitted.
 
-An unrecognized ``kind`` is a violation, not a silent skip. A metric that is missing from the results, or whose value is ``None``, is also a loud violation rather than a pass.
+An unrecognized ``kind`` is a violation, not a silent skip. A missing or ``None`` ``client.*`` value with an active threshold is a loud violation. Unavailable ``gpu.*`` and ``prom.*`` values are reported as skipped subtests.
 
 For ``min_ratio``, the ``reference`` names another metric in the same cell. If that reference is missing, ``None``, or zero, the check fails with a message naming the reason.
 
@@ -825,7 +834,7 @@ The threshold file is located in one of two ways:
 Metrics
 =======
 
-Metrics live in namespaces. Each numeric metric becomes one test, and therefore one row in the HTML report. A metric that could not be measured skips rather than failing. Read the measured values from the results table and the per-cell logs; the report's Value and Unit columns are currently disabled.
+Metrics live in namespaces. ``test_verify_cell_metrics`` is one parent phase per cell and lists each active threshold gate as a subtest in its expandable HTML panel. Missing ``gpu.*`` and ``prom.*`` values skip their subtests; missing ``client.*`` values with an active threshold fail. Record-only metrics do not create passing subtests; read them from the results table and per-cell logs.
 
 Client metrics
 --------------


### PR DESCRIPTION
## Summary
- Collapse one-row-per-metric pytest tests into `test_verify_cell_metrics` so each cell reports active threshold gates as pass/fail/skip subtests.
- Keep HTML reports aligned with those verdicts, including skipped GPU/Prometheus metrics, without treating record-only values as passing tests.

## Test plan
- [x] make fmt-check
- [x] make lint
- [x] make ut
