### PR TITLE
feat(rvs): enable Run Deck for rvs_cvs

### DIFF
--- a/cvs/lib/health/__init__.py
+++ b/cvs/lib/health/__init__.py
@@ -1,0 +1,1 @@
+'''Health-suite helpers (RVS parsing and related).'''

--- a/cvs/lib/health/rvs_parsing.py
+++ b/cvs/lib/health/rvs_parsing.py
@@ -49,7 +49,7 @@ _IET_PASS = re.compile(
 )
 _BABEL_ROW = re.compile(
     r"^\s*(?P<gpu>\d+)\s+(?P<kernel>Read|Write|Copy|Mul|Add|Triad|Dot)\s+"
-    r"(?P<mbytes>[\d.]+)\s+(?P<max_mb>[\d.]+)\s+(?P<min_mb>[\d.]+)\s+(?P<avg_mb>[\d.]+)\s*$",
+    r"(?P<mbytes_s>[\d.]+)\s+(?P<min_sec>[\d.]+)\s+(?P<max_sec>[\d.]+)\s+(?P<avg_sec>[\d.]+)\s*$",
     re.I,
 )
 _MODULE_NAME = re.compile(r"Module name\s*:\s*(?P<module>\S+)", re.I)
@@ -190,7 +190,7 @@ def parse_rvs_output(text, node, module=None):
                     current_module or "babel",
                     current_action or kernel,
                     "babel_mbytes_s",
-                    float(m.group("avg_mb")),
+                    float(m.group("mbytes_s")),
                     "MB/s",
                     extra={"kernel": kernel},
                 )
@@ -223,10 +223,6 @@ def append_rvs_records(store, text, node, module=None, failed=None):
                 passed=None if failed is None else (not failed),
             )
         ]
-    elif failed is True:
-        for rec in recs:
-            if rec.get("passed") is None:
-                rec["passed"] = False
     elif failed is False:
         for rec in recs:
             if rec.get("passed") is None:

--- a/cvs/lib/health/rvs_parsing.py
+++ b/cvs/lib/health/rvs_parsing.py
@@ -1,0 +1,231 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Parse ROCm Validation Suite stdout into Run Deck records.
+
+Numeric lines follow the RVS user-guide RESULT formats (GST GFLOPS, PEBB/PBQT
+GBps duration, IET Power(W), BABEL kernel tables). Interval GST samples without
+a Target GFLOPS line are ignored.
+'''
+
+import re
+
+_TEST_MODULE = {
+    "gst_single": "gst",
+    "pebb_single": "pebb",
+    "pbqt_single": "pbqt",
+    "babel_stream": "babel",
+    "iet_stress": "iet",
+    "mem_test": "mem",
+    "level_config": "level",
+    "gpu_enumeration": "gpup",
+}
+
+_GST_FINAL = re.compile(
+    r"\[(?P<action>[^\]]+)\]\s*\[GPU::\s*(?P<gpu>\S+)\]\s*"
+    r"GFLOPS\s+(?P<value>[\d.]+)\s+Target GFLOPS:\s+(?P<target>[\d.]+)\s+"
+    r"met:\s*(?P<met>TRUE|FALSE)",
+    re.I,
+)
+_PEBB_DONE = re.compile(
+    r"\[(?P<action>[^\]]+)\]\s*pcie-bandwidth.*?\[GPU::\s*\S+\s*-\s*(?P<gpu>\S+)\s*-"
+    r".*?h2d::(?P<h2d>\S+)\s+d2h::(?P<d2h>\S+)\s+(?P<value>[\d.]+)\s+GBps\s+duration:",
+    re.I,
+)
+_PBQT_DONE = re.compile(
+    r"\[(?P<action>[^\]]+)\]\s*p2p-bandwidth.*?\[GPU::\s*\S+\s*-\s*(?P<src>\S+)\s*-"
+    r".*?\[GPU::\s*\S+\s*-\s*(?P<dst>\S+)\s*-.*?bidirectional:\s*(?P<bidi>\S+)\s+"
+    r"(?P<value>[\d.]+)\s+GBps\s+duration:",
+    re.I,
+)
+_IET_POWER = re.compile(
+    r"\[(?P<action>[^\]]+)\]\s*\[GPU::\s*(?P<gpu>\S+)\]\s*Power\(W\)\s+(?P<value>[\d.]+)",
+    re.I,
+)
+_IET_PASS = re.compile(
+    r"\[(?P<action>[^\]]+)\]\s*\[GPU::\s*(?P<gpu>\S+)\]\s*pass:\s*(?P<met>TRUE|FALSE)",
+    re.I,
+)
+_BABEL_ROW = re.compile(
+    r"^\s*(?P<gpu>\d+)\s+(?P<kernel>Read|Write|Copy|Mul|Add|Triad|Dot)\s+"
+    r"(?P<mbytes>[\d.]+)\s+(?P<max_mb>[\d.]+)\s+(?P<min_mb>[\d.]+)\s+(?P<avg_mb>[\d.]+)\s*$",
+    re.I,
+)
+_MODULE_NAME = re.compile(r"Module name\s*:\s*(?P<module>\S+)", re.I)
+_ACTION_NAME = re.compile(r"Action name\s*:\s*(?P<action>\S+)", re.I)
+_NO_GPUS = re.compile(r"No supported GPUs available", re.I)
+
+_BABEL_KERNELS = frozenset({"read", "write", "copy", "mul", "add", "triad", "dot"})
+
+
+def normalize_module(name):
+    if not name:
+        return ""
+    return _TEST_MODULE.get(name, name)
+
+
+def _row(node, gpu, module, action, metric, value, unit, target=None, passed=None, extra=None):
+    rec = {
+        "node": node,
+        "gpu": str(gpu) if gpu is not None else "",
+        "module": module or "",
+        "action": action or "",
+        "metric": metric,
+        "value": value,
+        "unit": unit,
+        "target": target,
+        "passed": passed,
+    }
+    if extra:
+        rec.update(extra)
+    return rec
+
+
+def _truthy(met):
+    return str(met).upper() == "TRUE"
+
+
+def parse_rvs_output(text, node, module=None):
+    """Return a list of metric records for one node's RVS stdout."""
+    module = normalize_module(module)
+    records = []
+    current_module = module
+    current_action = ""
+    iet_peak = {}
+
+    for raw in (text or "").splitlines():
+        line = raw.strip()
+        m = _MODULE_NAME.search(line)
+        if m:
+            current_module = normalize_module(m.group("module"))
+            continue
+        m = _ACTION_NAME.search(line)
+        if m:
+            current_action = m.group("action")
+            continue
+
+        m = _GST_FINAL.search(line)
+        if m:
+            records.append(
+                _row(
+                    node,
+                    m.group("gpu"),
+                    current_module or "gst",
+                    m.group("action").strip(),
+                    "gflops",
+                    float(m.group("value")),
+                    "GFLOPS",
+                    target=float(m.group("target")),
+                    passed=_truthy(m.group("met")),
+                )
+            )
+            continue
+
+        m = _PEBB_DONE.search(line)
+        if m:
+            records.append(
+                _row(
+                    node,
+                    m.group("gpu"),
+                    current_module or "pebb",
+                    m.group("action").strip(),
+                    "pcie_gbps",
+                    float(m.group("value")),
+                    "GB/s",
+                    extra={"h2d": m.group("h2d"), "d2h": m.group("d2h")},
+                )
+            )
+            continue
+
+        m = _PBQT_DONE.search(line)
+        if m:
+            src, dst = m.group("src"), m.group("dst")
+            records.append(
+                _row(
+                    node,
+                    src,
+                    current_module or "pbqt",
+                    m.group("action").strip(),
+                    "p2p_gbps",
+                    float(m.group("value")),
+                    "GB/s",
+                    extra={"dst": dst, "bidirectional": m.group("bidi")},
+                )
+            )
+            continue
+
+        m = _IET_POWER.search(line)
+        if m:
+            key = (m.group("gpu"), m.group("action").strip())
+            val = float(m.group("value"))
+            prev = iet_peak.get(key)
+            if prev is None or val > prev:
+                iet_peak[key] = val
+            continue
+
+        m = _IET_PASS.search(line)
+        if m:
+            records.append(
+                _row(
+                    node,
+                    m.group("gpu"),
+                    current_module or "iet",
+                    m.group("action").strip(),
+                    "status",
+                    None,
+                    "",
+                    passed=_truthy(m.group("met")),
+                )
+            )
+            continue
+
+        m = _BABEL_ROW.match(line)
+        if m and m.group("kernel").lower() in _BABEL_KERNELS:
+            kernel = m.group("kernel")
+            records.append(
+                _row(
+                    node,
+                    m.group("gpu"),
+                    current_module or "babel",
+                    current_action or kernel,
+                    "babel_mbytes_s",
+                    float(m.group("avg_mb")),
+                    "MB/s",
+                    extra={"kernel": kernel},
+                )
+            )
+
+    for (gpu, action), peak in sorted(iet_peak.items()):
+        records.append(_row(node, gpu, current_module or "iet", action, "power_w", peak, "W"))
+
+    if _NO_GPUS.search(text or ""):
+        records.append(_row(node, "", current_module or "gpup", "enumerate", "status", None, "", passed=False))
+    elif (current_module or module) == "gpup" and not records:
+        records.append(_row(node, "", "gpup", "enumerate", "status", None, "", passed=True))
+
+    return records
+
+
+def append_rvs_records(store, text, node, module=None, failed=None):
+    """Append parsed records onto store['records']. Adds a status row when empty."""
+    recs = parse_rvs_output(text, node, module=module)
+    if not recs:
+        recs = [
+            _row(
+                node,
+                "",
+                normalize_module(module) or "rvs",
+                module or "rvs",
+                "status",
+                None,
+                "",
+                passed=None if failed is None else (not failed),
+            )
+        ]
+    elif failed:
+        for rec in recs:
+            if rec.get("passed") is None:
+                rec["passed"] = False
+    store.setdefault("records", []).extend(recs)
+    return recs

--- a/cvs/lib/health/rvs_parsing.py
+++ b/cvs/lib/health/rvs_parsing.py
@@ -160,8 +160,8 @@ def parse_rvs_output(text, node, module=None):
             key = (m.group("gpu"), m.group("action").strip())
             val = float(m.group("value"))
             prev = iet_peak.get(key)
-            if prev is None or val > prev:
-                iet_peak[key] = val
+            if prev is None or val > prev[0]:
+                iet_peak[key] = (val, current_module or "iet")
             continue
 
         m = _IET_PASS.search(line)
@@ -196,8 +196,8 @@ def parse_rvs_output(text, node, module=None):
                 )
             )
 
-    for (gpu, action), peak in sorted(iet_peak.items()):
-        records.append(_row(node, gpu, current_module or "iet", action, "power_w", peak, "W"))
+    for (gpu, action), (peak, iet_module) in sorted(iet_peak.items()):
+        records.append(_row(node, gpu, iet_module, action, "power_w", peak, "W"))
 
     if _NO_GPUS.search(text or ""):
         records.append(_row(node, "", current_module or "gpup", "enumerate", "status", None, "", passed=False))
@@ -223,9 +223,13 @@ def append_rvs_records(store, text, node, module=None, failed=None):
                 passed=None if failed is None else (not failed),
             )
         ]
-    elif failed:
+    elif failed is True:
         for rec in recs:
             if rec.get("passed") is None:
                 rec["passed"] = False
+    elif failed is False:
+        for rec in recs:
+            if rec.get("passed") is None:
+                rec["passed"] = True
     store.setdefault("records", []).extend(recs)
     return recs

--- a/cvs/lib/health/unittests/test_rvs_parsing.py
+++ b/cvs/lib/health/unittests/test_rvs_parsing.py
@@ -81,16 +81,29 @@ class TestParseRvsOutput(unittest.TestCase):
         self.assertEqual(len(status), 1)
         self.assertTrue(status[0]["passed"])
 
-    def test_babel_triad_row_uses_avg_column(self):
-        line = "42583 Triad 6031416.066 6031416.066 5879289.313 5950804.403"
+    def test_babel_row_uses_mbytes_sec_column(self):
+        line = "42583 Triad 4011893.551 0.00020 0.00035 0.00028"
         records = parse_rvs_output(line, "node1", module="babel")
         self.assertEqual(len(records), 1)
         rec = records[0]
         self.assertEqual(rec["gpu"], "42583")
         self.assertEqual(rec["action"], "Triad")
+        self.assertEqual(rec["kernel"], "Triad")
         self.assertEqual(rec["metric"], "babel_mbytes_s")
-        self.assertAlmostEqual(rec["value"], 5950804.403)
-        self.assertEqual(rec["unit"], "MB/s")
+
+    def test_babel_action_name_does_not_collapse_kernels(self):
+        text = "\n".join(
+            [
+                "Action name :babel-1",
+                "42583 Read 100.0 0.001 0.002 0.0015",
+                "42583 Triad 4011893.551 0.00020 0.00035 0.00028",
+            ]
+        )
+        records = parse_rvs_output(text, "node1", module="babel")
+        self.assertEqual([r["kernel"] for r in records], ["Read", "Triad"])
+        self.assertEqual({r["action"] for r in records}, {"babel-1"})
+        self.assertAlmostEqual(records[0]["value"], 100.0)
+        self.assertAlmostEqual(records[1]["value"], 4011893.551)
 
     def test_gpu_enumeration_no_supported_gpus(self):
         records = parse_rvs_output("No supported GPUs available", "node1", module="gpu_enumeration")
@@ -124,7 +137,24 @@ class TestAppendRvsRecords(unittest.TestCase):
         self.assertIsNone(recs[0]["passed"])
         self.assertEqual(store["records"], recs)
 
-    def test_append_failed_sets_passed_false_on_unset_records(self):
+    def test_append_failed_does_not_override_explicit_verdicts(self):
+        text = "\n".join(
+            [
+                "Module name :gst",
+                "[gst-Tflops] [GPU:: 11806] GFLOPS 100.0 Target GFLOPS: 5000.0 met: FALSE",
+                "[gst-Tflops] [GPU:: 42583] GFLOPS 6478.0 Target GFLOPS: 5000.0 met: TRUE",
+                "Module name :iet",
+                "[iet_stress] [GPU:: 42583] pass: TRUE",
+            ]
+        )
+        store = {}
+        recs = append_rvs_records(store, text, "node1", module="level_config", failed=True)
+        by_key = {(r["module"], r["gpu"], r["metric"]): r for r in recs}
+        self.assertFalse(by_key[("gst", "11806", "gflops")]["passed"])
+        self.assertTrue(by_key[("gst", "42583", "gflops")]["passed"])
+        self.assertTrue(by_key[("iet", "42583", "status")]["passed"])
+
+    def test_append_failed_leaves_unset_records_unmarked(self):
         line = (
             "[pcie_h2d_bandwidth] pcie-bandwidth [ 1/16] [CPU:: 0] "
             "[GPU:: 2 - 42583 - 0000:05:00.0] h2d::true d2h::false "
@@ -133,7 +163,7 @@ class TestAppendRvsRecords(unittest.TestCase):
         store = {}
         recs = append_rvs_records(store, line, "node1", module="pebb", failed=True)
         self.assertEqual(len(recs), 1)
-        self.assertFalse(recs[0]["passed"])
+        self.assertIsNone(recs[0]["passed"])
 
     def test_append_success_sets_passed_true_on_unset_records(self):
         line = (

--- a/cvs/lib/health/unittests/test_rvs_parsing.py
+++ b/cvs/lib/health/unittests/test_rvs_parsing.py
@@ -1,0 +1,125 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Unit tests for RVS stdout parsing in cvs/lib/health/rvs_parsing.py.
+'''
+
+import unittest
+
+from cvs.lib.health.rvs_parsing import append_rvs_records, parse_rvs_output
+
+
+class TestParseRvsOutput(unittest.TestCase):
+    def test_gst_final_line(self):
+        line = "[gst-Tflops-8K-trig-fp64] [GPU:: 42583] GFLOPS 6478.066983 Target GFLOPS: 5000.000000 met: TRUE"
+        records = parse_rvs_output(line, "node1", module="gst_single")
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["node"], "node1")
+        self.assertEqual(rec["gpu"], "42583")
+        self.assertEqual(rec["module"], "gst")
+        self.assertEqual(rec["action"], "gst-Tflops-8K-trig-fp64")
+        self.assertEqual(rec["metric"], "gflops")
+        self.assertAlmostEqual(rec["value"], 6478.066983)
+        self.assertEqual(rec["unit"], "GFLOPS")
+        self.assertAlmostEqual(rec["target"], 5000.0)
+        self.assertTrue(rec["passed"])
+
+    def test_gst_interval_line_without_target_ignored(self):
+        interval = "[gst-Tflops-8K-trig-fp64] [GPU:: 42583] GFLOPS 6100.123456"
+        final = "[gst-Tflops-8K-trig-fp64] [GPU:: 42583] GFLOPS 6478.066983 Target GFLOPS: 5000.000000 met: TRUE"
+        records = parse_rvs_output("\n".join([interval, final]), "node1", module="gst")
+        self.assertEqual(len(records), 1)
+        self.assertAlmostEqual(records[0]["value"], 6478.066983)
+
+    def test_pebb_duration_line(self):
+        line = (
+            "[pcie_h2d_bandwidth] pcie-bandwidth [ 1/16] [CPU:: 0] "
+            "[GPU:: 2 - 42583 - 0000:05:00.0] h2d::true d2h::false "
+            "57.678 GBps duration: 0.223392 secs"
+        )
+        records = parse_rvs_output(line, "node1", module="pebb")
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["gpu"], "42583")
+        self.assertEqual(rec["metric"], "pcie_gbps")
+        self.assertAlmostEqual(rec["value"], 57.678)
+        self.assertEqual(rec["unit"], "GB/s")
+        self.assertEqual(rec["h2d"], "true")
+        self.assertEqual(rec["d2h"], "false")
+
+    def test_pbqt_duration_line(self):
+        line = (
+            "[xgmi_d2d_unidir_bandwidth] p2p-bandwidth[48/56] "
+            "[GPU:: 8 - 11806 - 0000:e5:00.0] [GPU:: 7 - 51771 - 0000:95:00.0] "
+            "bidirectional: false 61.370 GBps duration: 0.227452 secs"
+        )
+        records = parse_rvs_output(line, "node1", module="pbqt")
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["gpu"], "11806")
+        self.assertEqual(rec["metric"], "p2p_gbps")
+        self.assertAlmostEqual(rec["value"], 61.370)
+        self.assertEqual(rec["dst"], "51771")
+        self.assertEqual(rec["bidirectional"], "false")
+
+    def test_iet_power_peak_and_pass(self):
+        text = "\n".join(
+            [
+                "[iet_stress] [GPU:: 42583] Power(W) 210.5",
+                "[iet_stress] [GPU:: 42583] Power(W) 245.8",
+                "[iet_stress] [GPU:: 42583] Power(W) 230.1",
+                "[iet_stress] [GPU:: 42583] pass: TRUE",
+            ]
+        )
+        records = parse_rvs_output(text, "node1", module="iet")
+        power = [r for r in records if r["metric"] == "power_w"]
+        status = [r for r in records if r["metric"] == "status"]
+        self.assertEqual(len(power), 1)
+        self.assertAlmostEqual(power[0]["value"], 245.8)
+        self.assertEqual(len(status), 1)
+        self.assertTrue(status[0]["passed"])
+
+    def test_babel_triad_row_uses_avg_column(self):
+        line = "42583 Triad 6031416.066 6031416.066 5879289.313 5950804.403"
+        records = parse_rvs_output(line, "node1", module="babel")
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["gpu"], "42583")
+        self.assertEqual(rec["action"], "Triad")
+        self.assertEqual(rec["metric"], "babel_mbytes_s")
+        self.assertAlmostEqual(rec["value"], 5950804.403)
+        self.assertEqual(rec["unit"], "MB/s")
+
+    def test_gpu_enumeration_no_supported_gpus(self):
+        records = parse_rvs_output("No supported GPUs available", "node1", module="gpu_enumeration")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["module"], "gpup")
+        self.assertEqual(records[0]["metric"], "status")
+        self.assertFalse(records[0]["passed"])
+
+
+class TestAppendRvsRecords(unittest.TestCase):
+    def test_append_empty_output_adds_status_row(self):
+        store = {}
+        recs = append_rvs_records(store, "", "node1", module="gst_single")
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["metric"], "status")
+        self.assertIsNone(recs[0]["passed"])
+        self.assertEqual(store["records"], recs)
+
+    def test_append_failed_sets_passed_false_on_unset_records(self):
+        line = (
+            "[pcie_h2d_bandwidth] pcie-bandwidth [ 1/16] [CPU:: 0] "
+            "[GPU:: 2 - 42583 - 0000:05:00.0] h2d::true d2h::false "
+            "57.678 GBps duration: 0.223392 secs"
+        )
+        store = {}
+        recs = append_rvs_records(store, line, "node1", module="pebb", failed=True)
+        self.assertEqual(len(recs), 1)
+        self.assertFalse(recs[0]["passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/health/unittests/test_rvs_parsing.py
+++ b/cvs/lib/health/unittests/test_rvs_parsing.py
@@ -100,6 +100,22 @@ class TestParseRvsOutput(unittest.TestCase):
         self.assertFalse(records[0]["passed"])
 
 
+    def test_iet_power_keeps_iet_module_after_later_module_line(self):
+        text = "\n".join(
+            [
+                "Module name :iet",
+                "[iet-stress-1400W-true] [GPU:: 42583] Power(W) 241.0",
+                "Module name :gst",
+                "[gst-Tflops-8K-trig-fp64] [GPU:: 42583] GFLOPS 100.0 Target GFLOPS: 50.0 met: TRUE",
+            ]
+        )
+        records = parse_rvs_output(text, "node1", module="level_config")
+        power = [r for r in records if r["metric"] == "power_w"]
+        self.assertEqual(len(power), 1)
+        self.assertEqual(power[0]["module"], "iet")
+        self.assertAlmostEqual(power[0]["value"], 241.0)
+
+
 class TestAppendRvsRecords(unittest.TestCase):
     def test_append_empty_output_adds_status_row(self):
         store = {}
@@ -119,6 +135,17 @@ class TestAppendRvsRecords(unittest.TestCase):
         recs = append_rvs_records(store, line, "node1", module="pebb", failed=True)
         self.assertEqual(len(recs), 1)
         self.assertFalse(recs[0]["passed"])
+
+    def test_append_success_sets_passed_true_on_unset_records(self):
+        line = (
+            "[pcie_h2d_bandwidth] pcie-bandwidth [ 1/16] [CPU:: 0] "
+            "[GPU:: 2 - 42583 - 0000:05:00.0] h2d::true d2h::false "
+            "57.678 GBps duration: 0.223392 secs"
+        )
+        store = {}
+        recs = append_rvs_records(store, line, "node1", module="pebb", failed=False)
+        self.assertEqual(len(recs), 1)
+        self.assertTrue(recs[0]["passed"])
 
 
 if __name__ == "__main__":

--- a/cvs/lib/health/unittests/test_rvs_parsing.py
+++ b/cvs/lib/health/unittests/test_rvs_parsing.py
@@ -99,7 +99,6 @@ class TestParseRvsOutput(unittest.TestCase):
         self.assertEqual(records[0]["metric"], "status")
         self.assertFalse(records[0]["passed"])
 
-
     def test_iet_power_keeps_iet_module_after_later_module_line(self):
         text = "\n".join(
             [

--- a/cvs/lib/report/README.md
+++ b/cvs/lib/report/README.md
@@ -28,7 +28,7 @@ flowchart LR
 | Session store | `registry.py` |
 | Profile schema | `profiles/schema.json` |
 | Config resolution | `rundeck/config_adapter.py` |
-| Dataset builders | `rundeck/dataset_builders/` — `sweep`, `series`, `matrix` |
+| Dataset builders | `rundeck/dataset_builders/` — `sweep`, `series`, `matrix`, `rvs` |
 | Card runtime | `rundeck/runtime/` |
 | Publish entry | `rundeck/generate_rundeck.py` |
 
@@ -143,7 +143,7 @@ cvs/lib/report/
     render.py                # static HTML
     config_adapter.py        # JSON profile → RunDeckConfig
     viewer_config.py         # interactive viewer config
-    dataset_builders/        # sweep, series, matrix
+    dataset_builders/        # sweep, series, matrix, rvs
     runtime/                 # card components + theme
   profiles/schema.json
   pytest_hooks.py            # session fixture binding

--- a/cvs/lib/report/profiles/hooks/rvs_run_card.py
+++ b/cvs/lib/report/profiles/hooks/rvs_run_card.py
@@ -1,0 +1,19 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Run-card rows for the RVS health suite.
+'''
+
+from cvs.lib.report.rundeck.config_builder import provenance_link_rows
+
+
+def rvs_run_card_display(variant, provenance):
+    meta = variant if isinstance(variant, dict) else {}
+    rows = [
+        ("Suite", "RVS", False),
+        ("RVS version", str(meta.get("rvs_version") or "—"), False),
+        ("Test level", str(meta.get("rvs_test_level") if meta.get("rvs_test_level") is not None else "—"), False),
+    ]
+    rows.extend(provenance_link_rows(provenance or {}))
+    return rows

--- a/cvs/lib/report/profiles/rvs_cvs.json
+++ b/cvs/lib/report/profiles/rvs_cvs.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "profile_id": "rvs_cvs_rundeck",
+  "suite_id": "rvs",
+  "report_basename": "rvs_run_deck",
+  "title": "RVS Run Deck",
+  "subtitle": "ROCm Validation Suite · GPU health and performance",
+  "footer": "CVS rvs_cvs · render-only · does not affect gates",
+  "link_name": "RVS Run Deck",
+  "dataset_builder": "rvs",
+  "interactive_viewer": false,
+  "tier_order": ["result"],
+  "sources": {
+    "results": "cvs_results_dict",
+    "variant": "variant_config"
+  },
+  "hooks": {
+    "run_card_display": "cvs.lib.report.profiles.hooks.rvs_run_card:rvs_run_card_display"
+  },
+  "cards": [
+    {"type": "run_card", "id": "run-card", "title": "Run card", "bind": "run_card_display"},
+    {"type": "gate_matrix", "id": "gates", "title": "Module results", "bind": "gate_matrix"},
+    {"type": "gate_heatmap", "bind": "gate_matrix", "when_empty": "hide"},
+    {
+      "type": "line_chart",
+      "id": "gst",
+      "title": "GST GFLOPS",
+      "bind": "datasets.rvs.charts.gst_gflops",
+      "when_empty": "hide",
+      "series": {"y_field": "gst_gflops", "unit": "GFLOPS", "x_label": "{x}"}
+    },
+    {
+      "type": "line_chart",
+      "id": "pebb",
+      "title": "PEBB PCIe bandwidth",
+      "bind": "datasets.rvs.charts.pebb_gbps",
+      "when_empty": "hide",
+      "series": {"y_field": "pebb_gbps", "unit": "GB/s", "x_label": "{x}"}
+    },
+    {
+      "type": "line_chart",
+      "id": "pbqt",
+      "title": "PBQT P2P bandwidth",
+      "bind": "datasets.rvs.charts.pbqt_gbps",
+      "when_empty": "hide",
+      "series": {"y_field": "pbqt_gbps", "unit": "GB/s", "x_label": "{x}"}
+    },
+    {
+      "type": "line_chart",
+      "id": "babel",
+      "title": "BABEL memory bandwidth",
+      "bind": "datasets.rvs.charts.babel_mbytes_s",
+      "when_empty": "hide",
+      "series": {"y_field": "babel_mbytes_s", "unit": "MB/s", "x_label": "{x}"}
+    },
+    {
+      "type": "line_chart",
+      "id": "iet",
+      "title": "IET peak power",
+      "bind": "datasets.rvs.charts.iet_power_w",
+      "when_empty": "hide",
+      "series": {"y_field": "iet_power_w", "unit": "W", "x_label": "{x}"}
+    },
+    {"type": "table", "id": "results", "title": "Full results", "bind": "results_table"}
+  ]
+}

--- a/cvs/lib/report/profiles/schema.json
+++ b/cvs/lib/report/profiles/schema.json
@@ -23,7 +23,7 @@
     "footer": { "type": "string" },
     "link_name": { "type": "string" },
     "extends": { "type": "string", "description": "Stem of another profile JSON to merge before this one (child wins)." },
-    "dataset_builder": { "enum": ["sweep", "series", "matrix"] },
+    "dataset_builder": { "enum": ["sweep", "series", "matrix", "rvs"] },
     "interactive_viewer": { "type": "boolean" },
     "viewer_cell_threshold": { "type": "integer", "minimum": 1 },
     "sources": {

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -81,7 +81,25 @@ class ProfileConfigResolver:
     def from_profile_dict(cls, profile: dict[str, Any]) -> InferenceReportConfig:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
-        if builder in ("series", "matrix"):
+        if builder in ("series", "matrix", "rvs"):
+            hooks = profile.get("hooks") or {}
+            kwargs = {}
+            if hooks.get("run_card_display"):
+                kwargs["run_card_display_builder"] = cls.import_callable(hooks["run_card_display"])
+            lifecycle = profile.get("lifecycle") or {}
+            if lifecycle.get("session_labels"):
+                kwargs["session_lifecycle_labels"] = tuple(lifecycle["session_labels"])
+            if profile.get("tier_order"):
+                kwargs["metric_tier_order"] = tuple(profile["tier_order"])
+            metric_units = {"bus_bw": "GB/s", "alg_bw": "GB/s"}
+            if builder == "rvs":
+                metric_units = {
+                    "gflops": "GFLOPS",
+                    "pcie_gbps": "GB/s",
+                    "p2p_gbps": "GB/s",
+                    "babel_mbytes_s": "MB/s",
+                    "power_w": "W",
+                }
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",
@@ -90,9 +108,10 @@ class ProfileConfigResolver:
                 footer=profile.get("footer") or "",
                 link_name=profile.get("link_name") or profile.get("title") or "Run Deck",
                 results_columns=(("Collective", None), ("Size", None), ("Bus BW", "bus_bw")),
-                metric_units={"bus_bw": "GB/s", "alg_bw": "GB/s"},
+                metric_units=metric_units,
                 tier_metric_specs=lambda _c, _t: {},
                 interactive_viewer=bool(profile.get("interactive_viewer", False)),
+                **kwargs,
             )
 
         hooks = profile.get("hooks") or {}

--- a/cvs/lib/report/rundeck/dataset_builders/__init__.py
+++ b/cvs/lib/report/rundeck/dataset_builders/__init__.py
@@ -1,3 +1,3 @@
 '''Normalize session data into ``datasets.*`` structures (no HTML).'''
 
-from cvs.lib.report.rundeck.dataset_builders import matrix, series, sweep  # noqa: F401
+from cvs.lib.report.rundeck.dataset_builders import matrix, rvs, series, sweep  # noqa: F401

--- a/cvs/lib/report/rundeck/dataset_builders/registry.py
+++ b/cvs/lib/report/rundeck/dataset_builders/registry.py
@@ -2,7 +2,7 @@
 Copyright 2025 Advanced Micro Devices, Inc.
 All rights reserved.
 
-Registry for Run Deck dataset builders (``sweep``, ``series``, ``matrix``).
+Registry for Run Deck dataset builders (``sweep``, ``series``, ``matrix``, ``rvs``).
 
 Builders are the Python extension point for new data shapes. Card types consume
 builder output; they are not builders themselves.

--- a/cvs/lib/report/rundeck/dataset_builders/rvs.py
+++ b/cvs/lib/report/rundeck/dataset_builders/rvs.py
@@ -1,0 +1,111 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+RVS dataset builder: module/GPU records → table, gate matrix, and bar charts.
+'''
+
+from cvs.lib.report.rundeck.dataset_builders.registry import register_dataset_builder
+
+_CHARTS = (
+    ("gflops", "gst_gflops"),
+    ("pcie_gbps", "pebb_gbps"),
+    ("p2p_gbps", "pbqt_gbps"),
+    ("babel_mbytes_s", "babel_mbytes_s"),
+    ("power_w", "iet_power_w"),
+)
+
+
+def _records(sources):
+    results = sources.get("results") or sources.get("cvs_results_dict") or {}
+    if isinstance(results, list):
+        return results
+    if isinstance(results, dict):
+        return list(results.get("records") or [])
+    return []
+
+
+def _gate_tier(rec):
+    passed = rec.get("passed")
+    if passed is True:
+        return "pass"
+    if passed is False:
+        return "fail"
+    return "record"
+
+
+def _gate_matrix(records):
+    grouped = {}
+    for rec in records:
+        label = " · ".join(p for p in (rec.get("node"), rec.get("module"), rec.get("gpu")) if p)
+        if not label:
+            continue
+        row = grouped.setdefault(
+            label,
+            {"label": label, "cell_id": label, "concurrency": 0, "tiers": {"result": "record"}},
+        )
+        tier = _gate_tier(rec)
+        cur = row["tiers"]["result"]
+        if tier == "fail" or cur == "fail":
+            row["tiers"]["result"] = "fail"
+        elif tier == "pass" and cur != "fail":
+            row["tiers"]["result"] = "pass"
+    return [grouped[k] for k in sorted(grouped)]
+
+
+def _series_for(records, metric):
+    by_action = {}
+    for rec in records:
+        if rec.get("metric") != metric or rec.get("value") is None:
+            continue
+        action = rec.get("action") or metric
+        by_action.setdefault(action, []).append(rec)
+    out = {}
+    for action, recs in by_action.items():
+        recs = sorted(recs, key=lambda r: (str(r.get("node")), str(r.get("gpu"))))
+        points = [(r.get("gpu") or i, r["value"]) for i, r in enumerate(recs)]
+        if points:
+            out[action] = [{"label": action, "points": points}]
+    return out
+
+
+def _table(records):
+    headers = ["Node", "GPU", "Module", "Action", "Metric", "Value", "Unit", "Target", "Pass"]
+    rows = []
+    for rec in records:
+        passed = rec.get("passed")
+        if passed is True:
+            pass_s = "TRUE"
+        elif passed is False:
+            pass_s = "FALSE"
+        else:
+            pass_s = "—"
+        val = rec.get("value")
+        tgt = rec.get("target")
+        rows.append(
+            [
+                rec.get("node") or "—",
+                rec.get("gpu") or "—",
+                rec.get("module") or "—",
+                rec.get("action") or "—",
+                rec.get("metric") or "—",
+                val if val is not None else "—",
+                rec.get("unit") or "—",
+                tgt if tgt is not None else "—",
+                pass_s,
+            ]
+        )
+    return {"headers": headers, "rows": rows}
+
+
+@register_dataset_builder("rvs")
+def build_rvs_datasets(sources, profile):
+    records = _records(sources)
+    charts = {chart_id: _series_for(records, metric) for metric, chart_id in _CHARTS}
+    return {
+        "records": records,
+        "charts": charts,
+        "gate_matrix": _gate_matrix(records),
+        "results_table": _table(records),
+        "metric_tier_order": tuple((profile or {}).get("tier_order") or ("result",)),
+    }

--- a/cvs/lib/report/rundeck/dataset_builders/rvs.py
+++ b/cvs/lib/report/rundeck/dataset_builders/rvs.py
@@ -53,20 +53,43 @@ def _gate_matrix(records):
     return [grouped[k] for k in sorted(grouped)]
 
 
+def _point_label(rec):
+    node = rec.get("node") or ""
+    gpu = rec.get("gpu") or ""
+    dst = rec.get("dst")
+    core = f"{gpu}->{dst}" if dst else gpu
+    if node and core:
+        return f"{node}/{core}"
+    return node or core or ""
+
+
+def _series_key(rec, metric):
+    if metric == "babel_mbytes_s":
+        return rec.get("kernel") or rec.get("action") or metric
+    return rec.get("action") or metric
+
+
 def _series_for(records, metric):
-    by_action = {}
+    by_key = {}
     for rec in records:
         if rec.get("metric") != metric or rec.get("value") is None:
             continue
-        action = rec.get("action") or metric
-        by_action.setdefault(action, []).append(rec)
+        by_key.setdefault(_series_key(rec, metric), []).append(rec)
     out = {}
-    for action, recs in by_action.items():
-        recs = sorted(recs, key=lambda r: (str(r.get("node")), str(r.get("gpu"))))
-        points = [(r.get("gpu") or i, r["value"]) for i, r in enumerate(recs)]
+    for key, recs in by_key.items():
+        recs = sorted(recs, key=lambda r: (str(r.get("node")), str(r.get("gpu")), str(r.get("dst") or "")))
+        points = [(_point_label(r) or i, r["value"]) for i, r in enumerate(recs)]
         if points:
-            out[action] = [{"label": action, "points": points}]
+            out[key] = [{"label": key, "points": points}]
     return out
+
+
+def _overall_status(records):
+    if any(rec.get("passed") is False for rec in records):
+        return "fail"
+    if any(rec.get("passed") is True for rec in records):
+        return "pass"
+    return "record"
 
 
 def _table(records):
@@ -107,5 +130,6 @@ def build_rvs_datasets(sources, profile):
         "charts": charts,
         "gate_matrix": _gate_matrix(records),
         "results_table": _table(records),
+        "overall_status": _overall_status(records),
         "metric_tier_order": tuple((profile or {}).get("tier_order") or ("result",)),
     }

--- a/cvs/lib/report/rundeck/payload.py
+++ b/cvs/lib/report/rundeck/payload.py
@@ -60,6 +60,7 @@ class RundeckPayloadBuilder:
             prov,
         )
 
+        primary = datasets.get(self.builder_id) or {}
         sweep_data = datasets.get("sweep") or {}
         cells = sweep_data.get("all_cells") or sweep_data.get("cells") or []
         panels = ComparisonPanelBuilder(
@@ -87,7 +88,7 @@ class RundeckPayloadBuilder:
                 "title": self.config.title,
                 "subtitle": self.config.subtitle,
                 "footer": self.config.footer,
-                "metric_tier_order": self.config.metric_tier_order,
+                "metric_tier_order": primary.get("metric_tier_order") or self.config.metric_tier_order,
                 "headline_metric": self.config.headline_metric,
                 "sweep_ttft_metric": self.config.sweep_ttft_metric,
                 "session_lifecycle_labels": self.config.session_lifecycle_labels,
@@ -102,8 +103,8 @@ class RundeckPayloadBuilder:
             "chart_series": sweep_data.get("chart_series") or {},
             "chart_config": sweep_data.get("chart_config") or [],
             "sweep_summaries": sweep_data.get("sweep_summaries") or [],
-            "gate_matrix": sweep_data.get("gate_matrix") or [],
-            "results_table": sweep_data.get("results_table") or datasets.get("series", {}).get("results_table") or {},
+            "gate_matrix": sweep_data.get("gate_matrix") or primary.get("gate_matrix") or [],
+            "results_table": sweep_data.get("results_table") or primary.get("results_table") or {},
             "panels": panels,
             "datasets": datasets,
             "deck_profile": self.profile_dict or {"cards": default_deck_cards()},

--- a/cvs/lib/report/rundeck/payload.py
+++ b/cvs/lib/report/rundeck/payload.py
@@ -83,7 +83,9 @@ class RundeckPayloadBuilder:
             "suite_id": self.config.suite_id,
             "generated_at": generated_at,
             "cvs_version": self.ctx.cvs_version,
-            "overall_status": sweep_data.get("overall_status") or ("record" if self.builder_id != "sweep" else "na"),
+            "overall_status": sweep_data.get("overall_status")
+            or primary.get("overall_status")
+            or ("record" if self.builder_id != "sweep" else "na"),
             "report": {
                 "title": self.config.title,
                 "subtitle": self.config.subtitle,

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -163,8 +163,10 @@ class DeckCardRenderer:
     def render_line_chart(self, _payload: dict, card: dict, data: Any) -> str:
         series_cfg = card.get("series") or {}
         y_field = series_cfg.get("y_field") or "bus_bw"
-        charts = data.get("charts") if isinstance(data, dict) else {}
-        raw = charts.get(y_field) if isinstance(charts, dict) else None
+        if isinstance(data, dict) and "charts" in data:
+            raw = (data.get("charts") or {}).get(y_field)
+        else:
+            raw = data
         entries: list = []
         if isinstance(raw, dict):
             for series_list in raw.values():
@@ -178,12 +180,15 @@ class DeckCardRenderer:
             return "<p class='muted'>No series data.</p>"
         parts = []
         title = card.get("title") or y_field
+        x_label = series_cfg.get("x_label") or "{x}"
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
             points = entry.get("points") or []
             label = entry.get("label") or title
-            part = self._charts.render_series_chart(str(label), points, series_cfg.get("unit") or "GB/s")
+            part = self._charts.render_series_chart(
+                str(label), points, series_cfg.get("unit") or "GB/s", x_label=x_label
+            )
             if part:
                 parts.append(part)
         return f"<div class='chart-grid'>{''.join(parts)}</div>" if parts else "<p class='muted'>No series data.</p>"

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -85,7 +85,10 @@ class SweepChartRenderer:
         x_labels = []
         for conc, val in points:
             h = self._bar_height_pct(val, min_val, max_val)
-            xlabel = x_label.format(x=conc)
+            try:
+                xlabel = x_label.format(x=conc)
+            except (KeyError, IndexError, ValueError):
+                xlabel = str(conc)
             tip = html.escape(f"{xlabel}: {fmt_num(val)} {unit}".strip())
             bars.append(
                 f"<div class='chart-col'>"
@@ -120,9 +123,12 @@ class SweepChartRenderer:
                 )
                 if not entry:
                     continue
+                points = entry.get("points") or []
+                if len(points) < 2:
+                    continue
                 part = self.render_bar_chart(
                     chart["title"],
-                    entry["points"],
+                    points,
                     chart["unit"],
                     accent=self._ACCENTS[idx % 3],
                 )

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -64,8 +64,9 @@ class SweepChartRenderer:
         unit: str,
         *,
         accent: str = "accent",
+        x_label: str = "C={x}",
     ) -> str:
-        if len(points) < 2:
+        if not points:
             return ""
         values = [p[1] for p in points]
         max_val = max(values) or 1.0
@@ -84,13 +85,14 @@ class SweepChartRenderer:
         x_labels = []
         for conc, val in points:
             h = self._bar_height_pct(val, min_val, max_val)
-            tip = html.escape(f"C={conc}: {fmt_num(val)} {unit}".strip())
+            xlabel = x_label.format(x=conc)
+            tip = html.escape(f"{xlabel}: {fmt_num(val)} {unit}".strip())
             bars.append(
                 f"<div class='chart-col'>"
                 f"<div class='chart-bar chart-bar-{accent} chart-has-tip' style='height:{h:.1f}%' "
                 f"data-tip='{tip}' tabindex='0' role='img' aria-label='{tip}'></div></div>"
             )
-            x_labels.append(f"<span class='chart-xlbl'>C={conc}</span>")
+            x_labels.append(f"<span class='chart-xlbl'>{html.escape(str(xlabel))}</span>")
         return (
             f"<div class='chart-panel'><h3>{html.escape(title)}</h3>"
             f"<div class='chart-viz'>"
@@ -138,12 +140,12 @@ class SweepChartRenderer:
             else "<p class='muted'>Concurrency charts need two or more points per sweep shape.</p>"
         )
 
-    def render_series_chart(self, title: str, points: list, unit: str) -> str:
+    def render_series_chart(self, title: str, points: list, unit: str, x_label: str = "C={x}") -> str:
         normalized = []
         for p in points:
             if isinstance(p, (list, tuple)) and len(p) >= 2:
                 normalized.append((p[0], p[1]))
-        return self.render_bar_chart(title, normalized, unit, accent="accent2")
+        return self.render_bar_chart(title, normalized, unit, accent="accent2", x_label=x_label)
 
 
 _DEFAULT_RENDERER = SweepChartRenderer()

--- a/cvs/lib/report/rundeck/unittests/test_dataset_builders_rvs.py
+++ b/cvs/lib/report/rundeck/unittests/test_dataset_builders_rvs.py
@@ -1,0 +1,109 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Unit tests for the RVS Run Deck dataset builder.
+'''
+
+import unittest
+
+from cvs.lib.report.rundeck.dataset_builders import rvs  # noqa: F401
+from cvs.lib.report.rundeck.dataset_builders.registry import build_datasets
+
+
+def _sample_records():
+    return [
+        {
+            "node": "node1",
+            "gpu": "42583",
+            "module": "gst",
+            "action": "gst-Tflops-8K-trig-fp64",
+            "metric": "gflops",
+            "value": 6478.0,
+            "unit": "GFLOPS",
+            "target": 5000.0,
+            "passed": True,
+        },
+        {
+            "node": "node1",
+            "gpu": "42583",
+            "module": "pebb",
+            "action": "pcie_h2d_bandwidth",
+            "metric": "pcie_gbps",
+            "value": 57.678,
+            "unit": "GB/s",
+            "passed": None,
+        },
+        {
+            "node": "node1",
+            "gpu": "11806",
+            "module": "pbqt",
+            "action": "xgmi_d2d_unidir_bandwidth",
+            "metric": "p2p_gbps",
+            "value": 61.37,
+            "unit": "GB/s",
+            "passed": None,
+        },
+        {
+            "node": "node1",
+            "gpu": "42583",
+            "module": "babel",
+            "action": "Triad",
+            "metric": "babel_mbytes_s",
+            "value": 5950804.403,
+            "unit": "MB/s",
+            "passed": None,
+        },
+        {
+            "node": "node1",
+            "gpu": "42583",
+            "module": "iet",
+            "action": "iet_stress",
+            "metric": "power_w",
+            "value": 245.8,
+            "unit": "W",
+            "passed": None,
+        },
+        {
+            "node": "node1",
+            "gpu": "42583",
+            "module": "iet",
+            "action": "iet_stress",
+            "metric": "status",
+            "value": None,
+            "unit": "",
+            "passed": False,
+        },
+    ]
+
+
+class TestRvsDatasetBuilder(unittest.TestCase):
+    def test_build_datasets_table_gate_matrix_and_charts(self):
+        sources = {"results": {"records": _sample_records()}}
+        profile = {"tier_order": ["result"]}
+        datasets = build_datasets("rvs", sources, profile)
+
+        table = datasets["results_table"]
+        self.assertEqual(
+            table["headers"],
+            ["Node", "GPU", "Module", "Action", "Metric", "Value", "Unit", "Target", "Pass"],
+        )
+        self.assertEqual(len(table["rows"]), len(_sample_records()))
+
+        tiers = {row["label"]: row["tiers"]["result"] for row in datasets["gate_matrix"]}
+        self.assertEqual(tiers["node1 · gst · 42583"], "pass")
+        self.assertEqual(tiers["node1 · iet · 42583"], "fail")
+
+        charts = datasets["charts"]
+        self.assertIn("gst_gflops", charts)
+        self.assertIn("pebb_gbps", charts)
+        self.assertIn("pbqt_gbps", charts)
+        self.assertIn("babel_mbytes_s", charts)
+        self.assertIn("iet_power_w", charts)
+        self.assertTrue(charts["gst_gflops"])
+        self.assertTrue(charts["pebb_gbps"])
+        self.assertEqual(datasets["metric_tier_order"], ("result",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/rundeck/unittests/test_dataset_builders_rvs.py
+++ b/cvs/lib/report/rundeck/unittests/test_dataset_builders_rvs.py
@@ -43,14 +43,16 @@ def _sample_records():
             "value": 61.37,
             "unit": "GB/s",
             "passed": None,
+            "dst": "51771",
         },
         {
             "node": "node1",
             "gpu": "42583",
             "module": "babel",
-            "action": "Triad",
+            "action": "babel-1",
+            "kernel": "Triad",
             "metric": "babel_mbytes_s",
-            "value": 5950804.403,
+            "value": 4011893.551,
             "unit": "MB/s",
             "passed": None,
         },
@@ -102,6 +104,12 @@ class TestRvsDatasetBuilder(unittest.TestCase):
         self.assertIn("iet_power_w", charts)
         self.assertTrue(charts["gst_gflops"])
         self.assertTrue(charts["pebb_gbps"])
+        gst_points = charts["gst_gflops"]["gst-Tflops-8K-trig-fp64"][0]["points"]
+        self.assertEqual(gst_points[0][0], "node1/42583")
+        self.assertIn("Triad", charts["babel_mbytes_s"])
+        pbqt_points = charts["pbqt_gbps"]["xgmi_d2d_unidir_bandwidth"][0]["points"]
+        self.assertEqual(pbqt_points[0][0], "node1/11806->51771")
+        self.assertEqual(datasets["overall_status"], "fail")
         self.assertEqual(datasets["metric_tier_order"], ("result",))
 
 

--- a/cvs/lib/report/rundeck/unittests/test_rvs_payload.py
+++ b/cvs/lib/report/rundeck/unittests/test_rvs_payload.py
@@ -1,0 +1,76 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Integration tests for the RVS Run Deck profile payload and HTML render path.
+'''
+
+import unittest
+
+from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.config_adapter import (
+    ProfileConfigResolver,
+    build_inference_config_from_profile,
+    resolve_report_config,
+)
+from cvs.lib.report.rundeck.payload import build_rundeck_payload
+from cvs.lib.report.rundeck.render import render_rundeck_html
+
+
+def _sample_records():
+    return [
+        {
+            "node": "node1",
+            "gpu": "42583",
+            "module": "gst",
+            "action": "gst-Tflops-8K-trig-fp64",
+            "metric": "gflops",
+            "value": 6478.0,
+            "unit": "GFLOPS",
+            "target": 5000.0,
+            "passed": True,
+        },
+        {
+            "node": "node1",
+            "gpu": "42583",
+            "module": "pebb",
+            "action": "pcie_h2d_bandwidth",
+            "metric": "pcie_gbps",
+            "value": 57.678,
+            "unit": "GB/s",
+            "passed": None,
+        },
+    ]
+
+
+class TestRvsRundeckPayload(unittest.TestCase):
+    def test_rvs_profile_resolves_without_sweep_hooks(self):
+        profile = load_json_profile("rvs_cvs")
+        self.assertIsNotNone(profile)
+        config = resolve_report_config(profile)
+        self.assertEqual(config.suite_id, "rvs")
+        self.assertEqual(ProfileConfigResolver.from_profile_dict(profile).suite_id, "rvs")
+        self.assertEqual(build_inference_config_from_profile(profile).suite_id, "rvs")
+
+    def test_rvs_payload_renders_core_panels(self):
+        from cvs.lib.report.rundeck.dataset_builders import rvs  # noqa: F401
+
+        profile = load_json_profile("rvs_cvs")
+        payload = build_rundeck_payload(
+            profile=profile,
+            store={
+                "cvs_results_dict": {"records": _sample_records()},
+                "variant_config": {"rvs_version": "2.3.1", "rvs_test_level": 1},
+                "lifecycle_report": {},
+            },
+            cvs_version="1.0.0",
+        )
+        self.assertEqual(payload["suite_id"], "rvs")
+        self.assertIn("rvs", payload["datasets"])
+        doc = render_rundeck_html(payload)
+        self.assertIn("RVS Run Deck", doc)
+        self.assertTrue("GST GFLOPS" in doc or "Full results" in doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/rundeck/unittests/test_rvs_payload.py
+++ b/cvs/lib/report/rundeck/unittests/test_rvs_payload.py
@@ -69,7 +69,9 @@ class TestRvsRundeckPayload(unittest.TestCase):
         self.assertIn("rvs", payload["datasets"])
         doc = render_rundeck_html(payload)
         self.assertIn("RVS Run Deck", doc)
-        self.assertTrue("GST GFLOPS" in doc or "Full results" in doc)
+        self.assertIn("GST GFLOPS", doc)
+        self.assertIn("Full results", doc)
+        self.assertEqual(payload["overall_status"], "pass")
 
 
 if __name__ == "__main__":

--- a/cvs/lib/report/unittests/test_auto_register.py
+++ b/cvs/lib/report/unittests/test_auto_register.py
@@ -34,6 +34,11 @@ class TestAutoRegister(unittest.TestCase):
         self.assertTrue(try_auto_register_suite_report(config))
         self.assertEqual(config._suite_report_config["suite_id"], "vllm")
 
+    def test_auto_register_loads_rvs_cvs_json_profile(self):
+        config = SimpleNamespace(_suite_name="rvs_cvs", _suite_report_config=None)
+        self.assertTrue(try_auto_register_suite_report(config))
+        self.assertEqual(config._suite_report_config["suite_id"], "rvs")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/tests/health/rvs_cvs.py
+++ b/cvs/tests/health/rvs_cvs.py
@@ -13,6 +13,7 @@ import json
 from packaging import version
 
 from cvs.lib.utils_lib import *
+from cvs.lib.health.rvs_parsing import append_rvs_records
 
 from cvs.lib import globals
 
@@ -54,6 +55,16 @@ def config_dict(config_file, cluster_dict):
 
     log.info("%s", config_dict)
     return config_dict
+
+
+@pytest.fixture(scope="module")
+def variant_config(rvs_version, rvs_test_level):
+    return {"rvs_version": rvs_version, "rvs_test_level": rvs_test_level}
+
+
+@pytest.fixture(scope="module")
+def cvs_results_dict():
+    return {"records": []}
 
 
 @pytest.fixture(scope="module")
@@ -401,7 +412,7 @@ def parse_rvs_test_results(test_config, out_dict):
             log.info(f'RVS {test_name} test passed on node {node}')
 
 
-def execute_rvs_test(orch, config_dict, test_name):
+def execute_rvs_test(orch, config_dict, test_name, cvs_results_dict=None):
     """
     Generic function to execute any RVS test.
 
@@ -409,6 +420,7 @@ def execute_rvs_test(orch, config_dict, test_name):
       orch: Orchestrator instance
       config_dict: RVS configuration dictionary
       test_name: Name of the test to execute
+      cvs_results_dict: Optional Run Deck session store
     """
     globals.error_list = []
 
@@ -477,6 +489,12 @@ def execute_rvs_test(orch, config_dict, test_name):
         print_test_output(log, out_dict)
         scan_test_results(out_dict)
 
+        fail_pattern = test_config.get('fail_regex_pattern', r'\[ERROR\s*\]')
+        if cvs_results_dict is not None:
+            for node, output in out_dict.items():
+                failed = bool(re.search(fail_pattern, output, re.I))
+                append_rvs_records(cvs_results_dict, output, node, module=test_name, failed=failed)
+
         # Parse and validate results
         parse_rvs_test_results(test_config, out_dict)
     else:
@@ -527,7 +545,7 @@ def parse_rvs_level_results(test_config, out_dict, level):
 ################################################################################
 
 
-def test_rvs_level_config(orch, config_dict, rvs_version, rvs_test_level):
+def test_rvs_level_config(orch, config_dict, rvs_version, rvs_test_level, cvs_results_dict):
     """
     Run RVS LEVEL-based configuration test.
     This test runs all RVS modules collectively using the -r (run level) option.
@@ -584,13 +602,19 @@ def test_rvs_level_config(orch, config_dict, rvs_version, rvs_test_level):
     print_test_output(log, out_dict)
     scan_test_results(out_dict)
 
+    fail_patterns = test_config.get('fail_regex_patterns', [])
+    if cvs_results_dict is not None:
+        for node, output in out_dict.items():
+            failed = any(re.search(p, output, re.I) for p in fail_patterns)
+            append_rvs_records(cvs_results_dict, output, node, module='level_config', failed=failed)
+
     # Parse and validate results
     parse_rvs_level_results(test_config, out_dict, rvs_test_level)
 
     update_test_result()
 
 
-def test_rvs_gpu_enumeration(orch, config_dict):
+def test_rvs_gpu_enumeration(orch, config_dict, cvs_results_dict):
     """
     Run RVS GPU enumeration test to detect and validate GPU presence.
     This is a basic connectivity and detection test.
@@ -611,13 +635,15 @@ def test_rvs_gpu_enumeration(orch, config_dict):
 
     # Validate that GPUs are detected
     for node in out_dict.keys():
-        if re.search(r'No supported GPUs available', out_dict[node], re.I):
+        failed = bool(re.search(r'No supported GPUs available', out_dict[node], re.I))
+        append_rvs_records(cvs_results_dict, out_dict[node], node, module='gpu_enumeration', failed=failed)
+        if failed:
             fail_test(f'No GPUs detected in RVS enumeration on node {node}')
 
     update_test_result()
 
 
-def test_rvs_mem_test(orch, config_dict, rvs_version, rvs_test_level):
+def test_rvs_mem_test(orch, config_dict, rvs_version, rvs_test_level, cvs_results_dict):
     """
     Run RVS Memory Test.
     This test validates GPU memory functionality and integrity.
@@ -634,10 +660,10 @@ def test_rvs_mem_test(orch, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_mem_test: {skip_reason}")
 
     test_name = 'mem_test'
-    execute_rvs_test(orch, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name, cvs_results_dict)
 
 
-def test_rvs_gst_single(orch, config_dict, rvs_version, rvs_test_level):
+def test_rvs_gst_single(orch, config_dict, rvs_version, rvs_test_level, cvs_results_dict):
     """
     Run RVS GST (GPU Stress Test) - Single GPU validation test.
     This test runs the GPU stress test configuration to validate GPU functionality
@@ -655,10 +681,10 @@ def test_rvs_gst_single(orch, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_gst_single: {skip_reason}")
 
     test_name = 'gst_single'
-    execute_rvs_test(orch, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name, cvs_results_dict)
 
 
-def test_rvs_iet_stress(orch, config_dict, rvs_version, rvs_test_level):
+def test_rvs_iet_stress(orch, config_dict, rvs_version, rvs_test_level, cvs_results_dict):
     """
     Run RVS IET (Peak Power Test) - Single GPU validation test.
     This test validates power consumption and thermal behavior under load.
@@ -675,10 +701,10 @@ def test_rvs_iet_stress(orch, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_iet_stress: {skip_reason}")
 
     test_name = 'iet_stress'
-    execute_rvs_test(orch, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name, cvs_results_dict)
 
 
-def test_rvs_pebb_single(orch, config_dict, rvs_version, rvs_test_level):
+def test_rvs_pebb_single(orch, config_dict, rvs_version, rvs_test_level, cvs_results_dict):
     """
     Run RVS PEBB (PCI Express Bandwidth Benchmark).
     This test measures and validates PCI Express bandwidth performance.
@@ -695,10 +721,10 @@ def test_rvs_pebb_single(orch, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_pebb_single: {skip_reason}")
 
     test_name = 'pebb_single'
-    execute_rvs_test(orch, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name, cvs_results_dict)
 
 
-def test_rvs_pbqt_single(orch, config_dict, rvs_version, rvs_test_level):
+def test_rvs_pbqt_single(orch, config_dict, rvs_version, rvs_test_level, cvs_results_dict):
     """
     Run RVS PBQT (P2P Benchmark and Qualification Tool).
     This test validates peer-to-peer communication between GPUs.
@@ -715,10 +741,10 @@ def test_rvs_pbqt_single(orch, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_pbqt_single: {skip_reason}")
 
     test_name = 'pbqt_single'
-    execute_rvs_test(orch, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name, cvs_results_dict)
 
 
-def test_rvs_babel_stream(orch, config_dict, rvs_version, rvs_test_level):
+def test_rvs_babel_stream(orch, config_dict, rvs_version, rvs_test_level, cvs_results_dict):
     """
     Run RVS BABEL Benchmark test.
     This test runs the BABEL streaming benchmark for GPU memory bandwidth validation.
@@ -735,4 +761,4 @@ def test_rvs_babel_stream(orch, config_dict, rvs_version, rvs_test_level):
         pytest.skip(f"test_rvs_babel_stream: {skip_reason}")
 
     test_name = 'babel_stream'
-    execute_rvs_test(orch, config_dict, test_name)
+    execute_rvs_test(orch, config_dict, test_name, cvs_results_dict)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a health-shaped Run Deck for `cvs run rvs_cvs`.

- Parses GST, PEBB, PBQT, BABEL, and IET RESULT lines without changing existing qualification gates.
- Adds module/GPU gate results, performance charts, and a full result table.
- Keeps the inference-only interactive viewer disabled.

Follow-up after review of replayed RVS stdout:
- BABEL charts the MBytes/sec column (not runtime seconds).
- A level-config fail regex no longer stamps every module failed; explicit `pass: TRUE` / `met: TRUE` rows stay.
- BABEL series split by kernel; bar labels include node/GPU (and PBQT src→dst).
- Deck `overall_status` comes from RVS records. Sweep charts keep a 2-point floor.

## Quality gates
Rebased on `main` (`b52ad313`).

- `make fmt-check` / `make lint`: clean
- unit tests: 1987 OK (1 skipped)

## Hardware validation
Not yet run. Requires `install_rvs` then `rvs_cvs` against the same `container.lifetime: persistent` container with a pinned `container.name`; the default `per_run` deletes the installed RVS between the two invocations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f68ab34f-cd89-48fe-b3ed-ea52c269bae6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f68ab34f-cd89-48fe-b3ed-ea52c269bae6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

