### PR TITLE
Link ATOM README doc references as relative hyperlinks.

### DIFF
--- a/cvs/input/config_file/inference/atom/README.md
+++ b/cvs/input/config_file/inference/atom/README.md
@@ -2,8 +2,10 @@
 
 JSON variant and threshold files for the ``atom`` suite. Full documentation:
 
-- **Configuration reference:** `docs/reference/configuration-files/inference/atom.rst`
-- **How-to run:** `docs/how-to/test-suites/inference/atom.rst`
+- **Configuration reference:**
+  [`docs/reference/configuration-files/inference/atom.rst`](../../../../../docs/reference/configuration-files/inference/atom.rst)
+- **How-to run:**
+  [`docs/how-to/test-suites/inference/atom.rst`](../../../../../docs/how-to/test-suites/inference/atom.rst)
 
 ## Shipped inventory (lab-validated)
 

--- a/cvs/tests/inference/atom/README.md
+++ b/cvs/tests/inference/atom/README.md
@@ -2,5 +2,7 @@
 
 Pytest suite invoked as ``cvs run atom`` (``atom.py``, ``conftest.py``, ``_shared.py``). Full documentation:
 
-- **How to run:** `docs/how-to/test-suites/inference/atom.rst`
-- **Configuration reference:** `docs/reference/configuration-files/inference/atom.rst`
+- **How to run:**
+  [`docs/how-to/test-suites/inference/atom.rst`](../../../../docs/how-to/test-suites/inference/atom.rst)
+- **Configuration reference:**
+  [`docs/reference/configuration-files/inference/atom.rst`](../../../../docs/reference/configuration-files/inference/atom.rst)


### PR DESCRIPTION
fixed the hyperlinks in the atom readme files