### PR TITLE
feat(ibperf): enable Run Deck for ib_perf_bw_test

### DIFF
--- a/cvs/lib/report/profiles/hooks/ibperf_run_card.py
+++ b/cvs/lib/report/profiles/hooks/ibperf_run_card.py
@@ -1,0 +1,27 @@
+'''
+Copyright 2025 Advanced Micro Devices Inc.
+All rights reserved.
+
+Run-card fields for the ibperf bandwidth suite.
+'''
+
+
+def _format_values(values):
+    if isinstance(values, (list, tuple)):
+        return ", ".join(str(value) for value in values)
+    if values in (None, ""):
+        return "—"
+    return str(values)
+
+
+def ibperf_run_card_display(variant, _provenance):
+    config = variant if isinstance(variant, dict) else {}
+    return [
+        ("GID index", _format_values(config.get("gid_index")), False),
+        ("Duration (s)", _format_values(config.get("duration")), False),
+        ("Message sizes", _format_values(config.get("msg_size_list")), False),
+        ("QP counts", _format_values(config.get("qp_count_list")), False),
+    ]
+
+
+__all__ = ["ibperf_run_card_display"]

--- a/cvs/lib/report/profiles/hooks/unittests/test_ibperf_run_card.py
+++ b/cvs/lib/report/profiles/hooks/unittests/test_ibperf_run_card.py
@@ -1,0 +1,34 @@
+'''Unit tests for the ibperf Run Deck run card.'''
+
+import unittest
+
+from cvs.lib.report.profiles.hooks.ibperf_run_card import ibperf_run_card_display
+
+
+class TestIbperfRunCard(unittest.TestCase):
+    def test_includes_only_whitelisted_ibperf_settings(self):
+        rows = ibperf_run_card_display(
+            {
+                "gid_index": "3",
+                "duration": "30",
+                "msg_size_list": [2, 4],
+                "qp_count_list": ["8", "16"],
+                "install_dir": "/secret/path",
+                "port_no": "1516",
+            },
+            {},
+        )
+
+        self.assertEqual(
+            rows,
+            [
+                ("GID index", "3", False),
+                ("Duration (s)", "30", False),
+                ("Message sizes", "2, 4", False),
+                ("QP counts", "8, 16", False),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/profiles/ib_perf_bw_test.json
+++ b/cvs/lib/report/profiles/ib_perf_bw_test.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "profile_id": "ib_perf_bw_test_rundeck",
+  "suite_id": "ib_perf_bw_test",
+  "metric_contract": {"id": "ibperf-bandwidth", "version": 1},
+  "report_basename": "ib_perf_bw_test_run_deck",
+  "title": "IB Performance Bandwidth Run Deck",
+  "subtitle": "Write, read, and send bandwidth across message sizes and QP counts",
+  "footer": "CVS ibperf · render-only · does not affect validation gates",
+  "link_name": "IB Performance Bandwidth Run Deck",
+  "dataset_builder": "ibperf",
+  "interactive_viewer": false,
+  "sources": {
+    "results": "cvs_results_dict",
+    "variant": "ibperf_variant_config"
+  },
+  "hooks": {
+    "run_card_display": "cvs.lib.report.profiles.hooks.ibperf_run_card:ibperf_run_card_display"
+  },
+  "cards": [
+    {"type": "run_card", "id": "run-card", "title": "Run card", "bind": "run_card_display"},
+    {
+      "type": "line_chart",
+      "id": "bandwidth",
+      "title": "Mean bandwidth by test and QP count",
+      "bind": "datasets.ibperf",
+      "series": {"y_field": "bus_bw", "unit": "Gb/s"}
+    },
+    {
+      "type": "table",
+      "id": "node-spread",
+      "title": "Per-node bandwidth spread",
+      "bind": "datasets.ibperf.results_table"
+    }
+  ]
+}

--- a/cvs/lib/report/profiles/ib_perf_bw_test.json
+++ b/cvs/lib/report/profiles/ib_perf_bw_test.json
@@ -24,7 +24,7 @@
       "id": "bandwidth",
       "title": "Mean bandwidth by test and QP count",
       "bind": "datasets.ibperf",
-      "series": {"y_field": "bus_bw", "unit": "Gb/s"}
+      "series": {"y_field": "bus_bw", "unit": "Gb/s", "x_label": "{x} B"}
     },
     {
       "type": "table",

--- a/cvs/lib/report/profiles/schema.json
+++ b/cvs/lib/report/profiles/schema.json
@@ -23,7 +23,7 @@
     "footer": { "type": "string" },
     "link_name": { "type": "string" },
     "extends": { "type": "string", "description": "Stem of another profile JSON to merge before this one (child wins)." },
-    "dataset_builder": { "enum": ["sweep", "series", "matrix"] },
+    "dataset_builder": { "enum": ["sweep", "series", "matrix", "ibperf"] },
     "interactive_viewer": { "type": "boolean" },
     "viewer_cell_threshold": { "type": "integer", "minimum": 1 },
     "sources": {

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -81,7 +81,11 @@ class ProfileConfigResolver:
     def from_profile_dict(cls, profile: dict[str, Any]) -> InferenceReportConfig:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
+        hooks = profile.get("hooks") or {}
         if builder in ("series", "matrix", "ibperf"):
+            run_card_builder = None
+            if hooks.get("run_card_display"):
+                run_card_builder = cls.import_callable(hooks["run_card_display"])
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",
@@ -93,9 +97,9 @@ class ProfileConfigResolver:
                 metric_units={"bus_bw": "GB/s", "alg_bw": "GB/s"},
                 tier_metric_specs=lambda _c, _t: {},
                 interactive_viewer=bool(profile.get("interactive_viewer", False)),
+                run_card_display_builder=run_card_builder,
             )
 
-        hooks = profile.get("hooks") or {}
         sweep = profile.get("sweep") or {}
 
         tier_metric_specs = (

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -82,10 +82,14 @@ class ProfileConfigResolver:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
         hooks = profile.get("hooks") or {}
-        if builder in ("series", "matrix", "ibperf"):
-            run_card_builder = None
+        if builder != "sweep":
+            extra = {}
             if hooks.get("run_card_display"):
-                run_card_builder = cls.import_callable(hooks["run_card_display"])
+                extra["run_card_display_builder"] = cls.import_callable(hooks["run_card_display"])
+            if hooks.get("launch_provenance"):
+                extra["launch_provenance_builder"] = cls.import_callable(hooks["launch_provenance"])
+            if profile.get("metric_contract"):
+                extra["metric_contract"] = profile["metric_contract"]
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",
@@ -97,7 +101,7 @@ class ProfileConfigResolver:
                 metric_units={"bus_bw": "GB/s", "alg_bw": "GB/s"},
                 tier_metric_specs=lambda _c, _t: {},
                 interactive_viewer=bool(profile.get("interactive_viewer", False)),
-                run_card_display_builder=run_card_builder,
+                **extra,
             )
 
         sweep = profile.get("sweep") or {}

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -81,7 +81,7 @@ class ProfileConfigResolver:
     def from_profile_dict(cls, profile: dict[str, Any]) -> InferenceReportConfig:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
-        if builder in ("series", "matrix"):
+        if builder in ("series", "matrix", "ibperf"):
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",

--- a/cvs/lib/report/rundeck/dataset_builders/__init__.py
+++ b/cvs/lib/report/rundeck/dataset_builders/__init__.py
@@ -1,3 +1,3 @@
 '''Normalize session data into ``datasets.*`` structures (no HTML).'''
 
-from cvs.lib.report.rundeck.dataset_builders import matrix, series, sweep  # noqa: F401
+from cvs.lib.report.rundeck.dataset_builders import ibperf, matrix, series, sweep  # noqa: F401

--- a/cvs/lib/report/rundeck/dataset_builders/ibperf.py
+++ b/cvs/lib/report/rundeck/dataset_builders/ibperf.py
@@ -71,9 +71,7 @@ def build_ibperf_datasets(sources, _profile):
                 except (TypeError, ValueError):
                     continue
                 if all_samples:
-                    points_by_qp.setdefault(qp_count, []).append(
-                        (size_number, sum(all_samples) / len(all_samples))
-                    )
+                    points_by_qp.setdefault(qp_count, []).append((size_number, sum(all_samples) / len(all_samples)))
 
         test_series = []
         for qp_count, points in sorted(points_by_qp.items(), key=lambda item: _sort_key(item[0])):

--- a/cvs/lib/report/rundeck/dataset_builders/ibperf.py
+++ b/cvs/lib/report/rundeck/dataset_builders/ibperf.py
@@ -1,0 +1,105 @@
+'''
+Copyright 2025 Advanced Micro Devices Inc.
+All rights reserved.
+
+Dataset builder for ibperf bandwidth results.
+'''
+
+from cvs.lib.report.rundeck.dataset_builders.registry import register_dataset_builder
+
+
+def _sort_key(value):
+    try:
+        return (0, int(value))
+    except (TypeError, ValueError):
+        return (1, str(value))
+
+
+def _metric_samples(instance_results, metric):
+    samples = []
+    for instance, metrics in sorted((instance_results or {}).items(), key=lambda item: _sort_key(item[0])):
+        if not isinstance(metrics, dict):
+            continue
+        try:
+            samples.append((instance, float(metrics[metric])))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return samples
+
+
+@register_dataset_builder("ibperf")
+def build_ibperf_datasets(sources, _profile):
+    results = sources.get("results") or sources.get("cvs_results_dict") or {}
+    charts = {}
+    table_rows = []
+
+    for test_name, sizes in sorted(results.items()):
+        if not isinstance(sizes, dict):
+            continue
+        points_by_qp = {}
+        for msg_size, qp_results in sorted(sizes.items(), key=lambda item: _sort_key(item[0])):
+            if not isinstance(qp_results, dict):
+                continue
+            for qp_count, node_results in sorted(qp_results.items(), key=lambda item: _sort_key(item[0])):
+                if not isinstance(node_results, dict):
+                    continue
+
+                all_samples = []
+                for node, instance_results in sorted(node_results.items()):
+                    samples = _metric_samples(instance_results, "bw")
+                    if not samples:
+                        continue
+                    all_samples.extend(value for _instance, value in samples)
+                    min_instance, min_bw = min(samples, key=lambda sample: sample[1])
+                    values = [value for _instance, value in samples]
+                    table_rows.append(
+                        [
+                            test_name,
+                            qp_count,
+                            msg_size,
+                            node,
+                            len(values),
+                            min_bw,
+                            sum(values) / len(values),
+                            max(values),
+                            min_instance,
+                        ]
+                    )
+
+                try:
+                    size_number = int(msg_size)
+                except (TypeError, ValueError):
+                    continue
+                if all_samples:
+                    points_by_qp.setdefault(qp_count, []).append(
+                        (size_number, sum(all_samples) / len(all_samples))
+                    )
+
+        test_series = []
+        for qp_count, points in sorted(points_by_qp.items(), key=lambda item: _sort_key(item[0])):
+            test_series.append(
+                {
+                    "label": f"{test_name} · QP {qp_count}",
+                    "points": sorted(points),
+                }
+            )
+        if test_series:
+            charts[test_name] = test_series
+
+    return {
+        "charts": {"bus_bw": charts},
+        "results_table": {
+            "headers": [
+                "Test",
+                "QP count",
+                "Message size (bytes)",
+                "Node",
+                "NIC/GPU samples",
+                "Min BW (Gb/s)",
+                "Mean BW (Gb/s)",
+                "Max BW (Gb/s)",
+                "Minimum GPU/NIC",
+            ],
+            "rows": table_rows,
+        },
+    }

--- a/cvs/lib/report/rundeck/dataset_builders/ibperf.py
+++ b/cvs/lib/report/rundeck/dataset_builders/ibperf.py
@@ -59,9 +59,9 @@ def build_ibperf_datasets(sources, _profile):
                             msg_size,
                             node,
                             len(values),
-                            min_bw,
-                            sum(values) / len(values),
-                            max(values),
+                            round(min_bw, 3),
+                            round(sum(values) / len(values), 3),
+                            round(max(values), 3),
                             min_instance,
                         ]
                     )
@@ -71,7 +71,9 @@ def build_ibperf_datasets(sources, _profile):
                 except (TypeError, ValueError):
                     continue
                 if all_samples:
-                    points_by_qp.setdefault(qp_count, []).append((size_number, sum(all_samples) / len(all_samples)))
+                    points_by_qp.setdefault(qp_count, []).append(
+                        (size_number, round(sum(all_samples) / len(all_samples), 3))
+                    )
 
         test_series = []
         for qp_count, points in sorted(points_by_qp.items(), key=lambda item: _sort_key(item[0])):
@@ -83,6 +85,8 @@ def build_ibperf_datasets(sources, _profile):
             )
         if test_series:
             charts[test_name] = test_series
+
+    table_rows.sort(key=lambda row: (str(row[0]), _sort_key(row[1]), _sort_key(row[2]), str(row[3])))
 
     return {
         "charts": {"bus_bw": charts},

--- a/cvs/lib/report/rundeck/generate_rundeck.py
+++ b/cvs/lib/report/rundeck/generate_rundeck.py
@@ -104,7 +104,10 @@ class RundeckPublisher:
         )
 
         viewer_path = self._write_viewer(profile, config, out_dir, payload)
-        summary_path = write_inference_ci_summary(payload, config, out_dir)
+        builder_id = profile.get("dataset_builder", "sweep") if isinstance(profile, dict) else "sweep"
+        summary_path = None
+        if builder_id == "sweep":
+            summary_path = write_inference_ci_summary(payload, config, out_dir)
         artifacts = {
             "html": html_path_written,
             "json": json_path,
@@ -152,7 +155,8 @@ class RundeckPublisher:
             return
         self.report_manager.add_html_to_report(artifacts["html"], link_name=config.link_name)
         self.report_manager.add_html_to_report(artifacts["json"], link_name=f"{config.link_name} JSON")
-        self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
+        if artifacts.get("summary") is not None:
+            self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
         viewer = artifacts.get("viewer")
         if viewer is not None:
             self.report_manager.add_html_to_report(viewer, link_name=f"{config.link_name} viewer")

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -23,6 +23,14 @@ from cvs.lib.report.types import DEFAULT_SESSION_LIFECYCLE_LABELS
 SESSION_FALLBACK = DEFAULT_SESSION_LIFECYCLE_LABELS
 
 
+def _chart_x_label(series_cfg):
+    if series_cfg.get("x_label"):
+        return series_cfg["x_label"]
+    if "x_label_prefix" in series_cfg:
+        return f"{series_cfg.get('x_label_prefix') or ''}{{x}}"
+    return "C={x}"
+
+
 class DeckCardRenderer:
     """Profile-driven card renderers for Run Deck static HTML sections."""
 
@@ -183,7 +191,12 @@ class DeckCardRenderer:
                 continue
             points = entry.get("points") or []
             label = entry.get("label") or title
-            part = self._charts.render_series_chart(str(label), points, series_cfg.get("unit") or "GB/s")
+            part = self._charts.render_series_chart(
+                str(label),
+                points,
+                series_cfg.get("unit") or "GB/s",
+                x_label=_chart_x_label(series_cfg),
+            )
             if part:
                 parts.append(part)
         return f"<div class='chart-grid'>{''.join(parts)}</div>" if parts else "<p class='muted'>No series data.</p>"

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -64,8 +64,10 @@ class SweepChartRenderer:
         unit: str,
         *,
         accent: str = "accent",
+        x_label="C={x}",
+        min_points=2,
     ) -> str:
-        if len(points) < 2:
+        if len(points) < min_points:
             return ""
         values = [p[1] for p in points]
         max_val = max(values) or 1.0
@@ -84,13 +86,17 @@ class SweepChartRenderer:
         x_labels = []
         for conc, val in points:
             h = self._bar_height_pct(val, min_val, max_val)
-            tip = html.escape(f"C={conc}: {fmt_num(val)} {unit}".strip())
+            try:
+                xlabel = x_label.format(x=conc)
+            except (KeyError, IndexError, ValueError):
+                xlabel = str(conc)
+            tip = html.escape(f"{xlabel}: {fmt_num(val)} {unit}".strip())
             bars.append(
                 f"<div class='chart-col'>"
                 f"<div class='chart-bar chart-bar-{accent} chart-has-tip' style='height:{h:.1f}%' "
                 f"data-tip='{tip}' tabindex='0' role='img' aria-label='{tip}'></div></div>"
             )
-            x_labels.append(f"<span class='chart-xlbl'>C={conc}</span>")
+            x_labels.append(f"<span class='chart-xlbl'>{html.escape(str(xlabel))}</span>")
         return (
             f"<div class='chart-panel'><h3>{html.escape(title)}</h3>"
             f"<div class='chart-viz'>"
@@ -138,12 +144,12 @@ class SweepChartRenderer:
             else "<p class='muted'>Concurrency charts need two or more points per sweep shape.</p>"
         )
 
-    def render_series_chart(self, title: str, points: list, unit: str) -> str:
+    def render_series_chart(self, title: str, points: list, unit: str, x_label="{x}"):
         normalized = []
         for p in points:
             if isinstance(p, (list, tuple)) and len(p) >= 2:
                 normalized.append((p[0], p[1]))
-        return self.render_bar_chart(title, normalized, unit, accent="accent2")
+        return self.render_bar_chart(title, normalized, unit, accent="accent2", x_label=x_label, min_points=1)
 
 
 _DEFAULT_RENDERER = SweepChartRenderer()

--- a/cvs/lib/report/rundeck/unittests/test_ibperf_dataset_builder.py
+++ b/cvs/lib/report/rundeck/unittests/test_ibperf_dataset_builder.py
@@ -75,6 +75,20 @@ class TestIbperfDatasetBuilder(unittest.TestCase):
         self.assertIn("Per-node bandwidth spread", document)
         self.assertIn("Message sizes", document)
         self.assertIn("2, 4", document)
+        self.assertIn("2 B", document)
+        self.assertNotIn("C=2", document)
+        self.assertEqual(payload.get("metric_contract"), {"id": "ibperf-bandwidth", "version": 1})
+
+    def test_single_message_size_still_renders_a_chart(self):
+        results = {"ib_write_bw": {2: {"8": {"node-a": {0: {"bw": "100.0"}}}}}}
+        payload = build_rundeck_payload(
+            profile=load_json_profile("ib_perf_bw_test"),
+            store={"cvs_results_dict": results, "variant_config": {"gid_index": "3"}},
+            cvs_version="1.0.0",
+        )
+        document = render_rundeck_html(payload)
+        self.assertIn("chart-bar", document)
+        self.assertNotIn("No series data.", document)
 
 
 if __name__ == "__main__":

--- a/cvs/lib/report/rundeck/unittests/test_ibperf_dataset_builder.py
+++ b/cvs/lib/report/rundeck/unittests/test_ibperf_dataset_builder.py
@@ -1,0 +1,81 @@
+'''Unit tests for the ibperf Run Deck dataset builder.'''
+
+import unittest
+
+from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.dataset_builders.registry import build_datasets
+from cvs.lib.report.rundeck.payload import build_rundeck_payload
+from cvs.lib.report.rundeck.render import render_rundeck_html
+
+
+def _ibperf_results():
+    return {
+        "ib_write_bw": {
+            2: {
+                "8": {
+                    "node-a": {
+                        0: {"bw": "100.0", "pps": "1.0"},
+                        1: {"bw": "110.0", "pps": "1.1"},
+                    },
+                    "node-b": {
+                        0: {"bw": "90.0", "pps": "0.9"},
+                        1: {"bw": "95.0", "pps": "0.95"},
+                    },
+                },
+                "16": {
+                    "node-a": {
+                        0: {"bw": "120.0", "pps": "1.2"},
+                        1: {"bw": "125.0", "pps": "1.25"},
+                    }
+                },
+            },
+            4: {
+                "8": {
+                    "node-a": {
+                        0: {"bw": "140.0", "pps": "1.4"},
+                        1: {"bw": "150.0", "pps": "1.5"},
+                    }
+                }
+            },
+        }
+    }
+
+
+class TestIbperfDatasetBuilder(unittest.TestCase):
+    def test_builds_qp_series_and_per_node_spread(self):
+        datasets = build_datasets("ibperf", {"results": _ibperf_results()}, {})
+
+        series = datasets["charts"]["bus_bw"]["ib_write_bw"]
+        self.assertEqual([entry["label"] for entry in series], ["ib_write_bw · QP 8", "ib_write_bw · QP 16"])
+        self.assertEqual(series[0]["points"], [(2, 98.75), (4, 145.0)])
+
+        rows = datasets["results_table"]["rows"]
+        node_a = next(row for row in rows if row[:4] == ["ib_write_bw", "8", 2, "node-a"])
+        self.assertEqual(node_a[4:], [2, 100.0, 105.0, 110.0, 0])
+
+    def test_profile_renders_run_card_charts_and_table(self):
+        profile = load_json_profile("ib_perf_bw_test")
+        payload = build_rundeck_payload(
+            profile=profile,
+            store={
+                "cvs_results_dict": _ibperf_results(),
+                "variant_config": {
+                    "gid_index": "3",
+                    "duration": "30",
+                    "msg_size_list": [2, 4],
+                    "qp_count_list": ["8", "16"],
+                },
+            },
+            cvs_version="1.0.0",
+        )
+
+        document = render_rundeck_html(payload)
+        self.assertIn("IB Performance Bandwidth Run Deck", document)
+        self.assertIn("ib_write_bw · QP 8", document)
+        self.assertIn("Per-node bandwidth spread", document)
+        self.assertIn("Message sizes", document)
+        self.assertIn("2, 4", document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/tests/ibperf/ib_perf_bw_test.py
+++ b/cvs/tests/ibperf/ib_perf_bw_test.py
@@ -113,6 +113,17 @@ def config_dict(config_file, cluster_dict):
 
 
 @pytest.fixture(scope="module")
+def cvs_results_dict():
+    ib_bw_dict.clear()
+    return ib_bw_dict
+
+
+@pytest.fixture(scope="module")
+def ibperf_variant_config(config_dict):
+    return config_dict
+
+
+@pytest.fixture(scope="module")
 def phdl(cluster_dict):
     """
     Build and return a parallel SSH handle (Pssh) for all cluster nodes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a render-only Run Deck for `cvs run ib_perf_bw_test`.

## Plan / code surfaces
- Profile `profiles/ib_perf_bw_test.json` with a dedicated `ibperf` dataset builder
- Session fixtures in `ib_perf_bw_test.py` (`cvs_results_dict`, `ibperf_variant_config`)
- Non-sweep profiles load run-card hooks (and metric_contract) instead of the inference default card

## Graphs / tables
- Mean bandwidth vs message size, series per test type and QP count
- Per-node min/mean/max bandwidth table
- Run card: gid index, duration, msg sizes, QP list — no cluster secrets

Validation gates (`verify_bw`, dmesg) are unchanged.

## Review follow-up (`9625dec7`)
- Message-size ticks are `{x} B`, not inference `C=`
- Single-size runs still render a chart
- `hooks/unittests` is collected by `make ut`
- Inference CI summary sidecar is skipped
- Bandwidth values are rounded; table rows sort test → QP → size

A shared `config_adapter` landing is still needed before merging the suite PR fleet.

## Quality
`make fmt-check` / `make lint` clean; targeted unittests pass. Hardware not run. Draft — do not merge yet.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bd374b-7c5a-4d24-be58-368133af2219?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bd374b-7c5a-4d24-be58-368133af2219&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

