### PR TITLE
feat(rccl): enable Run Deck for perf, regression, and pairwise

### DIFF
--- a/cvs/lib/report/profile.py
+++ b/cvs/lib/report/profile.py
@@ -26,6 +26,9 @@ PROFILE_STEM_ALIASES: dict[str, str] = {
     "sglang_disagg_distributed": "sglang",
     "vllm_single": "vllm",
     "vllm_distributed": "vllm",
+    "rccl_perf": "rccl",
+    "rccl_regression": "rccl",
+    "rccl_pairwise": "rccl",
 }
 
 DEFAULT_SOURCES: dict[str, str] = {

--- a/cvs/lib/report/profiles/hooks/rccl_run_card.py
+++ b/cvs/lib/report/profiles/hooks/rccl_run_card.py
@@ -1,0 +1,49 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Run-card hook for RCCL perf, regression, and pairwise suite stems.
+'''
+
+from cvs.lib.report.rundeck.config_builder import provenance_link_rows, thresholds_run_card_row
+
+
+def _mpi_field(variant, key, default="\u2014"):
+    mpi = getattr(variant, "mpi_params", None) or {}
+    if isinstance(mpi, dict) and mpi.get(key) not in (None, ""):
+        return str(mpi[key])
+    return default
+
+
+def _test_field(variant, key, default="\u2014"):
+    params = getattr(variant, "rccl_test_params", None) or {}
+    if isinstance(params, dict) and params.get(key) not in (None, ""):
+        value = params[key]
+        if isinstance(value, list):
+            return ", ".join(str(item) for item in value)
+        return str(value)
+    return default
+
+
+def rccl_run_card_display(variant, provenance):
+    nnodes = getattr(variant, "nnodes", None)
+    rows = [
+        ("Framework", getattr(variant, "framework", None) or "rccl", False),
+        ("Nodes", str(nnodes) if nnodes not in (None, "") else "\u2014", False),
+        ("MPI nodes", _mpi_field(variant, "no_of_nodes"), False),
+        ("Local ranks", _mpi_field(variant, "no_of_local_ranks"), False),
+        ("Collectives", _test_field(variant, "rccl_collective"), False),
+        ("Msg size", f"{_test_field(variant, 'start_msg_size')} .. {_test_field(variant, 'end_msg_size')}", False),
+        thresholds_run_card_row(variant),
+    ]
+    nic = None
+    cvs_params = getattr(variant, "cvs_params", None) or {}
+    if isinstance(cvs_params, dict):
+        nic = cvs_params.get("nic_model")
+    if nic:
+        rows.insert(-1, ("NIC model", str(nic), False))
+    rows.extend(provenance_link_rows(provenance))
+    return rows
+
+
+__all__ = ["rccl_run_card_display"]

--- a/cvs/lib/report/profiles/hooks/rccl_session.py
+++ b/cvs/lib/report/profiles/hooks/rccl_session.py
@@ -13,7 +13,11 @@ from cvs.lib import rccl_lib
 def variant_from_config(config_dict, cluster_dict):
     node_dict = (cluster_dict or {}).get("node_dict") or {}
     cvs_params = (config_dict or {}).get("cvs_params") or {}
-    verify = str(cvs_params.get("verify_bus_bw") or "").lower() in ("true", "1", "yes")
+
+    def _on(key):
+        return str(cvs_params.get(key) or "").lower() in ("true", "1", "yes")
+
+    verify = _on("verify_bus_bw") or _on("verify_bw_dip") or _on("verify_lat_dip")
     return SimpleNamespace(
         framework="rccl",
         gpu_arch=(config_dict or {}).get("gpu_arch") or "\u2014",

--- a/cvs/lib/report/profiles/hooks/rccl_session.py
+++ b/cvs/lib/report/profiles/hooks/rccl_session.py
@@ -1,0 +1,32 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Shared Run Deck session helpers for RCCL suite stems.
+'''
+
+from types import SimpleNamespace
+
+from cvs.lib import rccl_lib
+
+
+def variant_from_config(config_dict, cluster_dict):
+    node_dict = (cluster_dict or {}).get("node_dict") or {}
+    cvs_params = (config_dict or {}).get("cvs_params") or {}
+    verify = str(cvs_params.get("verify_bus_bw") or "").lower() in ("true", "1", "yes")
+    return SimpleNamespace(
+        framework="rccl",
+        gpu_arch=(config_dict or {}).get("gpu_arch") or "\u2014",
+        nnodes=len(node_dict),
+        mpi_params=(config_dict or {}).get("mpi_params") or {},
+        rccl_test_params=(config_dict or {}).get("rccl_test_params") or {},
+        cvs_params=cvs_params,
+        enforce_thresholds=verify,
+    )
+
+
+def publish_graph(raw_results, store):
+    graph = rccl_lib.convert_to_graph_dict(raw_results or {})
+    store.clear()
+    store.update(graph)
+    return graph

--- a/cvs/lib/report/profiles/hooks/unittests/test_rccl_run_card.py
+++ b/cvs/lib/report/profiles/hooks/unittests/test_rccl_run_card.py
@@ -35,7 +35,7 @@ class TestRcclRunCard(unittest.TestCase):
             {
                 "mpi_params": {"no_of_nodes": "2"},
                 "rccl_test_params": {"start_msg_size": "1024"},
-                "cvs_params": {"verify_bus_bw": "True", "nic_model": "thor"},
+                "cvs_params": {"verify_bus_bw": "False", "verify_bw_dip": "True", "nic_model": "thor"},
             },
             {"node_dict": {"n0": {}, "n1": {}}},
         )

--- a/cvs/lib/report/profiles/hooks/unittests/test_rccl_run_card.py
+++ b/cvs/lib/report/profiles/hooks/unittests/test_rccl_run_card.py
@@ -1,0 +1,65 @@
+'''Unit tests for the RCCL Run Deck run-card hook.'''
+
+import unittest
+from types import SimpleNamespace
+
+from cvs.lib.report.profiles.hooks.rccl_run_card import rccl_run_card_display
+from cvs.lib.report.profiles.hooks.rccl_session import publish_graph, variant_from_config
+
+
+class TestRcclRunCard(unittest.TestCase):
+    def test_rows_include_mpi_and_collectives(self):
+        variant = SimpleNamespace(
+            framework="rccl",
+            nnodes=2,
+            mpi_params={"no_of_nodes": "2", "no_of_local_ranks": "8"},
+            rccl_test_params={
+                "rccl_collective": ["all_reduce_perf", "all_gather_perf"],
+                "start_msg_size": "1024",
+                "end_msg_size": "16g",
+            },
+            cvs_params={"nic_model": "thor", "verify_bus_bw": "False"},
+            enforce_thresholds=False,
+        )
+        rows = rccl_run_card_display(variant, {"pytest_html_path": "/tmp/report.html"})
+        labels = [label for label, _value, _link in rows]
+        self.assertIn("MPI nodes", labels)
+        self.assertIn("Collectives", labels)
+        self.assertIn("NIC model", labels)
+        self.assertIn("Pytest report", labels)
+        collectives = next(value for label, value, _link in rows if label == "Collectives")
+        self.assertIn("all_reduce_perf", collectives)
+
+    def test_variant_and_publish_graph(self):
+        variant = variant_from_config(
+            {
+                "mpi_params": {"no_of_nodes": "2"},
+                "rccl_test_params": {"start_msg_size": "1024"},
+                "cvs_params": {"verify_bus_bw": "True", "nic_model": "thor"},
+            },
+            {"node_dict": {"n0": {}, "n1": {}}},
+        )
+        self.assertEqual(variant.nnodes, 2)
+        self.assertTrue(variant.enforce_thresholds)
+
+        store = {"stale": 1}
+        raw = {
+            "all_reduce_perf": [
+                {
+                    "name": "all_reduce_perf",
+                    "size": 8,
+                    "inPlace": 0,
+                    "busBw": 1.5,
+                    "algBw": 1.2,
+                    "time": 10.0,
+                }
+            ]
+        }
+        graph = publish_graph(raw, store)
+        self.assertNotIn("stale", store)
+        self.assertEqual(graph["all_reduce_perf"][8]["bus_bw"], 1.5)
+        self.assertEqual(store["all_reduce_perf"][8]["bus_bw"], 1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/profiles/rccl.json
+++ b/cvs/lib/report/profiles/rccl.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "profile_id": "rccl_rundeck",
+  "suite_id": "rccl",
+  "report_basename": "rccl_run_deck",
+  "title": "RCCL Run Deck",
+  "subtitle": "RCCL · bus/algorithm bandwidth and latency vs message size",
+  "footer": "CVS rccl · render-only · does not affect gates",
+  "link_name": "RCCL Run Deck",
+  "dataset_builder": "series",
+  "interactive_viewer": false,
+  "sources": {
+    "results": "cvs_results_dict",
+    "variant": "variant_config"
+  },
+  "hooks": {
+    "run_card_display": "cvs.lib.report.profiles.hooks.rccl_run_card:rccl_run_card_display"
+  },
+  "series": {
+    "x_field": "size",
+    "y_fields": ["bus_bw", "alg_bw", "time"]
+  },
+  "cards": [
+    {"type": "run_card", "id": "run-card", "title": "Run card", "bind": "run_card_display"},
+    {
+      "type": "line_chart",
+      "id": "bus-bw",
+      "title": "Bus bandwidth vs message size",
+      "bind": "datasets.series",
+      "series": {"y_field": "bus_bw", "unit": "GB/s"}
+    },
+    {
+      "type": "line_chart",
+      "id": "alg-bw",
+      "title": "Algorithm bandwidth vs message size",
+      "bind": "datasets.series",
+      "series": {"y_field": "alg_bw", "unit": "GB/s"}
+    },
+    {
+      "type": "line_chart",
+      "id": "time",
+      "title": "Time vs message size",
+      "bind": "datasets.series",
+      "series": {"y_field": "time", "unit": "us"}
+    },
+    {"type": "table", "id": "results", "title": "Full results", "bind": "results_table"}
+  ]
+}

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -82,6 +82,12 @@ class ProfileConfigResolver:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
         if builder in ("series", "matrix"):
+            hooks = profile.get("hooks") or {}
+            extra = {}
+            if hooks.get("run_card_display"):
+                extra["run_card_display_builder"] = cls.import_callable(hooks["run_card_display"])
+            if hooks.get("launch_provenance"):
+                extra["launch_provenance_builder"] = cls.import_callable(hooks["launch_provenance"])
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",
@@ -93,6 +99,7 @@ class ProfileConfigResolver:
                 metric_units={"bus_bw": "GB/s", "alg_bw": "GB/s"},
                 tier_metric_specs=lambda _c, _t: {},
                 interactive_viewer=bool(profile.get("interactive_viewer", False)),
+                **extra,
             )
 
         hooks = profile.get("hooks") or {}

--- a/cvs/lib/report/rundeck/dataset_builders/series.py
+++ b/cvs/lib/report/rundeck/dataset_builders/series.py
@@ -12,6 +12,17 @@ from typing import Any
 from cvs.lib.report.rundeck.dataset_builders.registry import register_dataset_builder
 
 
+def _format_msg_size(size_key):
+    try:
+        n = int(size_key)
+    except (TypeError, ValueError):
+        return str(size_key)
+    for base, suffix in ((1 << 30, "G"), (1 << 20, "M"), (1 << 10, "K")):
+        if n >= base and n % base == 0:
+            return f"{n // base}{suffix}"
+    return str(n)
+
+
 def _graph_to_series(graph_dict: dict, *, y_field: str = "bus_bw") -> dict[str, list[dict]]:
     """Convert RCCL ``convert_to_graph_dict`` output to chart series."""
     series_by_name: dict[str, list[dict]] = {}
@@ -27,7 +38,7 @@ def _graph_to_series(graph_dict: dict, *, y_field: str = "bus_bw") -> dict[str, 
             if y_val is None:
                 continue
             try:
-                points.append((int(size_key), float(y_val)))
+                points.append((_format_msg_size(size_key), float(y_val)))
             except (TypeError, ValueError):
                 continue
         if points:

--- a/cvs/lib/report/rundeck/generate_rundeck.py
+++ b/cvs/lib/report/rundeck/generate_rundeck.py
@@ -104,7 +104,10 @@ class RundeckPublisher:
         )
 
         viewer_path = self._write_viewer(profile, config, out_dir, payload)
-        summary_path = write_inference_ci_summary(payload, config, out_dir)
+        builder_id = profile.get("dataset_builder", "sweep") if isinstance(profile, dict) else "sweep"
+        summary_path = None
+        if builder_id == "sweep":
+            summary_path = write_inference_ci_summary(payload, config, out_dir)
         artifacts = {
             "html": html_path_written,
             "json": json_path,
@@ -152,7 +155,8 @@ class RundeckPublisher:
             return
         self.report_manager.add_html_to_report(artifacts["html"], link_name=config.link_name)
         self.report_manager.add_html_to_report(artifacts["json"], link_name=f"{config.link_name} JSON")
-        self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
+        if artifacts.get("summary") is not None:
+            self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
         viewer = artifacts.get("viewer")
         if viewer is not None:
             self.report_manager.add_html_to_report(viewer, link_name=f"{config.link_name} viewer")

--- a/cvs/lib/report/rundeck/render.py
+++ b/cvs/lib/report/rundeck/render.py
@@ -79,7 +79,10 @@ def render_rundeck_html(payload: dict) -> str:
         if pending_gate_nav:
             nav_items.append(pending_gate_nav)
 
-    model_label = next((v for lbl, v, _ in payload.get("run_card_display", []) if lbl == "Model"), "run")
+    model_label = next((v for lbl, v, _ in payload.get("run_card_display", []) if lbl == "Model"), None)
+    if not model_label or str(model_label).strip() in ("—", "-", ""):
+        report_meta = payload.get("report") or {}
+        model_label = payload.get("suite_id") or report_meta.get("title") or "run"
     overall = payload.get("overall_status", "na")
     viewer_name = (payload.get("summary") or {}).get("viewer_html")
     prev_panel = (payload.get("panels") or {}).get("prev_run") or {}

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -183,7 +183,12 @@ class DeckCardRenderer:
                 continue
             points = entry.get("points") or []
             label = entry.get("label") or title
-            part = self._charts.render_series_chart(str(label), points, series_cfg.get("unit") or "GB/s")
+            part = self._charts.render_series_chart(
+                str(label),
+                points,
+                series_cfg.get("unit") or "GB/s",
+                x_label=series_cfg.get("x_label") or "{x}",
+            )
             if part:
                 parts.append(part)
         return f"<div class='chart-grid'>{''.join(parts)}</div>" if parts else "<p class='muted'>No series data.</p>"

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -64,8 +64,10 @@ class SweepChartRenderer:
         unit: str,
         *,
         accent: str = "accent",
+        x_label="C={x}",
+        min_points=2,
     ) -> str:
-        if len(points) < 2:
+        if len(points) < min_points:
             return ""
         values = [p[1] for p in points]
         max_val = max(values) or 1.0
@@ -84,13 +86,17 @@ class SweepChartRenderer:
         x_labels = []
         for conc, val in points:
             h = self._bar_height_pct(val, min_val, max_val)
-            tip = html.escape(f"C={conc}: {fmt_num(val)} {unit}".strip())
+            try:
+                xlabel = x_label.format(x=conc)
+            except (KeyError, IndexError, ValueError):
+                xlabel = str(conc)
+            tip = html.escape(f"{xlabel}: {fmt_num(val)} {unit}".strip())
             bars.append(
                 f"<div class='chart-col'>"
                 f"<div class='chart-bar chart-bar-{accent} chart-has-tip' style='height:{h:.1f}%' "
                 f"data-tip='{tip}' tabindex='0' role='img' aria-label='{tip}'></div></div>"
             )
-            x_labels.append(f"<span class='chart-xlbl'>C={conc}</span>")
+            x_labels.append(f"<span class='chart-xlbl'>{html.escape(str(xlabel))}</span>")
         return (
             f"<div class='chart-panel'><h3>{html.escape(title)}</h3>"
             f"<div class='chart-viz'>"
@@ -138,12 +144,12 @@ class SweepChartRenderer:
             else "<p class='muted'>Concurrency charts need two or more points per sweep shape.</p>"
         )
 
-    def render_series_chart(self, title: str, points: list, unit: str) -> str:
+    def render_series_chart(self, title: str, points: list, unit: str, x_label="{x}"):
         normalized = []
         for p in points:
             if isinstance(p, (list, tuple)) and len(p) >= 2:
                 normalized.append((p[0], p[1]))
-        return self.render_bar_chart(title, normalized, unit, accent="accent2")
+        return self.render_bar_chart(title, normalized, unit, accent="accent2", x_label=x_label, min_points=1)
 
 
 _DEFAULT_RENDERER = SweepChartRenderer()

--- a/cvs/lib/report/rundeck/unittests/test_rccl_payload.py
+++ b/cvs/lib/report/rundeck/unittests/test_rccl_payload.py
@@ -1,0 +1,58 @@
+'''Unit tests for RCCL series Run Deck payload and HTML.'''
+
+import unittest
+from types import SimpleNamespace
+
+from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.payload import build_rundeck_payload
+from cvs.lib.report.rundeck.render import render_rundeck_html
+
+
+def _graph():
+    return {
+        "all_reduce_perf": {
+            "1024": {"bus_bw": 12.5, "alg_bw": 11.0, "time": 100.0},
+            "2048": {"bus_bw": 40.0, "alg_bw": 36.0, "time": 180.0},
+        },
+        "all_gather_perf": {
+            "1024": {"bus_bw": 10.0, "alg_bw": 9.0, "time": 120.0},
+        },
+    }
+
+
+class TestRcclRundeckPayload(unittest.TestCase):
+    def test_payload_and_html_include_series_panels(self):
+        profile = load_json_profile("rccl")
+        self.assertIsNotNone(profile)
+        store = {
+            "cvs_results_dict": _graph(),
+            "variant_config": SimpleNamespace(
+                framework="rccl",
+                nnodes=2,
+                mpi_params={"no_of_nodes": "2", "no_of_local_ranks": "8"},
+                rccl_test_params={
+                    "rccl_collective": ["all_reduce_perf"],
+                    "start_msg_size": "1024",
+                    "end_msg_size": "16g",
+                },
+                cvs_params={"nic_model": "thor"},
+                enforce_thresholds=False,
+            ),
+        }
+        payload = build_rundeck_payload(profile=profile, store=store, cvs_version="1.0.0")
+        series = payload["datasets"]["series"]
+        self.assertIn("bus_bw", series["charts"])
+        self.assertTrue(series["results_table"]["rows"])
+        self.assertEqual(payload["results_table"]["headers"][0], "Collective")
+
+        doc = render_rundeck_html(payload)
+        self.assertIn("RCCL Run Deck", doc)
+        self.assertIn("Bus bandwidth vs message size", doc)
+        self.assertIn("Algorithm bandwidth vs message size", doc)
+        self.assertIn("Time vs message size", doc)
+        self.assertIn("all_reduce_perf", doc)
+        self.assertIn("Full results", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/rundeck/unittests/test_rccl_payload.py
+++ b/cvs/lib/report/rundeck/unittests/test_rccl_payload.py
@@ -4,6 +4,7 @@ import unittest
 from types import SimpleNamespace
 
 from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.dataset_builders import series  # noqa: F401
 from cvs.lib.report.rundeck.payload import build_rundeck_payload
 from cvs.lib.report.rundeck.render import render_rundeck_html
 
@@ -11,11 +12,11 @@ from cvs.lib.report.rundeck.render import render_rundeck_html
 def _graph():
     return {
         "all_reduce_perf": {
-            "1024": {"bus_bw": 12.5, "alg_bw": 11.0, "time": 100.0},
-            "2048": {"bus_bw": 40.0, "alg_bw": 36.0, "time": 180.0},
+            1024: {"bus_bw": 12.5, "alg_bw": 11.0, "time": 100.0},
+            2048: {"bus_bw": 40.0, "alg_bw": 36.0, "time": 180.0},
         },
         "all_gather_perf": {
-            "1024": {"bus_bw": 10.0, "alg_bw": 9.0, "time": 120.0},
+            1024: {"bus_bw": 10.0, "alg_bw": 9.0, "time": 120.0},
         },
     }
 
@@ -40,10 +41,13 @@ class TestRcclRundeckPayload(unittest.TestCase):
             ),
         }
         payload = build_rundeck_payload(profile=profile, store=store, cvs_version="1.0.0")
-        series = payload["datasets"]["series"]
-        self.assertIn("bus_bw", series["charts"])
-        self.assertTrue(series["results_table"]["rows"])
+        series_ds = payload["datasets"]["series"]
+        self.assertIn("bus_bw", series_ds["charts"])
+        self.assertTrue(series_ds["results_table"]["rows"])
         self.assertEqual(payload["results_table"]["headers"][0], "Collective")
+        labels = [row[0] for row in payload["run_card_display"]]
+        self.assertIn("MPI nodes", labels)
+        self.assertIn("Collectives", labels)
 
         doc = render_rundeck_html(payload)
         self.assertIn("RCCL Run Deck", doc)
@@ -52,6 +56,9 @@ class TestRcclRundeckPayload(unittest.TestCase):
         self.assertIn("Time vs message size", doc)
         self.assertIn("all_reduce_perf", doc)
         self.assertIn("Full results", doc)
+        self.assertIn("1K", doc)
+        self.assertNotIn("C=1024", doc)
+        self.assertIn("<title>RCCL Run Deck &mdash; rccl</title>", doc)
 
 
 if __name__ == "__main__":

--- a/cvs/lib/report/unittests/test_auto_register.py
+++ b/cvs/lib/report/unittests/test_auto_register.py
@@ -29,6 +29,12 @@ class TestAutoRegister(unittest.TestCase):
         self.assertTrue(try_auto_register_suite_report(config))
         self.assertEqual(config._suite_report_config["suite_id"], "sglang")
 
+    def test_auto_register_loads_rccl_perf_alias(self):
+        config = SimpleNamespace(_suite_name="rccl_perf", _suite_report_config=None)
+        self.assertTrue(try_auto_register_suite_report(config))
+        self.assertEqual(config._suite_report_config["suite_id"], "rccl")
+        self.assertEqual(config._suite_report_config["dataset_builder"], "series")
+
     def test_auto_register_loads_vllm_json_profile(self):
         config = SimpleNamespace(_suite_name="vllm", _suite_report_config=None)
         self.assertTrue(try_auto_register_suite_report(config))

--- a/cvs/lib/report/unittests/test_profile.py
+++ b/cvs/lib/report/unittests/test_profile.py
@@ -16,6 +16,17 @@ class TestProfile(unittest.TestCase):
         )
         self.assertEqual(sources_for_profile(cfg), DEFAULT_SOURCES)
 
+    def test_rccl_stems_share_one_profile(self):
+        for stem in ("rccl", "rccl_perf", "rccl_regression", "rccl_pairwise"):
+            profile = load_json_profile(stem)
+            self.assertIsNotNone(profile, stem)
+            self.assertEqual(profile["suite_id"], "rccl")
+            self.assertEqual(profile["dataset_builder"], "series")
+            self.assertEqual(
+                profile["hooks"]["run_card_display"],
+                "cvs.lib.report.profiles.hooks.rccl_run_card:rccl_run_card_display",
+            )
+
     def test_sglang_stems_share_one_profile(self):
         for stem in ("sglang_single", "sglang_distributed", "sglang_disagg_distributed"):
             profile = load_json_profile(stem)

--- a/cvs/tests/rccl/rccl_pairwise.py
+++ b/cvs/tests/rccl/rccl_pairwise.py
@@ -6,8 +6,21 @@ from cvs.lib.parallel_ssh_lib import *
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 from cvs.lib import globals
+from cvs.lib.report.profiles.hooks.rccl_session import publish_graph, variant_from_config
 
 log = globals.log
+
+rccl_res_dict = {}
+
+
+@pytest.fixture(scope="module")
+def cvs_results_dict():
+    return {}
+
+
+@pytest.fixture(scope="module")
+def variant_config(config_dict, cluster_dict):
+    return variant_from_config(config_dict, cluster_dict)
 
 
 @pytest.fixture(scope="module")
@@ -126,6 +139,8 @@ def run_pairwise_rccl(phdl, shdl, node_pair_vpc, node_pair_mgmt, config_dict, ph
             node_pair_vpc,  # vpc_node_list       (passed to mpirun -H)
         )
         log.info('Pairwise result for %s: %s', phase_label, result_dict)
+        if result_dict:
+            rccl_res_dict[phase_label] = result_dict
     except Exception as exc:
         log.error('Pairwise RCCL failed for %s: %s', phase_label, exc)
         return None, False
@@ -448,3 +463,10 @@ def test_rccl_incremental(phdl, shdl, cluster_dict, config_dict, vpc_node_list):
     )
 
     update_test_result()
+
+
+def test_gen_graph(cvs_results_dict):
+    log.info('Final pairwise result dict')
+    log.info("%s", rccl_res_dict)
+    graph = publish_graph(rccl_res_dict, cvs_results_dict)
+    log.info("%s", graph)

--- a/cvs/tests/rccl/rccl_perf.py
+++ b/cvs/tests/rccl/rccl_perf.py
@@ -21,6 +21,7 @@ from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 
 from cvs.lib import globals
+from cvs.lib.report.profiles.hooks.rccl_session import publish_graph, variant_from_config
 
 log = globals.log
 
@@ -29,6 +30,16 @@ rccl_res_dict = {}
 
 
 # Importing additional cmd line args to script ..
+@pytest.fixture(scope="module")
+def cvs_results_dict():
+    return {}
+
+
+@pytest.fixture(scope="module")
+def variant_config(config_dict, cluster_dict):
+    return variant_from_config(config_dict, cluster_dict)
+
+
 @pytest.fixture(scope="module")
 def cluster_file(pytestconfig):
     """
@@ -370,10 +381,10 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective):
     update_test_result()
 
 
-def test_gen_graph(request):
+def test_gen_graph(request, cvs_results_dict):
     log.info('Final Global result dict')
     log.info("%s", rccl_res_dict)
-    rccl_graph_dict = rccl_lib.convert_to_graph_dict(rccl_res_dict)
+    rccl_graph_dict = publish_graph(rccl_res_dict, cvs_results_dict)
     log.info("%s", rccl_graph_dict)
 
     proc_id = os.getpid()

--- a/cvs/tests/rccl/rccl_regression.py
+++ b/cvs/tests/rccl/rccl_regression.py
@@ -19,6 +19,7 @@ from cvs.lib.parallel_ssh_lib import *
 from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 from cvs.lib import globals
+from cvs.lib.report.profiles.hooks.rccl_session import publish_graph, variant_from_config
 
 log = globals.log
 
@@ -27,6 +28,16 @@ rccl_res_dict = {}
 
 
 # Importing additional cmd line args to script ..
+@pytest.fixture(scope="module")
+def cvs_results_dict():
+    return {}
+
+
+@pytest.fixture(scope="module")
+def variant_config(config_dict, cluster_dict):
+    return variant_from_config(config_dict, cluster_dict)
+
+
 @pytest.fixture(scope="module")
 def cluster_file(pytestconfig):
     """
@@ -444,10 +455,10 @@ def test_rccl_perf(phdl, shdl, cluster_dict, config_dict, rccl_collective, regre
     update_test_result()
 
 
-def test_gen_graph(request):
+def test_gen_graph(request, cvs_results_dict):
     log.info('Final Global result dict')
     log.info("%s", rccl_res_dict)
-    rccl_graph_dict = rccl_lib.convert_to_graph_dict(rccl_res_dict)
+    rccl_graph_dict = publish_graph(rccl_res_dict, cvs_results_dict)
     log.info("%s", rccl_graph_dict)
 
     proc_id = os.getpid()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a series-shaped Run Deck for `cvs run rccl_perf`, `rccl_regression`, and `rccl_pairwise` (shared `profiles/rccl.json` plus stem aliases).

## Plan / code surfaces
- Profile auto-load via `PROFILE_STEM_ALIASES` → `rccl.json`
- Session fixtures `cvs_results_dict` + `variant_config`; `test_gen_graph` publishes `convert_to_graph_dict` output
- Pairwise also records per-phase `all_reduce_perf` lists into the same graph store
- Existing amCharts HTML reports are unchanged; this is an extra dashboard at session finish

## Graphs
- Bus bandwidth vs message size (one series per collective / pairwise phase)
- Algorithm bandwidth vs message size
- Time vs message size
- Full results table (collective, size, bus BW, alg BW, time)
- Run card: nodes, MPI ranks, collectives, msg-size range, NIC model

Qualification gates are not changed. Interactive inference viewer is off.

## Review follow-up (`4be52260`)
- Series/matrix profiles now load `hooks.run_card_display` (and launch provenance)
- Message-size ticks are humanized (`1K`) instead of inference `C=` labels
- `hooks/unittests/__init__.py` so `test_rccl_run_card.py` is collected
- Thresholds row treats `verify_bus_bw` / `verify_bw_dip` / `verify_lat_dip`
- Inference CI summary sidecar is skipped for non-sweep builders
- Document title falls back to `suite_id` when Model is empty

## Quality
- `make fmt-check` / `make lint`: clean
- Targeted report unittests: 119 OK

Hardware not run. Draft — do not merge yet.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bd374b-7c5a-4d24-be58-368133af2219?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bd374b-7c5a-4d24-be58-368133af2219&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

