### PR TITLE
feat(vllm): allow vllm_distributed on more than two hosts

### DIFF
--- a/cvs/input/config_file/inference/vllm/README.md
+++ b/cvs/input/config_file/inference/vllm/README.md
@@ -24,7 +24,7 @@ is absent, but keeping one pair per directory avoids the trap entirely.
 | Mode | PP | Host behavior |
 |---|---|---|
 | `single` | 1 | first cluster host only |
-| `distributed` | 2 | exactly two cluster hosts form one service |
+| `distributed` | from config | all cluster hosts form one service |
 
 For mapping-style `node_dict`, "first cluster host" means the first JSON key in
 insertion order. `vllm_single` scopes the cluster to that host and rewrites
@@ -36,8 +36,10 @@ TP is **per model**, following the source workload list: TP=4 for
 everything else. A TP=4 distributed variant still spans 2 nodes via PP=2,
 using 4 GPUs per node.
 
-Distributed configs support one-host fallback or exactly two hosts. CVS rejects
-larger clusters until a matching N-host recipe and threshold set are available.
+Distributed configs use every host in the cluster file, with one-host fallback
+when only a single host is present. Packaged recipes set PP=2 for two-host
+runs; align `pipeline_parallel_size` and thresholds with your host count
+before treating a larger cluster as pass/fail.
 
 ## Sweeps
 

--- a/cvs/lib/inference/unittests/test_vllm_topology.py
+++ b/cvs/lib/inference/unittests/test_vllm_topology.py
@@ -2,7 +2,7 @@ import unittest
 from types import SimpleNamespace
 
 from cvs.cli_plugins.list_plugin import ListPlugin
-from cvs.lib.inference.vllm_topology import build_vllm_targets, resolve_vllm_topology, scope_vllm_cluster
+from cvs.lib.inference.vllm_topology import build_vllm_targets, scope_vllm_cluster
 
 
 def _variant(pp="1", ray=False, ib_netdev=None, env=None):
@@ -46,9 +46,12 @@ class TestVllmTopology(unittest.TestCase):
         self.assertEqual(targets, (("node0", "node1"),))
         self.assertEqual(pp, 2)
 
-    def test_distributed_rejects_more_than_two_hosts(self):
-        with self.assertRaisesRegex(ValueError, "exactly two"):
-            resolve_vllm_topology("distributed", _variant(pp="2", ib_netdev="eth0"), ["node0", "node1", "node2"])
+    def test_distributed_uses_all_cluster_hosts(self):
+        variant = _variant(pp="4", env={"NCCL_SOCKET_IFNAME": "eno0"})
+        hosts = ["node0", "node1", "node2", "node3"]
+        targets, pp = build_vllm_targets("distributed", variant, hosts)
+        self.assertEqual(targets, (tuple(hosts),))
+        self.assertEqual(pp, 4)
 
     def test_distributed_one_host_uses_singleton_fallback(self):
         targets, pp = build_vllm_targets("distributed", _variant(pp="2"), ["node0"])

--- a/cvs/lib/inference/vllm_topology.py
+++ b/cvs/lib/inference/vllm_topology.py
@@ -68,11 +68,6 @@ def resolve_vllm_topology(mode, variant, hosts) -> EffectiveVllmTopology:
         raise ValueError(f"unknown vLLM mode: {mode!r}")
     if len(hosts) == 1:
         return EffectiveVllmTopology("single", hosts, 1)
-    if len(hosts) != 2:
-        raise ValueError(
-            "vllm_distributed currently supports exactly two cluster hosts; "
-            "add an explicit N-host recipe and thresholds before using a larger cluster"
-        )
 
     is_ray = variant.server_params.distributed_executor_backend == "ray"
     effective_pp = variant.server_params.pipeline_parallel_size

--- a/docs/how-to/test-suites/inference/vllm.rst
+++ b/docs/how-to/test-suites/inference/vllm.rst
@@ -6,7 +6,7 @@
 Run vLLM inference benchmarks
 *****************************
 
-The vLLM suites measure LLM serving throughput, latency, and accuracy on AMD Instinct GPUs. ``vllm_single`` runs on the first cluster host and ignores additional hosts. ``vllm_distributed`` supports one-host fallback or the current two-host distributed recipes; larger clusters require an explicit recipe and calibrated thresholds.
+The vLLM suites measure LLM serving throughput, latency, and accuracy on AMD Instinct GPUs. ``vllm_single`` runs on the first cluster host and ignores additional hosts. ``vllm_distributed`` uses every host in the cluster file, with one-host fallback when only a single host is present. Packaged distributed recipes and thresholds are calibrated for two hosts; retune them before treating other sizes as pass/fail.
 
 For a mapping-style ``node_dict``, "first cluster host" is the first JSON key
 in insertion order. ``vllm_single`` rewrites ``head_node_dict.mgmt_ip`` to that
@@ -103,7 +103,7 @@ Step 3: Run the suite
     --html /tmp/cvs/vllm.html --self-contained-html \
     --log-file /tmp/cvs/cvs.log
 
-Use ``vllm_distributed`` for one distributed service across a two-host cluster:
+Use ``vllm_distributed`` for one distributed service across the cluster:
 
 .. code:: bash
 
@@ -145,7 +145,7 @@ A skipped ``test_setup_sshd`` row is expected. vLLM communicates over the host n
 Going multinode
 ===============
 
-The cluster file determines the host count. Current distributed recipes support exactly two hosts, or one-host fallback. For distributed runs, configure ``server_params.pipeline_parallel_size`` and the HCA, socket-interface, and GID settings under ``container.env``. CVS derives the rendezvous address from the cluster head.
+The cluster file determines the host count: ``vllm_distributed`` forms one service from every listed host, or falls back to a single-node run when only one host is present. For distributed runs, configure ``server_params.pipeline_parallel_size`` to match the intended layout and set the HCA, socket-interface, and GID settings under ``container.env``. CVS derives the rendezvous address from the cluster head. Packaged configs use two hosts and ``pipeline_parallel_size`` of 2.
 
 Using the default backend (mp)
 ------------------------------

--- a/docs/reference/configuration-files/inference/vllm.rst
+++ b/docs/reference/configuration-files/inference/vllm.rst
@@ -6,7 +6,7 @@
 vLLM inference configuration file
 **********************************
 
-The vLLM suites benchmark LLM serving throughput, latency, and accuracy on AMD Instinct GPUs. ``vllm_single`` runs on the first cluster host and ignores additional hosts. ``vllm_distributed`` supports one-host fallback or the current two-host distributed recipes. Larger clusters require an explicit recipe and calibrated thresholds.
+The vLLM suites benchmark LLM serving throughput, latency, and accuracy on AMD Instinct GPUs. ``vllm_single`` runs on the first cluster host and ignores additional hosts. ``vllm_distributed`` uses every host in the cluster file, with one-host fallback when only a single host is present. Packaged distributed recipes and thresholds are calibrated for two hosts; retune them before treating other sizes as pass/fail.
 
 For a mapping-style ``node_dict``, "first cluster host" means the first JSON key
 in insertion order. ``vllm_single`` scopes execution to that host and rewrites
@@ -228,14 +228,14 @@ These rules are enforced when the configuration file loads, before anything star
 
    * - Condition
      - Rule
-   * - exactly two cluster hosts, backend is not ray
+   * - two or more cluster hosts, backend is not ray
      - ``pipeline_parallel_size`` **must** be greater than 1
-   * - exactly two cluster hosts, backend is ray
+   * - two or more cluster hosts, backend is ray
      - ``pipeline_parallel_size`` of 1 is valid
    * - ``pipeline_parallel_size`` > 1
      - The distributed suite requires more than one cluster host
-   * - exactly two cluster hosts, either backend
-     - ``container.env.NCCL_SOCKET_IFNAME`` is **required**; larger clusters are rejected until a dedicated recipe exists
+   * - two or more cluster hosts, either backend
+     - ``container.env.NCCL_SOCKET_IFNAME`` is **required**
 
 The corresponding error messages are:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the hard two-host cap on `vllm_distributed`.

`resolve_vllm_topology()` previously rejected any cluster with more than two hosts. The job path already derived `--nnodes` and per-rank `--node-rank` from the orchestrator host list, so the cap was the only blocker for 3+ node runs.

**Behavior now**
- One host: unchanged single-node fallback (`PP=1`)
- Two or more hosts: one distributed service across every cluster host
- Unchanged: mp still requires `pipeline_parallel_size > 1`; multi-host still requires `container.env.NCCL_SOCKET_IFNAME` (or the legacy `ib_netdev` fallback)

Packaged MI3xx/MI325X recipes remain two-host with `pipeline_parallel_size: 2`. Operators running a larger cluster need matching PP and calibrated thresholds; this PR does not add 4-node configs.

**Docs** updated in the vLLM how-to, config reference, and `cvs/input/config_file/inference/vllm/README.md`.

**Checks**: `make fmt-check`, `make lint`, and `make ut` (1825 tests) pass.


