### PR TITLE
Drop unused ATOM JSON run_card and fall back to container.image

### DIFF
--- a/cvs/input/config_file/inference/atom/mi3xx_atom_deepseek-r1_fp8_distributed.json
+++ b/cvs/input/config_file/inference/atom/mi3xx_atom_deepseek-r1_fp8_distributed.json
@@ -12,10 +12,6 @@
     "precision": "fp8"
   },
   "enforce_thresholds": false,
-  "run_card": {
-    "atom_image_pin": "<changeme>",
-    "notes": "DeepSeek-R1-0528 FP8 two-node PP=2 via vllm_atom; align master_addr and ib_netdev with cluster"
-  },
   "container": {
     "lifetime": "per_run",
     "name": "atom_mi3xx_multi",

--- a/cvs/input/config_file/inference/atom/mi3xx_atom_deepseek-r1_fp8_single.json
+++ b/cvs/input/config_file/inference/atom/mi3xx_atom_deepseek-r1_fp8_single.json
@@ -17,10 +17,6 @@
   "profiles": {
     "perf": {
       "enforce_thresholds": false,
-      "run_card": {
-        "atom_image_pin": "<changeme>",
-        "notes": "DeepSeek-R1-0528 FP8 single-node: atom driver perf gate (1K/1K) plus accuracy"
-      },
       "container": {
         "lifetime": "per_run",
         "name": "atom_mi3xx",
@@ -154,10 +150,6 @@
     },
     "mtp3": {
       "enforce_thresholds": false,
-      "run_card": {
-        "atom_image_pin": "<changeme>",
-        "notes": "DeepSeek-R1-0528 FP8 single-node MTP-3 speculative decode perf and gsm8k quality"
-      },
       "container": {
         "lifetime": "per_run",
         "name": "atom_mi3xx",

--- a/cvs/input/config_file/inference/atom/mi3xx_atom_qwen3.5-397b-a17b_fp8_single.json
+++ b/cvs/input/config_file/inference/atom/mi3xx_atom_qwen3.5-397b-a17b_fp8_single.json
@@ -12,10 +12,6 @@
     "precision": "fp8"
   },
   "enforce_thresholds": false,
-  "run_card": {
-    "atom_image_pin": "<changeme>",
-    "notes": "amd/Qwen3.5-397B-A17B-FP8 (fp8) single-node atom perf plus accuracy"
-  },
   "container": {
     "lifetime": "per_run",
     "name": "atom_mi3xx",

--- a/cvs/lib/inference/atom/atom_config_loader.py
+++ b/cvs/lib/inference/atom/atom_config_loader.py
@@ -161,6 +161,15 @@ class AtomRunCard(_Forbid):
     notes: str = ""
 
 
+def resolved_atom_image_pin(variant):
+    rc = getattr(variant, "run_card", None)
+    pin = (getattr(rc, "atom_image_pin", None) or "").strip() if rc is not None else ""
+    if pin:
+        return pin
+    container = getattr(variant, "container", None)
+    return str(getattr(container, "image", "") or "").strip()
+
+
 class MtpQualityConfig(_Forbid):
     enabled: bool = False
     chat_template_prompt: str = "Say hello in one short sentence."

--- a/cvs/lib/inference/unittests/test_atom_config_loader.py
+++ b/cvs/lib/inference/unittests/test_atom_config_loader.py
@@ -21,6 +21,7 @@ from cvs.lib.inference.atom.atom_config_loader import (
     orchestrator_container_from_variant,
     placeholder_gated_threshold_cell,
     resolve_atom_profile,
+    resolved_atom_image_pin,
     reuse_server_flag,
     server_session_key,
 )
@@ -370,6 +371,8 @@ class TestATOMAtomConfigLoader(unittest.TestCase):
         root = Path(__file__).resolve().parents[3]
         variant = _atom_config(root, "mi3xx_atom_qwen3.5-397b-a17b_fp8_single.json")
         self.assertEqual(variant.model.id, "amd/Qwen3.5-397B-A17B-FP8")
+        self.assertEqual(variant.run_card.atom_image_pin, "")
+        self.assertEqual(resolved_atom_image_pin(variant), variant.container.image)
         self.assertEqual(
             variant.expected_cells(),
             [

--- a/cvs/lib/report/presets/atom.py
+++ b/cvs/lib/report/presets/atom.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any, List, Tuple
 
+from cvs.lib.inference.atom.atom_config_loader import resolved_atom_image_pin
 from cvs.lib.inference.utils.inference_suite_results_table import ATOM_RESULTS_COLUMNS
 from cvs.lib.inference.atom.atom_parsing import (
     CLIENT_METRIC_UNITS,
@@ -53,11 +54,12 @@ _ATOM_CHART_SERIES = (
 
 def _atom_run_card_display(variant: Any, provenance: dict) -> List[Tuple[str, str, bool]]:
     rc = variant.run_card
+    image = resolved_atom_image_pin(variant) or "\u2014"
     rows: List[Tuple[str, str, bool]] = [
         ("Model", variant.model.id, False),
         ("GPU", variant.gpu_arch, False),
         ("Driver", variant.params.driver, False),
-        ("Image pin", rc.atom_image_pin or "\u2014", False),
+        ("Image pin", image, False),
         ("TP", str(variant.params.tensor_parallelism), False),
         thresholds_run_card_row(variant),
     ]

--- a/cvs/lib/report/profiles/hooks/atom_run_card.py
+++ b/cvs/lib/report/profiles/hooks/atom_run_card.py
@@ -9,16 +9,18 @@ from __future__ import annotations
 
 from typing import Any, List, Tuple
 
+from cvs.lib.inference.atom.atom_config_loader import resolved_atom_image_pin
 from cvs.lib.report.rundeck.config_builder import provenance_link_rows, thresholds_run_card_row
 
 
 def atom_run_card_display(variant: Any, provenance: dict) -> List[Tuple[str, str, bool]]:
     rc = variant.run_card
+    image = resolved_atom_image_pin(variant) or "\u2014"
     rows: List[Tuple[str, str, bool]] = [
         ("Model", variant.model.id, False),
         ("GPU", variant.gpu_arch, False),
         ("Driver", variant.params.driver, False),
-        ("Image pin", rc.atom_image_pin or "\u2014", False),
+        ("Image pin", image, False),
         ("TP", str(variant.params.tensor_parallelism), False),
         thresholds_run_card_row(variant),
     ]

--- a/cvs/tests/inference/atom/conftest.py
+++ b/cvs/tests/inference/atom/conftest.py
@@ -17,6 +17,7 @@ from cvs.lib.inference.utils.inference_suite_lifecycle import (
 from cvs.lib.inference.atom.atom_config_loader import (
     load_variant,
     orchestrator_container_from_variant,
+    resolved_atom_image_pin,
 )
 from cvs.lib.inference.atom.atom_dmesg import capture_dmesg_timestamp
 from cvs.lib.utils_lib import resolve_cluster_config_placeholders
@@ -43,8 +44,9 @@ def _log_variant_run_card(variant_config, config_profile=None):
     atom_args = variant_config.roles.server.atom_args
     if atom_args:
         parts.append(f"atom_args={len(atom_args)} tokens")
-    if rc.atom_image_pin:
-        parts.append(f"image_pin={rc.atom_image_pin}")
+    image = resolved_atom_image_pin(variant_config)
+    if image:
+        parts.append(f"image={image}")
     if rc.upstream_run_url:
         parts.append(f"upstream_run={rc.upstream_run_url}")
     if rc.notes:


### PR DESCRIPTION
## Summary
Shipped ATOM configs listed 
un_card.atom_image_pin as a duplicate of container.image. That block was unused at launch and only showed up in reports and logs.

This PR removes 
un_card from the shipped ATOM JSON stems. AtomRunCard stays optional in the loader with defaults, so existing configs that still set it keep working.

Reports and suite logs now resolve the image label through 
esolved_atom_image_pin in tom_config_loader. That helper prefers a pin when one is set and otherwise uses container.image. It lives on the loader instead of the report hook so conftest does not import the report layer.

## Test plan
- [x] Unit test after Qwen load asserts an empty pin falls back to container.image
- [x] 	est_all_atom_configs_load_with_aligned_thresholds still passes without JSON 
un_card
- [x] Confirmed remaining ATOM JSON stems no longer ship a 
un_card block
