### PR TITLE
feat(vllm): flatten metric threshold contract

### DIFF
--- a/cvs/input/config_file/inference/vllm/README.md
+++ b/cvs/input/config_file/inference/vllm/README.md
@@ -101,18 +101,19 @@ without validating both registration and call sites in the exact image.
 
 ## Thresholds
 
-`enforce_thresholds` is **false** on every config, so nothing gates and metrics
-are only recorded. Each threshold file carries a placeholder for every metric
-the suite can gate on — 56 per cell. That full grid is a convenience for later
-calibration, **not** a loader requirement: the vLLM loader checks cell coverage
-only, and an absent metric spec means "don't gate this metric". A threshold file
-may gate just the handful of metrics you care about.
+`enforce_thresholds` is **false** on every config, so nothing gates. vLLM
+supports 56 registry metrics and reports every finite value it produces. Each
+packaged threshold cell intentionally retains the previous 32-metric assertion
+subset: 23 client/run metrics, all 5 GPU metrics, and all 4 Prometheus metrics.
+That subset is a packaging choice, **not** a loader requirement: users may add
+any other registered metric or remove any existing entry, and only retained
+entries gate when enforcement is enabled.
 
-| Family | Count | Source of the list |
-|---|---|---|
-| Client/run | 47 | `vllm_metrics.METRIC_REGISTRY` |
-| GPU | 5 | Registry definitions composed from `GPU_METRICS` |
-| Prometheus | 4 | `vllm_metrics.METRIC_REGISTRY` |
+| Family | Packaged subset | Registry total | Source of the list |
+|---|---:|---:|---|
+| Client/run | 23 | 47 | `vllm_metrics.METRIC_REGISTRY` |
+| GPU | 5 | 5 | Registry definitions composed from `GPU_METRICS` |
+| Prometheus | 4 | 4 | `vllm_metrics.METRIC_REGISTRY` |
 
 **Every value is `0`**, meaning *not yet measured* — not a real bound. On a
 `max` kind, `0` is an impossible bound, so enabling enforcement before

--- a/cvs/input/config_file/inference/vllm/README.md
+++ b/cvs/input/config_file/inference/vllm/README.md
@@ -103,21 +103,35 @@ without validating both registration and call sites in the exact image.
 
 `enforce_thresholds` is **false** on every config, so nothing gates and metrics
 are only recorded. Each threshold file carries a placeholder for every metric
-the suite can gate on — 32 per file. That full grid is a convenience for later
+the suite can gate on — 56 per cell. That full grid is a convenience for later
 calibration, **not** a loader requirement: the vLLM loader checks cell coverage
 only, and an absent metric spec means "don't gate this metric". A threshold file
 may gate just the handful of metrics you care about.
 
 | Family | Count | Source of the list |
 |---|---|---|
-| `client.*` | 23 | the suite's gated-metric set |
-| `gpu.*` | 5 | `cvs.lib.utils.gpu.GPU_METRICS` |
-| `prom.*` | 4 | `vllm_server_metrics.PROM_METRICS` |
+| Client/run | 47 | `vllm_metrics.METRIC_REGISTRY` |
+| GPU | 5 | Registry definitions composed from `GPU_METRICS` |
+| Prometheus | 4 | `vllm_metrics.METRIC_REGISTRY` |
 
 **Every value is `0`**, meaning *not yet measured* — not a real bound. On a
-`max`/`max_ms` kind, `0` is an impossible bound, so enabling enforcement before
+`max` kind, `0` is an impossible bound, so enabling enforcement before
 calibrating fails loudly rather than passing silently. Replace them with
 measured values from a calibration run before flipping `enforce_thresholds`.
+
+Metric names are bare, for example:
+
+```json
+"output_throughput": {"kind": "min", "value": 4000},
+"mean_ttft_ms": {"kind": "max", "value": 500}
+```
+
+Every spec must contain exactly `kind` and `value`. `kind` is fixed by the
+registry (`min` or `max`), and `value` must be a finite JSON number. Prefixed
+names such as `client.output_throughput`, legacy kinds such as `min_tok_s` and
+`max_ms`, and extra fields are rejected at load time even when enforcement is
+disabled. Reports use metric contract `vllm-bare` version 1; older namespaced
+Run Deck JSON files are intentionally incompatible as comparison baselines.
 
 ### Accuracy
 
@@ -129,7 +143,7 @@ Accuracy is split across the two files, unlike the three families above:
   then by lm-eval metric key. Add it when configuring accuracy tasks.
 
 Because the threshold keys are derived from the task ids you choose, they
-cannot be pre-enumerated the way `client.*`/`gpu.*`/`prom.*` can — the two
+cannot be pre-enumerated the way sweep metrics can — the two
 blocks must be filled in together:
 
 ```jsonc

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for deepseek-r1-0528_fp8 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for deepseek-r1-0528_fp8 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-r1-0528_fp8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for deepseek-v4-flash_fp8 (distributed, TP=4, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-flash_fp8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for deepseek-v4-flash_fp8 (single, TP=4, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for deepseek-v4-pro_fp8 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_deepseek-v4-pro_fp8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for deepseek-v4-pro_fp8 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for glm-51_fp8 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-51_fp8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for glm-51_fp8 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for glm-52_fp8 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_glm-52_fp8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for glm-52_fp8 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for gpt-oss-120b_mxfp4 (distributed, TP=4, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_gpt-oss-120b_mxfp4_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for gpt-oss-120b_mxfp4 (single, TP=4, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for kimi-k25_w4a8 (distributed, TP=4, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k25_w4a8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for kimi-k25_w4a8 (single, TP=4, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for kimi-k26_mxfp4 (distributed, TP=4, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k26_mxfp4_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for kimi-k26_mxfp4 (single, TP=4, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=4,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for kimi-k27-code_mxfp4 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_kimi-k27-code_mxfp4_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for kimi-k27-code_mxfp4 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for llama33-70b_fp8 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for llama33-70b_fp8 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_llama33-70b_fp8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for mimo-v25-pro_fp8 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mimo-v25-pro_fp8_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for mimo-v25-pro_fp8 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for minimax-m3_bf16 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for minimax-m3_bf16 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_minimax-m3_bf16_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for mistral-large-3_bf16 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for mistral-large-3_bf16 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_mistral-large-3_bf16_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_distributed_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for qwen35-397b-a17b_bf16 (distributed, TP=8, PP=2, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_distributed_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_distributed_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=2,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_single_threshold.json
@@ -1,40 +1,12 @@
 {
-  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment": "Uncalibrated zero placeholders for the packaged 32-metric assertion subset. The paired config keeps enforce_thresholds false, so all finite metrics record without gating. Add or remove registered metrics as needed, and replace every retained placeholder with a measured value before enabling enforcement.",
   "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -46,43 +18,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -98,23 +38,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -138,18 +66,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -158,23 +74,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },
@@ -228,39 +132,11 @@
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "max_concurrency": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_concurrent_requests": {
-      "kind": "min",
-      "value": 0
-    },
-    "num_prompts": {
-      "kind": "min",
-      "value": 0
-    },
-    "completed": {
-      "kind": "min",
-      "value": 0
-    },
     "failed": {
       "kind": "max",
       "value": 0
     },
     "success_rate": {
-      "kind": "min",
-      "value": 0
-    },
-    "duration": {
-      "kind": "max",
-      "value": 0
-    },
-    "request_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "goodput": {
       "kind": "min",
       "value": 0
     },
@@ -272,43 +148,11 @@
       "kind": "min",
       "value": 0
     },
-    "per_gpu_throughput": {
-      "kind": "min",
-      "value": 0
-    },
-    "decode_throughput_p50": {
-      "kind": "min",
-      "value": 0
-    },
-    "max_output_tokens_per_s": {
-      "kind": "min",
-      "value": 0
-    },
-    "rtfx": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_input_tokens": {
-      "kind": "min",
-      "value": 0
-    },
-    "total_output_tokens": {
-      "kind": "min",
-      "value": 0
-    },
     "mean_ttft_ms": {
       "kind": "max",
       "value": 0
     },
     "median_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_ttft_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_ttft_ms": {
       "kind": "max",
       "value": 0
     },
@@ -324,23 +168,11 @@
       "kind": "max",
       "value": 0
     },
-    "normalized_ttft_ms_per_tok": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_tpot_ms": {
       "kind": "max",
       "value": 0
     },
     "median_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_tpot_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_tpot_ms": {
       "kind": "max",
       "value": 0
     },
@@ -364,18 +196,6 @@
       "kind": "max",
       "value": 0
     },
-    "std_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p90_itl_ms": {
-      "kind": "max",
-      "value": 0
-    },
     "p95_itl_ms": {
       "kind": "max",
       "value": 0
@@ -384,23 +204,11 @@
       "kind": "max",
       "value": 0
     },
-    "decode_latency_ratio": {
-      "kind": "max",
-      "value": 0
-    },
     "mean_e2el_ms": {
       "kind": "max",
       "value": 0
     },
     "median_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "std_e2el_ms": {
-      "kind": "max",
-      "value": 0
-    },
-    "p50_e2el_ms": {
       "kind": "max",
       "value": 0
     },

--- a/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_single_threshold.json
+++ b/cvs/input/config_file/inference/vllm/mi325x_vllm_qwen35-397b-a17b_bf16_single_threshold.json
@@ -1,263 +1,455 @@
 {
-  "_comment": "Uncalibrated placeholders for qwen35-397b-a17b_bf16 (single, TP=8, CONC=16 and CONC=32). Every value is 0 and means 'not yet measured' -- covers client.*, gpu.* and prom.*. enforce_thresholds is false in the config, so these record without gating. Replace with measured values from a calibration run before enabling enforcement.",
-  "_comment_accuracy": "The accuracy block is keyed by accuracy task id, then by lm-eval metric key, so it cannot be pre-enumerated the way client/gpu/prom can -- its contents follow whichever tasks config.json selects in accuracy.tasks, which is empty. Shape to fill in alongside a task: \"accuracy\": {\"<task-id>\": {\"<lm_eval_task>.<metric>\": {\"kind\": \"min\", \"value\": 0}}}, where <metric> is the results.json key with commas replaced by __ (e.g. gsm8k.exact_match__strict-match). Exempt from the sweep-cell coverage check via NON_SWEEP_THRESHOLD_KEYS.",
+  "_comment": "Uncalibrated zero placeholders for all 56 canonical bare vLLM metrics. The paired config keeps enforce_thresholds false, so these values record without gating. Replace every placeholder with a measured value before enabling enforcement.",
+  "_comment_accuracy": "The optional top-level accuracy block is task-qualified and exempt from vLLM sweep metric validation. Its shape remains: \"accuracy\": {\"<task-id>\": {\"<lm-eval-metric>\": {\"kind\": \"min\", \"value\": 0}}}.",
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   },
   "ISL=1024,OSL=1024,TP=8,PP=1,CONC=32": {
-    "client.total_token_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.output_throughput": {
-      "kind": "min_tok_s",
-      "value": 0
-    },
-    "client.mean_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_ttft_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_tpot_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_itl_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.mean_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.median_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p90_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p95_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.p99_e2el_ms": {
-      "kind": "max_ms",
-      "value": 0
-    },
-    "client.success_rate": {
+    "max_concurrency": {
       "kind": "min",
       "value": 0
     },
-    "client.failed": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.peak_gpu_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_memory_mb": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.model_load_s": {
-      "kind": "max",
-      "value": 0
-    },
-    "gpu.gpu_bandwidth_util_pct": {
+    "max_concurrent_requests": {
       "kind": "min",
       "value": 0
     },
-    "gpu.gpu_compute_util_pct": {
+    "num_prompts": {
       "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p50_ms": {
-      "kind": "max_ms",
+    "completed": {
+      "kind": "min",
       "value": 0
     },
-    "prom.queue_time_p95_ms": {
-      "kind": "max_ms",
+    "failed": {
+      "kind": "max",
       "value": 0
     },
-    "prom.prefill_time_p50_ms": {
-      "kind": "max_ms",
+    "success_rate": {
+      "kind": "min",
       "value": 0
     },
-    "prom.prefill_time_p95_ms": {
-      "kind": "max_ms",
+    "duration": {
+      "kind": "max",
+      "value": 0
+    },
+    "request_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "goodput": {
+      "kind": "min",
+      "value": 0
+    },
+    "output_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_token_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "per_gpu_throughput": {
+      "kind": "min",
+      "value": 0
+    },
+    "decode_throughput_p50": {
+      "kind": "min",
+      "value": 0
+    },
+    "max_output_tokens_per_s": {
+      "kind": "min",
+      "value": 0
+    },
+    "rtfx": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_input_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "total_output_tokens": {
+      "kind": "min",
+      "value": 0
+    },
+    "mean_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_ttft_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "normalized_ttft_ms_per_tok": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_tpot_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_itl_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "decode_latency_ratio": {
+      "kind": "max",
+      "value": 0
+    },
+    "mean_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "median_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "std_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p50_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p90_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p95_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "p99_e2el_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "peak_gpu_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_memory_mb": {
+      "kind": "max",
+      "value": 0
+    },
+    "model_load_s": {
+      "kind": "max",
+      "value": 0
+    },
+    "gpu_bandwidth_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "gpu_compute_util_pct": {
+      "kind": "min",
+      "value": 0
+    },
+    "queue_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "queue_time_p95_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p50_ms": {
+      "kind": "max",
+      "value": 0
+    },
+    "prefill_time_p95_ms": {
+      "kind": "max",
       "value": 0
     }
   }

--- a/cvs/lib/inference/unittests/test_vllm_config_contract.py
+++ b/cvs/lib/inference/unittests/test_vllm_config_contract.py
@@ -1,4 +1,5 @@
 import json
+import math
 import unittest
 from pathlib import Path
 
@@ -16,6 +17,40 @@ from cvs.lib.inference.utils.vllm_metrics import METRIC_REGISTRY
 
 CELL = "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16"
 EXPECTED_PACKAGED_CONFIG_COUNT = 28
+EXPECTED_PACKAGED_THRESHOLD_NAMES = (
+    "failed",
+    "success_rate",
+    "output_throughput",
+    "total_token_throughput",
+    "mean_ttft_ms",
+    "median_ttft_ms",
+    "p90_ttft_ms",
+    "p95_ttft_ms",
+    "p99_ttft_ms",
+    "mean_tpot_ms",
+    "median_tpot_ms",
+    "p90_tpot_ms",
+    "p95_tpot_ms",
+    "p99_tpot_ms",
+    "mean_itl_ms",
+    "median_itl_ms",
+    "p95_itl_ms",
+    "p99_itl_ms",
+    "mean_e2el_ms",
+    "median_e2el_ms",
+    "p90_e2el_ms",
+    "p95_e2el_ms",
+    "p99_e2el_ms",
+    "peak_gpu_memory_mb",
+    "model_load_memory_mb",
+    "model_load_s",
+    "gpu_bandwidth_util_pct",
+    "gpu_compute_util_pct",
+    "queue_time_p50_ms",
+    "queue_time_p95_ms",
+    "prefill_time_p50_ms",
+    "prefill_time_p95_ms",
+)
 REJECTED_AITER_ENV = {
     "VLLM_USE_AITER_UNIFIED_ATTENTION",
     "VLLM_ROCM_USE_AITER_FUSED_MOE_A16W4",
@@ -241,9 +276,14 @@ class TestPackagedVllmCatalog(unittest.TestCase):
                     self.assertEqual(run.cell.tp, variant.server_params.tensor_parallel_size)
                     self.assertEqual(run.cell.pp, variant.server_params.pipeline_parallel_size)
 
-    def test_threshold_catalog_matches_full_bare_registry_in_order(self):
-        definitions = list(METRIC_REGISTRY)
-        expected_names = [definition.name for definition in definitions]
+    def test_threshold_catalog_matches_packaged_subset_in_registry_order(self):
+        definitions_by_name = {definition.name: definition for definition in METRIC_REGISTRY}
+        expected_names = list(EXPECTED_PACKAGED_THRESHOLD_NAMES)
+        self.assertEqual(len(expected_names), 32)
+        self.assertEqual(
+            expected_names,
+            [definition.name for definition in METRIC_REGISTRY if definition.name in EXPECTED_PACKAGED_THRESHOLD_NAMES],
+        )
         configs = _packaged_configs()
         paths = [path.with_name(json.loads(path.read_text())["threshold_json"]) for path in configs]
         self.assertEqual(len(paths), EXPECTED_PACKAGED_CONFIG_COUNT)
@@ -256,16 +296,15 @@ class TestPackagedVllmCatalog(unittest.TestCase):
                 cell_count += len(cells)
                 for specs in cells.values():
                     self.assertEqual(list(specs), expected_names)
-                    self.assertEqual(
-                        specs,
-                        {
-                            definition.name: {
-                                "kind": definition.direction,
-                                "value": 0,
-                            }
-                            for definition in definitions
-                        },
-                    )
+                    for name, spec in specs.items():
+                        self.assertNotIn(".", name)
+                        self.assertIn(name, definitions_by_name)
+                        self.assertEqual(set(spec), {"kind", "value"})
+                        self.assertEqual(spec["kind"], definitions_by_name[name].direction)
+                        self.assertIsInstance(spec["value"], (int, float))
+                        self.assertNotIsInstance(spec["value"], bool)
+                        self.assertTrue(math.isfinite(spec["value"]))
+                        self.assertEqual(spec["value"], 0)
         self.assertEqual(cell_count, 56)
 
     def test_rejected_aiter_names_are_absent(self):

--- a/cvs/lib/inference/unittests/test_vllm_config_contract.py
+++ b/cvs/lib/inference/unittests/test_vllm_config_contract.py
@@ -11,6 +11,7 @@ from cvs.lib.inference.utils.vllm_config_loader import (
     load_variant,
     serialize_cli_options,
 )
+from cvs.lib.inference.utils.vllm_metrics import METRIC_REGISTRY
 
 
 CELL = "ISL=1024,OSL=1024,TP=8,PP=2,CONC=16"
@@ -239,6 +240,33 @@ class TestPackagedVllmCatalog(unittest.TestCase):
                 for run in runs:
                     self.assertEqual(run.cell.tp, variant.server_params.tensor_parallel_size)
                     self.assertEqual(run.cell.pp, variant.server_params.pipeline_parallel_size)
+
+    def test_threshold_catalog_matches_full_bare_registry_in_order(self):
+        definitions = list(METRIC_REGISTRY)
+        expected_names = [definition.name for definition in definitions]
+        configs = _packaged_configs()
+        paths = [path.with_name(json.loads(path.read_text())["threshold_json"]) for path in configs]
+        self.assertEqual(len(paths), EXPECTED_PACKAGED_CONFIG_COUNT)
+        cell_count = 0
+        for config_path, threshold_path in zip(configs, paths):
+            with self.subTest(threshold=threshold_path.name):
+                self.assertFalse(load_variant(config_path, {"username": "test"}).enforce_thresholds)
+                payload = json.loads(threshold_path.read_text())
+                cells = {key: value for key, value in payload.items() if not key.startswith("_") and key != "accuracy"}
+                cell_count += len(cells)
+                for specs in cells.values():
+                    self.assertEqual(list(specs), expected_names)
+                    self.assertEqual(
+                        specs,
+                        {
+                            definition.name: {
+                                "kind": definition.direction,
+                                "value": 0,
+                            }
+                            for definition in definitions
+                        },
+                    )
+        self.assertEqual(cell_count, 56)
 
     def test_rejected_aiter_names_are_absent(self):
         for path in _packaged_configs():

--- a/cvs/lib/inference/unittests/test_vllm_config_loader.py
+++ b/cvs/lib/inference/unittests/test_vllm_config_loader.py
@@ -47,6 +47,32 @@ class TestPartialThresholdCells(unittest.TestCase):
                 variant = _variant({CELL: {}}, enforce=enforce)
                 self.assertEqual(variant.thresholds[CELL], {})
 
+    def test_cell_metadata_loads_with_enforcement_off_and_on(self):
+        thresholds = {
+            CELL: {
+                "_comment": "calibrate before enforcing",
+                "_example": {"output_throughput": {"kind": "min", "value": 1}},
+                "output_throughput": {"kind": "min", "value": 0},
+            }
+        }
+        for enforce in (False, True):
+            with self.subTest(enforce=enforce):
+                variant = _variant(thresholds, enforce=enforce)
+                self.assertEqual(variant.thresholds, thresholds)
+
+    def test_non_metadata_unknown_key_is_rejected(self):
+        for enforce in (False, True):
+            for metric in ("notes", "_typo", "_metadata", "_"):
+                with self.subTest(enforce=enforce, metric=metric):
+                    with self.assertRaisesRegex(
+                        ValidationError,
+                        f"unknown vLLM threshold metric {metric!r}",
+                    ):
+                        _variant(
+                            {CELL: {metric: {"kind": "min", "value": 0}}},
+                            enforce=enforce,
+                        )
+
     def test_enforcement_still_requires_selected_run_cell(self):
         _variant({}, enforce=False)
         with self.assertRaisesRegex(ValidationError, "missing threshold coverage"):

--- a/cvs/lib/inference/unittests/test_vllm_config_loader.py
+++ b/cvs/lib/inference/unittests/test_vllm_config_loader.py
@@ -1,46 +1,21 @@
-'''
-Copyright 2025 Advanced Micro Devices, Inc.
-All rights reserved.
+'''Unit tests for strict vLLM threshold schema validation.'''
 
-Unit tests for cvs.lib.inference.utils.vllm_config_loader's gpu.*/prom.*
-threshold coverage in _check_thresholds_cover_sweep. No hardware.
-
-_check_thresholds_cover_sweep only requires that every sweep cell have a
-threshold entry -- it never requires that entry name every gated metric.
-Operators may gate only the metrics they care about; test_metric/
-test_gpu_metric/test_prom_metric already treat an absent spec as
-"don't gate this metric" at evaluation time.
-'''
-
+import math
 import unittest
+
+from pydantic import ValidationError
 
 from cvs.lib.inference.utils.vllm_config_loader import (
     GATED_GPU_METRICS,
     GATED_PROM_METRICS,
     VariantConfig,
 )
-from cvs.lib.inference.utils.vllm_parsing import GATED_METRICS
 
 
-def _full_gated_specs():
-    """A spec for every gated client.*, gpu.*, and prom.* metric -- the
-    minimum that satisfies coverage. Values are inert so the set passes
-    without asserting anything; these tests pin the coverage gate, not the
-    numbers."""
-    out = {}
-    for m in GATED_METRICS:
-        kind = "max_ms" if m.endswith("_ms") else "max" if m == "failed" else "min"
-        out[f"client.{m}"] = {"kind": kind, "value": 0 if kind == "min" else 1e12}
-    for m in GATED_GPU_METRICS:
-        kind = "max" if m in ("peak_gpu_memory_mb", "model_load_memory_mb", "model_load_s") else "min"
-        out[f"gpu.{m}"] = {"kind": kind, "value": 0 if kind == "min" else 1e12}
-    for m in GATED_PROM_METRICS:
-        out[f"prom.{m}"] = {"kind": "max_ms", "value": 1e12}
-    return out
+CELL = "ISL=128,OSL=2048,TP=8,PP=1,CONC=16"
 
 
-def _variant(thresholds, enforce):
-    cell = "ISL=128,OSL=2048,TP=8,PP=1,CONC=16"
+def _variant(thresholds, enforce=False):
     return VariantConfig(
         enforce_thresholds=enforce,
         threshold_json="threshold.json",
@@ -51,38 +26,104 @@ def _variant(thresholds, enforce):
             "hf_token_file": "/home/x/.hf",
         },
         container={"name": "test", "image": "test", "runtime": {"name": "docker", "args": {}}},
-        server_params={"model": "amd/Llama-3.1-70B-Instruct-FP8-KV", "tensor_parallel_size": 8},
-        sweeps={cell: {}},
-        runs=[cell],
+        server_params={"model": "amd/model", "tensor_parallel_size": 8},
+        sweeps={CELL: {}},
+        runs=[CELL],
         thresholds=thresholds,
     )
 
 
-class TestGpuGatedMetricCoverage(unittest.TestCase):
-    """The gpu.* axis of vllm_config_loader's _check_thresholds_cover_sweep."""
+class TestPartialThresholdCells(unittest.TestCase):
+    def test_one_spec_cell_loads_with_enforcement_off_and_on(self):
+        thresholds = {CELL: {"output_throughput": {"kind": "min", "value": 0}}}
+        for enforce in (False, True):
+            with self.subTest(enforce=enforce):
+                variant = _variant(thresholds, enforce=enforce)
+                self.assertEqual(variant.thresholds, thresholds)
 
-    _CELL = "ISL=128,OSL=2048,TP=8,PP=1,CONC=16"
+    def test_empty_cell_loads_with_enforcement_off_and_on(self):
+        for enforce in (False, True):
+            with self.subTest(enforce=enforce):
+                variant = _variant({CELL: {}}, enforce=enforce)
+                self.assertEqual(variant.thresholds[CELL], {})
 
-    def _variant_with(self, thresholds, enforce):
-        return _variant(thresholds, enforce)
+    def test_enforcement_still_requires_selected_run_cell(self):
+        _variant({}, enforce=False)
+        with self.assertRaisesRegex(ValidationError, "missing threshold coverage"):
+            _variant({}, enforce=True)
 
-    def test_full_gated_set_constructs(self):
-        vc = self._variant_with({self._CELL: _full_gated_specs()}, enforce=True)
-        self.assertEqual(vc.enforce_thresholds, True)
+    def test_accuracy_is_exempt_from_vllm_metric_validation(self):
+        accuracy = {
+            "gsm8k": {
+                "gsm8k.exact_match__strict-match": {
+                    "kind": "min",
+                    "value": 0,
+                    "tolerance_pct": 5,
+                }
+            }
+        }
+        variant = _variant({CELL: {}, "accuracy": accuracy}, enforce=True)
+        self.assertEqual(variant.thresholds["accuracy"], accuracy)
 
-    def test_missing_gpu_metric_does_not_raise_when_enforced(self):
-        # Operators may gate only a subset of gpu.* metrics; an absent one is
-        # simply not gated, not an authoring error.
-        specs = _full_gated_specs()
-        del specs["gpu.peak_gpu_memory_mb"]
-        vc = self._variant_with({self._CELL: specs}, enforce=True)
-        self.assertNotIn("gpu.peak_gpu_memory_mb", vc.thresholds[self._CELL])
 
-    def test_no_gpu_specs_at_all_does_not_raise_when_enforced(self):
-        vc = self._variant_with({self._CELL: {}}, enforce=True)
-        self.assertEqual(vc.thresholds[self._CELL], {})
+class TestStrictThresholdSpecs(unittest.TestCase):
+    def assertRejected(self, metric, spec):
+        with self.assertRaises(ValidationError):
+            _variant({CELL: {metric: spec}})
 
-    def test_all_five_gpu_metrics_are_gated(self):
+    def test_rejects_nonfinite_or_non_builtin_values(self):
+        for value in (True, "1", None, [], {}, math.nan, math.inf, -math.inf):
+            with self.subTest(value=value):
+                self.assertRejected(
+                    "output_throughput",
+                    {"kind": "min", "value": value},
+                )
+
+    def test_rejects_missing_unknown_and_legacy_kinds(self):
+        for spec in (
+            {"value": 1},
+            {"kind": "min"},
+            {"kind": "info", "value": 1},
+            {"kind": "min_tok_s", "value": 1},
+            {"kind": "max_ms", "value": 1},
+            {"kind": "within", "value": 1},
+            {"kind": "min_ratio", "value": 1},
+            {"kind": "other", "value": 1},
+        ):
+            with self.subTest(spec=spec):
+                self.assertRejected("output_throughput", spec)
+
+    def test_rejects_direction_mismatch(self):
+        self.assertRejected("output_throughput", {"kind": "max", "value": 1})
+        self.assertRejected("mean_ttft_ms", {"kind": "min", "value": 1})
+
+    def test_rejects_prefixed_and_unknown_metric_names(self):
+        for metric in ("client.output_throughput", "gpu.gpu_compute_util_pct", "prom.queue_time_p50_ms", "new_metric"):
+            with self.subTest(metric=metric):
+                self.assertRejected(metric, {"kind": "min", "value": 1})
+
+    def test_rejects_extra_spec_fields(self):
+        for field, value in (
+            ("unit", "tok/s"),
+            ("reference", "total_token_throughput"),
+            ("tolerance_pct", 5),
+            ("extra", 1),
+        ):
+            with self.subTest(field=field):
+                self.assertRejected(
+                    "output_throughput",
+                    {"kind": "min", "value": 1, field: value},
+                )
+
+    def test_accepts_finite_int_float_zero_and_negative(self):
+        for value in (0, -1, 1.5):
+            with self.subTest(value=value):
+                variant = _variant({CELL: {"output_throughput": {"kind": "min", "value": value}}})
+                self.assertEqual(variant.thresholds[CELL]["output_throughput"]["value"], value)
+
+
+class TestDatasourceViews(unittest.TestCase):
+    def test_gpu_and_prometheus_names_are_bare_and_complete(self):
         self.assertEqual(
             GATED_GPU_METRICS,
             {
@@ -93,39 +134,6 @@ class TestGpuGatedMetricCoverage(unittest.TestCase):
                 "gpu_compute_util_pct",
             },
         )
-
-
-class TestPromGatedMetricCoverage(unittest.TestCase):
-    """The prom.* axis of vllm_config_loader's _check_thresholds_cover_sweep.
-
-    Mirrors TestGpuGatedMetricCoverage: prom.* is a fully separate, parallel
-    gated family, not part of client.*'s tiering machinery, so its coverage
-    is proven independently here rather than in test_vllm_deck_profile.py.
-    """
-
-    _CELL = "ISL=128,OSL=2048,TP=8,PP=1,CONC=16"
-
-    def _variant_with(self, thresholds, enforce):
-        return _variant(thresholds, enforce)
-
-    def test_full_gated_set_constructs(self):
-        vc = self._variant_with({self._CELL: _full_gated_specs()}, enforce=True)
-        self.assertEqual(vc.enforce_thresholds, True)
-
-    def test_missing_prom_metric_does_not_raise_when_enforced(self):
-        # Operators may gate only a subset of prom.* metrics; an absent one is
-        # simply not gated, not an authoring error.
-        specs = _full_gated_specs()
-        del specs["prom.queue_time_p50_ms"]
-        vc = self._variant_with({self._CELL: specs}, enforce=True)
-        self.assertNotIn("prom.queue_time_p50_ms", vc.thresholds[self._CELL])
-
-    def test_only_one_prom_metric_gated_does_not_raise_when_enforced(self):
-        specs = {"prom.queue_time_p50_ms": {"kind": "max_ms", "value": 200}}
-        vc = self._variant_with({self._CELL: specs}, enforce=True)
-        self.assertEqual(vc.thresholds[self._CELL], specs)
-
-    def test_all_four_prom_metrics_are_gated(self):
         self.assertEqual(
             GATED_PROM_METRICS,
             {

--- a/cvs/lib/inference/unittests/test_vllm_config_loader_accuracy.py
+++ b/cvs/lib/inference/unittests/test_vllm_config_loader_accuracy.py
@@ -69,16 +69,7 @@ class TestAccuracyThresholdKeyDoesNotTripSweepCoverage(unittest.TestCase):
     _CELL = "ISL=1024,OSL=1024,TP=8,PP=1,CONC=16"
 
     def _full_gated_specs(self):
-        from cvs.lib.inference.utils.vllm_config_loader import GATED_GPU_METRICS
-        from cvs.lib.inference.utils.vllm_parsing import GATED_METRICS
-
-        out = {}
-        for m in GATED_METRICS:
-            kind = "max_ms" if m.endswith("_ms") else "max" if m == "failed" else "min"
-            out[f"client.{m}"] = {"kind": kind, "value": 0 if kind == "min" else 1e12}
-        for m in GATED_GPU_METRICS:
-            out[f"gpu.{m}"] = {"kind": "min", "value": 0}
-        return out
+        return {"output_throughput": {"kind": "min", "value": 0}}
 
     def test_accuracy_key_alongside_full_sweep_coverage_constructs(self):
         vc = VariantConfig(

--- a/cvs/lib/inference/unittests/test_vllm_deck_profile.py
+++ b/cvs/lib/inference/unittests/test_vllm_deck_profile.py
@@ -80,6 +80,7 @@ class TestVllmDeckProfile(unittest.TestCase):
         self.assertEqual(cfg.inference_test_substring, "test_vllm_inference")
         self.assertEqual(cfg.row_card_test_names, ("test_verify_cell_metrics",))
         self.assertEqual(cfg.metric_prefix, "")
+        self.assertTrue(callable(cfg.metric_verdict))
         self.assertEqual(cfg.metric_contract, {"id": "vllm-bare", "version": 1})
 
     def test_vllm_profile_lifecycle_labels_match_what_suite_records(self):

--- a/cvs/lib/inference/unittests/test_vllm_deck_profile.py
+++ b/cvs/lib/inference/unittests/test_vllm_deck_profile.py
@@ -8,11 +8,10 @@ from pathlib import Path
 
 from cvs.lib.inference.vllm_topology import EffectiveVllmTopology
 from cvs.lib.inference.utils.vllm_config_loader import load_variant
-from cvs.lib.inference.utils.vllm_parsing import (
+from cvs.lib.inference.utils.vllm_metrics import (
     CLIENT_METRICS,
-    GATED_METRICS,
-    METRIC_TIER_ORDER,
-    METRIC_TIERS,
+    METRIC_CATEGORIES,
+    METRIC_REGISTRY,
     VLLM_RESULTS_COLUMNS,
     tier_metric_specs,
 )
@@ -40,35 +39,38 @@ class TestVllmDeckProfile(unittest.TestCase):
         )
 
     def test_metric_tiers_subset_of_tier_order(self):
-        self.assertTrue(set(METRIC_TIERS) <= set(METRIC_TIER_ORDER))
+        profile = load_json_profile("vllm")
+        config = build_inference_config_from_profile(profile)
+        self.assertEqual(config.metric_tier_order, METRIC_CATEGORIES)
+        self.assertNotIn("record", config.metric_tier_order)
 
     def test_gated_metrics_partitioned_exactly_once(self):
-        tiered = [m for names in METRIC_TIERS.values() for m in names]
-        self.assertEqual(len(tiered), len(set(tiered)))
-        self.assertEqual(set(tiered), set(GATED_METRICS))
+        tiered = [
+            definition.name
+            for category in METRIC_CATEGORIES
+            for definition in METRIC_REGISTRY
+            if definition.category == category
+        ]
+        self.assertEqual(tiered, [definition.name for definition in METRIC_REGISTRY])
 
     def test_gated_metrics_subset_of_client_metrics(self):
         client_short = {short for short, _unit in CLIENT_METRICS}
-        missing = GATED_METRICS - client_short
-        self.assertEqual(missing, set(), f"GATED_METRICS not in CLIENT_METRICS: {missing}")
+        registered_client = {definition.name for definition in METRIC_REGISTRY if definition.datasource == "client"}
+        self.assertEqual(client_short, registered_client)
 
     def test_tier_metric_specs_throughput(self):
         cell = {
-            "client.output_throughput": {"kind": "min_tok_s", "value": 1},
-            "client.mean_ttft_ms": {"kind": "max_ms", "value": 2},
+            "output_throughput": {"kind": "min", "value": 1},
+            "mean_ttft_ms": {"kind": "max", "value": 2},
         }
         specs = tier_metric_specs(cell, "throughput")
-        self.assertIn("client.output_throughput", specs)
-        self.assertNotIn("client.mean_ttft_ms", specs)
+        self.assertIn("output_throughput", specs)
+        self.assertNotIn("mean_ttft_ms", specs)
 
-    def test_tier_metric_specs_record_includes_non_tiered(self):
-        cell = {
-            "client.num_prompts": {"kind": "within", "value": 100},
-            "client.output_throughput": {"kind": "min_tok_s", "value": 1},
-        }
-        specs = tier_metric_specs(cell, "record")
-        self.assertIn("client.num_prompts", specs)
-        self.assertNotIn("client.output_throughput", specs)
+    def test_tier_metric_specs_has_no_static_record_tier(self):
+        cell = {"num_prompts": {"kind": "min", "value": 100}}
+        self.assertEqual(tier_metric_specs(cell, "record"), {})
+        self.assertEqual(tier_metric_specs(cell, "run_health"), cell)
 
     def test_vllm_json_profile_identity(self):
         profile = load_json_profile("vllm")
@@ -77,6 +79,8 @@ class TestVllmDeckProfile(unittest.TestCase):
         self.assertEqual(cfg.suite_id, "vllm")
         self.assertEqual(cfg.inference_test_substring, "test_vllm_inference")
         self.assertEqual(cfg.row_card_test_names, ("test_verify_cell_metrics",))
+        self.assertEqual(cfg.metric_prefix, "")
+        self.assertEqual(cfg.metric_contract, {"id": "vllm-bare", "version": 1})
 
     def test_vllm_profile_lifecycle_labels_match_what_suite_records(self):
         profile = load_json_profile("vllm")
@@ -123,19 +127,24 @@ class TestVllmDeckProfile(unittest.TestCase):
         variant.bind_effective_topology(EffectiveVllmTopology("distributed", ("node0", "node1"), 2))
         cell_id = variant.expected_cells()[0]
         variant.enforce_thresholds = True
-        variant.thresholds = {cell_id: {"client.output_throughput": {"kind": "min_tok_s", "value": 1000.0}}}
+        variant.thresholds = {cell_id: {"output_throughput": {"kind": "min", "value": 1000.0}}}
         run = variant.resolved_runs()[0]
         key = (variant.model_id, "", str(run.cell.isl), str(run.cell.osl), run.cell.key, run.cell.concurrency)
         profile = load_json_profile("vllm_distributed")
         payload = build_inference_report_payload(
             config=build_inference_config_from_profile(profile),
             variant_config=variant,
-            inf_res_dict={key: {"node0": {"client.output_throughput": 500.0}}},
+            inf_res_dict={key: {"node0": {"output_throughput": 500.0}}},
             lifecycle_report={},
         )
         self.assertEqual(payload["cells"][0]["cell_id"], cell_id)
         self.assertEqual(payload["cells"][0]["tiers"]["throughput"], "fail")
         self.assertEqual(payload["overall_status"], "fail")
+        self.assertEqual(payload["metric_contract"], {"id": "vllm-bare", "version": 1})
+        self.assertEqual(
+            payload["viewer_config"]["metric_contract"],
+            {"id": "vllm-bare", "version": 1},
+        )
 
 
 if __name__ == "__main__":

--- a/cvs/lib/inference/unittests/test_vllm_job_ray_backend.py
+++ b/cvs/lib/inference/unittests/test_vllm_job_ray_backend.py
@@ -973,11 +973,11 @@ class TestVllmJobIsReady(unittest.TestCase):
 class TestVllmJobParseResults(unittest.TestCase):
     """parse_results() fetches the client results artifact via orch.exec_on_head
     (which returns {host: content}), json-loads it, and returns
-    to_client_metrics(raw, tp=self.tp, isl=self.isl, pp=self.pp) per host. Two
+    project_vllm_metrics(raw, tp=self.tp, isl=self.isl, pp=self.pp) per host. Two
     documented exception modes: empty/missing artifact -> RuntimeError;
     unparseable JSON -> RuntimeError. Exception assertions pin the TYPE only
     (message text is an implementation detail per the authoring anti-patterns).
-    The happy path pins the delegation to to_client_metrics with the correct
+    The happy path pins the delegation to project_vllm_metrics with the correct
     keyword-only tp/isl/pp."""
 
     def test_empty_artifact_raises_runtimeerror(self):
@@ -1013,7 +1013,7 @@ class TestVllmJobParseResults(unittest.TestCase):
         self.assertIn("line two", message)
 
     def test_valid_artifact_delegates_to_to_client_metrics_with_tp_isl_pp(self):
-        # tp, isl, and pp are keyword-only in to_client_metrics, so they MUST
+        # tp, isl, and pp are keyword-only in project_vllm_metrics, so they MUST
         # arrive as kwargs; raw (the json-loaded artifact) arrives positionally.
         # Patching the symbol as imported into vllm_job keeps this impl-blind on
         # the metric math.
@@ -1021,7 +1021,7 @@ class TestVllmJobParseResults(unittest.TestCase):
         # Round-3 finding 1: capture and assert the RETURN VALUE, not just that the
         # mock was called with the right args. Production threads the metric result
         # back out as {host: to_client_metrics(...)}; a mutant that calls
-        # to_client_metrics for its side effect but then stores `raw` (or the wrong
+        # project_vllm_metrics for its side effect but then stores `raw` (or the wrong
         # host key, or returns early) would satisfy a call-args-only check while
         # breaking the actual output. The mock's return_value is the independent
         # oracle for what must appear under the head host key.
@@ -1034,19 +1034,20 @@ class TestVllmJobParseResults(unittest.TestCase):
         import json as _json
 
         raw = {"output_throughput": 1234.0, "request_goodput": 10.0}
-        sentinel = {"client.sentinel": 1}
+        sentinel = {"output_throughput": 1}
         for pp in ("1", "2"):
             with self.subTest(pp=pp):
                 orch = RecordingOrch(head_responder=lambda cmd: {HEAD: _json.dumps(raw)}, hosts=[HEAD])
                 job = _job(orch=orch, serve_args={}, nnodes="1", pp=pp, ib_netdev=None, isl="1024")
-                with mock.patch("cvs.lib.inference.vllm_job.to_client_metrics") as m_tcm:
-                    m_tcm.return_value = sentinel
+                with mock.patch("cvs.lib.inference.vllm_job.project_vllm_metrics") as projector:
+                    projector.return_value = sentinel
                     result = job.parse_results()
-                self.assertTrue(m_tcm.called, "parse_results must delegate to to_client_metrics")
-                args, kwargs = m_tcm.call_args
+                self.assertTrue(projector.called, "parse_results must delegate to project_vllm_metrics")
+                args, kwargs = projector.call_args
                 self.assertEqual(kwargs.get("tp"), job.tp)
                 self.assertEqual(kwargs.get("isl"), job.isl)
                 self.assertEqual(kwargs.get("pp"), job.pp)
+                self.assertIn("/results", kwargs.get("artifact_path"))
                 self.assertEqual(args[0], raw, "raw must be the json-loaded artifact passed positionally")
                 # The metric result must be threaded back out under the head host key --
                 # NOT the raw artifact, and NOT dropped/re-keyed.

--- a/cvs/lib/inference/unittests/test_vllm_report_contract.py
+++ b/cvs/lib/inference/unittests/test_vllm_report_contract.py
@@ -3,6 +3,7 @@
 import json
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -113,8 +114,7 @@ class TestVllmReportContract(unittest.TestCase):
                     }
                 )
             )
-            config = _config()
-            object.__setattr__(config, "prev_run_json", str(baseline))
+            config = replace(_config(), prev_run_json=str(baseline))
             payload = build_inference_report_payload(
                 config=config,
                 variant_config=_variant(),

--- a/cvs/lib/inference/unittests/test_vllm_report_contract.py
+++ b/cvs/lib/inference/unittests/test_vllm_report_contract.py
@@ -1,0 +1,165 @@
+'''Integration tests for the vLLM Run Deck metric contract.'''
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from cvs.lib.report.ci_summary import render_ci_summary_html
+from cvs.lib.report.inference import build_inference_report_payload
+from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.config_adapter import build_inference_config_from_profile
+from cvs.lib.report.rundeck.payload import build_rundeck_payload
+from cvs.lib.report.rundeck.render import render_rundeck_html
+from cvs.lib.report.rundeck.viewer_config import build_viewer_config
+from cvs.lib.report.viewer.scaffold import write_interactive_viewer
+
+
+CELL = "ISL=128,OSL=128,TP=1,PP=1,CONC=1"
+KEY = ("model", "", "128", "128", CELL, 1)
+
+
+def _config():
+    return build_inference_config_from_profile(load_json_profile("vllm"))
+
+
+def _variant(actual_thresholds=None, enforce=True):
+    return SimpleNamespace(
+        model_id="model",
+        enforce_thresholds=enforce,
+        thresholds={CELL: actual_thresholds or {}},
+        server_params=SimpleNamespace(model="model", tensor_parallel_size=1),
+        cell_key=lambda _isl, _osl, _conc: CELL,
+    )
+
+
+class TestVllmReportContract(unittest.TestCase):
+    def test_strict_verdict_hook_fails_missing_actual(self):
+        payload = build_inference_report_payload(
+            config=_config(),
+            variant_config=_variant({"output_throughput": {"kind": "min", "value": 1}}),
+            inf_res_dict={KEY: {"head": {}}},
+            lifecycle_report={},
+        )
+
+        self.assertEqual(payload["cells"][0]["tiers"]["throughput"], "fail")
+        self.assertEqual(payload["overall_status"], "fail")
+
+    def test_both_payload_builders_include_contract_and_bare_viewer_columns(self):
+        variant = _variant({"output_throughput": {"kind": "min", "value": 1}})
+        results = {
+            KEY: {
+                "head": {
+                    "output_throughput": 2.0,
+                    "mean_ttft_ms": 4.0,
+                    "gpu_compute_util_pct": 50.0,
+                }
+            }
+        }
+        profile = load_json_profile("vllm")
+        inference_payload = build_inference_report_payload(
+            config=_config(),
+            variant_config=variant,
+            inf_res_dict=results,
+            lifecycle_report={},
+        )
+        rundeck_payload = build_rundeck_payload(
+            profile=profile,
+            store={
+                "inf_res_dict": results,
+                "variant_config": variant,
+                "lifecycle_report": {},
+            },
+        )
+
+        for payload in (inference_payload, rundeck_payload):
+            with self.subTest(builder=payload.keys()):
+                self.assertEqual(
+                    payload["metric_contract"],
+                    {"id": "vllm-bare", "version": 1},
+                )
+                self.assertEqual(
+                    payload["viewer_config"]["metric_contract"],
+                    {"id": "vllm-bare", "version": 1},
+                )
+                columns = payload["viewer_config"]["table_columns"]
+                metric_columns = {column["metric"] for column in columns if "metric" in column}
+                self.assertIn("total_token_throughput", metric_columns)
+                self.assertIn("output_throughput", payload["viewer_config"]["metrics"])
+                self.assertFalse(any(metric.startswith("client.") for metric in metric_columns))
+                self.assertIn("output_throughput", payload["cells"][0]["actuals"])
+
+    def test_config_only_viewer_config_retains_contract(self):
+        viewer = build_viewer_config({}, _config())
+        self.assertEqual(viewer["metric_contract"], {"id": "vllm-bare", "version": 1})
+        self.assertIn("output_throughput", viewer["metrics"])
+
+    def test_legacy_previous_run_is_explicitly_incompatible(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = Path(tmp) / "legacy.json"
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "suite_id": "vllm",
+                        "cells": [
+                            {
+                                "cell_id": CELL,
+                                "host": "head",
+                                "actuals": {"client.output_throughput": 100},
+                            }
+                        ],
+                    }
+                )
+            )
+            config = _config()
+            object.__setattr__(config, "prev_run_json", str(baseline))
+            payload = build_inference_report_payload(
+                config=config,
+                variant_config=_variant(),
+                inf_res_dict={KEY: {"head": {"output_throughput": 90}}},
+                lifecycle_report={},
+            )
+
+            panel = payload["panels"]["prev_run"]
+            self.assertFalse(panel["compatible"])
+            self.assertEqual(panel["rows"], [])
+            self.assertIn("metric_contract", panel["incompatibility"])
+            deck = render_rundeck_html(payload)
+            summary = render_ci_summary_html(
+                payload,
+                config,
+                full_report_basename="vllm_run_deck",
+            )
+            self.assertIn("Baseline comparison incompatible", deck)
+            self.assertIn("comparisons suppressed", summary)
+            self.assertNotIn("none flagged", summary)
+
+    def test_manual_viewer_validates_contract_before_indexing_baseline_cells(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "viewer.html"
+            write_interactive_viewer(
+                path,
+                json_basename="vllm.json",
+                title="vLLM",
+                embed_payload={
+                    "schema_version": 1,
+                    "suite_id": "vllm",
+                    "metric_contract": {"id": "vllm-bare", "version": 1},
+                    "cells": [],
+                    "viewer_config": build_viewer_config({}, _config()),
+                },
+            )
+            document = path.read_text()
+
+        validator = document.index("baselineIncompatibilityReason(data)")
+        indexing = document.index("(data.cells || []).forEach")
+        self.assertLess(validator, indexing)
+        self.assertIn("Baseline incompatible:", document)
+        self.assertIn("comparisons suppressed", document)
+        self.assertIn("escapeHtmlText(baselineIncompatibility)", document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/inference/unittests/test_vllm_server_metrics.py
+++ b/cvs/lib/inference/unittests/test_vllm_server_metrics.py
@@ -16,7 +16,7 @@ Contract under test:
       to >= 0. None if `after` has no buckets.
   histogram_quantile(buckets, q) -> linear interpolation between bucket
       boundaries; None on empty/zero-count buckets.
-  to_prom_metrics(before_text, after_text) -> the composed prom.* dict;
+  to_prom_metrics(before_text, after_text) -> canonical bare metric dict;
       all-None (never partial, never a raise) if either scrape is
       missing/unparseable.
 
@@ -261,7 +261,7 @@ class TestHistogramQuantile(unittest.TestCase):
 
 class TestToPromMetrics(unittest.TestCase):
     def test_all_prom_metrics_keys_present_shape(self):
-        expected_keys = {f"prom.{short}" for short, _unit in PROM_METRICS}
+        expected_keys = {short for short, _unit in PROM_METRICS}
         out = to_prom_metrics(None, None)
         self.assertEqual(set(out.keys()), expected_keys)
 
@@ -281,6 +281,22 @@ class TestToPromMetrics(unittest.TestCase):
         for k in out:
             self.assertIsNone(out[k])
 
+    def test_unbounded_only_histograms_do_not_emit_infinity(self):
+        before = _full_scrape_text(
+            {"+Inf": 0.0},
+            0.0,
+            {"+Inf": 0.0},
+            0.0,
+        )
+        after = _full_scrape_text(
+            {"+Inf": 1.0},
+            10.0,
+            {"+Inf": 1.0},
+            10.0,
+        )
+        out = to_prom_metrics(before, after)
+        self.assertTrue(all(value is None for value in out.values()))
+
     def test_end_to_end_realistic_before_after_pair(self):
         # "before" scrape: server already served 3 queue-wait observations
         # from a prior cell (0.1, 0.2, 0.4s) -- the reused-server baseline.
@@ -297,14 +313,14 @@ class TestToPromMetrics(unittest.TestCase):
         # This cell's isolated queue-wait observations are exactly [0.6, 0.9]
         # (0.6 falls in bucket 0.8, 0.9 falls in bucket 1.0); p50 of 2 obs
         # falls in/around the first of the two remaining buckets.
-        self.assertIsNotNone(out["prom.queue_time_p50_ms"])
-        self.assertIsNotNone(out["prom.queue_time_p95_ms"])
-        self.assertIsNotNone(out["prom.prefill_time_p50_ms"])
-        self.assertIsNotNone(out["prom.prefill_time_p95_ms"])
+        self.assertIsNotNone(out["queue_time_p50_ms"])
+        self.assertIsNotNone(out["queue_time_p95_ms"])
+        self.assertIsNotNone(out["prefill_time_p50_ms"])
+        self.assertIsNotNone(out["prefill_time_p95_ms"])
         # Values are in ms (seconds * 1000), and in the right ballpark given
         # only [0.6, 0.9] contributed post-diff (600-1000ms range).
-        self.assertGreater(out["prom.queue_time_p50_ms"], 500)
-        self.assertLess(out["prom.queue_time_p50_ms"], 1100)
+        self.assertGreater(out["queue_time_p50_ms"], 500)
+        self.assertLess(out["queue_time_p50_ms"], 1100)
 
     def test_prom_metric_units_cover_every_metric(self):
         for short, unit in PROM_METRICS:

--- a/cvs/lib/inference/utils/unittests/test_vllm_metrics.py
+++ b/cvs/lib/inference/utils/unittests/test_vllm_metrics.py
@@ -11,6 +11,7 @@ from cvs.lib.inference.utils.vllm_metrics import (
     METRIC_REGISTRY,
     METRIC_UNITS,
     PROM_METRICS,
+    UnknownMetricContractError,
     VLLM_GPU_METRICS,
     is_finite_number,
     merge_metric_sources,
@@ -160,7 +161,7 @@ class TestBareProjection(unittest.TestCase):
         self.assertNotIn("burstiness", metrics)
 
     def test_unknown_finite_numeric_field_names_artifact(self):
-        with self.assertRaisesRegex(ValueError, "node0:/tmp/results"):
+        with self.assertRaises(UnknownMetricContractError) as raised:
             project_vllm_metrics(
                 {"output_throughput": 1.0, "new_upstream_number": 2},
                 tp=1,
@@ -168,6 +169,10 @@ class TestBareProjection(unittest.TestCase):
                 isl=1,
                 artifact_path="node0:/tmp/results",
             )
+        self.assertEqual(
+            str(raised.exception),
+            "unknown finite numeric vLLM result field 'new_upstream_number': node0:/tmp/results",
+        )
 
     def test_unknown_nonnumeric_and_boolean_fields_are_ignored(self):
         metrics = project_vllm_metrics(

--- a/cvs/lib/inference/utils/unittests/test_vllm_metrics.py
+++ b/cvs/lib/inference/utils/unittests/test_vllm_metrics.py
@@ -1,0 +1,301 @@
+'''Unit tests for the canonical vLLM metric contract.'''
+
+import json
+import math
+import unittest
+from pathlib import Path
+
+from cvs.lib.inference.utils.vllm_metrics import (
+    METRIC_CATEGORIES,
+    METRIC_NAMES,
+    METRIC_REGISTRY,
+    METRIC_UNITS,
+    PROM_METRICS,
+    VLLM_GPU_METRICS,
+    is_finite_number,
+    merge_metric_sources,
+    metric_verdict,
+    project_vllm_metrics,
+)
+from cvs.lib.utils.gpu import GPU_METRICS
+
+
+EXPECTED_NAMES = (
+    "max_concurrency",
+    "max_concurrent_requests",
+    "num_prompts",
+    "completed",
+    "failed",
+    "success_rate",
+    "duration",
+    "request_throughput",
+    "goodput",
+    "output_throughput",
+    "total_token_throughput",
+    "per_gpu_throughput",
+    "decode_throughput_p50",
+    "max_output_tokens_per_s",
+    "rtfx",
+    "total_input_tokens",
+    "total_output_tokens",
+    "mean_ttft_ms",
+    "median_ttft_ms",
+    "std_ttft_ms",
+    "p50_ttft_ms",
+    "p90_ttft_ms",
+    "p95_ttft_ms",
+    "p99_ttft_ms",
+    "normalized_ttft_ms_per_tok",
+    "mean_tpot_ms",
+    "median_tpot_ms",
+    "std_tpot_ms",
+    "p50_tpot_ms",
+    "p90_tpot_ms",
+    "p95_tpot_ms",
+    "p99_tpot_ms",
+    "mean_itl_ms",
+    "median_itl_ms",
+    "std_itl_ms",
+    "p50_itl_ms",
+    "p90_itl_ms",
+    "p95_itl_ms",
+    "p99_itl_ms",
+    "decode_latency_ratio",
+    "mean_e2el_ms",
+    "median_e2el_ms",
+    "std_e2el_ms",
+    "p50_e2el_ms",
+    "p90_e2el_ms",
+    "p95_e2el_ms",
+    "p99_e2el_ms",
+    "peak_gpu_memory_mb",
+    "model_load_memory_mb",
+    "model_load_s",
+    "gpu_bandwidth_util_pct",
+    "gpu_compute_util_pct",
+    "queue_time_p50_ms",
+    "queue_time_p95_ms",
+    "prefill_time_p50_ms",
+    "prefill_time_p95_ms",
+)
+
+
+def _widened_fixture():
+    path = Path(__file__).resolve().parents[2] / "unittests/fixtures/vllm_results_widened.json"
+    return json.loads(path.read_text())
+
+
+class TestMetricRegistry(unittest.TestCase):
+    def test_exact_ordered_inventory(self):
+        self.assertEqual(METRIC_NAMES, EXPECTED_NAMES)
+        self.assertEqual(len(METRIC_REGISTRY), 56)
+        self.assertEqual(len(METRIC_NAMES), len(set(METRIC_NAMES)))
+        self.assertTrue(all("." not in name for name in METRIC_NAMES))
+
+    def test_every_definition_is_complete_and_immutable(self):
+        self.assertEqual(set(METRIC_UNITS), set(EXPECTED_NAMES))
+        self.assertEqual(
+            METRIC_CATEGORIES,
+            ("run_health", "throughput", "ttft", "tpot", "itl", "e2el", "gpu", "prometheus"),
+        )
+        for definition in METRIC_REGISTRY:
+            with self.subTest(metric=definition.name):
+                self.assertTrue(definition.unit)
+                self.assertIn(definition.datasource, {"client", "gpu", "prometheus"})
+                self.assertTrue(definition.category)
+                self.assertIn(definition.direction, {"min", "max"})
+                self.assertTrue(definition.derivation)
+                self.assertTrue(definition.required_inputs)
+                with self.assertRaises(AttributeError):
+                    definition.direction = "other"
+
+    def test_gpu_and_prometheus_views_come_from_registry(self):
+        self.assertEqual(VLLM_GPU_METRICS, tuple(GPU_METRICS))
+        self.assertEqual(
+            tuple(name for name, _unit in PROM_METRICS),
+            (
+                "queue_time_p50_ms",
+                "queue_time_p95_ms",
+                "prefill_time_p50_ms",
+                "prefill_time_p95_ms",
+            ),
+        )
+
+    def test_exact_threshold_directions(self):
+        minimum = {
+            "max_concurrency",
+            "max_concurrent_requests",
+            "num_prompts",
+            "completed",
+            "success_rate",
+            "request_throughput",
+            "goodput",
+            "output_throughput",
+            "total_token_throughput",
+            "per_gpu_throughput",
+            "decode_throughput_p50",
+            "max_output_tokens_per_s",
+            "rtfx",
+            "total_input_tokens",
+            "total_output_tokens",
+            "gpu_bandwidth_util_pct",
+            "gpu_compute_util_pct",
+        }
+        actual = {definition.name for definition in METRIC_REGISTRY if definition.direction == "min"}
+        self.assertEqual(actual, minimum)
+
+
+class TestBareProjection(unittest.TestCase):
+    def test_widened_fixture_projects_exactly_47_client_metrics(self):
+        raw = _widened_fixture()
+        raw["request_rate"] = 4.5
+        raw["burstiness"] = 2.0
+        metrics = project_vllm_metrics(raw, tp=8, pp=1, isl=1024)
+
+        self.assertEqual(len(metrics), 47)
+        self.assertEqual(set(metrics), set(EXPECTED_NAMES[:47]))
+        self.assertEqual(metrics["goodput"], raw["request_goodput"])
+        self.assertNotIn("request_goodput", metrics)
+        self.assertNotIn("request_rate", metrics)
+        self.assertNotIn("burstiness", metrics)
+
+    def test_unknown_finite_numeric_field_names_artifact(self):
+        with self.assertRaisesRegex(ValueError, "node0:/tmp/results"):
+            project_vllm_metrics(
+                {"output_throughput": 1.0, "new_upstream_number": 2},
+                tp=1,
+                pp=1,
+                isl=1,
+                artifact_path="node0:/tmp/results",
+            )
+
+    def test_unknown_nonnumeric_and_boolean_fields_are_ignored(self):
+        metrics = project_vllm_metrics(
+            {"output_throughput": 0, "unknown": "text", "flag": True},
+            tp=1,
+            pp=1,
+            isl=1,
+        )
+        self.assertEqual(metrics, {"output_throughput": 0})
+
+    def test_registered_values_must_be_finite_builtin_numbers(self):
+        metrics = project_vllm_metrics(
+            {
+                "output_throughput": True,
+                "mean_ttft_ms": math.nan,
+                "mean_tpot_ms": math.inf,
+                "rtfx": 0.0,
+            },
+            tp=1,
+            pp=1,
+            isl=1,
+        )
+        self.assertEqual(metrics, {"rtfx": 0.0})
+
+    def test_derived_metrics_preserve_real_zero(self):
+        metrics = project_vllm_metrics(
+            {
+                "completed": 0,
+                "failed": 1,
+                "total_token_throughput": 0.0,
+                "mean_ttft_ms": 0,
+                "p99_itl_ms": 0,
+                "p50_itl_ms": 2,
+            },
+            tp=8,
+            pp=2,
+            isl=128,
+        )
+        self.assertEqual(metrics["success_rate"], 0.0)
+        self.assertEqual(metrics["per_gpu_throughput"], 0.0)
+        self.assertEqual(metrics["normalized_ttft_ms_per_tok"], 0.0)
+        self.assertEqual(metrics["decode_latency_ratio"], 0.0)
+
+
+class TestMetricSourceMerge(unittest.TestCase):
+    def test_disjoint_sources_preserve_zero(self):
+        merged = merge_metric_sources(
+            {"output_throughput": 0},
+            {"gpu_compute_util_pct": 0.0},
+            {"queue_time_p50_ms": 0},
+        )
+        self.assertEqual(
+            merged,
+            {
+                "output_throughput": 0,
+                "gpu_compute_util_pct": 0.0,
+                "queue_time_p50_ms": 0,
+            },
+        )
+
+    def test_rejects_wrong_source_and_collision(self):
+        with self.assertRaisesRegex(ValueError, "unknown gpu"):
+            merge_metric_sources({}, {"output_throughput": 1}, {})
+        with self.assertRaisesRegex(ValueError, "collision"):
+            merge_metric_sources(
+                {"output_throughput": 1},
+                {},
+                {"queue_time_p50_ms": 1, "output_throughput": 2},
+            )
+
+
+class TestStrictMetricVerdict(unittest.TestCase):
+    def test_min_boundaries_cover_int_float_zero_and_negative(self):
+        cases = [
+            (-2, -1, "fail"),
+            (-1, -1, "pass"),
+            (0, -1, "pass"),
+            (0.5, 1.0, "fail"),
+            (1.0, 1.0, "pass"),
+            (2, 1.0, "pass"),
+        ]
+        for actual, target, expected in cases:
+            with self.subTest(actual=actual, target=target):
+                status, _reason = metric_verdict(
+                    "output_throughput",
+                    actual,
+                    {"kind": "min", "value": target},
+                )
+                self.assertEqual(status, expected)
+
+    def test_max_boundaries_cover_int_float_zero_and_negative(self):
+        cases = [
+            (-2, -1, "pass"),
+            (-1, -1, "pass"),
+            (0, -1, "fail"),
+            (0.5, 1.0, "pass"),
+            (1.0, 1.0, "pass"),
+            (2, 1.0, "fail"),
+        ]
+        for actual, target, expected in cases:
+            with self.subTest(actual=actual, target=target):
+                status, _reason = metric_verdict(
+                    "mean_ttft_ms",
+                    actual,
+                    {"kind": "max", "value": target},
+                )
+                self.assertEqual(status, expected)
+
+    def test_every_invalid_actual_fails(self):
+        for actual in (None, True, "1", [], {}, {1}, math.nan, math.inf, -math.inf):
+            with self.subTest(actual=actual):
+                status, reason = metric_verdict(
+                    "output_throughput",
+                    actual,
+                    {"kind": "min", "value": 0},
+                )
+                self.assertEqual(status, "fail")
+                self.assertIn("finite built-in", reason)
+
+    def test_finite_number_excludes_bool_and_subclasses(self):
+        class IntSubclass(int):
+            pass
+
+        self.assertTrue(is_finite_number(0))
+        self.assertTrue(is_finite_number(-0.5))
+        self.assertFalse(is_finite_number(True))
+        self.assertFalse(is_finite_number(IntSubclass(1)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/inference/utils/unittests/test_vllm_verification.py
+++ b/cvs/lib/inference/utils/unittests/test_vllm_verification.py
@@ -1,144 +1,145 @@
 '''Unit tests for vLLM metric verification verdicts.'''
 
+import math
 import unittest
 
 from cvs.lib.inference.utils.vllm_verification import (
     active_metric_specs,
     evaluate_metric_verdicts,
-    metric_definitions,
     reportable_metric_specs,
 )
 
 
-class TestMetricDefinitions(unittest.TestCase):
-    def test_definitions_cover_all_metric_families(self):
-        definitions = {item['metric']: item for item in metric_definitions()}
-
-        self.assertEqual(definitions['client.output_throughput']['unit'], 'tok/s')
-        self.assertEqual(definitions['gpu.gpu_compute_util_pct']['missing_status'], 'skip')
-        self.assertEqual(definitions['prom.queue_time_p95_ms']['missing_status'], 'skip')
-
-
-class TestActiveMetricSpecs(unittest.TestCase):
-    def test_reportable_specs_are_separate_from_active_gates(self):
+class TestMetricSpecs(unittest.TestCase):
+    def test_partial_specs_remain_partial_and_registry_ordered(self):
         thresholds = {
-            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
-            'client.goodput': {'kind': 'info', 'value': 0},
+            "mean_ttft_ms": {"kind": "max", "value": 50},
+            "output_throughput": {"kind": "min", "value": 100},
         }
-
+        self.assertEqual(
+            [item["metric"] for item in reportable_metric_specs(thresholds)],
+            ["output_throughput", "mean_ttft_ms"],
+        )
         self.assertEqual(active_metric_specs(thresholds, enforce_thresholds=False), ())
         self.assertEqual(
-            [item['metric'] for item in reportable_metric_specs(thresholds)],
-            ['client.goodput', 'client.output_throughput'],
+            [item["metric"] for item in active_metric_specs(thresholds, enforce_thresholds=True)],
+            ["output_throughput", "mean_ttft_ms"],
         )
-        active = active_metric_specs(thresholds, enforce_thresholds=True)
-        self.assertEqual([item['metric'] for item in active], ['client.output_throughput'])
+
+    def test_empty_partial_cell_has_no_active_specs(self):
+        self.assertEqual(reportable_metric_specs({}), ())
+        self.assertEqual(active_metric_specs({}, enforce_thresholds=True), ())
 
 
 class TestEvaluateMetricVerdicts(unittest.TestCase):
-    def test_record_only_reports_configured_specs_without_asserted_passes(self):
-        thresholds = {
-            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
-            'gpu.gpu_compute_util_pct': {'kind': 'min', 'value': 80},
-        }
+    def test_rows_include_all_finite_actuals_and_configured_missing_metrics(self):
         actuals = {
-            'head': {
-                'client.output_throughput': 99,
-                'client.mean_ttft_ms': 40,
-                'gpu.gpu_compute_util_pct': None,
+            "head": {
+                "request_throughput": 3.0,
+                "output_throughput": 99,
+                "mean_ttft_ms": None,
+                "failed": "bad",
             }
+        }
+        thresholds = {
+            "output_throughput": {"kind": "min", "value": 100},
+            "mean_ttft_ms": {"kind": "max", "value": 50},
         }
 
         verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=False)
 
         self.assertEqual(
-            [(item['metric'], item['status'], item['enforced']) for item in verdicts],
+            [(item["metric"], item["status"], item["enforced"]) for item in verdicts],
             [
-                ('client.output_throughput', 'record', False),
-                ('gpu.gpu_compute_util_pct', 'record', False),
+                ("request_throughput", "record", False),
+                ("output_throughput", "record", False),
+                ("mean_ttft_ms", "record", False),
             ],
         )
-        self.assertNotIn('client.mean_ttft_ms', {item['metric'] for item in verdicts})
-        self.assertIn('metric unavailable', verdicts[1]['reason'])
-        self.assertTrue(all('no threshold asserted' in item['reason'] for item in verdicts))
 
-    def test_info_spec_remains_record_only_when_other_gates_are_enforced(self):
-        thresholds = {
-            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
-            'client.goodput': {'kind': 'info', 'value': 0},
-        }
-        actuals = {'head': {'client.output_throughput': 100, 'client.goodput': 10}}
-
-        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
-
-        self.assertEqual([item['status'] for item in verdicts], ['record', 'pass'])
-        self.assertEqual([item['enforced'] for item in verdicts], [False, True])
-
-    def test_evaluates_sibling_metrics_after_failure(self):
-        thresholds = {
-            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
-            'client.mean_ttft_ms': {'kind': 'max_ms', 'value': 50},
-        }
+    def test_only_present_enforced_specs_gate(self):
         actuals = {
-            'head': {
-                'client.output_throughput': 99,
-                'client.mean_ttft_ms': 40,
+            "head": {
+                "request_throughput": 1,
+                "output_throughput": 99,
+                "mean_ttft_ms": 40,
             }
         }
-
+        thresholds = {"output_throughput": {"kind": "min", "value": 100}}
         verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
-
-        self.assertEqual([item['status'] for item in verdicts], ['fail', 'pass'])
-        self.assertIn('actual 99.0 tok/s < min 100.0 tok/s', verdicts[0]['reason'])
-
-    def test_missing_client_fails_and_missing_gpu_prom_skip(self):
-        thresholds = {
-            'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
-            'gpu.gpu_compute_util_pct': {'kind': 'min', 'value': 80},
-            'prom.queue_time_p95_ms': {'kind': 'max_ms', 'value': 50},
-        }
-
-        verdicts = evaluate_metric_verdicts({'head': {}}, thresholds, enforce_thresholds=True)
 
         self.assertEqual(
-            {item['metric']: item['status'] for item in verdicts},
-            {
-                'client.output_throughput': 'fail',
-                'gpu.gpu_compute_util_pct': 'skip',
-                'prom.queue_time_p95_ms': 'skip',
-            },
+            [(item["metric"], item["status"], item["enforced"]) for item in verdicts],
+            [
+                ("request_throughput", "record", False),
+                ("output_throughput", "fail", True),
+                ("mean_ttft_ms", "record", False),
+            ],
         )
 
-    def test_min_ratio_uses_complete_actuals(self):
+    def test_mixed_failure_and_pass_are_both_computed(self):
         thresholds = {
-            'client.output_throughput': {
-                'kind': 'min_ratio',
-                'reference': 'client.total_token_throughput',
-                'value': 0.5,
-            }
+            "output_throughput": {"kind": "min", "value": 100},
+            "mean_ttft_ms": {"kind": "max", "value": 50},
         }
+        actuals = {"head": {"output_throughput": 99, "mean_ttft_ms": 40}}
+
+        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
+
+        self.assertEqual([item["status"] for item in verdicts], ["fail", "pass"])
+
+    def test_keeps_one_verdict_per_metric_per_host(self):
+        thresholds = {"output_throughput": {"kind": "min", "value": 100}}
         actuals = {
-            'head': {
-                'client.output_throughput': 60,
-                'client.total_token_throughput': 100,
-            }
+            "head": {"output_throughput": 100},
+            "worker": {"output_throughput": 200},
         }
 
         verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
 
-        self.assertEqual(verdicts[0]['status'], 'pass')
+        self.assertEqual([verdict["node"] for verdict in verdicts], ["head", "worker"])
+        self.assertTrue(all(verdict["status"] == "pass" for verdict in verdicts))
 
-    def test_keeps_one_verdict_per_host(self):
-        thresholds = {'client.output_throughput': {'kind': 'min_tok_s', 'value': 100}}
-        actuals = {
-            'head': {'client.output_throughput': 100},
-            'worker': {'client.output_throughput': 200},
+    def test_every_invalid_gated_actual_fails(self):
+        for actual in (None, True, "1", [], {}, {1}, math.nan, math.inf, -math.inf):
+            with self.subTest(actual=actual):
+                verdicts = evaluate_metric_verdicts(
+                    {"head": {"output_throughput": actual}},
+                    {"output_throughput": {"kind": "min", "value": 0}},
+                    enforce_thresholds=True,
+                )
+                self.assertEqual(verdicts[0]["status"], "fail")
+
+    def test_invalid_ungated_values_do_not_gate(self):
+        for enforce in (False, True):
+            with self.subTest(enforce=enforce):
+                verdicts = evaluate_metric_verdicts(
+                    {"head": {"output_throughput": "bad", "request_throughput": 1}},
+                    {},
+                    enforce_thresholds=enforce,
+                )
+                self.assertEqual(
+                    [(item["metric"], item["status"], item["enforced"]) for item in verdicts],
+                    [("request_throughput", "record", False)],
+                )
+
+    def test_missing_gpu_and_prometheus_gates_fail_never_skip(self):
+        thresholds = {
+            "gpu_compute_util_pct": {"kind": "min", "value": 80},
+            "queue_time_p95_ms": {"kind": "max", "value": 50},
         }
 
-        verdicts = evaluate_metric_verdicts(actuals, thresholds, enforce_thresholds=True)
+        verdicts = evaluate_metric_verdicts({"head": {}}, thresholds, enforce_thresholds=True)
 
-        self.assertEqual([verdict['node'] for verdict in verdicts], ['head', 'worker'])
+        self.assertEqual(
+            {item["metric"]: item["status"] for item in verdicts},
+            {
+                "gpu_compute_util_pct": "fail",
+                "queue_time_p95_ms": "fail",
+            },
+        )
+        self.assertNotIn("skip", {item["status"] for item in verdicts})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/cvs/lib/inference/utils/vllm_config_loader.py
+++ b/cvs/lib/inference/utils/vllm_config_loader.py
@@ -51,6 +51,8 @@ def _validate_vllm_thresholds(thresholds):
         if not isinstance(cell, dict):
             raise ValueError(f"vLLM threshold cell {cell_key!r} must be an object")
         for metric, raw_spec in cell.items():
+            if metric.startswith(_METADATA_PREFIXES):
+                continue
             spec = VllmThresholdSpec.model_validate(raw_spec).model_dump()
             validate_threshold_spec(metric, spec)
 

--- a/cvs/lib/inference/utils/vllm_config_loader.py
+++ b/cvs/lib/inference/utils/vllm_config_loader.py
@@ -7,15 +7,14 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, create_model, model_validator
 
 from cvs.lib.inference.utils.accuracy_config import AccuracyConfig
-from cvs.lib.inference.utils.vllm_server_metrics import PROM_METRICS
+from cvs.lib.inference.utils.vllm_metrics import METRIC_REGISTRY, validate_threshold_spec
 from cvs.lib.utils.config_loader import substitute_config
-from cvs.lib.utils.gpu import GPU_METRICS
 
-GATED_GPU_METRICS = {key for key, _unit in GPU_METRICS}
-GATED_PROM_METRICS = {key for key, _unit in PROM_METRICS}
+GATED_GPU_METRICS = {definition.name for definition in METRIC_REGISTRY if definition.datasource == "gpu"}
+GATED_PROM_METRICS = {definition.name for definition in METRIC_REGISTRY if definition.datasource == "prometheus"}
 _CELL_RE = re.compile(
     r"^ISL=(?P<isl>[1-9]\d*),OSL=(?P<osl>[1-9]\d*),TP=(?P<tp>[1-9]\d*),PP=(?P<pp>[1-9]\d*),CONC=(?P<concurrency>[1-9]\d*)$"
 )
@@ -35,6 +34,25 @@ class _Options(BaseModel):
 
     def extra_options(self) -> Dict[str, Any]:
         return dict(self.model_extra or {})
+
+
+VllmThresholdSpec = create_model(
+    "VllmThresholdSpec",
+    __base__=_Forbid,
+    kind=(Any, ...),
+    value=(Any, ...),
+)
+
+
+def _validate_vllm_thresholds(thresholds):
+    for cell_key, cell in thresholds.items():
+        if cell_key == "accuracy":
+            continue
+        if not isinstance(cell, dict):
+            raise ValueError(f"vLLM threshold cell {cell_key!r} must be an object")
+        for metric, raw_spec in cell.items():
+            spec = VllmThresholdSpec.model_validate(raw_spec).model_dump()
+            validate_threshold_spec(metric, spec)
 
 
 class RuntimeArgs(_Forbid):
@@ -267,6 +285,7 @@ class VariantConfig(_Forbid):
 
     @model_validator(mode="after")
     def _validate_runs_and_thresholds(self):
+        _validate_vllm_thresholds(self.thresholds)
         if not self.runs:
             raise ValueError("runs must be a nonempty explicit list")
         parsed = {key: RunCell.parse(key) for key in self.sweeps}

--- a/cvs/lib/inference/utils/vllm_metrics.py
+++ b/cvs/lib/inference/utils/vllm_metrics.py
@@ -36,6 +36,10 @@ _METADATA_FIELDS = frozenset(
 )
 
 
+class UnknownMetricContractError(ValueError):
+    """A finite artifact field falls outside the canonical vLLM registry."""
+
+
 def _raw(name, unit, category, direction, raw_source=None):
     source = raw_source or name
     return MetricDefinition(name, source, 'identity', (source,), unit, 'client', category, direction)
@@ -337,7 +341,7 @@ def project_vllm_metrics(raw, *, tp, isl, pp='1', artifact_path='results'):
             continue
         if raw_name in _METADATA_FIELDS or not is_finite_number(value):
             continue
-        raise ValueError(f'unknown finite numeric vLLM result field {raw_name!r}: {artifact_path}')
+        raise UnknownMetricContractError(f'unknown finite numeric vLLM result field {raw_name!r}: {artifact_path}')
 
     context = {'tp': tp, 'pp': pp, 'isl': isl}
     for definition in _DERIVED_CLIENT_METRICS:

--- a/cvs/lib/inference/utils/vllm_metrics.py
+++ b/cvs/lib/inference/utils/vllm_metrics.py
@@ -1,0 +1,393 @@
+'''Canonical metric contract for CVS vLLM benchmark results.'''
+
+import math
+from collections import namedtuple
+from types import MappingProxyType
+
+from cvs.lib.utils.gpu import GPU_METRICS as _SHARED_GPU_METRICS
+
+
+MetricDefinition = namedtuple(
+    'MetricDefinition',
+    (
+        'name',
+        'raw_source',
+        'derivation',
+        'required_inputs',
+        'unit',
+        'datasource',
+        'category',
+        'direction',
+    ),
+)
+
+METRIC_CONTRACT = MappingProxyType({'id': 'vllm-bare', 'version': 1})
+_METADATA_FIELDS = frozenset(
+    {
+        'date',
+        'endpoint_type',
+        'backend',
+        'label',
+        'model_id',
+        'tokenizer_id',
+        'burstiness',
+        'request_rate',
+    }
+)
+
+
+def _raw(name, unit, category, direction, raw_source=None):
+    source = raw_source or name
+    return MetricDefinition(name, source, 'identity', (source,), unit, 'client', category, direction)
+
+
+def _derived(name, unit, category, direction, derivation, required_inputs):
+    return MetricDefinition(name, None, derivation, tuple(required_inputs), unit, 'client', category, direction)
+
+
+def _gpu_definitions():
+    definitions = []
+    for name, unit in _SHARED_GPU_METRICS:
+        if name == 'peak_gpu_memory_mb':
+            derivation = 'poll_max'
+            required_inputs = ('gpu.used_vram',)
+            direction = 'max'
+        elif name == 'model_load_memory_mb':
+            derivation = 'snapshot_delta'
+            required_inputs = ('gpu.used_vram.before', 'gpu.used_vram.after')
+            direction = 'max'
+        elif name == 'model_load_s':
+            derivation = 'server_readiness_elapsed'
+            required_inputs = ('server_start', 'server_ready')
+            direction = 'max'
+        elif name == 'gpu_bandwidth_util_pct':
+            derivation = 'poll_mean'
+            required_inputs = ('gpu.umc_activity',)
+            direction = 'min'
+        elif name == 'gpu_compute_util_pct':
+            derivation = 'poll_mean'
+            required_inputs = ('gpu.gfx_activity',)
+            direction = 'min'
+        else:
+            raise ValueError(f'unsupported shared GPU metric {name!r}')
+        definitions.append(
+            MetricDefinition(
+                name,
+                None,
+                derivation,
+                required_inputs,
+                unit,
+                'gpu',
+                'gpu',
+                direction,
+            )
+        )
+    return tuple(definitions)
+
+
+METRIC_REGISTRY = (
+    _raw('max_concurrency', '-', 'run_health', 'min'),
+    _raw('max_concurrent_requests', '-', 'run_health', 'min'),
+    _raw('num_prompts', '-', 'run_health', 'min'),
+    _raw('completed', '-', 'run_health', 'min'),
+    _raw('failed', '-', 'run_health', 'max'),
+    _derived(
+        'success_rate',
+        '-',
+        'run_health',
+        'min',
+        'success_rate',
+        ('completed', 'failed'),
+    ),
+    _raw('duration', 's', 'run_health', 'max'),
+    _raw('request_throughput', 'req/s', 'throughput', 'min'),
+    _raw('goodput', 'req/s', 'throughput', 'min', raw_source='request_goodput'),
+    _raw('output_throughput', 'tok/s', 'throughput', 'min'),
+    _raw('total_token_throughput', 'tok/s', 'throughput', 'min'),
+    _derived(
+        'per_gpu_throughput',
+        'tok/s',
+        'throughput',
+        'min',
+        'per_gpu_throughput',
+        ('total_token_throughput', 'tp', 'pp'),
+    ),
+    _derived(
+        'decode_throughput_p50',
+        'tok/s',
+        'throughput',
+        'min',
+        'decode_throughput_p50',
+        ('median_tpot_ms',),
+    ),
+    _raw('max_output_tokens_per_s', 'tok/s', 'throughput', 'min'),
+    _raw('rtfx', '-', 'throughput', 'min'),
+    _raw('total_input_tokens', '-', 'throughput', 'min'),
+    _raw('total_output_tokens', '-', 'throughput', 'min'),
+    _raw('mean_ttft_ms', 'ms', 'ttft', 'max'),
+    _raw('median_ttft_ms', 'ms', 'ttft', 'max'),
+    _raw('std_ttft_ms', 'ms', 'ttft', 'max'),
+    _raw('p50_ttft_ms', 'ms', 'ttft', 'max'),
+    _raw('p90_ttft_ms', 'ms', 'ttft', 'max'),
+    _raw('p95_ttft_ms', 'ms', 'ttft', 'max'),
+    _raw('p99_ttft_ms', 'ms', 'ttft', 'max'),
+    _derived(
+        'normalized_ttft_ms_per_tok',
+        'ms/tok',
+        'ttft',
+        'max',
+        'normalized_ttft_ms_per_tok',
+        ('mean_ttft_ms', 'isl'),
+    ),
+    _raw('mean_tpot_ms', 'ms', 'tpot', 'max'),
+    _raw('median_tpot_ms', 'ms', 'tpot', 'max'),
+    _raw('std_tpot_ms', 'ms', 'tpot', 'max'),
+    _raw('p50_tpot_ms', 'ms', 'tpot', 'max'),
+    _raw('p90_tpot_ms', 'ms', 'tpot', 'max'),
+    _raw('p95_tpot_ms', 'ms', 'tpot', 'max'),
+    _raw('p99_tpot_ms', 'ms', 'tpot', 'max'),
+    _raw('mean_itl_ms', 'ms', 'itl', 'max'),
+    _raw('median_itl_ms', 'ms', 'itl', 'max'),
+    _raw('std_itl_ms', 'ms', 'itl', 'max'),
+    _raw('p50_itl_ms', 'ms', 'itl', 'max'),
+    _raw('p90_itl_ms', 'ms', 'itl', 'max'),
+    _raw('p95_itl_ms', 'ms', 'itl', 'max'),
+    _raw('p99_itl_ms', 'ms', 'itl', 'max'),
+    _derived(
+        'decode_latency_ratio',
+        '-',
+        'itl',
+        'max',
+        'decode_latency_ratio',
+        ('p99_itl_ms', 'p50_itl_ms'),
+    ),
+    _raw('mean_e2el_ms', 'ms', 'e2el', 'max'),
+    _raw('median_e2el_ms', 'ms', 'e2el', 'max'),
+    _raw('std_e2el_ms', 'ms', 'e2el', 'max'),
+    _raw('p50_e2el_ms', 'ms', 'e2el', 'max'),
+    _raw('p90_e2el_ms', 'ms', 'e2el', 'max'),
+    _raw('p95_e2el_ms', 'ms', 'e2el', 'max'),
+    _raw('p99_e2el_ms', 'ms', 'e2el', 'max'),
+    *_gpu_definitions(),
+    MetricDefinition(
+        'queue_time_p50_ms',
+        None,
+        'histogram_quantile_p50',
+        ('vllm:request_queue_time_seconds.before', 'vllm:request_queue_time_seconds.after'),
+        'ms',
+        'prometheus',
+        'prometheus',
+        'max',
+    ),
+    MetricDefinition(
+        'queue_time_p95_ms',
+        None,
+        'histogram_quantile_p95',
+        ('vllm:request_queue_time_seconds.before', 'vllm:request_queue_time_seconds.after'),
+        'ms',
+        'prometheus',
+        'prometheus',
+        'max',
+    ),
+    MetricDefinition(
+        'prefill_time_p50_ms',
+        None,
+        'histogram_quantile_p50',
+        ('vllm:request_prefill_time_seconds.before', 'vllm:request_prefill_time_seconds.after'),
+        'ms',
+        'prometheus',
+        'prometheus',
+        'max',
+    ),
+    MetricDefinition(
+        'prefill_time_p95_ms',
+        None,
+        'histogram_quantile_p95',
+        ('vllm:request_prefill_time_seconds.before', 'vllm:request_prefill_time_seconds.after'),
+        'ms',
+        'prometheus',
+        'prometheus',
+        'max',
+    ),
+)
+
+METRICS_BY_NAME = MappingProxyType({definition.name: definition for definition in METRIC_REGISTRY})
+METRIC_NAMES = tuple(METRICS_BY_NAME)
+METRIC_UNITS = MappingProxyType({definition.name: definition.unit for definition in METRIC_REGISTRY})
+METRIC_CATEGORIES = tuple(dict.fromkeys(definition.category for definition in METRIC_REGISTRY))
+CLIENT_METRICS = tuple(
+    (definition.name, definition.unit) for definition in METRIC_REGISTRY if definition.datasource == 'client'
+)
+VLLM_GPU_METRICS = tuple(
+    (definition.name, definition.unit) for definition in METRIC_REGISTRY if definition.datasource == 'gpu'
+)
+PROM_METRICS = tuple(
+    (definition.name, definition.unit) for definition in METRIC_REGISTRY if definition.datasource == 'prometheus'
+)
+PROM_METRIC_UNITS = MappingProxyType(dict(PROM_METRICS))
+_RAW_CLIENT_METRICS = MappingProxyType(
+    {
+        definition.raw_source: definition.name
+        for definition in METRIC_REGISTRY
+        if definition.datasource == 'client' and definition.raw_source is not None
+    }
+)
+_DERIVED_CLIENT_METRICS = tuple(
+    definition for definition in METRIC_REGISTRY if definition.datasource == 'client' and definition.raw_source is None
+)
+_NAMES_BY_DATASOURCE = MappingProxyType(
+    {
+        datasource: frozenset(definition.name for definition in METRIC_REGISTRY if definition.datasource == datasource)
+        for datasource in ('client', 'gpu', 'prometheus')
+    }
+)
+
+VLLM_RESULTS_COLUMNS = (
+    ('Model', None),
+    ('GPU', None),
+    ('ISL', None),
+    ('OSL', None),
+    ('Policy', None),
+    ('Conc', None),
+    ('Host', None),
+    ('Req/s', 'request_throughput'),
+    ('Total tok/s', 'total_token_throughput'),
+    ('Mean TTFT (ms)', 'mean_ttft_ms'),
+    ('P95 TTFT (ms)', 'p95_ttft_ms'),
+    ('Mean TPOT (ms)', 'mean_tpot_ms'),
+    ('P95 TPOT (ms)', 'p95_tpot_ms'),
+    ('P99 ITL (ms)', 'p99_itl_ms'),
+    ('Goodput (req/s)', 'goodput'),
+)
+
+
+def is_finite_number(value):
+    return type(value) in (int, float) and math.isfinite(value)
+
+
+def metric_contract():
+    return dict(METRIC_CONTRACT)
+
+
+def metric_definitions():
+    return METRIC_REGISTRY
+
+
+def report_metric_units():
+    return dict(METRIC_UNITS)
+
+
+def tier_metric_specs(thresholds_cell, tier):
+    return {
+        definition.name: thresholds_cell[definition.name]
+        for definition in METRIC_REGISTRY
+        if definition.category == tier and definition.name in thresholds_cell
+    }
+
+
+def _number(value):
+    if type(value) in (int, float):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_ratio(numerator, denominator):
+    numerator = _number(numerator)
+    denominator = _number(denominator)
+    if numerator is None or denominator in (None, 0.0):
+        return None
+    return numerator / denominator
+
+
+def _derive_metric(definition, values, context):
+    inputs = {name: context.get(name, values.get(name)) for name in definition.required_inputs}
+    if definition.derivation == 'success_rate':
+        completed = inputs['completed']
+        failed = inputs['failed']
+        total = None if completed is None or failed is None else completed + failed
+        return _safe_ratio(completed, total)
+    if definition.derivation == 'per_gpu_throughput':
+        tp = _number(inputs['tp'])
+        pp = _number(inputs['pp'])
+        gpu_count = None if tp is None or pp is None else tp * pp
+        return _safe_ratio(inputs['total_token_throughput'], gpu_count)
+    if definition.derivation == 'decode_throughput_p50':
+        return _safe_ratio(1000.0, inputs['median_tpot_ms'])
+    if definition.derivation == 'normalized_ttft_ms_per_tok':
+        return _safe_ratio(inputs['mean_ttft_ms'], inputs['isl'])
+    if definition.derivation == 'decode_latency_ratio':
+        return _safe_ratio(inputs['p99_itl_ms'], inputs['p50_itl_ms'])
+    raise ValueError(f'unknown vLLM metric derivation {definition.derivation!r}')
+
+
+def project_vllm_metrics(raw, *, tp, isl, pp='1', artifact_path='results'):
+    '''Project one vLLM benchmark artifact into finite canonical bare metrics.'''
+    if not isinstance(raw, dict):
+        raise ValueError(f'vLLM results artifact must contain an object: {artifact_path}')
+
+    metrics = {}
+    for raw_name, value in raw.items():
+        metric_name = _RAW_CLIENT_METRICS.get(raw_name)
+        if metric_name is not None:
+            if is_finite_number(value):
+                metrics[metric_name] = value
+            continue
+        if raw_name in _METADATA_FIELDS or not is_finite_number(value):
+            continue
+        raise ValueError(f'unknown finite numeric vLLM result field {raw_name!r}: {artifact_path}')
+
+    context = {'tp': tp, 'pp': pp, 'isl': isl}
+    for definition in _DERIVED_CLIENT_METRICS:
+        value = _derive_metric(definition, metrics, context)
+        if is_finite_number(value):
+            metrics[definition.name] = value
+    return metrics
+
+
+def merge_metric_sources(client_metrics, gpu_metrics, prometheus_metrics):
+    '''Validate and disjointly merge the three vLLM metric datasources.'''
+    merged = {}
+    for datasource, source in (
+        ('client', client_metrics),
+        ('gpu', gpu_metrics),
+        ('prometheus', prometheus_metrics),
+    ):
+        collisions = set(merged) & set(source)
+        if collisions:
+            raise ValueError(f'vLLM metric source collision: {sorted(collisions)}')
+        unknown = set(source) - _NAMES_BY_DATASOURCE[datasource]
+        if unknown:
+            raise ValueError(f'unknown {datasource} vLLM metrics: {sorted(unknown)}')
+        merged.update(source)
+    return merged
+
+
+def validate_threshold_spec(metric, spec):
+    definition = METRICS_BY_NAME.get(metric)
+    if definition is None:
+        raise ValueError(f'unknown vLLM threshold metric {metric!r}')
+    if type(spec.get('kind')) is not str or spec['kind'] != definition.direction:
+        raise ValueError(f'{metric} threshold kind must be {definition.direction!r}, got {spec.get("kind")!r}')
+    if not is_finite_number(spec.get('value')):
+        raise ValueError(f'{metric} threshold value must be a finite built-in int or float')
+
+
+def metric_verdict(metric, actual, spec):
+    '''Evaluate one canonical vLLM min/max threshold without coercion.'''
+    try:
+        validate_threshold_spec(metric, spec)
+    except (AttributeError, KeyError, ValueError) as exc:
+        return 'fail', str(exc)
+    if not is_finite_number(actual):
+        return 'fail', f'{metric}: actual must be a finite built-in int or float, got {actual!r}'
+
+    direction = METRICS_BY_NAME[metric].direction
+    target = spec['value']
+    if direction == 'min' and actual < target:
+        return 'fail', f'{metric}: actual {actual} < min {target}'
+    if direction == 'max' and actual > target:
+        return 'fail', f'{metric}: actual {actual} > max {target}'
+    return 'pass', ''

--- a/cvs/lib/inference/utils/vllm_server_metrics.py
+++ b/cvs/lib/inference/utils/vllm_server_metrics.py
@@ -4,18 +4,14 @@ All rights reserved.
 
 Pure parsers for vLLM's engine-side Prometheus `/metrics` endpoint.
 
-This module owns the *vocabulary and math* of the `prom.*` namespace -- the
-mapping from two raw Prometheus text-exposition scrapes (one taken before a
-sweep cell's client run, one taken after) to the namespaced metric dict that
-downstream code (threshold files, the per-metric HTML rows, `evaluate_all`)
-keys on. Deliberately free of I/O and orchestration, matching
-`vllm_parsing.py`'s split: callers (`vllm_job.py`) fetch the scrape text,
-this module turns it into numbers.
-
-Namespacing contract: `prom.*` -- percentile metrics interpolated from
-Prometheus Histograms scraped off the live vLLM server, distinct from
-`client.*` (measured by the load generator) and `gpu.*` (amd-smi snapshots).
-Its own namespace rather than joining either of those.
+This module maps two raw Prometheus text-exposition scrapes (one taken before
+a sweep cell's client run, one taken after) into the bare Prometheus-backed
+keys owned by the vLLM metric registry, such as `queue_time_p50_ms` and
+`prefill_time_p95_ms`. The registry records their Prometheus datasource; the
+threshold, verdict, and reporting surfaces all use the same bare names.
+Deliberately free of I/O and orchestration, matching the client projector's
+split: callers (`vllm_job.py`) fetch the scrape text, and this module turns it
+into numbers.
 
 vLLM's histogram buckets are cumulative per scrape (each `le` bucket already
 counts everything at or below it), but the *counters themselves* are
@@ -41,8 +37,6 @@ from cvs.lib.inference.utils.vllm_metrics import (
 PROM_METRICS = _REGISTRY_PROM_METRICS
 PROM_METRIC_UNITS = _REGISTRY_PROM_METRIC_UNITS
 
-# vLLM Prometheus histogram names this module reads, and the (short_name
-# prefix, quantile) pairs each feeds into PROM_METRICS above.
 _QUEUE_TIME_METRIC = "vllm:request_queue_time_seconds"
 _PREFILL_TIME_METRIC = "vllm:request_prefill_time_seconds"
 

--- a/cvs/lib/inference/utils/vllm_server_metrics.py
+++ b/cvs/lib/inference/utils/vllm_server_metrics.py
@@ -28,17 +28,18 @@ never a single scrape.
 
 from __future__ import annotations
 
+import math
 import re
 
-# Human-readable derived metrics exposed as HTML rows (one row per entry per
-# cell), mirroring gpu.py's GPU_METRICS shape.
-PROM_METRICS: list[tuple[str, str]] = [
-    ("queue_time_p50_ms", "ms"),
-    ("queue_time_p95_ms", "ms"),
-    ("prefill_time_p50_ms", "ms"),
-    ("prefill_time_p95_ms", "ms"),
-]
-PROM_METRIC_UNITS: dict[str, str] = {k: u for k, u in PROM_METRICS}
+from cvs.lib.inference.utils.vllm_metrics import (
+    PROM_METRICS as _REGISTRY_PROM_METRICS,
+)
+from cvs.lib.inference.utils.vllm_metrics import (
+    PROM_METRIC_UNITS as _REGISTRY_PROM_METRIC_UNITS,
+)
+
+PROM_METRICS = _REGISTRY_PROM_METRICS
+PROM_METRIC_UNITS = _REGISTRY_PROM_METRIC_UNITS
 
 # vLLM Prometheus histogram names this module reads, and the (short_name
 # prefix, quantile) pairs each feeds into PROM_METRICS above.
@@ -173,18 +174,19 @@ def histogram_quantile(buckets: "dict[str, float] | None", q: float) -> "float |
 def _quantile_ms(before_metrics: dict, after_metrics: dict, metric_name: str, q: float) -> "float | None":
     diffed = diff_histogram(before_metrics.get(metric_name), after_metrics.get(metric_name))
     seconds = histogram_quantile(diffed, q)
-    return None if seconds is None else seconds * 1000.0
+    milliseconds = None if seconds is None else seconds * 1000.0
+    return milliseconds if type(milliseconds) in (int, float) and math.isfinite(milliseconds) else None
 
 
 def to_prom_metrics(before_text: "str | None", after_text: "str | None") -> dict:
-    """Composed entry point: two raw scrape texts -> the `prom.*` metric dict.
+    """Composed entry point: two raw scrape texts -> canonical vLLM metrics.
 
     Analogous to vllm_parsing.py's to_client_metrics(). Returns an all-None
     dict (never a partial one, never a raise) if either scrape is
     missing/unparseable: a transport failure must degrade every prom.* key
     for the cell, not crash it.
     """
-    all_none = {f"prom.{short}": None for short, _unit in PROM_METRICS}
+    all_none = {short: None for short, _unit in PROM_METRICS}
     if not before_text or not after_text:
         return all_none
 
@@ -195,6 +197,6 @@ def to_prom_metrics(before_text: "str | None", after_text: "str | None") -> dict
 
     result = dict(all_none)
     for qname, q in _QUANTILES.items():
-        result[f"prom.queue_time_{qname}_ms"] = _quantile_ms(before_metrics, after_metrics, _QUEUE_TIME_METRIC, q)
-        result[f"prom.prefill_time_{qname}_ms"] = _quantile_ms(before_metrics, after_metrics, _PREFILL_TIME_METRIC, q)
+        result[f"queue_time_{qname}_ms"] = _quantile_ms(before_metrics, after_metrics, _QUEUE_TIME_METRIC, q)
+        result[f"prefill_time_{qname}_ms"] = _quantile_ms(before_metrics, after_metrics, _PREFILL_TIME_METRIC, q)
     return result

--- a/cvs/lib/inference/utils/vllm_verification.py
+++ b/cvs/lib/inference/utils/vllm_verification.py
@@ -1,111 +1,92 @@
 '''Threshold verdict helpers for vLLM metric verification subtests.'''
 
-from __future__ import annotations
+from cvs.lib.inference.utils.vllm_metrics import (
+    METRIC_CATEGORIES,
+    METRIC_CONTRACT,
+    METRIC_NAMES,
+    METRIC_REGISTRY,
+    METRIC_UNITS,
+    metric_contract,
+    metric_definitions,
+    metric_verdict,
+    report_metric_units,
+    tier_metric_specs,
+)
+from cvs.lib.inference.utils.vllm_metrics import is_finite_number as _is_finite_number
 
-from typing import Any, Mapping
-
-from cvs.lib.inference.utils.vllm_parsing import CLIENT_METRICS
-from cvs.lib.inference.utils.vllm_server_metrics import PROM_METRICS
-from cvs.lib.utils.gpu import GPU_METRICS
-from cvs.lib.utils.verdict import ThresholdViolation, evaluate_all
-
-
-def metric_definitions() -> tuple[dict[str, str], ...]:
-    '''Return ordered vLLM metric metadata keyed by fully qualified names.'''
-    definitions = []
-    for prefix, metrics, missing_status in (
-        ('client.', CLIENT_METRICS, 'fail'),
-        ('gpu.', GPU_METRICS, 'skip'),
-        ('prom.', PROM_METRICS, 'skip'),
-    ):
-        for short_name, unit in metrics:
-            definitions.append(
-                {
-                    'metric': f'{prefix}{short_name}',
-                    'unit': unit,
-                    'missing_status': missing_status,
-                }
-            )
-    return tuple(definitions)
-
-
-def report_metric_units() -> dict[str, str]:
-    '''Return units for fully qualified metrics and vLLM's client shorthand.'''
-    units = {definition['metric']: definition['unit'] for definition in metric_definitions()}
-    units.update(
-        {metric.removeprefix('client.'): unit for metric, unit in units.items() if metric.startswith('client.')}
-    )
-    return units
+__all__ = [
+    'METRIC_CATEGORIES',
+    'METRIC_CONTRACT',
+    'METRIC_NAMES',
+    'METRIC_REGISTRY',
+    'METRIC_UNITS',
+    'active_metric_specs',
+    'evaluate_metric_verdicts',
+    'metric_contract',
+    'metric_definitions',
+    'metric_verdict',
+    'report_metric_units',
+    'reportable_metric_specs',
+    'tier_metric_specs',
+]
 
 
-def active_metric_specs(
-    thresholds: Mapping[str, Mapping[str, Any]],
-    *,
-    enforce_thresholds: bool,
-) -> tuple[dict[str, Any], ...]:
-    '''Return configured, enforced, non-informational metric specs in display order.'''
+def active_metric_specs(thresholds, *, enforce_thresholds):
+    '''Return configured and enforced metric specs in registry order.'''
     if not enforce_thresholds:
         return ()
-
-    return tuple(
-        definition for definition in reportable_metric_specs(thresholds) if definition['spec'].get('kind') != 'info'
-    )
+    return reportable_metric_specs(thresholds)
 
 
-def reportable_metric_specs(
-    thresholds: Mapping[str, Mapping[str, Any]],
-) -> tuple[dict[str, Any], ...]:
-    '''Return configured metric specs in display order, whether enforced or not.'''
+def reportable_metric_specs(thresholds):
+    '''Return configured metric specs in registry order.'''
     specs = []
-    for definition in metric_definitions():
-        spec = thresholds.get(definition['metric'])
-        if not isinstance(spec, Mapping):
+    for definition in METRIC_REGISTRY:
+        spec = thresholds.get(definition.name)
+        if not isinstance(spec, dict):
             continue
-        specs.append({**definition, 'spec': dict(spec)})
+        specs.append(
+            {
+                'metric': definition.name,
+                'unit': definition.unit,
+                'datasource': definition.datasource,
+                'category': definition.category,
+                'direction': definition.direction,
+                'spec': dict(spec),
+            }
+        )
     return tuple(specs)
 
 
-def evaluate_metric_verdicts(
-    actuals_by_host: Mapping[str, Mapping[str, Any]],
-    thresholds: Mapping[str, Mapping[str, Any]],
-    *,
-    enforce_thresholds: bool,
-) -> list[dict[str, Any]]:
-    '''Build report rows and evaluate only enforced vLLM metric gates.'''
+def evaluate_metric_verdicts(actuals_by_host, thresholds, *, enforce_thresholds):
+    '''Build all vLLM rows before the parent emits threshold subtests.'''
     verdicts = []
-    reportable_specs = reportable_metric_specs(thresholds)
     for host, actuals in actuals_by_host.items():
-        for definition in reportable_specs:
-            metric = definition['metric']
+        for definition in METRIC_REGISTRY:
+            metric = definition.name
+            spec = thresholds.get(metric)
             value = actuals.get(metric)
-            enforced = enforce_thresholds and definition['spec'].get('kind') != 'info'
-            record_reason = (
-                'threshold enforcement disabled; no threshold asserted'
-                if not enforce_thresholds
-                else 'informational metric; no threshold asserted'
-            )
+            if not _is_finite_number(value) and spec is None:
+                continue
+            enforced = bool(enforce_thresholds and spec is not None)
             verdict = {
                 'node': str(host),
                 'metric': metric,
-                'unit': definition['unit'],
+                'label': metric,
+                'unit': definition.unit,
                 'actual': value,
-                'spec': definition['spec'],
+                'spec': spec,
                 'enforced': enforced,
                 'status': 'pass' if enforced else 'record',
-                'reason': '' if enforced else record_reason,
+                'reason': '',
             }
-            if value is None:
-                unavailable = f'{metric}: value is None (metric unavailable for this run)'
-                if enforced:
-                    verdict['status'] = definition['missing_status']
-                    verdict['reason'] = unavailable
-                else:
-                    verdict['reason'] = f'{unavailable}; no threshold asserted'
-            elif enforced:
-                try:
-                    evaluate_all(actuals, {metric: definition['spec']})
-                except ThresholdViolation as exc:
-                    verdict['status'] = 'fail'
-                    verdict['reason'] = str(exc)
+            if enforced:
+                verdict['status'], verdict['reason'] = metric_verdict(metric, value, spec)
+            elif spec is None:
+                verdict['reason'] = 'metric produced without a configured threshold'
+            else:
+                verdict['reason'] = 'threshold enforcement disabled; no threshold asserted'
+                if not _is_finite_number(value):
+                    verdict['reason'] = f'{metric}: unavailable or non-finite actual recorded; no threshold asserted'
             verdicts.append(verdict)
     return verdicts

--- a/cvs/lib/inference/vllm_job.py
+++ b/cvs/lib/inference/vllm_job.py
@@ -41,7 +41,7 @@ from typing import Optional
 
 from cvs.lib import globals
 from cvs.lib.inference.utils.vllm_config_loader import serialize_cli_options
-from cvs.lib.inference.utils.vllm_parsing import to_client_metrics
+from cvs.lib.inference.utils.vllm_metrics import project_vllm_metrics
 from cvs.lib.utils.model_query_lib import OpenAIProbe
 
 log = globals.log
@@ -651,5 +651,11 @@ class VllmJob:
                 # stack trace or an HTML error page, and raw newlines there
                 # would break up CI output and pasted ticket bodies.
                 raise RuntimeError(f"unparseable results artifact on {host}: {artifact}: {e}: {text[:500]!r}") from e
-            results[host] = to_client_metrics(raw, tp=self.tp, isl=self.isl, pp=self.pp)
+            results[host] = project_vllm_metrics(
+                raw,
+                tp=self.tp,
+                isl=self.isl,
+                pp=self.pp,
+                artifact_path=f'{host}:{artifact}',
+            )
         return results

--- a/cvs/lib/report/accuracy_lifecycle.py
+++ b/cvs/lib/report/accuracy_lifecycle.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import math
 import os
 from typing import Any, Dict, Mapping, Optional
 
 SCALE_ACCURACY_REF_ENV = "CVS_ATOM_SCALE_ACCURACY_REF_JSON"
+
+
+def _finite_accuracy_value(value):
+    if type(value) not in (int, float):
+        return None
+    try:
+        normalized = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return normalized if math.isfinite(normalized) else None
 
 
 def resolve_scale_accuracy_ref_json_path(config_path: str = "") -> str:
@@ -23,10 +34,9 @@ def extract_accuracy_from_lifecycle(lifecycle_report: Mapping[str, list]) -> Dic
                 continue
             if "." not in str(label):
                 continue
-            try:
-                out[str(label)] = float(value)
-            except (TypeError, ValueError):
-                continue
+            normalized = _finite_accuracy_value(value)
+            if normalized is not None:
+                out[str(label)] = normalized
     return out
 
 
@@ -40,14 +50,11 @@ def build_accuracy_prev_run_panel(
     baseline = baseline_payload.get("accuracy") or {}
     if not isinstance(baseline, dict):
         return None
-    current_val = current.get(metric_key)
-    baseline_val = baseline.get(metric_key)
+    current_val = _finite_accuracy_value(current.get(metric_key))
+    baseline_val = _finite_accuracy_value(baseline.get(metric_key))
     if current_val is None or baseline_val is None:
         return None
-    try:
-        delta = float(current_val) - float(baseline_val)
-    except (TypeError, ValueError):
-        return None
+    delta = current_val - baseline_val
     regression = delta < -max_drop
     return {
         "metric_key": metric_key,
@@ -77,14 +84,11 @@ def build_scale_accuracy_panel(
     rows = []
     any_regression = False
     for metric_key in metric_keys:
-        current_val = current.get(metric_key)
-        baseline_val = baseline.get(metric_key)
+        current_val = _finite_accuracy_value(current.get(metric_key))
+        baseline_val = _finite_accuracy_value(baseline.get(metric_key))
         if current_val is None or baseline_val is None:
             continue
-        try:
-            delta = float(current_val) - float(baseline_val)
-        except (TypeError, ValueError):
-            continue
+        delta = current_val - baseline_val
         regression = delta < -max_drop
         any_regression = any_regression or regression
         rows.append(

--- a/cvs/lib/report/cell_build.py
+++ b/cvs/lib/report/cell_build.py
@@ -81,7 +81,7 @@ class CellRecordBuilder:
                 metric,
                 actuals.get(metric),
                 spec,
-                evaluator=getattr(self.config, "metric_verdict", None),
+                evaluator=self.config.metric_verdict,
             )
             if status == "fail":
                 return "fail"
@@ -177,14 +177,19 @@ class CellRecordBuilder:
                             full,
                             actual,
                             spec,
-                            evaluator=getattr(self.config, "metric_verdict", None),
+                            evaluator=self.config.metric_verdict,
                         )
                         if enforce and spec
                         else "record"
                     ),
                     "bar_pct": (
                         bar_pct(float(actual), spec)
-                        if spec is not None and type(actual) in (int, float) and math.isfinite(actual)
+                        if spec is not None
+                        and actual is not None
+                        and (
+                            self.config.metric_verdict is None
+                            or (type(actual) in (int, float) and math.isfinite(actual))
+                        )
                         else None
                     ),
                     "margin": margin_text(actual, spec) if spec else None,

--- a/cvs/lib/report/cell_build.py
+++ b/cvs/lib/report/cell_build.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, List, Mapping, Optional
 
 from cvs.lib.report.formatting import fmt_num
@@ -9,8 +10,13 @@ from cvs.lib.report.types import InferenceReportConfig
 from cvs.lib.report.verdict import _check_one
 
 
-def metric_pass(metric: str, actual: Any, spec: Optional[dict]) -> str:
-    if spec is None or actual is None:
+def metric_pass(metric: str, actual: Any, spec: Optional[dict], evaluator=None) -> str:
+    if spec is None:
+        return "na"
+    if evaluator is not None:
+        status, _reason = evaluator(metric, actual, spec)
+        return status
+    if actual is None:
         return "na"
     err = _check_one(metric, actual, spec)
     return "fail" if err else "pass"
@@ -71,7 +77,12 @@ class CellRecordBuilder:
         if not specs:
             return "na"
         for metric, spec in specs.items():
-            status = metric_pass(metric, actuals.get(metric), spec)
+            status = metric_pass(
+                metric,
+                actuals.get(metric),
+                spec,
+                evaluator=getattr(self.config, "metric_verdict", None),
+            )
             if status == "fail":
                 return "fail"
             if status == "na":
@@ -161,8 +172,21 @@ class CellRecordBuilder:
                     "actual": actual,
                     "unit": self.config.metric_units.get(short, ""),
                     "spec": spec,
-                    "status": metric_pass(full, actual, spec) if enforce and spec else "record",
-                    "bar_pct": bar_pct(float(actual), spec) if spec is not None and actual is not None else None,
+                    "status": (
+                        metric_pass(
+                            full,
+                            actual,
+                            spec,
+                            evaluator=getattr(self.config, "metric_verdict", None),
+                        )
+                        if enforce and spec
+                        else "record"
+                    ),
+                    "bar_pct": (
+                        bar_pct(float(actual), spec)
+                        if spec is not None and type(actual) in (int, float) and math.isfinite(actual)
+                        else None
+                    ),
                     "margin": margin_text(actual, spec) if spec else None,
                 }
             )

--- a/cvs/lib/report/ci_summary.py
+++ b/cvs/lib/report/ci_summary.py
@@ -112,12 +112,17 @@ class CiSummaryBuilder:
             else "<p class='muted'>No cells recorded.</p>"
         )
 
-        regressions = self._prev_run_regressions()
-        prev_line = (
-            f"<p><strong>Baseline regressions:</strong> {regressions}</p>"
-            if regressions
-            else "<p><strong>Baseline regressions:</strong> none flagged</p>"
-        )
+        prev_panel = (self.payload.get("panels") or {}).get("prev_run") or {}
+        if prev_panel.get("compatible") is False:
+            reason = html.escape(str(prev_panel.get("incompatibility") or "metric contract mismatch"))
+            prev_line = f"<p><strong>Baseline comparison:</strong> incompatible; comparisons suppressed ({reason})</p>"
+        else:
+            regressions = self._prev_run_regressions()
+            prev_line = (
+                f"<p><strong>Baseline regressions:</strong> {regressions}</p>"
+                if regressions
+                else "<p><strong>Baseline regressions:</strong> none flagged</p>"
+            )
 
         if parity:
             parity_line = (

--- a/cvs/lib/report/inference_payload.py
+++ b/cvs/lib/report/inference_payload.py
@@ -290,7 +290,7 @@ class InferencePayloadBuilder:
             "results_table": self._results_builder.build(self.ctx.inf_res_dict),
             "panels": panels,
         }
-        metric_contract = getattr(self.config, "metric_contract", None)
+        metric_contract = self.config.metric_contract
         if metric_contract is not None:
             payload["metric_contract"] = dict(metric_contract)
         payload["viewer_config"] = build_viewer_config({}, self.config)

--- a/cvs/lib/report/inference_payload.py
+++ b/cvs/lib/report/inference_payload.py
@@ -290,6 +290,9 @@ class InferencePayloadBuilder:
             "results_table": self._results_builder.build(self.ctx.inf_res_dict),
             "panels": panels,
         }
+        metric_contract = getattr(self.config, "metric_contract", None)
+        if metric_contract is not None:
+            payload["metric_contract"] = dict(metric_contract)
         payload["viewer_config"] = build_viewer_config({}, self.config)
         return payload
 

--- a/cvs/lib/report/json_io.py
+++ b/cvs/lib/report/json_io.py
@@ -24,3 +24,24 @@ def index_cells_by_id_host(report_json: Mapping[str, Any]) -> dict[tuple[str, st
         if isinstance(cell, dict):
             index[cell_id_host_key(cell)] = cell
     return index
+
+
+def report_incompatibility(
+    report_json,
+    *,
+    expected_schema_version=1,
+    expected_suite_id="",
+    expected_metric_contract=None,
+):
+    """Return why a contract-qualified report cannot be used as a baseline."""
+    if expected_metric_contract is None:
+        return ""
+    if report_json.get("schema_version") != expected_schema_version:
+        return f"schema_version {report_json.get('schema_version')!r} is incompatible with {expected_schema_version!r}"
+    if report_json.get("suite_id") != expected_suite_id:
+        return f"suite_id {report_json.get('suite_id')!r} is incompatible with {expected_suite_id!r}"
+    if report_json.get("metric_contract") != expected_metric_contract:
+        return (
+            f"metric_contract {report_json.get('metric_contract')!r} is incompatible with {expected_metric_contract!r}"
+        )
+    return ""

--- a/cvs/lib/report/panels/panel_builder.py
+++ b/cvs/lib/report/panels/panel_builder.py
@@ -55,27 +55,35 @@ class ComparisonPanelBuilder:
             report_dir=self.report_dir,
         )
         if prev_run_path:
+            baseline_payload = load_report_json(Path(prev_run_path))
+            if not isinstance(baseline_payload, dict):
+                baseline_payload = {}
             prev_run_panel = build_prev_run_panel(
                 cells,
                 Path(prev_run_path),
                 headline_metric=self.config.headline_metric,
                 expected_suite_id=self.config.suite_id,
-                expected_metric_contract=getattr(self.config, "metric_contract", None),
+                expected_metric_contract=self.config.metric_contract,
+                baseline_payload=baseline_payload,
             )
             if prev_run_panel:
                 panels["prev_run"] = prev_run_panel
 
-            if lifecycle_report and (not prev_run_panel or prev_run_panel.get("compatible", True)):
+            if lifecycle_report:
                 current_accuracy = extract_accuracy_from_lifecycle(lifecycle_report)
-                baseline_payload = load_report_json(Path(prev_run_path)) or {}
-                accuracy_prev = build_accuracy_prev_run_panel(
-                    current_accuracy,
-                    baseline_payload,
-                    metric_key=self.config.gsm8k_prev_run_metric,
-                    max_drop=self.config.gsm8k_prev_run_max_drop,
+                accuracy_baseline_compatible = (
+                    baseline_payload.get("schema_version") == 1
+                    and baseline_payload.get("suite_id") == self.config.suite_id
                 )
-                if accuracy_prev:
-                    panels["accuracy_prev_run"] = accuracy_prev
+                if accuracy_baseline_compatible:
+                    accuracy_prev = build_accuracy_prev_run_panel(
+                        current_accuracy,
+                        baseline_payload,
+                        metric_key=self.config.gsm8k_prev_run_metric,
+                        max_drop=self.config.gsm8k_prev_run_max_drop,
+                    )
+                    if accuracy_prev:
+                        panels["accuracy_prev_run"] = accuracy_prev
 
                 scale_ref = resolve_scale_accuracy_ref_json_path(getattr(self.config, "scale_accuracy_ref_json", ""))
                 if scale_ref:

--- a/cvs/lib/report/panels/panel_builder.py
+++ b/cvs/lib/report/panels/panel_builder.py
@@ -59,11 +59,13 @@ class ComparisonPanelBuilder:
                 cells,
                 Path(prev_run_path),
                 headline_metric=self.config.headline_metric,
+                expected_suite_id=self.config.suite_id,
+                expected_metric_contract=getattr(self.config, "metric_contract", None),
             )
             if prev_run_panel:
                 panels["prev_run"] = prev_run_panel
 
-            if lifecycle_report:
+            if lifecycle_report and (not prev_run_panel or prev_run_panel.get("compatible", True)):
                 current_accuracy = extract_accuracy_from_lifecycle(lifecycle_report)
                 baseline_payload = load_report_json(Path(prev_run_path)) or {}
                 accuracy_prev = build_accuracy_prev_run_panel(

--- a/cvs/lib/report/panels/prev_run.py
+++ b/cvs/lib/report/panels/prev_run.py
@@ -17,6 +17,7 @@ from cvs.lib.report.metrics import HEADLINE_THROUGHPUT_METRIC
 
 PREV_RUN_ENV = "CVS_INFERENCE_PREV_REPORT_JSON"
 DEFAULT_THRESHOLD_PCT = 5.0
+_UNSET = object()
 
 
 def resolve_prev_run_json_path(
@@ -44,10 +45,14 @@ def build_prev_run_panel(
     expected_schema_version=1,
     expected_suite_id="",
     expected_metric_contract=None,
+    baseline_payload=_UNSET,
 ) -> Optional[dict]:
     if not baseline_json_path.is_file():
         return None
-    baseline_payload = load_report_json(baseline_json_path) or {}
+    if baseline_payload is _UNSET:
+        baseline_payload = load_report_json(baseline_json_path)
+    if not isinstance(baseline_payload, dict):
+        baseline_payload = {}
     incompatibility = report_incompatibility(
         baseline_payload,
         expected_schema_version=expected_schema_version,

--- a/cvs/lib/report/panels/prev_run.py
+++ b/cvs/lib/report/panels/prev_run.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import List, Optional
 
 from cvs.lib.report.compare import build_prev_run_compare_row
-from cvs.lib.report.json_io import cell_id_host_key, index_cells_by_id_host, load_report_json
+from cvs.lib.report.json_io import (
+    cell_id_host_key,
+    index_cells_by_id_host,
+    load_report_json,
+    report_incompatibility,
+)
 from cvs.lib.report.metrics import HEADLINE_THROUGHPUT_METRIC
 
 PREV_RUN_ENV = "CVS_INFERENCE_PREV_REPORT_JSON"
@@ -36,10 +41,27 @@ def build_prev_run_panel(
     *,
     headline_metric: str = HEADLINE_THROUGHPUT_METRIC,
     threshold_pct: float = DEFAULT_THRESHOLD_PCT,
+    expected_schema_version=1,
+    expected_suite_id="",
+    expected_metric_contract=None,
 ) -> Optional[dict]:
     if not baseline_json_path.is_file():
         return None
-    baseline = index_cells_by_id_host(load_report_json(baseline_json_path) or {})
+    baseline_payload = load_report_json(baseline_json_path) or {}
+    incompatibility = report_incompatibility(
+        baseline_payload,
+        expected_schema_version=expected_schema_version,
+        expected_suite_id=expected_suite_id,
+        expected_metric_contract=expected_metric_contract,
+    )
+    if incompatibility:
+        return {
+            "baseline_json": str(baseline_json_path),
+            "compatible": False,
+            "incompatibility": incompatibility,
+            "rows": [],
+        }
+    baseline = index_cells_by_id_host(baseline_payload)
     if not baseline:
         return None
 
@@ -59,5 +81,6 @@ def build_prev_run_panel(
         "baseline_json": str(baseline_json_path),
         "headline_metric": headline_metric,
         "threshold_pct": threshold_pct,
+        "compatible": True,
         "rows": rows,
     }

--- a/cvs/lib/report/panels/unittests/test_prev_run.py
+++ b/cvs/lib/report/panels/unittests/test_prev_run.py
@@ -3,12 +3,47 @@
 import json
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
+from unittest import mock
 
+from cvs.lib.report.panels import panel_builder
+from cvs.lib.report.panels.panel_builder import ComparisonPanelBuilder
 from cvs.lib.report.panels.prev_run import build_prev_run_panel, resolve_prev_run_json_path
+from cvs.lib.report.testing.fixtures import generic_inference_report_config
+
+ACCURACY_METRIC = "gsm8k_flex.gsm8k.exact_match__flexible-extract"
 
 
 class TestPrevRun(unittest.TestCase):
+    def build_accuracy_panels(self, baseline_payload):
+        cell = {
+            "cell_id": "ISL=128,OSL=128,TP=1,PP=1,CONC=1",
+            "host": "head",
+            "actuals": {"output_throughput": 100.0},
+        }
+        baseline_payload = {**baseline_payload, "cells": [cell]}
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = Path(tmp) / "baseline.json"
+            baseline.write_text(json.dumps(baseline_payload), encoding="utf-8")
+            config = replace(
+                generic_inference_report_config(),
+                suite_id="vllm",
+                prev_run_json=str(baseline),
+                metric_contract={"id": "vllm-bare", "version": 1},
+            )
+            lifecycle = {
+                "pkg/vllm.py::test_accuracy_eval[gsm8k_flex]": [
+                    (ACCURACY_METRIC, 0.92, ""),
+                ]
+            }
+            with mock.patch(
+                "cvs.lib.report.panels.panel_builder.load_report_json",
+                wraps=panel_builder.load_report_json,
+            ) as loader:
+                panels = ComparisonPanelBuilder(config).build([cell], lifecycle_report=lifecycle)
+        return panels, loader.call_count
+
     def test_prev_run_panel_flags_regression(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -53,6 +88,86 @@ class TestPrevRun(unittest.TestCase):
                 report_dir=tmp_path,
             )
             self.assertEqual(resolved, str(sibling))
+
+    def test_accuracy_comparison_survives_performance_contract_mismatch(self):
+        panels, load_count = self.build_accuracy_panels(
+            {
+                "schema_version": 1,
+                "suite_id": "vllm",
+                "accuracy": {ACCURACY_METRIC: 0.94},
+            }
+        )
+
+        self.assertEqual(load_count, 1)
+        self.assertFalse(panels["prev_run"]["compatible"])
+        self.assertIn("metric_contract", panels["prev_run"]["incompatibility"])
+        self.assertAlmostEqual(
+            panels["accuracy_prev_run"]["compare.prev_run.gsm8k_delta"],
+            -0.02,
+        )
+
+    def test_accuracy_comparison_rejects_wrong_suite(self):
+        panels, load_count = self.build_accuracy_panels(
+            {
+                "schema_version": 1,
+                "suite_id": "other",
+                "accuracy": {ACCURACY_METRIC: 0.94},
+            }
+        )
+
+        self.assertEqual(load_count, 1)
+        self.assertIn("suite_id", panels["prev_run"]["incompatibility"])
+        self.assertNotIn("accuracy_prev_run", panels)
+
+    def test_accuracy_comparison_rejects_wrong_schema(self):
+        panels, load_count = self.build_accuracy_panels(
+            {
+                "schema_version": 2,
+                "suite_id": "vllm",
+                "accuracy": {ACCURACY_METRIC: 0.94},
+            }
+        )
+
+        self.assertEqual(load_count, 1)
+        self.assertIn("schema_version", panels["prev_run"]["incompatibility"])
+        self.assertNotIn("accuracy_prev_run", panels)
+
+    def test_accuracy_comparison_accepts_fully_compatible_baseline(self):
+        panels, load_count = self.build_accuracy_panels(
+            {
+                "schema_version": 1,
+                "suite_id": "vllm",
+                "metric_contract": {"id": "vllm-bare", "version": 1},
+                "accuracy": {ACCURACY_METRIC: 0.94},
+            }
+        )
+
+        self.assertEqual(load_count, 1)
+        self.assertTrue(panels["prev_run"]["compatible"])
+        self.assertIn("accuracy_prev_run", panels)
+
+    def test_non_object_baseline_is_handled_safely(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = Path(tmp) / "invalid-shape.json"
+            baseline.write_text("[1, 2, 3]", encoding="utf-8")
+            config = replace(
+                generic_inference_report_config(),
+                suite_id="vllm",
+                prev_run_json=str(baseline),
+                metric_contract={"id": "vllm-bare", "version": 1},
+            )
+
+            panels = ComparisonPanelBuilder(config).build(
+                [],
+                lifecycle_report={
+                    "pkg/vllm.py::test_accuracy_eval[gsm8k_flex]": [
+                        ("gsm8k_flex.gsm8k.exact_match__flexible-extract", 0.92, ""),
+                    ]
+                },
+            )
+
+        self.assertFalse(panels["prev_run"]["compatible"])
+        self.assertNotIn("accuracy_prev_run", panels)
 
 
 if __name__ == "__main__":

--- a/cvs/lib/report/profiles/schema.json
+++ b/cvs/lib/report/profiles/schema.json
@@ -8,6 +8,15 @@
     "schema_version": { "type": "integer", "const": 1 },
     "profile_id": { "type": "string" },
     "suite_id": { "type": "string" },
+    "metric_contract": {
+      "type": "object",
+      "required": ["id", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "version": { "type": "integer", "minimum": 1 }
+      }
+    },
     "report_basename": { "type": "string" },
     "title": { "type": "string" },
     "subtitle": { "type": "string" },
@@ -32,6 +41,8 @@
       "properties": {
         "tier_metric_specs": { "type": "string" },
         "metric_units": { "type": "string" },
+        "metric_categories": { "type": "string" },
+        "metric_verdict": { "type": "string" },
         "run_card_display": { "type": "string" },
         "launch_provenance": { "type": "string" }
       }

--- a/cvs/lib/report/profiles/vllm.json
+++ b/cvs/lib/report/profiles/vllm.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "profile_id": "vllm_rundeck",
   "suite_id": "vllm",
+  "metric_contract": {"id": "vllm-bare", "version": 1},
   "report_basename": "vllm_run_deck",
   "title": "vLLM Run Deck",
   "subtitle": "vLLM · single-node & PP-distributed lab performance summary",
@@ -16,15 +17,16 @@
     "lifecycle": "lifecycle"
   },
   "hooks": {
-    "tier_metric_specs": "cvs.lib.inference.utils.vllm_parsing:tier_metric_specs",
-    "metric_units": "cvs.lib.inference.utils.vllm_parsing:CLIENT_METRIC_UNITS"
+    "tier_metric_specs": "cvs.lib.inference.utils.vllm_metrics:tier_metric_specs",
+    "metric_units": "cvs.lib.inference.utils.vllm_metrics:METRIC_UNITS",
+    "metric_categories": "cvs.lib.inference.utils.vllm_metrics:METRIC_CATEGORIES",
+    "metric_verdict": "cvs.lib.inference.utils.vllm_metrics:metric_verdict"
   },
   "sweep": {
-    "metric_prefix": "client.",
-    "tier_order": ["throughput", "ttft", "tpot", "latency", "health", "record"],
-    "throughput_metric": "client.output_throughput",
-    "ttft_metric": "client.mean_ttft_ms",
-    "headline_metric": "client.output_throughput",
+    "metric_prefix": "",
+    "throughput_metric": "output_throughput",
+    "ttft_metric": "mean_ttft_ms",
+    "headline_metric": "output_throughput",
     "results_table_columns": [
       ["Model", null],
       ["GPU", null],
@@ -33,14 +35,14 @@
       ["Policy", null],
       ["Conc", null],
       ["Host", null],
-      ["Req/s", "client.request_throughput"],
-      ["Total tok/s", "client.total_token_throughput"],
-      ["Mean TTFT (ms)", "client.mean_ttft_ms"],
-      ["P95 TTFT (ms)", "client.p95_ttft_ms"],
-      ["Mean TPOT (ms)", "client.mean_tpot_ms"],
-      ["P95 TPOT (ms)", "client.p95_tpot_ms"],
-      ["P99 ITL (ms)", "client.p99_itl_ms"],
-      ["Goodput (req/s)", "client.goodput"]
+      ["Req/s", "request_throughput"],
+      ["Total tok/s", "total_token_throughput"],
+      ["Mean TTFT (ms)", "mean_ttft_ms"],
+      ["P95 TTFT (ms)", "p95_ttft_ms"],
+      ["Mean TPOT (ms)", "mean_tpot_ms"],
+      ["P95 TPOT (ms)", "p95_tpot_ms"],
+      ["P99 ITL (ms)", "p99_itl_ms"],
+      ["Goodput (req/s)", "goodput"]
     ],
     "cell_highlights": [
       ["output_throughput", "Output tok/s"],
@@ -79,9 +81,9 @@
   "viewer": {
     "interactivity": {
       "enabled": true,
-      "tpot_metric": "client.mean_tpot_ms",
-      "output_throughput_metric": "client.output_throughput",
-      "total_throughput_metric": "client.total_token_throughput"
+      "tpot_metric": "mean_tpot_ms",
+      "output_throughput_metric": "output_throughput",
+      "total_throughput_metric": "total_token_throughput"
     }
   },
   "cards": [

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -107,6 +107,16 @@ class ProfileConfigResolver:
         if tier_metric_specs is None:
             raise ValueError("JSON sweep profile requires hooks.tier_metric_specs")
 
+        metric_verdict = None
+        if hooks.get("metric_verdict"):
+            metric_verdict = cls.import_callable(hooks["metric_verdict"])
+
+        metric_categories = None
+        if hooks.get("metric_categories"):
+            metric_categories = cls.import_object(hooks["metric_categories"])
+            if callable(metric_categories):
+                metric_categories = metric_categories()
+
         metric_units_spec = hooks.get("metric_units") or sweep.get("metric_units_hook")
         if metric_units_spec:
             metric_units = cls.import_object(str(metric_units_spec))
@@ -150,7 +160,10 @@ class ProfileConfigResolver:
             metric_units=metric_units,
             tier_metric_specs=tier_metric_specs,
             metric_tier_order=tuple(
-                sweep.get("tier_order") or profile.get("tier_order") or ("throughput", "health", "record")
+                metric_categories
+                or sweep.get("tier_order")
+                or profile.get("tier_order")
+                or ("throughput", "health", "record")
             ),
             metric_prefix=str(cls._sweep_setting(sweep, profile, "metric_prefix", "client.")),
             cell_highlights=cell_highlights or None,
@@ -177,6 +190,8 @@ class ProfileConfigResolver:
             headline_metric=sweep.get("headline_metric")
             or sweep.get("throughput_metric")
             or "client.output_throughput",
+            metric_verdict=metric_verdict,
+            metric_contract=profile.get("metric_contract"),
             **kwargs,
         )
 

--- a/cvs/lib/report/rundeck/config_builder.py
+++ b/cvs/lib/report/rundeck/config_builder.py
@@ -110,8 +110,10 @@ def make_inference_report_config(
     row_card_extras = kwargs.pop("row_card_extras", True)
     interactive_viewer = kwargs.pop("interactive_viewer", True)
     viewer_cell_threshold = kwargs.pop("viewer_cell_threshold", 24)
+    metric_verdict = kwargs.pop("metric_verdict", None)
+    metric_contract = kwargs.pop("metric_contract", None)
 
-    return InferenceReportConfig(
+    config = InferenceReportConfig(
         suite_id=suite_id,
         report_basename=basename,
         title=display_title,
@@ -134,3 +136,8 @@ def make_inference_report_config(
         run_card_display_builder=run_card_display_builder or _default_run_card,
         **kwargs,
     )
+    if metric_verdict is not None:
+        object.__setattr__(config, "metric_verdict", metric_verdict)
+    if metric_contract is not None:
+        object.__setattr__(config, "metric_contract", dict(metric_contract))
+    return config

--- a/cvs/lib/report/rundeck/config_builder.py
+++ b/cvs/lib/report/rundeck/config_builder.py
@@ -133,11 +133,9 @@ def make_inference_report_config(
         row_card_test_names=row_card_test_names,
         interactive_viewer=interactive_viewer,
         viewer_cell_threshold=viewer_cell_threshold,
+        metric_verdict=metric_verdict,
+        metric_contract=dict(metric_contract) if metric_contract is not None else None,
         run_card_display_builder=run_card_display_builder or _default_run_card,
         **kwargs,
     )
-    if metric_verdict is not None:
-        object.__setattr__(config, "metric_verdict", metric_verdict)
-    if metric_contract is not None:
-        object.__setattr__(config, "metric_contract", dict(metric_contract))
     return config

--- a/cvs/lib/report/rundeck/payload.py
+++ b/cvs/lib/report/rundeck/payload.py
@@ -108,6 +108,9 @@ class RundeckPayloadBuilder:
             "datasets": datasets,
             "deck_profile": self.profile_dict or {"cards": default_deck_cards()},
         }
+        metric_contract = getattr(self.config, "metric_contract", None)
+        if metric_contract is not None:
+            payload["metric_contract"] = dict(metric_contract)
 
         if isinstance(self.profile, dict) and self.profile.get("cards"):
             payload["deck_profile"] = self.profile

--- a/cvs/lib/report/rundeck/payload.py
+++ b/cvs/lib/report/rundeck/payload.py
@@ -108,7 +108,7 @@ class RundeckPayloadBuilder:
             "datasets": datasets,
             "deck_profile": self.profile_dict or {"cards": default_deck_cards()},
         }
-        metric_contract = getattr(self.config, "metric_contract", None)
+        metric_contract = self.config.metric_contract
         if metric_contract is not None:
             payload["metric_contract"] = dict(metric_contract)
 

--- a/cvs/lib/report/rundeck/render.py
+++ b/cvs/lib/report/rundeck/render.py
@@ -82,6 +82,14 @@ def render_rundeck_html(payload: dict) -> str:
     model_label = next((v for lbl, v, _ in payload.get("run_card_display", []) if lbl == "Model"), "run")
     overall = payload.get("overall_status", "na")
     viewer_name = (payload.get("summary") or {}).get("viewer_html")
+    prev_panel = (payload.get("panels") or {}).get("prev_run") or {}
+    incompatibility = ""
+    if prev_panel.get("compatible") is False:
+        reason = html.escape(str(prev_panel.get("incompatibility") or "metric contract mismatch"))
+        incompatibility = (
+            "<section class='panel'><strong>Baseline comparison incompatible:</strong> "
+            f"{reason}. Comparisons are suppressed.</section>"
+        )
 
     nav = _build_nav(nav_items, viewer_name)
     return f"""<!DOCTYPE html>
@@ -91,5 +99,6 @@ def render_rundeck_html(payload: dict) -> str:
 <div class="hero-head"><div><h1>{html.escape(report.get('title', 'Run Deck'))}</h1>
 <p class="subtitle">{html.escape(report.get('subtitle', ''))}</p></div>{status_badge_html(overall)}</div>
 {nav}
+{incompatibility}
 {''.join(sections)}
 <footer class="page-foot">{html.escape(report.get('footer', ''))}</footer></div></body></html>"""

--- a/cvs/lib/report/rundeck/unittests/test_config_builder.py
+++ b/cvs/lib/report/rundeck/unittests/test_config_builder.py
@@ -1,6 +1,7 @@
 '''Tests for inference report preset builder.'''
 
 import unittest
+from dataclasses import asdict, fields, replace
 
 from cvs.lib.report.rundeck.config_builder import make_inference_report_config
 
@@ -23,6 +24,8 @@ class TestConfigBuilder(unittest.TestCase):
         self.assertTrue(cfg.cell_highlights)
         self.assertTrue(cfg.chart_series)
         self.assertTrue(cfg.interactive_viewer)
+        self.assertIsNone(cfg.metric_verdict)
+        self.assertIsNone(cfg.metric_contract)
 
     def test_make_inference_report_config_overrides(self):
         cfg = make_inference_report_config(
@@ -35,6 +38,29 @@ class TestConfigBuilder(unittest.TestCase):
         )
         self.assertEqual(cfg.inference_test_substring, "test_custom_inference")
         self.assertEqual(cfg.report_basename, "custom_report")
+
+    def test_metric_contract_fields_use_normal_dataclass_paths(self):
+        def metric_verdict(_metric, _actual, _spec):
+            return "pass", ""
+
+        contract = {"id": "demo", "version": 1}
+        cfg = make_inference_report_config(
+            suite_id="x",
+            results_columns=(),
+            metric_units={},
+            tier_metric_specs=lambda _c, _t: {},
+            metric_verdict=metric_verdict,
+            metric_contract=contract,
+        )
+        contract["version"] = 2
+
+        self.assertIs(cfg.metric_verdict, metric_verdict)
+        self.assertEqual(cfg.metric_contract, {"id": "demo", "version": 1})
+        self.assertGreaterEqual({field.name for field in fields(cfg)}, {"metric_verdict", "metric_contract"})
+        self.assertEqual(asdict(cfg)["metric_contract"], {"id": "demo", "version": 1})
+        replaced = replace(cfg, title="Replacement")
+        self.assertIs(replaced.metric_verdict, metric_verdict)
+        self.assertEqual(replaced.metric_contract, {"id": "demo", "version": 1})
 
 
 if __name__ == "__main__":

--- a/cvs/lib/report/rundeck/viewer_config.py
+++ b/cvs/lib/report/rundeck/viewer_config.py
@@ -80,7 +80,7 @@ class ViewerConfigBuilder:
             "comparison_hint": comparison_hint,
             "interactivity": interactivity,
         }
-        metric_contract = getattr(self.config, "metric_contract", None)
+        metric_contract = self.config.metric_contract
         if metric_contract is not None:
             config["metric_contract"] = dict(metric_contract)
         return config

--- a/cvs/lib/report/rundeck/viewer_config.py
+++ b/cvs/lib/report/rundeck/viewer_config.py
@@ -65,7 +65,7 @@ class ViewerConfigBuilder:
         comparison_hint = self.viewer.get("comparison_hint") or (
             f"Compare {' / '.join(dim_labels.get(f, f.upper()) for f in group_by)} shapes at each concurrency"
         )
-        return {
+        config = {
             "group_by": group_by,
             "group_labels": dim_labels,
             "filters": [{"field": f, "label": self._field_label(f)} for f in filter_fields],
@@ -80,6 +80,10 @@ class ViewerConfigBuilder:
             "comparison_hint": comparison_hint,
             "interactivity": interactivity,
         }
+        metric_contract = getattr(self.config, "metric_contract", None)
+        if metric_contract is not None:
+            config["metric_contract"] = dict(metric_contract)
+        return config
 
     def _group_by(self) -> list[str]:
         return list(self.viewer.get("group_by") or self.sweep.get("group_by") or ("isl", "osl"))
@@ -186,7 +190,7 @@ class ViewerConfigBuilder:
                 field = LABEL_TO_FIELD.get(str(label))
                 if field and field != "cell_id":
                     columns.append({"field": field, "label": str(label)})
-            elif str(key).startswith("client."):
+            elif str(key).startswith("client.") or str(key) in self.config.metric_units:
                 columns.append({"metric": str(key), "label": str(label)})
         if len(columns) <= 1:
             columns.extend(

--- a/cvs/lib/report/types.py
+++ b/cvs/lib/report/types.py
@@ -66,6 +66,8 @@ class InferenceReportConfig:
     viewer_cell_threshold: int = 24
     prev_run_json: str = ""
     framework_parity_ref_json: str = ""
+    metric_verdict: Optional[Callable] = None
+    metric_contract: Optional[dict] = None
     gsm8k_prev_run_metric: str = "gsm8k_flex.gsm8k.exact_match__flexible-extract"
     gsm8k_prev_run_max_drop: float = 0.01
     run_card_display_builder: RunCardDisplayFn = field(default=lambda _variant, _prov: [("Suite", "inference", False)])

--- a/cvs/lib/report/unittests/test_accuracy_lifecycle.py
+++ b/cvs/lib/report/unittests/test_accuracy_lifecycle.py
@@ -1,9 +1,11 @@
 '''Unit tests for accuracy lifecycle extraction and prev-run panel.'''
 
+import math
 import unittest
 
 from cvs.lib.report.accuracy_lifecycle import (
     build_accuracy_prev_run_panel,
+    build_scale_accuracy_panel,
     extract_accuracy_from_lifecycle,
 )
 
@@ -20,6 +22,27 @@ class TestAccuracyLifecycle(unittest.TestCase):
         self.assertEqual(out["gsm8k_flex.gsm8k.exact_match__flexible-extract"], 0.95)
         self.assertNotIn("accuracy_eval", out)
 
+    def test_extract_accuracy_accepts_only_finite_builtin_numbers(self):
+        lifecycle = {
+            "pkg/vllm.py::test_accuracy_eval[types]": [
+                ("task.zero", 0, ""),
+                ("task.one", 1.0, ""),
+                ("task.string", "0.5", ""),
+                ("task.bool", True, ""),
+                ("task.none", None, ""),
+                ("task.list", [0.5], ""),
+                ("task.object", {"value": 0.5}, ""),
+                ("task.nan", math.nan, ""),
+                ("task.inf", math.inf, ""),
+                ("task.neg_inf", -math.inf, ""),
+            ]
+        }
+
+        self.assertEqual(
+            extract_accuracy_from_lifecycle(lifecycle),
+            {"task.zero": 0.0, "task.one": 1.0},
+        )
+
     def test_accuracy_prev_run_panel_regression(self):
         current = {"gsm8k_flex.gsm8k.exact_match__flexible-extract": 0.92}
         baseline = {"accuracy": {"gsm8k_flex.gsm8k.exact_match__flexible-extract": 0.94}}
@@ -28,9 +51,37 @@ class TestAccuracyLifecycle(unittest.TestCase):
         self.assertTrue(panel["regression"])
         self.assertAlmostEqual(panel["compare.prev_run.gsm8k_delta"], -0.02)
 
-    def test_scale_accuracy_panel(self):
-        from cvs.lib.report.accuracy_lifecycle import build_scale_accuracy_panel
+    def test_accuracy_prev_run_rejects_invalid_current_and_baseline_values(self):
+        metric = "gsm8k_flex.gsm8k.exact_match__flexible-extract"
+        invalid = ("0.5", True, None, [0.5], {"value": 0.5}, math.nan, math.inf, -math.inf)
+        for value in invalid:
+            with self.subTest(location="current", value=value):
+                self.assertIsNone(
+                    build_accuracy_prev_run_panel(
+                        {metric: value},
+                        {"accuracy": {metric: 0.5}},
+                    )
+                )
+            with self.subTest(location="baseline", value=value):
+                self.assertIsNone(
+                    build_accuracy_prev_run_panel(
+                        {metric: 0.5},
+                        {"accuracy": {metric: value}},
+                    )
+                )
 
+    def test_accuracy_prev_run_normalizes_valid_int_float_boundaries(self):
+        metric = "gsm8k_flex.gsm8k.exact_match__flexible-extract"
+        panel = build_accuracy_prev_run_panel(
+            {metric: 0},
+            {"accuracy": {metric: 1.0}},
+        )
+
+        self.assertEqual(panel["current"], 0.0)
+        self.assertEqual(panel["baseline"], 1.0)
+        self.assertEqual(panel["compare.prev_run.gsm8k_delta"], -1.0)
+
+    def test_scale_accuracy_panel(self):
         current = {
             "gsm8k_flex.gsm8k.exact_match__flexible-extract": 0.93,
             "hellaswag.hellaswag.acc_norm__none": 0.80,
@@ -45,6 +96,23 @@ class TestAccuracyLifecycle(unittest.TestCase):
         self.assertIsNotNone(panel)
         self.assertTrue(panel["regression"])
         self.assertEqual(len(panel["rows"]), 2)
+
+    def test_scale_accuracy_ignores_invalid_values(self):
+        current = {
+            "gsm8k_flex.gsm8k.exact_match__flexible-extract": "0.93",
+            "hellaswag.hellaswag.acc_norm__none": 1,
+        }
+        reference = {
+            "accuracy": {
+                "gsm8k_flex.gsm8k.exact_match__flexible-extract": 0.94,
+                "hellaswag.hellaswag.acc_norm__none": 0.5,
+            }
+        }
+
+        panel = build_scale_accuracy_panel(current, reference)
+
+        self.assertEqual(len(panel["rows"]), 1)
+        self.assertEqual(panel["rows"][0]["current"], 1.0)
 
 
 if __name__ == "__main__":

--- a/cvs/lib/report/unittests/test_cell_build.py
+++ b/cvs/lib/report/unittests/test_cell_build.py
@@ -2,11 +2,13 @@
 
 import unittest
 from dataclasses import replace
+import math
 from types import SimpleNamespace
 
+from cvs.lib.inference.utils.vllm_metrics import metric_verdict as vllm_metric_verdict
 from cvs.lib.report.cell_build import bar_pct, build_cell_record, resolve_pytest_nodeids_for_cell
 from cvs.lib.report.formatting import pytest_row_href
-from cvs.lib.report.testing.fixtures import generic_inference_report_config
+from cvs.lib.report.testing.fixtures import generic_inference_report_config, generic_variant
 
 
 class TestCellBuild(unittest.TestCase):
@@ -100,6 +102,51 @@ class TestCellBuild(unittest.TestCase):
         self.assertEqual(bar_pct(1.0, {"kind": "within", "value": 1.0}), 100.0)
         self.assertEqual(bar_pct(1.0, {"kind": "unknown", "value": 1.0}), 50.0)
         self.assertEqual(bar_pct(1.0, {"kind": "min", "value": 0.0}), 0.0)
+
+    def test_default_evaluator_preserves_legacy_bar_coercion(self):
+        variant = generic_variant()
+        variant.enforce_thresholds = False
+        key = ("org/example-model", "mi300x", "1024", "1024", "default", 128)
+        for actual, expected in (("500", 50.0), (True, 0.1)):
+            with self.subTest(actual=actual):
+                cell = build_cell_record(
+                    generic_inference_report_config(),
+                    key=key,
+                    host="10.0.0.1",
+                    actuals={"client.output_throughput": actual},
+                    variant_config=variant,
+                    lifecycle_report={},
+                    multi_host=False,
+                )
+                self.assertEqual(cell["metrics"][0]["bar_pct"], expected)
+
+    def test_vllm_evaluator_rejects_invalid_bar_values(self):
+        config = replace(
+            generic_inference_report_config(),
+            metric_prefix="",
+            cell_highlights=(("output_throughput", "Output tok/s"),),
+            metric_units={"output_throughput": "tok/s"},
+            metric_verdict=vllm_metric_verdict,
+        )
+        variant = generic_variant()
+        cell_id = variant.cell_key("1024", "1024", 128)
+        variant.thresholds = {cell_id: {"output_throughput": {"kind": "min", "value": 1000.0}}}
+        key = ("org/example-model", "mi300x", "1024", "1024", "default", 128)
+
+        for actual in (True, math.nan, math.inf, "500", "not-a-number"):
+            with self.subTest(actual=actual):
+                cell = build_cell_record(
+                    config,
+                    key=key,
+                    host="10.0.0.1",
+                    actuals={"output_throughput": actual},
+                    variant_config=variant,
+                    lifecycle_report={},
+                    multi_host=False,
+                )
+                metric = cell["metrics"][0]
+                self.assertEqual(metric["status"], "fail")
+                self.assertIsNone(metric["bar_pct"])
 
 
 if __name__ == "__main__":

--- a/cvs/lib/report/unittests/test_profile.py
+++ b/cvs/lib/report/unittests/test_profile.py
@@ -27,11 +27,15 @@ class TestProfile(unittest.TestCase):
                 "cvs.lib.report.profiles.hooks.sglang_run_card:sglang_run_card_display",
             )
 
-    def test_vllm_hooks_point_at_inference_parsing(self):
+    def test_vllm_hooks_point_at_canonical_metric_contract(self):
         profile = load_json_profile("vllm")
         self.assertEqual(
             profile["hooks"]["metric_units"],
-            "cvs.lib.inference.utils.vllm_parsing:CLIENT_METRIC_UNITS",
+            "cvs.lib.inference.utils.vllm_metrics:METRIC_UNITS",
+        )
+        self.assertEqual(
+            profile["hooks"]["metric_verdict"],
+            "cvs.lib.inference.utils.vllm_metrics:metric_verdict",
         )
         self.assertNotIn("run_card_display", profile.get("hooks", {}))
 
@@ -43,7 +47,7 @@ class TestProfile(unittest.TestCase):
         config = build_inference_config_from_profile(profile)
         shorts = [short for short, _label in config.cell_highlights]
         self.assertIn("output_throughput", shorts)
-        self.assertEqual(config.full_metric("output_throughput"), "client.output_throughput")
+        self.assertEqual(config.full_metric("output_throughput"), "output_throughput")
 
     def test_sglang_profile_preserves_empty_metric_prefix(self):
         from cvs.lib.report.rundeck.config_adapter import build_inference_config_from_profile

--- a/cvs/lib/report/viewer/interactive.html
+++ b/cvs/lib/report/viewer/interactive.html
@@ -300,6 +300,7 @@ let interactivityTooltipLastMeta = null;
 let heatmapMetricKey = 'client.output_throughput';
 let marginMetricKey = 'client.output_throughput';
 let prevRunByKey = null;
+let baselineIncompatibility = '';
 let deltaThresholdPct = 5;
 
 const FALLBACK_VIEWER_CONFIG = {
@@ -472,6 +473,16 @@ function initViewerUi() {
 
 function $(id) { return document.getElementById(id); }
 
+function escapeHtmlText(value) {
+  return String(value).replace(/[&<>"']/g, char => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[char]);
+}
+
 function cellMapKey(c) {
   return String(c.cell_id || '') + '\0' + String(c.host || '');
 }
@@ -490,8 +501,15 @@ function prevRunChangeFlags(deltaPct, threshold) {
 function applyPrevRunPanel(panel) {
   if (!panel || !panel.rows) {
     prevRunByKey = null;
+    baselineIncompatibility = '';
     return;
   }
+  if (panel.compatible === false) {
+    prevRunByKey = null;
+    baselineIncompatibility = panel.incompatibility || 'metric contract mismatch';
+    return;
+  }
+  baselineIncompatibility = '';
   prevRunByKey = new Map();
   panel.rows.forEach(r => {
     prevRunByKey.set(cellMapKey(r), r);
@@ -503,7 +521,33 @@ function applyPrevRunPanel(panel) {
   }
 }
 
+function baselineIncompatibilityReason(data) {
+  const expected = reportData && reportData.metric_contract;
+  if (!expected) return '';
+  if (data.schema_version !== reportData.schema_version) {
+    return 'schema_version ' + JSON.stringify(data.schema_version)
+      + ' does not match ' + JSON.stringify(reportData.schema_version);
+  }
+  if (data.suite_id !== reportData.suite_id) {
+    return 'suite_id ' + JSON.stringify(data.suite_id)
+      + ' does not match ' + JSON.stringify(reportData.suite_id);
+  }
+  const actual = data.metric_contract;
+  if (!actual || actual.id !== expected.id || actual.version !== expected.version) {
+    return 'metric_contract ' + JSON.stringify(actual)
+      + ' does not match ' + JSON.stringify(expected);
+  }
+  return '';
+}
+
 function buildPrevRunFromBaseline(data) {
+  const incompatibility = baselineIncompatibilityReason(data);
+  if (incompatibility) {
+    prevRunByKey = null;
+    baselineIncompatibility = incompatibility;
+    return;
+  }
+  baselineIncompatibility = '';
   const headline = (reportData.report || {}).headline_metric || 'client.output_throughput';
   const threshold = Number($('f-delta-threshold').value) || deltaThresholdPct;
   const baseMap = new Map();
@@ -1523,7 +1567,11 @@ function renderTable(rows) {
     + '<span><strong>' + passN + '</strong> pass</span>'
     + (failN ? '<span><strong>' + failN + '</strong> fail</span>' : '')
     + '<span>Charts and heatmap follow filters</span>'
-    + (prevRunByKey ? '<span>baseline comparison active</span>' : '');
+    + (prevRunByKey ? '<span>baseline comparison active</span>' : '')
+    + (baselineIncompatibility
+      ? '<span><strong>Baseline incompatible:</strong> ' + escapeHtmlText(baselineIncompatibility)
+        + '; comparisons suppressed</span>'
+      : '');
 
   updateCellsHeader();
   const tbody = $('rows');
@@ -1667,6 +1715,7 @@ if (baselineInput) {
     const file = ev.target.files && ev.target.files[0];
     if (!file) {
       prevRunByKey = null;
+      baselineIncompatibility = '';
       if (reportData && reportData.panels && reportData.panels.prev_run) {
         applyPrevRunPanel(reportData.panels.prev_run);
       }

--- a/cvs/tests/inference/vllm/_common.py
+++ b/cvs/tests/inference/vllm/_common.py
@@ -12,6 +12,7 @@ from cvs.lib.inference.utils.inference_suite_lifecycle import test_accuracy_eval
 from cvs.lib.inference.utils.vllm_config_loader import load_variant
 from cvs.lib.inference.utils.vllm_metrics import (
     METRIC_REGISTRY,
+    UnknownMetricContractError,
     VLLM_RESULTS_COLUMNS,
     is_finite_number,
     merge_metric_sources,
@@ -143,23 +144,29 @@ def _gpu_snap(orch):
 
 
 def _clear_live_server(lifecycle):
-    lifecycle.live_server_state = None
+    lifecycle.live_server_sig = None
     lifecycle.live_server_job = None
+    lifecycle.model_load_s = None
+    lifecycle.model_load_memory_mb = None
 
 
 def _live_server_measurements(lifecycle, signature):
-    state = getattr(lifecycle, "live_server_state", None)
-    if not isinstance(state, tuple) or len(state) != 3 or state[0] != signature:
+    if getattr(lifecycle, "live_server_sig", None) != signature:
         return None
-    return state[1], state[2]
+    if getattr(lifecycle, "live_server_job", None) is None:
+        return None
+    return (
+        getattr(lifecycle, "model_load_s", None),
+        getattr(lifecycle, "model_load_memory_mb", None),
+    )
 
 
 def _load_measurements(before, after, elapsed):
     before_vram = before.get("gpu.used_vram")
     after_vram = after.get("gpu.used_vram")
-    if not all(is_finite_number(value) for value in (before_vram, after_vram, elapsed)):
-        return None
-    return elapsed, after_vram - before_vram
+    load_s = elapsed if is_finite_number(elapsed) else None
+    load_mb = after_vram - before_vram if is_finite_number(before_vram) and is_finite_number(after_vram) else None
+    return load_s, load_mb
 
 
 def _finite_or_none(value):
@@ -225,21 +232,22 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
         pytest.skip("a prior lifecycle stage failed")
     isl = run.cell.isl
     osl = run.cell.osl
-    job = VllmJob(
-        orch=orch,
-        variant=variant_config,
-        hf_token=hf_token,
-        isl=isl,
-        osl=osl,
-        concurrency=run.cell.concurrency,
-        num_prompts=run.benchmark_params["num_prompts"],
-        benchmark_params=run.benchmark_params,
-        ib_hcas=getattr(lifecycle, "ib_hcas", []),
-    )
+    job = None
     load_s = None
     load_mb = None
     poll_readings = []
     try:
+        job = VllmJob(
+            orch=orch,
+            variant=variant_config,
+            hf_token=hf_token,
+            isl=isl,
+            osl=osl,
+            concurrency=run.cell.concurrency,
+            num_prompts=run.benchmark_params["num_prompts"],
+            benchmark_params=run.benchmark_params,
+            ib_hcas=getattr(lifecycle, "ib_hcas", []),
+        )
         signature = job.server_signature()
         measurements = _live_server_measurements(lifecycle, signature)
         if measurements is not None:
@@ -249,7 +257,6 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
             _clear_live_server(lifecycle)
             job.stop_server()
             job.build_server_cmd()
-            lifecycle.live_server_job = job
             before = _gpu_snap(orch)
             started = time.monotonic()
             job.start_server()
@@ -257,10 +264,11 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
             elapsed = time.monotonic() - started
             lifecycle.record(request.node.nodeid, "server_ready", elapsed)
             after = _gpu_snap(orch)
-            measurements = _load_measurements(before, after, elapsed)
-            if measurements is not None:
-                load_s, load_mb = measurements
-                lifecycle.live_server_state = (signature, load_s, load_mb)
+            load_s, load_mb = _load_measurements(before, after, elapsed)
+            lifecycle.live_server_sig = signature
+            lifecycle.live_server_job = job
+            lifecycle.model_load_s = load_s
+            lifecycle.model_load_memory_mb = load_mb
 
         html_path = getattr(request.config.option, "htmlpath", None)
         html_dir = getattr(request.config, "_test_html_dir", "test_html")
@@ -288,25 +296,29 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
             )
         after_prom = scrape_vllm_metrics(orch, job.base_url, job.port_no)
         results = job.parse_results()
+
+        aggregate = agg_readings(poll_readings)
+        gpu_results = {
+            "peak_gpu_memory_mb": _finite_or_none(aggregate.get("peak_gpu_memory_mb")),
+            "model_load_memory_mb": load_mb,
+            "model_load_s": load_s,
+            "gpu_bandwidth_util_pct": _finite_or_none(aggregate.get("gpu_bandwidth_util_pct")),
+            "gpu_compute_util_pct": _finite_or_none(aggregate.get("gpu_compute_util_pct")),
+        }
+        prom_results = to_prom_metrics(before_prom, after_prom)
+        published_results = {
+            host: merge_metric_sources(actuals, gpu_results, prom_results) for host, actuals in results.items()
+        }
+        inf_res_dict[_cell_result_key(variant_config, run)] = published_results
+    except UnknownMetricContractError:
+        raise
     except Exception:
         lifecycle.failed = True
         dump_job = getattr(lifecycle, "live_server_job", None) or job
         _clear_live_server(lifecycle)
-        dump_job.dump_server_log()
+        if dump_job is not None:
+            dump_job.dump_server_log()
         raise
-
-    aggregate = agg_readings(poll_readings)
-    gpu_results = {
-        "peak_gpu_memory_mb": _finite_or_none(aggregate.get("peak_gpu_memory_mb")),
-        "model_load_memory_mb": load_mb,
-        "model_load_s": load_s,
-        "gpu_bandwidth_util_pct": _finite_or_none(aggregate.get("gpu_bandwidth_util_pct")),
-        "gpu_compute_util_pct": _finite_or_none(aggregate.get("gpu_compute_util_pct")),
-    }
-    prom_results = to_prom_metrics(before_prom, after_prom)
-    for host, actuals in results.items():
-        results[host] = merge_metric_sources(actuals, gpu_results, prom_results)
-    inf_res_dict[_cell_result_key(variant_config, run)] = results
 
 
 def test_verify_cell_metrics(run, inf_res_dict, variant_config, lifecycle, request, subtests):

--- a/cvs/tests/inference/vllm/_common.py
+++ b/cvs/tests/inference/vllm/_common.py
@@ -12,7 +12,6 @@ from cvs.lib.inference.utils.inference_suite_lifecycle import test_accuracy_eval
 from cvs.lib.inference.utils.vllm_config_loader import load_variant
 from cvs.lib.inference.utils.vllm_metrics import (
     METRIC_REGISTRY,
-    UnknownMetricContractError,
     VLLM_RESULTS_COLUMNS,
     is_finite_number,
     merge_metric_sources,
@@ -310,8 +309,6 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
             host: merge_metric_sources(actuals, gpu_results, prom_results) for host, actuals in results.items()
         }
         inf_res_dict[_cell_result_key(variant_config, run)] = published_results
-    except UnknownMetricContractError:
-        raise
     except Exception:
         lifecycle.failed = True
         dump_job = getattr(lifecycle, "live_server_job", None) or job

--- a/cvs/tests/inference/vllm/_common.py
+++ b/cvs/tests/inference/vllm/_common.py
@@ -1,5 +1,6 @@
 '''Shared vLLM lifecycle tests for the explicit single and distributed suites.'''
 
+import json
 import pathlib
 import shlex
 import time
@@ -9,7 +10,13 @@ import pytest
 from cvs.lib import globals
 from cvs.lib.inference.utils.inference_suite_lifecycle import test_accuracy_eval  # noqa: F401
 from cvs.lib.inference.utils.vllm_config_loader import load_variant
-from cvs.lib.inference.utils.vllm_parsing import VLLM_RESULTS_COLUMNS
+from cvs.lib.inference.utils.vllm_metrics import (
+    METRIC_REGISTRY,
+    VLLM_RESULTS_COLUMNS,
+    is_finite_number,
+    merge_metric_sources,
+    metric_contract,
+)
 from cvs.lib.inference.utils.vllm_server_metrics import to_prom_metrics
 from cvs.lib.inference.utils.vllm_verification import evaluate_metric_verdicts
 from cvs.lib.inference.vllm_job import VllmJob, scrape_vllm_metrics
@@ -30,6 +37,7 @@ _FETCH_POLL_WAIT_S = 30
 _SMOKE_ISL = 128
 _SMOKE_OSL = 32
 _SMOKE_MAX_MODEL_LEN = 512
+VLLM_JUNIT_PROPERTY = "cvs_vllm_metrics_v1"
 
 
 def pytest_generate_tests(metafunc):
@@ -134,6 +142,53 @@ def _gpu_snap(orch):
         return {}
 
 
+def _clear_live_server(lifecycle):
+    lifecycle.live_server_state = None
+    lifecycle.live_server_job = None
+
+
+def _live_server_measurements(lifecycle, signature):
+    state = getattr(lifecycle, "live_server_state", None)
+    if not isinstance(state, tuple) or len(state) != 3 or state[0] != signature:
+        return None
+    return state[1], state[2]
+
+
+def _load_measurements(before, after, elapsed):
+    before_vram = before.get("gpu.used_vram")
+    after_vram = after.get("gpu.used_vram")
+    if not all(is_finite_number(value) for value in (before_vram, after_vram, elapsed)):
+        return None
+    return elapsed, after_vram - before_vram
+
+
+def _finite_or_none(value):
+    return value if is_finite_number(value) else None
+
+
+def _record_junit_metrics(node, actuals_by_host):
+    actuals = {}
+    for host in sorted(actuals_by_host, key=str):
+        host_actuals = actuals_by_host[host]
+        actuals[str(host)] = {
+            definition.name: _finite_or_none(host_actuals[definition.name])
+            for definition in METRIC_REGISTRY
+            if definition.name in host_actuals
+        }
+    payload = json.dumps(
+        {
+            "actuals_by_host": actuals,
+            "metric_contract": metric_contract(),
+        },
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    properties = [(key, value) for key, value in getattr(node, "user_properties", []) if key != VLLM_JUNIT_PROPERTY]
+    properties.append((VLLM_JUNIT_PROPERTY, payload))
+    node.user_properties = properties
+
+
 def test_openai_compatible_smoke(orch, variant_config, hf_token, vllm_targets, lifecycle, request):
     if lifecycle.failed:
         pytest.skip("a prior lifecycle stage failed")
@@ -186,9 +241,12 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
     poll_readings = []
     try:
         signature = job.server_signature()
-        if getattr(lifecycle, "live_server_sig", None) == signature:
+        measurements = _live_server_measurements(lifecycle, signature)
+        if measurements is not None:
+            load_s, load_mb = measurements
             lifecycle.record(request.node.nodeid, "server_ready", 0.0)
         else:
+            _clear_live_server(lifecycle)
             job.stop_server()
             job.build_server_cmd()
             lifecycle.live_server_job = job
@@ -196,11 +254,13 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
             started = time.monotonic()
             job.start_server()
             job.wait_ready()
-            load_s = time.monotonic() - started
-            lifecycle.record(request.node.nodeid, "server_ready", load_s)
-            lifecycle.live_server_sig = signature
+            elapsed = time.monotonic() - started
+            lifecycle.record(request.node.nodeid, "server_ready", elapsed)
             after = _gpu_snap(orch)
-            load_mb = ((after.get("gpu.used_vram") or 0) - (before.get("gpu.used_vram") or 0)) or None
+            measurements = _load_measurements(before, after, elapsed)
+            if measurements is not None:
+                load_s, load_mb = measurements
+                lifecycle.live_server_state = (signature, load_s, load_mb)
 
         html_path = getattr(request.config.option, "htmlpath", None)
         html_dir = getattr(request.config, "_test_html_dir", "test_html")
@@ -230,22 +290,22 @@ def test_vllm_inference(orch, variant_config, hf_token, vllm_targets, run, inf_r
         results = job.parse_results()
     except Exception:
         lifecycle.failed = True
-        lifecycle.live_server_sig = None
-        getattr(lifecycle, "live_server_job", job).dump_server_log()
+        dump_job = getattr(lifecycle, "live_server_job", None) or job
+        _clear_live_server(lifecycle)
+        dump_job.dump_server_log()
         raise
 
     aggregate = agg_readings(poll_readings)
     gpu_results = {
-        "gpu.peak_gpu_memory_mb": aggregate.get("peak_gpu_memory_mb"),
-        "gpu.model_load_memory_mb": load_mb,
-        "gpu.model_load_s": load_s,
-        "gpu.gpu_bandwidth_util_pct": aggregate.get("gpu_bandwidth_util_pct"),
-        "gpu.gpu_compute_util_pct": aggregate.get("gpu_compute_util_pct"),
+        "peak_gpu_memory_mb": _finite_or_none(aggregate.get("peak_gpu_memory_mb")),
+        "model_load_memory_mb": load_mb,
+        "model_load_s": load_s,
+        "gpu_bandwidth_util_pct": _finite_or_none(aggregate.get("gpu_bandwidth_util_pct")),
+        "gpu_compute_util_pct": _finite_or_none(aggregate.get("gpu_compute_util_pct")),
     }
     prom_results = to_prom_metrics(before_prom, after_prom)
-    for actuals in results.values():
-        actuals.update(gpu_results)
-        actuals.update(prom_results)
+    for host, actuals in results.items():
+        results[host] = merge_metric_sources(actuals, gpu_results, prom_results)
     inf_res_dict[_cell_result_key(variant_config, run)] = results
 
 
@@ -265,18 +325,15 @@ def test_verify_cell_metrics(run, inf_res_dict, variant_config, lifecycle, reque
         pytest.skip(f"no configured metric specs for {run.cell.key}")
 
     record_benchmark_metric_rows(request.node, verdicts, columns=VLLM_RESULTS_COLUMNS)
+    _record_junit_metrics(request.node, host_dict)
     asserted_verdicts = [verdict for verdict in verdicts if verdict["enforced"]]
     started = time.monotonic()
     for verdict in asserted_verdicts:
         with subtests.test(node=verdict["node"], metric=verdict["metric"]):
-            if verdict["status"] == "skip":
-                pytest.skip(verdict["reason"])
             assert verdict["status"] == "pass", verdict["reason"]
     lifecycle.record(request.node.nodeid, "metric_verification", time.monotonic() - started)
     if not asserted_verdicts:
         pytest.skip(f"metrics recorded without active threshold gates for {run.cell.key}")
-    if all(verdict["status"] == "skip" for verdict in asserted_verdicts):
-        pytest.skip(f"all active metrics were unavailable for {run.cell.key}")
 
 
 def test_teardown(orch, lifecycle, request):

--- a/cvs/tests/inference/vllm/_shared.py
+++ b/cvs/tests/inference/vllm/_shared.py
@@ -12,6 +12,7 @@ from tabulate import tabulate
 import pytest
 
 from cvs.lib import globals
+from cvs.lib.inference.utils.vllm_metrics import VLLM_RESULTS_COLUMNS
 
 log = globals.log
 
@@ -39,44 +40,11 @@ def test_print_results_table(inf_res_dict):
     if not inf_res_dict:
         log.info("inf_res_dict empty, nothing to print")
         return
-    headers = [
-        "Model",
-        "GPU",
-        "ISL",
-        "OSL",
-        "Policy",
-        "Conc",
-        "Host",
-        "Req/s",
-        "Total tok/s",
-        "Mean TTFT (ms)",
-        "P95 TTFT (ms)",
-        "Mean TPOT (ms)",
-        "P95 TPOT (ms)",
-        "P99 ITL (ms)",
-        "Goodput (req/s)",
-    ]
+    headers = [label for label, _metric in VLLM_RESULTS_COLUMNS]
+    metric_keys = [metric for _label, metric in VLLM_RESULTS_COLUMNS[7:]]
     rows = []
     for key, host_dict in inf_res_dict.items():
         model, gpu, isl, osl, policy, conc = key
         for host, m in host_dict.items():
-            rows.append(
-                [
-                    model,
-                    gpu,
-                    isl,
-                    osl,
-                    policy,
-                    conc,
-                    host,
-                    _cell(m, "client.request_throughput"),
-                    _cell(m, "client.total_token_throughput"),
-                    _cell(m, "client.mean_ttft_ms"),
-                    _cell(m, "client.p95_ttft_ms"),
-                    _cell(m, "client.mean_tpot_ms"),
-                    _cell(m, "client.p95_tpot_ms"),
-                    _cell(m, "client.p99_itl_ms"),
-                    _cell(m, "client.goodput"),
-                ]
-            )
+            rows.append([model, gpu, isl, osl, policy, conc, host] + [_cell(m, metric) for metric in metric_keys])
     log.info("\n" + tabulate(rows, headers=headers, tablefmt="github"))

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -22,7 +22,7 @@ from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFacto
 from cvs.lib import globals
 from cvs.lib.inference.vllm_topology import resolve_vllm_topology, scope_vllm_cluster
 from cvs.lib.inference.utils.vllm_config_loader import load_variant
-from cvs.lib.inference.utils.vllm_parsing import VLLM_RESULTS_COLUMNS
+from cvs.lib.inference.utils.vllm_metrics import VLLM_RESULTS_COLUMNS
 from cvs.lib.report.benchmark_metric_registry import (
     benchmark_metric_columns_for_nodeid,
     benchmark_metric_rows_from_item,

--- a/cvs/tests/inference/vllm/conftest.py
+++ b/cvs/tests/inference/vllm/conftest.py
@@ -136,6 +136,10 @@ class _Lifecycle:
         self.failed = False
         self.torn_down = False
         self.report = {}  # nodeid -> list[(label, value, unit)]
+        self.live_server_sig = None
+        self.live_server_job = None
+        self.model_load_s = None
+        self.model_load_memory_mb = None
 
     def record(self, nodeid, label, value, unit="s"):
         self.report.setdefault(nodeid, []).append((label, value, unit))

--- a/cvs/tests/inference/vllm/unittests/test_common.py
+++ b/cvs/tests/inference/vllm/unittests/test_common.py
@@ -1,6 +1,8 @@
 '''Unit tests for shared vLLM metric verification stages.'''
 
+import json
 import unittest
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest import mock
 
@@ -12,6 +14,20 @@ from cvs.tests.inference.vllm import _common
 
 class _FakeStash(dict):
     pass
+
+
+class _CapturingSubtests:
+    def __init__(self):
+        self.calls = []
+        self.failures = []
+
+    @contextmanager
+    def test(self, **kwargs):
+        self.calls.append(kwargs)
+        try:
+            yield
+        except AssertionError as exc:
+            self.failures.append(str(exc))
 
 
 class TestVerifyCellMetrics(unittest.TestCase):
@@ -31,7 +47,7 @@ class TestVerifyCellMetrics(unittest.TestCase):
             model_id='org/model',
             thresholds={
                 cell.key: {
-                    'client.output_throughput': {'kind': 'min_tok_s', 'value': 100},
+                    'output_throughput': {'kind': 'min', 'value': 100},
                 }
             },
             enforce_thresholds=False,
@@ -40,8 +56,9 @@ class TestVerifyCellMetrics(unittest.TestCase):
         inf_res_dict = {
             result_key: {
                 'head': {
-                    'client.output_throughput': 99,
-                    'client.mean_ttft_ms': 40,
+                    'output_throughput': 99,
+                    'mean_ttft_ms': 40,
+                    'queue_time_p50_ms': None,
                 }
             }
         }
@@ -63,9 +80,79 @@ class TestVerifyCellMetrics(unittest.TestCase):
             )
 
         rows = registry.benchmark_metric_rows_for_nodeid(node.nodeid)
-        self.assertEqual([(row['metric'], row['status']) for row in rows], [('client.output_throughput', 'record')])
+        self.assertEqual(
+            [(row['metric'], row['status']) for row in rows],
+            [('output_throughput', 'record'), ('mean_ttft_ms', 'record')],
+        )
         subtests.test.assert_not_called()
         lifecycle.record.assert_called_once()
+        properties = [value for key, value in node.user_properties if key == _common.VLLM_JUNIT_PROPERTY]
+        self.assertEqual(len(properties), 1)
+        payload = json.loads(properties[0])
+        self.assertEqual(payload["metric_contract"], {"id": "vllm-bare", "version": 1})
+        self.assertEqual(
+            payload["actuals_by_host"]["head"],
+            {
+                "mean_ttft_ms": 40,
+                "output_throughput": 99,
+                "queue_time_p50_ms": None,
+            },
+        )
+
+    def test_mixed_pass_fail_siblings_and_multiple_hosts_all_run(self):
+        cell = SimpleNamespace(
+            key='ISL=1024,OSL=1024,TP=8,PP=1,CONC=16',
+            isl=1024,
+            osl=1024,
+            concurrency=16,
+        )
+        run = SimpleNamespace(cell=cell)
+        variant = SimpleNamespace(
+            model_id='org/model',
+            thresholds={
+                cell.key: {
+                    'output_throughput': {'kind': 'min', 'value': 100},
+                    'mean_ttft_ms': {'kind': 'max', 'value': 50},
+                }
+            },
+            enforce_thresholds=True,
+        )
+        result_key = _common._cell_result_key(variant, run)
+        inf_res_dict = {
+            result_key: {
+                'head': {'output_throughput': 99, 'mean_ttft_ms': 40},
+                'worker': {'output_throughput': 101, 'mean_ttft_ms': 60},
+            }
+        }
+        node = SimpleNamespace(
+            nodeid='cvs/tests/inference/vllm/vllm_single.py::test_verify_cell_metrics[cell]',
+            stash=_FakeStash(),
+            user_properties=[],
+        )
+        lifecycle = SimpleNamespace(record=mock.Mock())
+        subtests = _CapturingSubtests()
+
+        _common.test_verify_cell_metrics(
+            run,
+            inf_res_dict,
+            variant,
+            lifecycle,
+            SimpleNamespace(node=node),
+            subtests,
+        )
+
+        self.assertEqual(
+            subtests.calls,
+            [
+                {'node': 'head', 'metric': 'output_throughput'},
+                {'node': 'head', 'metric': 'mean_ttft_ms'},
+                {'node': 'worker', 'metric': 'output_throughput'},
+                {'node': 'worker', 'metric': 'mean_ttft_ms'},
+            ],
+        )
+        self.assertEqual(len(subtests.failures), 2)
+        keys = [key for key, _value in node.user_properties]
+        self.assertEqual(keys.count(_common.VLLM_JUNIT_PROPERTY), 1)
 
 
 if __name__ == '__main__':

--- a/cvs/tests/inference/vllm/unittests/test_conftest.py
+++ b/cvs/tests/inference/vllm/unittests/test_conftest.py
@@ -2,6 +2,7 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 from cvs.lib.report import benchmark_metric_registry as registry
 from cvs.lib.report.render.perf_metric_table import is_benchmark_metrics_extra
@@ -25,6 +26,38 @@ class TestVllmMetricReportHook(unittest.TestCase):
     def setUp(self):
         registry._ROWS_BY_NODEID.clear()
         registry._COLUMNS_BY_NODEID.clear()
+
+    def test_lifecycle_starts_without_live_server_state(self):
+        lifecycle = vllm_conftest._Lifecycle()
+
+        self.assertIsNone(lifecycle.live_server_sig)
+        self.assertIsNone(lifecycle.live_server_job)
+        self.assertIsNone(lifecycle.model_load_s)
+        self.assertIsNone(lifecycle.model_load_memory_mb)
+
+    def test_collection_order_keeps_teardown_last(self):
+        names = [
+            "test_teardown",
+            "test_accuracy_eval",
+            "test_verify_cell_metrics",
+            "test_vllm_inference",
+            "test_launch_container",
+        ]
+        items = [SimpleNamespace(originalname=name, name=name) for name in names]
+
+        with mock.patch.object(vllm_conftest, "validate_vllm_execution_mode"):
+            vllm_conftest.pytest_collection_modifyitems(SimpleNamespace(), items)
+
+        self.assertEqual(
+            [item.originalname for item in items],
+            [
+                "test_launch_container",
+                "test_vllm_inference",
+                "test_verify_cell_metrics",
+                "test_accuracy_eval",
+                "test_teardown",
+            ],
+        )
 
     def test_makereport_attaches_and_stamps_metric_panel(self):
         nodeid = 'cvs/tests/inference/vllm/vllm_single.py::test_verify_cell_metrics[cell]'

--- a/cvs/tests/inference/vllm/unittests/test_conftest.py
+++ b/cvs/tests/inference/vllm/unittests/test_conftest.py
@@ -32,10 +32,10 @@ class TestVllmMetricReportHook(unittest.TestCase):
         rows = [
             {
                 'node': 'head',
-                'metric': 'client.output_throughput',
+                'metric': 'output_throughput',
                 'status': 'record',
                 'actual': 99,
-                'spec': {'kind': 'min_tok_s', 'value': 100},
+                'spec': {'kind': 'min', 'value': 100},
                 'enforced': False,
             }
         ]

--- a/cvs/tests/inference/vllm/unittests/test_load_metric_reuse.py
+++ b/cvs/tests/inference/vllm/unittests/test_load_metric_reuse.py
@@ -174,10 +174,10 @@ class TestLoadMetricReuse(unittest.TestCase):
         self.assertEqual(self.metrics_for(second)["model_load_memory_mb"], 0)
         self.assertEqual(self.lifecycle.model_load_memory_mb, 0)
 
-    def test_contract_drift_fails_cell_but_preserves_server_for_next_cell(self):
-        first = _run(1)
-        first_job = _job(("same",))
-        first_job.parse_results.side_effect = lambda: project_vllm_metrics(
+    def test_contract_drift_marks_lifecycle_failed_and_clears_server(self):
+        run = _run(1)
+        job = _job(("same",))
+        job.parse_results.side_effect = lambda: project_vllm_metrics(
             {"output_throughput": 1.0, "new_metric": 2.0},
             tp=1,
             pp=1,
@@ -187,26 +187,18 @@ class TestLoadMetricReuse(unittest.TestCase):
 
         with self.assertRaises(UnknownMetricContractError):
             self.invoke(
-                first,
-                first_job,
+                run,
+                job,
                 [{"gpu.used_vram": 100}, {"gpu.used_vram": 125}],
             )
 
-        self.assertFalse(self.lifecycle.failed)
-        self.assertEqual(self.lifecycle.live_server_sig, ("same",))
-        self.assertIs(self.lifecycle.live_server_job, first_job)
-        self.assertEqual(self.lifecycle.model_load_s, 2.0)
-        self.assertEqual(self.lifecycle.model_load_memory_mb, 25)
-        self.assertNotIn(_common._cell_result_key(self.variant, first), self.results)
-        first_job.dump_server_log.assert_not_called()
-
-        second = _run(2)
-        second_job = _job(("same",))
-        gpu_snap = self.invoke(second, second_job, [])
-
-        self.assertEqual(gpu_snap.call_count, 0)
-        second_job.start_server.assert_not_called()
-        self.assertEqual(self.metrics_for(second)["output_throughput"], 1.0)
+        self.assertTrue(self.lifecycle.failed)
+        self.assertIsNone(self.lifecycle.live_server_sig)
+        self.assertIsNone(self.lifecycle.live_server_job)
+        self.assertIsNone(self.lifecycle.model_load_s)
+        self.assertIsNone(self.lifecycle.model_load_memory_mb)
+        self.assertNotIn(_common._cell_result_key(self.variant, run), self.results)
+        job.dump_server_log.assert_called_once()
 
     def test_generic_projection_value_error_stops_later_cells(self):
         run = _run(1)

--- a/cvs/tests/inference/vllm/unittests/test_load_metric_reuse.py
+++ b/cvs/tests/inference/vllm/unittests/test_load_metric_reuse.py
@@ -4,6 +4,7 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+from cvs.lib.inference.utils.vllm_metrics import UnknownMetricContractError, project_vllm_metrics
 from cvs.tests.inference.vllm import _common
 
 
@@ -39,7 +40,15 @@ def _request(nodeid):
 
 
 def _lifecycle():
-    return SimpleNamespace(failed=False, record=mock.Mock(), ib_hcas=[])
+    return SimpleNamespace(
+        failed=False,
+        record=mock.Mock(),
+        ib_hcas=[],
+        live_server_sig=None,
+        live_server_job=None,
+        model_load_s=None,
+        model_load_memory_mb=None,
+    )
 
 
 class TestLoadMetricReuse(unittest.TestCase):
@@ -125,24 +134,31 @@ class TestLoadMetricReuse(unittest.TestCase):
 
         second_job.stop_server.assert_called_once()
         second_job.start_server.assert_called_once()
-        self.assertEqual(self.lifecycle.live_server_state, (("second",), 2.0, 30))
+        self.assertEqual(self.lifecycle.live_server_sig, ("second",))
+        self.assertIs(self.lifecycle.live_server_job, second_job)
+        self.assertEqual(self.lifecycle.model_load_s, 2.0)
+        self.assertEqual(self.lifecycle.model_load_memory_mb, 30)
 
-    def test_unavailable_snapshot_does_not_create_reusable_state(self):
+    def test_unavailable_snapshot_reuses_server_and_elapsed_load_time(self):
         first = _run(1)
-        self.invoke(first, _job(("same",)), [{}, {"gpu.used_vram": 125}])
+        first_job = _job(("same",))
+        self.invoke(first, first_job, [{}, {"gpu.used_vram": 125}])
 
-        self.assertIsNone(self.lifecycle.live_server_state)
-        self.assertIsNone(self.metrics_for(first)["model_load_s"])
+        self.assertEqual(self.lifecycle.live_server_sig, ("same",))
+        self.assertIs(self.lifecycle.live_server_job, first_job)
+        self.assertEqual(self.lifecycle.model_load_s, 2.0)
+        self.assertIsNone(self.lifecycle.model_load_memory_mb)
+        self.assertEqual(self.metrics_for(first)["model_load_s"], 2.0)
         self.assertIsNone(self.metrics_for(first)["model_load_memory_mb"])
 
         second = _run(2)
         second_job = _job(("same",))
-        self.invoke(
-            second,
-            second_job,
-            [{"gpu.used_vram": 125}, {"gpu.used_vram": 150}],
-        )
-        second_job.start_server.assert_called_once()
+        gpu_snap = self.invoke(second, second_job, [])
+
+        self.assertEqual(gpu_snap.call_count, 0)
+        second_job.start_server.assert_not_called()
+        self.assertEqual(self.metrics_for(second)["model_load_s"], 2.0)
+        self.assertIsNone(self.metrics_for(second)["model_load_memory_mb"])
 
     def test_zero_memory_delta_is_preserved_and_reused(self):
         first = _run(1)
@@ -156,13 +172,181 @@ class TestLoadMetricReuse(unittest.TestCase):
 
         self.assertEqual(self.metrics_for(first)["model_load_memory_mb"], 0)
         self.assertEqual(self.metrics_for(second)["model_load_memory_mb"], 0)
+        self.assertEqual(self.lifecycle.model_load_memory_mb, 0)
 
-    def test_failure_clears_live_server_state(self):
+    def test_contract_drift_fails_cell_but_preserves_server_for_next_cell(self):
+        first = _run(1)
+        first_job = _job(("same",))
+        first_job.parse_results.side_effect = lambda: project_vllm_metrics(
+            {"output_throughput": 1.0, "new_metric": 2.0},
+            tp=1,
+            pp=1,
+            isl=128,
+            artifact_path="head:/tmp/results",
+        )
+
+        with self.assertRaises(UnknownMetricContractError):
+            self.invoke(
+                first,
+                first_job,
+                [{"gpu.used_vram": 100}, {"gpu.used_vram": 125}],
+            )
+
+        self.assertFalse(self.lifecycle.failed)
+        self.assertEqual(self.lifecycle.live_server_sig, ("same",))
+        self.assertIs(self.lifecycle.live_server_job, first_job)
+        self.assertEqual(self.lifecycle.model_load_s, 2.0)
+        self.assertEqual(self.lifecycle.model_load_memory_mb, 25)
+        self.assertNotIn(_common._cell_result_key(self.variant, first), self.results)
+        first_job.dump_server_log.assert_not_called()
+
+        second = _run(2)
+        second_job = _job(("same",))
+        gpu_snap = self.invoke(second, second_job, [])
+
+        self.assertEqual(gpu_snap.call_count, 0)
+        second_job.start_server.assert_not_called()
+        self.assertEqual(self.metrics_for(second)["output_throughput"], 1.0)
+
+    def test_generic_projection_value_error_stops_later_cells(self):
+        run = _run(1)
+        job = _job(("same",))
+        job.parse_results.side_effect = ValueError("invalid result artifact")
+
+        with self.assertRaisesRegex(ValueError, "invalid result artifact"):
+            self.invoke(
+                run,
+                job,
+                [{"gpu.used_vram": 100}, {"gpu.used_vram": 125}],
+            )
+
+        self.assertTrue(self.lifecycle.failed)
+        self.assertIsNone(self.lifecycle.live_server_sig)
+        self.assertIsNone(self.lifecycle.live_server_job)
+        self.assertIsNone(self.lifecycle.model_load_s)
+        self.assertIsNone(self.lifecycle.model_load_memory_mb)
+        job.dump_server_log.assert_called_once()
+
+    def test_constructor_failure_clears_state_without_unbound_job(self):
+        run = _run(1)
+
+        with (
+            mock.patch.object(_common, "VllmJob", side_effect=RuntimeError("construction failed")),
+            self.assertRaisesRegex(RuntimeError, "construction failed"),
+        ):
+            _common.test_vllm_inference(
+                mock.Mock(),
+                self.variant,
+                "",
+                (("head",),),
+                run,
+                self.results,
+                self.lifecycle,
+                _request("test_vllm_inference[construction-failure]"),
+            )
+
+        self.assertTrue(self.lifecycle.failed)
+        self.assertIsNone(self.lifecycle.live_server_sig)
+        self.assertIsNone(self.lifecycle.live_server_job)
+        self.assertIsNone(self.lifecycle.model_load_s)
+        self.assertIsNone(self.lifecycle.model_load_memory_mb)
+
+    def test_merge_failure_does_not_publish_partial_results(self):
+        run = _run(1)
+        job = _job(("same",))
+        job.parse_results.return_value = {
+            "head": {"output_throughput": 1.0},
+            "worker": {"output_throughput": 2.0},
+        }
+        merge_calls = 0
+
+        def fail_second_merge(client_metrics, gpu_metrics, prom_metrics):
+            nonlocal merge_calls
+            merge_calls += 1
+            if merge_calls == 2:
+                raise ValueError("merge failed")
+            return {**client_metrics, **gpu_metrics, **prom_metrics}
+
+        with (
+            mock.patch.object(_common, "merge_metric_sources", side_effect=fail_second_merge),
+            self.assertRaisesRegex(ValueError, "merge failed"),
+        ):
+            self.invoke(
+                run,
+                job,
+                [{"gpu.used_vram": 100}, {"gpu.used_vram": 125}],
+            )
+
+        self.assertTrue(self.lifecycle.failed)
+        self.assertNotIn(_common._cell_result_key(self.variant, run), self.results)
+        self.assertIsNone(self.lifecycle.live_server_sig)
+        job.dump_server_log.assert_called_once()
+
+    def test_success_publishes_all_hosts_atomically(self):
+        run = _run(1)
+        job = _job(("same",))
+        parsed = {
+            "head": {"output_throughput": 1.0},
+            "worker": {"output_throughput": 2.0},
+        }
+        job.parse_results.return_value = parsed
+
+        self.invoke(
+            run,
+            job,
+            [{"gpu.used_vram": 100}, {"gpu.used_vram": 125}],
+        )
+
+        published = self.results[_common._cell_result_key(self.variant, run)]
+        self.assertEqual(set(published), {"head", "worker"})
+        self.assertEqual(published["head"]["output_throughput"], 1.0)
+        self.assertEqual(published["worker"]["output_throughput"], 2.0)
+        self.assertIsNot(published, parsed)
+        self.assertEqual(
+            parsed,
+            {
+                "head": {"output_throughput": 1.0},
+                "worker": {"output_throughput": 2.0},
+            },
+        )
+
+    def test_restart_failure_clears_server_identity_and_measurements(self):
+        run = _run(1)
+        job = _job(("new",))
+        job.stop_server.side_effect = RuntimeError("stop failed")
+        self.lifecycle.live_server_sig = ("old",)
+        self.lifecycle.live_server_job = mock.Mock()
+        self.lifecycle.model_load_s = 1.0
+        self.lifecycle.model_load_memory_mb = 2.0
+
+        with (
+            mock.patch.object(_common, "VllmJob", return_value=job),
+            self.assertRaisesRegex(RuntimeError, "stop failed"),
+        ):
+            _common.test_vllm_inference(
+                mock.Mock(),
+                self.variant,
+                "",
+                (("head",),),
+                run,
+                self.results,
+                self.lifecycle,
+                _request("test_vllm_inference[restart-failure]"),
+            )
+
+        self.assertIsNone(self.lifecycle.live_server_sig)
+        self.assertIsNone(self.lifecycle.live_server_job)
+        self.assertIsNone(self.lifecycle.model_load_s)
+        self.assertIsNone(self.lifecycle.model_load_memory_mb)
+
+    def test_failure_clears_server_identity_and_measurements(self):
         run = _run(1)
         job = _job(("same",))
         job.run_client.side_effect = RuntimeError("client failed")
-        self.lifecycle.live_server_state = (("old",), 1.0, 2.0)
+        self.lifecycle.live_server_sig = ("old",)
         self.lifecycle.live_server_job = mock.Mock()
+        self.lifecycle.model_load_s = 1.0
+        self.lifecycle.model_load_memory_mb = 2.0
 
         with (
             mock.patch.object(_common, "VllmJob", return_value=job),
@@ -185,8 +369,10 @@ class TestLoadMetricReuse(unittest.TestCase):
                 _request("test_vllm_inference[failure]"),
             )
 
-        self.assertIsNone(self.lifecycle.live_server_state)
+        self.assertIsNone(self.lifecycle.live_server_sig)
         self.assertIsNone(self.lifecycle.live_server_job)
+        self.assertIsNone(self.lifecycle.model_load_s)
+        self.assertIsNone(self.lifecycle.model_load_memory_mb)
 
 
 if __name__ == "__main__":

--- a/cvs/tests/inference/vllm/unittests/test_load_metric_reuse.py
+++ b/cvs/tests/inference/vllm/unittests/test_load_metric_reuse.py
@@ -1,0 +1,193 @@
+'''Unit tests for vLLM server load metric reuse.'''
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from cvs.tests.inference.vllm import _common
+
+
+def _run(concurrency):
+    cell = SimpleNamespace(
+        key=f"ISL=128,OSL=128,TP=1,PP=1,CONC={concurrency}",
+        isl=128,
+        osl=128,
+        concurrency=concurrency,
+    )
+    return SimpleNamespace(cell=cell, benchmark_params={"num_prompts": 2})
+
+
+def _job(signature):
+    job = mock.MagicMock()
+    job.server_signature.return_value = signature
+    job.nnodes = "1"
+    job.hosts = ("head",)
+    job.base_url = "http://0.0.0.0"
+    job.port_no = "8888"
+    job.parse_results.return_value = {"head": {"output_throughput": 1.0}}
+    return job
+
+
+def _request(nodeid):
+    return SimpleNamespace(
+        node=SimpleNamespace(nodeid=nodeid),
+        config=SimpleNamespace(
+            option=SimpleNamespace(htmlpath=None),
+            _test_html_dir="test_html",
+        ),
+    )
+
+
+def _lifecycle():
+    return SimpleNamespace(failed=False, record=mock.Mock(), ib_hcas=[])
+
+
+class TestLoadMetricReuse(unittest.TestCase):
+    def setUp(self):
+        self.variant = SimpleNamespace(model_id="model")
+        self.results = {}
+        self.lifecycle = _lifecycle()
+        self.patches = [
+            mock.patch.object(_common, "start_gpu_poller", return_value="poller"),
+            mock.patch.object(_common, "stop_and_collect_gpu_poller", return_value=[]),
+            mock.patch.object(_common, "scrape_vllm_metrics", return_value=None),
+            mock.patch.object(
+                _common,
+                "agg_readings",
+                return_value={
+                    "peak_gpu_memory_mb": 0,
+                    "gpu_bandwidth_util_pct": 0,
+                    "gpu_compute_util_pct": 0,
+                },
+            ),
+            mock.patch.object(_common, "to_prom_metrics", return_value={}),
+        ]
+        for patcher in self.patches:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def invoke(self, run, job, snapshots):
+        with (
+            mock.patch.object(_common, "VllmJob", return_value=job),
+            mock.patch.object(_common, "_gpu_snap", side_effect=snapshots) as gpu_snap,
+            mock.patch.object(_common.time, "monotonic", side_effect=[10.0, 12.0]),
+        ):
+            _common.test_vllm_inference(
+                mock.Mock(),
+                self.variant,
+                "",
+                (("head",),),
+                run,
+                self.results,
+                self.lifecycle,
+                _request(f"test_vllm_inference[{run.cell.key}]"),
+            )
+        return gpu_snap
+
+    def metrics_for(self, run):
+        key = _common._cell_result_key(self.variant, run)
+        return self.results[key]["head"]
+
+    def test_reuses_valid_load_measurements_for_same_server(self):
+        first = _run(1)
+        first_job = _job(("same",))
+        self.invoke(
+            first,
+            first_job,
+            [{"gpu.used_vram": 100.0}, {"gpu.used_vram": 125.0}],
+        )
+
+        second = _run(2)
+        second_job = _job(("same",))
+        gpu_snap = self.invoke(second, second_job, [])
+
+        self.assertEqual(gpu_snap.call_count, 0)
+        second_job.start_server.assert_not_called()
+        self.assertEqual(self.metrics_for(first)["model_load_s"], 2.0)
+        self.assertEqual(self.metrics_for(first)["model_load_memory_mb"], 25.0)
+        self.assertEqual(self.metrics_for(second)["model_load_s"], 2.0)
+        self.assertEqual(self.metrics_for(second)["model_load_memory_mb"], 25.0)
+
+    def test_changed_signature_restarts_and_replaces_measurements(self):
+        first = _run(1)
+        self.invoke(
+            first,
+            _job(("first",)),
+            [{"gpu.used_vram": 100}, {"gpu.used_vram": 125}],
+        )
+        second = _run(2)
+        second_job = _job(("second",))
+        self.invoke(
+            second,
+            second_job,
+            [{"gpu.used_vram": 200}, {"gpu.used_vram": 230}],
+        )
+
+        second_job.stop_server.assert_called_once()
+        second_job.start_server.assert_called_once()
+        self.assertEqual(self.lifecycle.live_server_state, (("second",), 2.0, 30))
+
+    def test_unavailable_snapshot_does_not_create_reusable_state(self):
+        first = _run(1)
+        self.invoke(first, _job(("same",)), [{}, {"gpu.used_vram": 125}])
+
+        self.assertIsNone(self.lifecycle.live_server_state)
+        self.assertIsNone(self.metrics_for(first)["model_load_s"])
+        self.assertIsNone(self.metrics_for(first)["model_load_memory_mb"])
+
+        second = _run(2)
+        second_job = _job(("same",))
+        self.invoke(
+            second,
+            second_job,
+            [{"gpu.used_vram": 125}, {"gpu.used_vram": 150}],
+        )
+        second_job.start_server.assert_called_once()
+
+    def test_zero_memory_delta_is_preserved_and_reused(self):
+        first = _run(1)
+        self.invoke(
+            first,
+            _job(("same",)),
+            [{"gpu.used_vram": 100}, {"gpu.used_vram": 100}],
+        )
+        second = _run(2)
+        self.invoke(second, _job(("same",)), [])
+
+        self.assertEqual(self.metrics_for(first)["model_load_memory_mb"], 0)
+        self.assertEqual(self.metrics_for(second)["model_load_memory_mb"], 0)
+
+    def test_failure_clears_live_server_state(self):
+        run = _run(1)
+        job = _job(("same",))
+        job.run_client.side_effect = RuntimeError("client failed")
+        self.lifecycle.live_server_state = (("old",), 1.0, 2.0)
+        self.lifecycle.live_server_job = mock.Mock()
+
+        with (
+            mock.patch.object(_common, "VllmJob", return_value=job),
+            mock.patch.object(
+                _common,
+                "_gpu_snap",
+                side_effect=[{"gpu.used_vram": 100}, {"gpu.used_vram": 125}],
+            ),
+            mock.patch.object(_common.time, "monotonic", side_effect=[10.0, 12.0]),
+            self.assertRaisesRegex(RuntimeError, "client failed"),
+        ):
+            _common.test_vllm_inference(
+                mock.Mock(),
+                self.variant,
+                "",
+                (("head",),),
+                run,
+                self.results,
+                self.lifecycle,
+                _request("test_vllm_inference[failure]"),
+            )
+
+        self.assertIsNone(self.lifecycle.live_server_state)
+        self.assertIsNone(self.lifecycle.live_server_job)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/tests/inference/vllm/unittests/test_reporting_integration.py
+++ b/cvs/tests/inference/vllm/unittests/test_reporting_integration.py
@@ -1,0 +1,137 @@
+'''Pytest-html and JUnit integration coverage for vLLM metric subtests.'''
+
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+import xml.etree.ElementTree as element_tree
+from pathlib import Path
+
+
+class TestVllmReportingIntegration(unittest.TestCase):
+    def test_bare_parent_rows_subtests_html_and_junit_property(self):
+        source = textwrap.dedent(
+            '''
+            from types import SimpleNamespace
+
+            import pytest
+
+            from cvs.tests.inference.vllm._common import (
+                test_verify_cell_metrics as verify_cell_metrics,
+            )
+
+            CELL = "ISL=128,OSL=128,TP=1,PP=1,CONC=1"
+
+            @pytest.fixture
+            def run():
+                return SimpleNamespace(
+                    cell=SimpleNamespace(
+                        key=CELL,
+                        isl=128,
+                        osl=128,
+                        concurrency=1,
+                    )
+                )
+
+            @pytest.fixture
+            def variant_config():
+                return SimpleNamespace(
+                    model_id="model",
+                    enforce_thresholds=True,
+                    thresholds={
+                        CELL: {
+                            "output_throughput": {"kind": "min", "value": 1}
+                        }
+                    },
+                )
+
+            @pytest.fixture
+            def inf_res_dict(run, variant_config):
+                key = (
+                    variant_config.model_id,
+                    "",
+                    "128",
+                    "128",
+                    CELL,
+                    1,
+                )
+                return {
+                    key: {
+                        "head": {
+                            "output_throughput": 2.0,
+                            "mean_ttft_ms": 3.0,
+                        }
+                    }
+                }
+
+            @pytest.fixture
+            def lifecycle():
+                return SimpleNamespace(record=lambda *args: None)
+
+            def test_verify_cell_metrics(
+                run,
+                inf_res_dict,
+                variant_config,
+                lifecycle,
+                request,
+                subtests,
+            ):
+                verify_cell_metrics(
+                    run,
+                    inf_res_dict,
+                    variant_config,
+                    lifecycle,
+                    request,
+                    subtests,
+                )
+            '''
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            test_path = root / "test_vllm_reporting.py"
+            html_path = root / "report.html"
+            xml_path = root / "report.xml"
+            test_path.write_text(source)
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    str(test_path),
+                    "-p",
+                    "cvs.tests.inference.vllm.conftest",
+                    f"--html={html_path}",
+                    "--self-contained-html",
+                    f"--junitxml={xml_path}",
+                    "-q",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(
+                completed.returncode,
+                0,
+                f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+            )
+            html = html_path.read_text()
+            xml_root = element_tree.parse(xml_path).getroot()
+
+        self.assertIn("output_throughput", html)
+        self.assertIn("mean_ttft_ms", html)
+        self.assertNotIn("client.output_throughput", html)
+        properties = [
+            prop for prop in xml_root.findall(".//property") if prop.attrib.get("name") == "cvs_vllm_metrics_v1"
+        ]
+        self.assertEqual(len(properties), 1)
+        value = properties[0].attrib["value"]
+        self.assertIn('"metric_contract":{"id":"vllm-bare","version":1}', value)
+        self.assertIn('"actuals_by_host":{"head":', value)
+        self.assertIn('"output_throughput":2.0', value)
+        self.assertNotIn("client.", value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/tests/inference/vllm/unittests/test_shared.py
+++ b/cvs/tests/inference/vllm/unittests/test_shared.py
@@ -13,7 +13,7 @@ from cvs.tests.inference.vllm import _shared
 
 class TestPrintResultsTable(unittest.TestCase):
     def test_blank_gpu_report_slot_preserves_six_field_key(self):
-        results = {("model", "", "1024", "1024", "default", 16): {"host": {"client.total_token_throughput": 1.0}}}
+        results = {("model", "", "1024", "1024", "default", 16): {"host": {"total_token_throughput": 1.0}}}
 
         with mock.patch.object(_shared.log, "info") as log_info:
             _shared.test_print_results_table(results)

--- a/docs/how-to/test-suites/inference/vllm.rst
+++ b/docs/how-to/test-suites/inference/vllm.rst
@@ -88,7 +88,11 @@ For a **multinode** configuration, also set:
 
 .. tip::
 
-  Leave ``enforce_thresholds`` set to ``false`` for your first run on new hardware. The run then measures and records everything without failing on thresholds you have not calibrated yet. Set it to ``true`` once you know what good looks like.
+  Leave ``enforce_thresholds`` set to ``false`` for your first run on new
+  hardware. The run reports every finite value produced from the 56-metric
+  registry without gating. Packaged threshold templates intentionally retain
+  the previous 32-metric assertion subset; you may add any other registered
+  metric or remove entries before enabling calibrated thresholds.
 
 .. _vllm-run-tests:
 

--- a/docs/how-to/test-suites/inference/vllm.rst
+++ b/docs/how-to/test-suites/inference/vllm.rst
@@ -126,8 +126,8 @@ Open the HTML report. Each lifecycle stage, benchmark cell, and verification pha
 
 - **Lifecycle rows** — container launch, topology discovery, model fetch, the OpenAI-compatible smoke test, then teardown. These tell you *how far* the run got.
 - **Inference rows** — one per sweep cell, labelled ``<combo>-conc<N>``.
-- **Verification rows** — one per cell. Expand the row to see its active threshold metric subtests. Unavailable GPU and Prometheus metrics are skipped; unavailable client metrics with active thresholds fail.
-- **Results table** — the summary is also printed to the console. Use the per-cell logs for record-only client, GPU, and Prometheus values.
+- **Verification rows** — one per cell. Expand the row to see every finite metric plus every configured threshold. Only configured thresholds create subtests when enforcement is enabled. A missing or invalid gated value fails for every datasource, including GPU and Prometheus.
+- **Results table** — the summary is also printed to the console. Metric names are bare (for example, ``output_throughput`` and ``queue_time_p95_ms``).
 
 Per-cell logs land under your configured ``log_dir``::
 
@@ -219,7 +219,12 @@ Common pitfalls
 
 **A threshold fails with "missing from actuals".** The threshold gates a metric this run did not produce. The suite owns benchmark percentile collection; do not add percentile controls to workload config.
 
-**A verification row skips.** Either the benchmark produced no parseable result for that cell, threshold enforcement is disabled, or the cell has no active metric gates. Check ``client.log`` and the server log for collection failures.
+**A verification parent skips.** Either the benchmark produced no parseable result for that cell, threshold enforcement is disabled, or the cell has no active metric gates. Finite values are still retained as record rows.
+
+**A Run Deck baseline is incompatible.** vLLM reports identify the bare metric
+contract as ``{"id":"vllm-bare","version":1}``. Historical reports containing
+``client.*``, ``gpu.*``, or ``prom.*`` metric keys cannot be compared. Generate
+a new baseline with the current suite.
 
 **The sweep is slower than expected.** Cells that differ only in concurrency reuse the running server; changing ISL, OSL, TP, PP, or any server argument forces a restart and a weight reload. Ordering ``runs`` so concurrency varies fastest avoids needless reloads.
 

--- a/docs/how-to/test-suites/inference/vllm.rst
+++ b/docs/how-to/test-suites/inference/vllm.rst
@@ -221,7 +221,7 @@ Common pitfalls
 
 **Container launch crashes with "too many values to unpack".** You placed ``env`` under ``container.runtime.args``. It belongs at the ``container`` top level.
 
-**A threshold fails with "missing from actuals".** The threshold gates a metric this run did not produce. The suite owns benchmark percentile collection; do not add percentile controls to workload config.
+**A threshold fails with "actual must be a finite built-in int or float".** The gated datasource did not produce a valid value. Inspect the raw benchmark artifact, GPU telemetry, or server metrics for that cell. The suite owns benchmark percentile collection; workload configuration cannot override it.
 
 **A verification parent skips.** Either the benchmark produced no parseable result for that cell, threshold enforcement is disabled, or the cell has no active metric gates. Finite values are still retained as record rows.
 

--- a/docs/reference/configuration-files/inference/vllm.rst
+++ b/docs/reference/configuration-files/inference/vllm.rst
@@ -774,6 +774,9 @@ Sweep specs are strict at load time regardless of enforcement:
 - ``kind`` must equal the registry direction, exactly ``min`` or ``max``.
 - ``value`` must be a finite JSON number. Booleans, strings, null, arrays,
   objects, NaN, and infinity are rejected.
+- Cell-level keys beginning with ``_comment`` or ``_example`` are metadata and
+  are ignored by metric validation; all other keys must name a registered
+  metric.
 - Prefixed names (``client.*``, ``gpu.*``, ``prom.*``), unknown names, legacy
   kinds (including ``min_tok_s`` and ``max_ms``), references, tolerances,
   units, ``info``, and extra fields are rejected.
@@ -851,9 +854,10 @@ GPU (5)
 ``peak_gpu_memory_mb``, ``model_load_memory_mb``, ``model_load_s``,
 ``gpu_bandwidth_util_pct``, ``gpu_compute_util_pct``. Load time and memory are
 captured once after successful readiness and reused for cells sharing that
-server. Both pre/post VRAM snapshots must be finite; otherwise both load
-measurements are unavailable and the server state is not reused. A real zero
-memory delta remains zero.
+server. Load time remains available whenever the elapsed measurement is finite.
+Load memory requires finite pre/post VRAM snapshots; missing snapshots do not
+disable server reuse or the elapsed measurement. A real zero memory delta
+remains zero.
 
 Prometheus (4)
 --------------
@@ -903,7 +907,9 @@ record-only HTML rows. The parent also emits one compact JUnit property with
 Run Deck tables, charts, and highlights use selected registry metrics rather
 than all 56 columns. Historical namespaced vLLM Run Deck artifacts do not match
 the contract: previous-run and manually selected viewer baselines display an
-explicit incompatibility and suppress comparisons.
+explicit incompatibility and suppress performance comparisons. A compatible
+task-qualified accuracy section in the same baseline remains independently
+eligible for accuracy comparison.
 
 Results table
 -------------
@@ -1049,10 +1055,12 @@ Troubleshooting
      - A ``runs[].combo`` does not match any declared name; the message lists the valid ones
    * - ``duplicate task id(s)``
      - Two ``accuracy.tasks`` entries share an ``id``
-   * - ``<metric>: unknown threshold kind``
-     - Typo or direction mismatch in ``kind``. The registry requires exactly ``min`` or ``max`` for each metric
-   * - ``<metric>: missing from actuals``
-     - A threshold gates a metric this run did not produce. Common cause: ``metric_percentiles`` omits the gated percentile
+   * - ``unknown vLLM threshold metric '<metric>'``
+     - The cell key does not begin with ``_`` and does not name one of the 56 registry metrics
+   * - ``<metric> threshold kind must be '<direction>', got '<kind>'``
+     - ``kind`` does not match the registry direction. Use the required ``min`` or ``max`` value shown in the message
+   * - ``<metric>: actual must be a finite built-in int or float, got <value>``
+     - The gated datasource did not produce a valid value. Inspect the benchmark artifact, GPU telemetry, or server metrics for that cell; percentile collection is harness-owned
    * - ``NotImplementedError: model.remote=1``
      - Remote model download is unimplemented. Pre-stage weights and set ``remote: 0``
    * - ``ValueError: too many values to unpack``

--- a/docs/reference/configuration-files/inference/vllm.rst
+++ b/docs/reference/configuration-files/inference/vllm.rst
@@ -750,256 +750,134 @@ concurrency varying fastest makes a sweep substantially quicker.
 Thresholds
 ==========
 
-Thresholds turn measurements into pass/fail results. They are keyed by cell key, then by fully-qualified metric name:
+Thresholds are keyed by canonical cell, then by a bare metric name:
 
 .. code:: json
 
     {
-      "ISL=1000,OSL=1000,TP=8,CONC=16": {
-        "client.total_token_throughput": { "kind": "min_tok_s", "value": 4000 },
-        "client.mean_ttft_ms":           { "kind": "max_ms",    "value": 500 },
-        "client.failed":                 { "kind": "max",       "value": 0 },
-        "client.success_rate":           { "kind": "min",       "value": 0.99 },
-        "gpu.gpu_compute_util_pct":      { "kind": "within",    "value": 90, "tolerance_pct": 10 },
-        "client.output_throughput":      { "kind": "min_ratio", "value": 0.8,
-                                           "reference": "client.total_token_throughput" }
+      "ISL=1000,OSL=1000,TP=8,PP=1,CONC=16": {
+        "output_throughput": {"kind": "min", "value": 4000},
+        "mean_ttft_ms": {"kind": "max", "value": 500},
+        "failed": {"kind": "max", "value": 0}
       }
     }
 
-Threshold kinds
----------------
+A cell may contain any subset of the registry, including an empty object. When
+``enforce_thresholds`` is true, every selected run must have a threshold cell,
+but only specs present in that cell create verification subtests. When it is
+false, produced and configured values remain ``record`` rows and no threshold
+subtests run.
 
-.. list-table::
-   :widths: 2 2 6
-   :header-rows: 1
+Sweep specs are strict at load time regardless of enforcement:
 
-   * - ``kind``
-     - Extra keys
-     - Fails when
-   * - ``min``
-     - —
-     - ``actual < value``
-   * - ``max``
-     - —
-     - ``actual > value``. Unit-agnostic upper bound, for counts such as ``failed``
-   * - ``max_ms``
-     - —
-     - ``actual > value``. Identical comparison to ``max``, but the message says "ms"
-   * - ``min_tok_s``
-     - —
-     - ``actual < value``. Identical comparison to ``min``, but the message says "tok/s"
-   * - ``within``
-     - ``tolerance_pct``
-     - ``actual`` falls outside ``value ± tolerance_pct`` percent
-   * - ``min_ratio``
-     - ``reference``
-     - ``actual / <reference metric>`` is less than ``value``
-   * - ``info``
-     - —
-     - Never. The value is recorded, but no verification subtest is emitted.
+- A spec contains exactly ``kind`` and ``value``.
+- ``kind`` must equal the registry direction, exactly ``min`` or ``max``.
+- ``value`` must be a finite JSON number. Booleans, strings, null, arrays,
+  objects, NaN, and infinity are rejected.
+- Prefixed names (``client.*``, ``gpu.*``, ``prom.*``), unknown names, legacy
+  kinds (including ``min_tok_s`` and ``max_ms``), references, tolerances,
+  units, ``info``, and extra fields are rejected.
 
-An unrecognized ``kind`` is a violation, not a silent skip. A missing or ``None`` ``client.*`` value with an active threshold is a loud violation. Unavailable ``gpu.*`` and ``prom.*`` values are reported as skipped subtests.
+``min`` fails below its value and passes at or above it. ``max`` fails above
+its value and passes at or below it. A gated actual that is missing, null,
+boolean, string, collection, NaN, or infinity fails for every datasource.
 
-For ``min_ratio``, the ``reference`` names another metric in the same cell. If that reference is missing, ``None``, or zero, the check fails with a message naming the reason.
-
-.. _vllm-threshold-coverage:
-
-Coverage checking
------------------
-
-At load time, every threshold cell must name a key in ``sweeps``. When
-``enforce_thresholds`` is true, every selected ``runs`` cell must have a
-threshold entry. Record-only runs may select uncalibrated cells.
-
-There is no per-metric coverage requirement. A cell's entry may spec a single metric or two dozen — a threshold file is free to gate only the metrics you care about rather than every member of every family.
-
-The ``accuracy`` key is exempt from cell-coverage checking, since it is keyed by task rather than by cell.
-
-Setting ``enforce_thresholds`` to ``false`` stops threshold violations from
-failing tests. The run still measures and records everything, which makes it
-the right setting for a first calibration run on new hardware.
-
-Which metrics are asserted is then decided per metric at evaluation time, not at load time. A metric is checked only when its cell carries a spec for it; with no spec it is measured and reported but never asserted. A spec of ``null`` is the explicit way to say the same thing.
+The optional top-level ``accuracy`` block remains task-qualified and is exempt
+from these vLLM sweep-name and spec rules.
 
 .. _vllm-threshold-discovery:
 
 Threshold file discovery
 ------------------------
 
-The threshold file is located in one of two ways:
-
-- **Explicit** — set ``threshold_json`` to a path. A relative path resolves against the configuration file's directory.
-- **Implicit** — if ``threshold_json`` is absent, the loader looks for exactly one file matching ``*threshold.json`` beside the configuration file. Finding more than one is an error, so add ``threshold_json`` when several coexist in a directory.
+Set ``threshold_json`` to the threshold file. A relative path resolves against
+the configuration file's directory. The packaged 28 files contain two cells
+each and all 56 metrics in canonical registry order. Their zero values are
+uncalibrated placeholders, and every paired config keeps enforcement disabled.
 
 Metrics
 =======
 
-Metrics live in namespaces. ``test_verify_cell_metrics`` is one parent phase per cell and lists each active threshold gate as a subtest in its expandable HTML panel. Missing ``gpu.*`` and ``prom.*`` values skip their subtests; missing ``client.*`` values with an active threshold fail. Record-only metrics do not create passing subtests; read them from the results table and per-cell logs.
+vLLM uses one ordered 56-entry bare-name registry. The metric name owns its
+raw source or derivation inputs, display unit, datasource, display category,
+and exact threshold direction. ``median_*`` and ``p50_*`` remain separate.
 
-Client metrics
+Run and health (7)
+------------------
+
+``max_concurrency``, ``max_concurrent_requests``, ``num_prompts``,
+``completed``, ``failed``, ``success_rate``, ``duration``.
+
+Throughput and totals (10)
+--------------------------
+
+``request_throughput``, ``goodput``, ``output_throughput``,
+``total_token_throughput``, ``per_gpu_throughput``,
+``decode_throughput_p50``, ``max_output_tokens_per_s``, ``rtfx``,
+``total_input_tokens``, ``total_output_tokens``.
+
+TTFT (8)
+--------
+
+``mean_ttft_ms``, ``median_ttft_ms``, ``std_ttft_ms``, ``p50_ttft_ms``,
+``p90_ttft_ms``, ``p95_ttft_ms``, ``p99_ttft_ms``,
+``normalized_ttft_ms_per_tok``.
+
+TPOT (7)
+--------
+
+``mean_tpot_ms``, ``median_tpot_ms``, ``std_tpot_ms``, ``p50_tpot_ms``,
+``p90_tpot_ms``, ``p95_tpot_ms``, ``p99_tpot_ms``.
+
+ITL (8)
+-------
+
+``mean_itl_ms``, ``median_itl_ms``, ``std_itl_ms``, ``p50_itl_ms``,
+``p90_itl_ms``, ``p95_itl_ms``, ``p99_itl_ms``, ``decode_latency_ratio``.
+
+End-to-end latency (7)
+----------------------
+
+``mean_e2el_ms``, ``median_e2el_ms``, ``std_e2el_ms``, ``p50_e2el_ms``,
+``p90_e2el_ms``, ``p95_e2el_ms``, ``p99_e2el_ms``.
+
+GPU (5)
+-------
+
+``peak_gpu_memory_mb``, ``model_load_memory_mb``, ``model_load_s``,
+``gpu_bandwidth_util_pct``, ``gpu_compute_util_pct``. Load time and memory are
+captured once after successful readiness and reused for cells sharing that
+server. Both pre/post VRAM snapshots must be finite; otherwise both load
+measurements are unavailable and the server state is not reused. A real zero
+memory delta remains zero.
+
+Prometheus (4)
 --------------
 
-Measured by the load generator (``vllm bench serve``) and namespaced ``client.*``. **Gated** marks the metrics designated as pass/fail criteria: they populate the report's gate matrix and they are the ones a threshold file normally specs. The mark does not make a metric mandatory — any metric, gated or not, is asserted only when its cell carries a spec for it (see :ref:`vllm-threshold-coverage`).
+``queue_time_p50_ms``, ``queue_time_p95_ms``, ``prefill_time_p50_ms``, and
+``prefill_time_p95_ms``. CVS diffs before/after histogram scrapes so reused
+server counters remain isolated to one cell.
 
-.. list-table::
-   :widths: 4 1 1 4
-   :header-rows: 1
+Directions
+----------
 
-   * - Metric
-     - Unit
-     - Gated
-     - Notes
-   * - ``client.total_token_throughput``
-     - tok/s
-     - yes
-     - Input plus output tokens per second
-   * - ``client.output_throughput``
-     - tok/s
-     - yes
-     - Generated tokens per second
-   * - ``client.mean_ttft_ms``
-     - ms
-     - yes
-     - Time to first token
-   * - ``client.median_ttft_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p90_ttft_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p95_ttft_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p99_ttft_ms``
-     - ms
-     - yes
-     -
-   * - ``client.mean_tpot_ms``
-     - ms
-     - yes
-     - Time per output token
-   * - ``client.median_tpot_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p90_tpot_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p95_tpot_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p99_tpot_ms``
-     - ms
-     - yes
-     -
-   * - ``client.mean_itl_ms``
-     - ms
-     - yes
-     - Inter-token latency
-   * - ``client.median_itl_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p95_itl_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p99_itl_ms``
-     - ms
-     - yes
-     - ITL has no p90 producer
-   * - ``client.mean_e2el_ms``
-     - ms
-     - yes
-     - End-to-end latency
-   * - ``client.median_e2el_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p90_e2el_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p95_e2el_ms``
-     - ms
-     - yes
-     -
-   * - ``client.p99_e2el_ms``
-     - ms
-     - yes
-     -
-   * - ``client.success_rate``
-     - \-
-     - yes
-     - Derived; see below
-   * - ``client.failed``
-     - \-
-     - yes
-     - Failed request count
-   * - ``client.max_concurrency``
-     - \-
-     - no
-     -
-   * - ``client.max_concurrent_requests``
-     - \-
-     - no
-     -
-   * - ``client.num_prompts``
-     - \-
-     - no
-     -
-   * - ``client.completed``
-     - \-
-     - no
-     -
-   * - ``client.duration``
-     - s
-     - no
-     -
-   * - ``client.request_throughput``
-     - req/s
-     - no
-     -
-   * - ``client.goodput``
-     - req/s
-     - no
-     - Alias of the stock ``request_goodput``; meaningful only with ``goodput_slo``
-   * - ``client.per_gpu_throughput``
-     - tok/s
-     - no
-     - Derived; see below
-   * - ``client.decode_throughput_p50``
-     - tok/s
-     - no
-     - Derived; see below
-   * - ``client.max_output_tokens_per_s``
-     - tok/s
-     - no
-     -
-   * - ``client.total_input_tokens``
-     - \-
-     - no
-     -
-   * - ``client.total_output_tokens``
-     - \-
-     - no
-     -
-   * - ``client.normalized_ttft_ms_per_tok``
-     - ms/tok
-     - no
-     - Derived; see below
-   * - ``client.decode_latency_ratio``
-     - \-
-     - no
-     - Derived; see below
+The following are ``min``: ``max_concurrency``,
+``max_concurrent_requests``, ``num_prompts``, ``completed``, ``success_rate``,
+``request_throughput``, ``goodput``, every token throughput/total metric,
+``rtfx``, ``gpu_bandwidth_util_pct``, and ``gpu_compute_util_pct``. Every other
+registry metric is ``max``.
 
-Derived client metrics
-~~~~~~~~~~~~~~~~~~~~~~
+Projection and derivation
+-------------------------
+
+The vLLM result projector accepts only finite built-in integer and float values;
+booleans are not numeric. Known metadata is ignored: ``date``,
+``endpoint_type``, ``backend``, ``label``, ``model_id``, ``tokenizer_id``,
+``burstiness``, and ``request_rate`` (including a finite request rate). Any
+unknown finite top-level numeric field fails parsing and names the artifact.
+The raw ``request_goodput`` field maps only to ``goodput``.
+
+Derived metrics are emitted only when their result is finite:
 
 .. code:: text
 
@@ -1009,75 +887,26 @@ Derived client metrics
   decode_throughput_p50       = 1000 / median_tpot_ms
   success_rate                = completed / (completed + failed)
 
-Every division is guarded: a missing, ``None``, or zero divisor yields ``None`` — reported as ``-`` — rather than a bogus zero or a crash.
+Reporting and compatibility
+---------------------------
 
-.. note::
+``test_verify_cell_metrics`` remains one parent per cell. It computes all host
+rows before emitting one subtest for each present, enforced spec, so one failure
+does not hide sibling verdicts. Finite produced values without a spec are
+record-only HTML rows. The parent also emits one compact JUnit property with
+``actuals_by_host`` and metric contract ``{"id":"vllm-bare","version":1}``.
 
-  ``client.request_rate`` is not surfaced as a metric row, because the stock benchmark emits the string ``inf`` rather than a number.
-
-  A new metric is **record-only by default**. Adding its name to the gated set marks it as a pass/fail criterion and files it under one of the report's gate-matrix tiers; it still only fails a run in those cells whose threshold entry specs it.
-
-GPU metrics
------------
-
-Sampled from ``amd-smi`` during the run and namespaced ``gpu.*``. None are gated by default.
-
-.. list-table::
-   :widths: 4 1 5
-   :header-rows: 1
-
-   * - Metric
-     - Unit
-     - Description
-   * - ``gpu.peak_gpu_memory_mb``
-     - MB
-     - Peak VRAM observed
-   * - ``gpu.model_load_memory_mb``
-     - MB
-     - VRAM attributable to loading weights
-   * - ``gpu.model_load_s``
-     - s
-     - Weight load duration
-   * - ``gpu.gpu_bandwidth_util_pct``
-     - %
-     - Memory bandwidth utilization
-   * - ``gpu.gpu_compute_util_pct``
-     - %
-     - Compute utilization
-
-Server metrics
---------------
-
-Scraped from the vLLM ``/metrics`` Prometheus endpoint and namespaced ``prom.*``.
-
-.. list-table::
-   :widths: 4 1 5
-   :header-rows: 1
-
-   * - Metric
-     - Unit
-     - Source histogram
-   * - ``prom.queue_time_p50_ms``
-     - ms
-     - ``vllm:request_queue_time_seconds``
-   * - ``prom.queue_time_p95_ms``
-     - ms
-     - ``vllm:request_queue_time_seconds``
-   * - ``prom.prefill_time_p50_ms``
-     - ms
-     - ``vllm:request_prefill_time_seconds``
-   * - ``prom.prefill_time_p95_ms``
-     - ms
-     - ``vllm:request_prefill_time_seconds``
-
-vLLM's Prometheus counters are cumulative over the server process lifetime, so a raw scrape after cell three would include cells one and two. The suite therefore scrapes **before and after each cell** and diffs the histogram buckets, giving per-cell quantiles. Quantiles are computed with the same interpolation PromQL's ``histogram_quantile`` uses.
-
-If the endpoint cannot be reached, all four report ``-`` and skip rather than failing the run.
+Run Deck tables, charts, and highlights use selected registry metrics rather
+than all 56 columns. Historical namespaced vLLM Run Deck artifacts do not match
+the contract: previous-run and manually selected viewer baselines display an
+explicit incompatibility and suppress comparisons.
 
 Results table
 -------------
 
-The summary table emits seven fixed columns — Model, GPU, ISL, OSL, Policy, Conc, Host — followed by Req/s, Total tok/s, Mean TTFT, P95 TTFT, Mean TPOT, P95 TPOT, P99 ITL, and Goodput.
+The summary table emits seven fixed columns — Model, GPU, ISL, OSL, Policy,
+Conc, Host — followed by Req/s, Total tok/s, Mean TTFT, P95 TTFT, Mean TPOT,
+P95 TPOT, P99 ITL, and Goodput.
 
 .. _vllm-accuracy:
 
@@ -1217,7 +1046,7 @@ Troubleshooting
    * - ``duplicate task id(s)``
      - Two ``accuracy.tasks`` entries share an ``id``
    * - ``<metric>: unknown threshold kind``
-     - Typo in ``kind``. Valid values are ``min``, ``max``, ``max_ms``, ``min_tok_s``, ``within``, ``min_ratio``
+     - Typo or direction mismatch in ``kind``. The registry requires exactly ``min`` or ``max`` for each metric
    * - ``<metric>: missing from actuals``
      - A threshold gates a metric this run did not produce. Common cause: ``metric_percentiles`` omits the gated percentile
    * - ``NotImplementedError: model.remote=1``

--- a/docs/reference/configuration-files/inference/vllm.rst
+++ b/docs/reference/configuration-files/inference/vllm.rst
@@ -792,8 +792,12 @@ Threshold file discovery
 
 Set ``threshold_json`` to the threshold file. A relative path resolves against
 the configuration file's directory. The packaged 28 files contain two cells
-each and all 56 metrics in canonical registry order. Their zero values are
-uncalibrated placeholders, and every paired config keeps enforcement disabled.
+each and intentionally retain the previous 32-metric assertion subset in
+canonical registry order. All 56 registry metrics remain supported, and every
+finite produced value is reported whether or not it has a threshold spec. The
+packaged zero values are uncalibrated placeholders, and every paired config
+keeps enforcement disabled. Users may add any other registered metric or
+remove any packaged entry.
 
 Metrics
 =======


### PR DESCRIPTION
## Summary

Replace vLLM's namespaced metric vocabulary with one bare, versioned 56-metric reporting contract while preserving per-cell threshold subtests.

Ticket: https://amd-hub.atlassian.net/browse/AIMVT-329

## Change

- flatten `client.`, `gpu.`, and `prom.` metric keys across results, thresholds, subtests, HTML, JUnit, and Run Deck
- report all 56 registered metrics while retaining the packaged catalog's established 32-metric assertion subset
- validate partial threshold cells as strict finite numeric `min`/`max` specs
- preserve merged metric-subtest reporting and leave ATOM behavior unchanged
- reject incompatible historical prefixed Run Deck baselines explicitly

## Live evidence

One-node TensorWave validation pending.

## Tests

- `make fmt-check`
- `make lint`
- `make test` — 1,834 unit tests passed with 1 expected skip; 65 CLI checks passed