### PR TITLE
feat(platform): enable Run Deck for host_configs_cvs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,6 @@ make ut          # sdist -> .test_venv -> run_all_unittests.py
   ```
 - See `cvs/tests/rccl/rccl_perf.py`, `cvs/tests/preflight/preflight_checks.py` for examples
 - Run Deck profiles live at `cvs/lib/report/profiles/<suite-stem>.json`; populate `cvs_results_dict` from facts already collected by the suite and keep report generation separate from pass/fail gates
-- For consistency and inventory suites, prefer per-node tables plus a cross-node drift matrix, disable the interactive inference viewer, and do not invent performance metrics or throughput charts
 
 ### Configuration Management
 - Cluster files: node topology, SSH credentials, head-node settings (`cvs/input/cluster_file/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ make ut          # sdist -> .test_venv -> run_all_unittests.py
   )
   ```
 - See `cvs/tests/rccl/rccl_perf.py`, `cvs/tests/preflight/preflight_checks.py` for examples
+- Run Deck profiles live at `cvs/lib/report/profiles/<suite-stem>.json`; populate `cvs_results_dict` from facts already collected by the suite and keep report generation separate from pass/fail gates
+- For consistency and inventory suites, prefer per-node tables plus a cross-node drift matrix, disable the interactive inference viewer, and do not invent performance metrics or throughput charts
 
 ### Configuration Management
 - Cluster files: node topology, SSH credentials, head-node settings (`cvs/input/cluster_file/`)

--- a/cvs/lib/platform/__init__.py
+++ b/cvs/lib/platform/__init__.py
@@ -1,0 +1,1 @@
+'''Platform inventory helpers.'''

--- a/cvs/lib/platform/host_inventory.py
+++ b/cvs/lib/platform/host_inventory.py
@@ -1,0 +1,130 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Normalize facts collected by the host configuration validation suite.
+'''
+
+import re
+
+
+FACT_LABELS = {
+    "os_release": "OS release",
+    "kernel": "Kernel",
+    "bios": "BIOS",
+    "rocm": "ROCm",
+    "gpu_count": "GPU count",
+    "online_memory": "Online memory",
+    "pci_realloc": "PCI realloc",
+    "iommu": "IOMMU",
+    "numa_balancing": "NUMA balancing",
+    "gpu_pcie": "GPU PCIe",
+    "nic_pcie": "NIC PCIe",
+    "pci_acs": "PCIe ACS",
+    "firmware": "GPU firmware",
+}
+
+
+def normalize_output(output):
+    value = str(output or "").strip()
+    return value or "\u2014"
+
+
+def parse_os_release(output):
+    text = str(output or "")
+    for key in ("PRETTY_NAME", "VERSION"):
+        match = re.search(rf'^{key}=(?:"([^"]*)"|([^\n]*))$', text, re.MULTILINE)
+        if match:
+            return (match.group(1) or match.group(2)).strip()
+    return normalize_output(text)
+
+
+def parse_kernel_version(output):
+    text = normalize_output(output)
+    parts = text.split()
+    if len(parts) >= 3 and parts[0] == "Linux":
+        return parts[2]
+    return text
+
+
+def parse_rocm_version(output):
+    text = str(output or "")
+    match = re.search(r"ROCm version:\s*([^\s]+)", text, re.I)
+    return match.group(1) if match else normalize_output(text)
+
+
+def parse_online_memory(output):
+    text = str(output or "")
+    match = re.search(r"Total online memory:\s*([0-9.A-Za-z]+)", text, re.I)
+    return match.group(1) if match else normalize_output(text)
+
+
+def parse_gpu_count(output):
+    return str(len(re.findall(r"accelerators:\s+Advanced", str(output or ""), re.I)))
+
+
+def parse_pci_realloc(output):
+    match = re.search(r"(?:^|\s)pci=realloc=([^\s]+)", str(output or ""), re.I)
+    return match.group(1) if match else "not set"
+
+
+def parse_iommu(output):
+    return "pt" if re.search(r"(?:^|\s)iommu=pt(?:\s|$)", str(output or ""), re.I) else "not set"
+
+
+def parse_numa_balancing(output):
+    match = re.search(r"=\s*([^\s]+)", str(output or ""))
+    return match.group(1) if match else normalize_output(output)
+
+
+def parse_pcie_link(output):
+    text = str(output or "")
+    speed = re.search(r"Speed\s+([^,\s]+)", text, re.I)
+    width = re.search(r"Width\s+(x[0-9]+)", text, re.I)
+    if speed and width:
+        return f"{speed.group(1)} \u00b7 {width.group(1)}"
+    return normalize_output(text)
+
+
+def parse_pci_acs(output):
+    return "enabled" if re.search(r"ACSCtl:", str(output or ""), re.I) else "disabled"
+
+
+def record_node_facts(store, key, output_by_node, parser=normalize_output):
+    nodes = store.setdefault("nodes", {})
+    for node, output in output_by_node.items():
+        nodes.setdefault(str(node), {})[key] = parser(output)
+
+
+def record_indexed_node_facts(store, key, index, output_by_node, parser=normalize_output):
+    nodes = store.setdefault("nodes", {})
+    for node, output in output_by_node.items():
+        indexed = nodes.setdefault(str(node), {}).setdefault(key, {})
+        indexed[str(index)] = parser(output)
+
+
+def record_gpu_firmware(store, firmware_by_node):
+    firmware = store.setdefault("firmware", {})
+    for node, gpu_entries in firmware_by_node.items():
+        node_firmware = firmware.setdefault(str(node), {})
+        if not isinstance(gpu_entries, list):
+            continue
+        for gpu_entry in gpu_entries:
+            if not isinstance(gpu_entry, dict):
+                continue
+            gpu = str(gpu_entry.get("gpu", "\u2014"))
+            gpu_firmware = node_firmware.setdefault(gpu, {})
+            for entry in gpu_entry.get("fw_list", []):
+                if not isinstance(entry, dict) or "fw_id" not in entry:
+                    continue
+                gpu_firmware[str(entry["fw_id"])] = normalize_output(entry.get("fw_version"))
+
+
+def collected_fact_keys(results):
+    keys = set()
+    for facts in (results.get("nodes") or {}).values():
+        if isinstance(facts, dict):
+            keys.update(facts)
+    if results.get("firmware"):
+        keys.add("firmware")
+    return sorted(keys)

--- a/cvs/lib/platform/host_inventory.py
+++ b/cvs/lib/platform/host_inventory.py
@@ -25,9 +25,27 @@ FACT_LABELS = {
 }
 
 
-def normalize_output(output):
+_UNAVAILABLE_MARKERS = (
+    "permission denied",
+    "password is required",
+    "connection timed out",
+    "command not found",
+    "no such file",
+    "name or service not known",
+    "could not resolve hostname",
+)
+
+
+def normalize_output(output, max_len=80):
     value = str(output or "").strip()
-    return value or "\u2014"
+    if not value:
+        return "\u2014"
+    lowered = value.lower()
+    if any(marker in lowered for marker in _UNAVAILABLE_MARKERS) or value.count("\n") > 2:
+        return "unavailable"
+    if len(value) > max_len:
+        return value[: max_len - 1] + "\u2026"
+    return value
 
 
 def parse_os_release(output):
@@ -104,19 +122,25 @@ def record_indexed_node_facts(store, key, index, output_by_node, parser=normaliz
 
 
 def record_gpu_firmware(store, firmware_by_node):
-    firmware = store.setdefault("firmware", {})
+    firmware = None
     for node, gpu_entries in firmware_by_node.items():
-        node_firmware = firmware.setdefault(str(node), {})
         if not isinstance(gpu_entries, list):
             continue
+        node_firmware = None
         for gpu_entry in gpu_entries:
             if not isinstance(gpu_entry, dict):
                 continue
             gpu = str(gpu_entry.get("gpu", "\u2014"))
-            gpu_firmware = node_firmware.setdefault(gpu, {})
+            gpu_firmware = None
             for entry in gpu_entry.get("fw_list", []):
                 if not isinstance(entry, dict) or "fw_id" not in entry:
                     continue
+                if firmware is None:
+                    firmware = store.setdefault("firmware", {})
+                if node_firmware is None:
+                    node_firmware = firmware.setdefault(str(node), {})
+                if gpu_firmware is None:
+                    gpu_firmware = node_firmware.setdefault(gpu, {})
                 gpu_firmware[str(entry["fw_id"])] = normalize_output(entry.get("fw_version"))
 
 

--- a/cvs/lib/platform/unittests/__init__.py
+++ b/cvs/lib/platform/unittests/__init__.py
@@ -1,0 +1,1 @@
+'''Unit tests for platform helpers.'''

--- a/cvs/lib/platform/unittests/test_host_inventory.py
+++ b/cvs/lib/platform/unittests/test_host_inventory.py
@@ -4,10 +4,14 @@ import unittest
 
 from cvs.lib.platform.host_inventory import (
     collected_fact_keys,
+    normalize_output,
     parse_gpu_count,
     parse_iommu,
     parse_kernel_version,
+    parse_numa_balancing,
+    parse_online_memory,
     parse_os_release,
+    parse_pci_acs,
     parse_pci_realloc,
     parse_pcie_link,
     parse_rocm_version,
@@ -67,6 +71,24 @@ class TestHostInventory(unittest.TestCase):
 
         self.assertEqual(results["firmware"]["node-a"]["0"]["CP_MEC1"], "32945")
         self.assertEqual(collected_fact_keys(results), ["firmware"])
+
+    def test_failed_firmware_collection_is_not_a_fact_category(self):
+        results = {}
+        record_gpu_firmware(results, {"n0": "sudo: a password is required", "n1": []})
+        self.assertNotIn("firmware", results)
+        self.assertEqual(collected_fact_keys(results), [])
+
+    def test_unparseable_remote_output_is_unavailable(self):
+        self.assertEqual(
+            normalize_output("ssh: connect to host 10.0.3.14 port 22: Connection timed out"), "unavailable"
+        )
+        self.assertEqual(
+            parse_kernel_version("Permission denied (publickey,password) for root@10.0.3.14"), "unavailable"
+        )
+        self.assertEqual(parse_online_memory("Total online memory: 1.3T"), "1.3T")
+        self.assertEqual(parse_numa_balancing("kernel.numa_balancing = 0"), "0")
+        self.assertEqual(parse_pci_acs("ACSCtl: SrcValid+"), "enabled")
+        self.assertEqual(parse_pci_acs(""), "disabled")
 
 
 if __name__ == "__main__":

--- a/cvs/lib/platform/unittests/test_host_inventory.py
+++ b/cvs/lib/platform/unittests/test_host_inventory.py
@@ -1,0 +1,73 @@
+'''Unit tests for host inventory normalization.'''
+
+import unittest
+
+from cvs.lib.platform.host_inventory import (
+    collected_fact_keys,
+    parse_gpu_count,
+    parse_iommu,
+    parse_kernel_version,
+    parse_os_release,
+    parse_pci_realloc,
+    parse_pcie_link,
+    parse_rocm_version,
+    record_gpu_firmware,
+    record_indexed_node_facts,
+    record_node_facts,
+)
+
+
+class TestHostInventory(unittest.TestCase):
+    def test_parses_scalar_command_outputs(self):
+        self.assertEqual(parse_os_release('NAME="Ubuntu"\nPRETTY_NAME="Ubuntu 24.04.1 LTS"\n'), "Ubuntu 24.04.1 LTS")
+        self.assertEqual(parse_kernel_version("Linux node-a 6.8.0-60-generic #63 SMP"), "6.8.0-60-generic")
+        self.assertEqual(parse_rocm_version("ROCm version: 7.0.2\nAMDSMI version: 26.0"), "7.0.2")
+        self.assertEqual(parse_pci_realloc("BOOT_IMAGE=/vmlinuz pci=realloc=off iommu=pt"), "off")
+        self.assertEqual(parse_iommu("BOOT_IMAGE=/vmlinuz pci=realloc=off iommu=pt"), "pt")
+        self.assertEqual(parse_pcie_link("LnkSta: Speed 32GT/s, Width x16"), "32GT/s \u00b7 x16")
+        self.assertEqual(
+            parse_gpu_count(
+                "01:00.0 Display controller: Advanced Micro Devices, Inc. [AMD/ATI] "
+                "VGA compatible controller\n"
+                "02:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI]"
+            ),
+            "1",
+        )
+
+    def test_records_node_and_indexed_facts(self):
+        results = {}
+        record_node_facts(results, "bios", {"node-b": "B2\n", "node-a": "A1\n"})
+        record_indexed_node_facts(
+            results,
+            "gpu_pcie",
+            "card0",
+            {"node-a": "LnkSta: Speed 32GT/s, Width x16"},
+            parse_pcie_link,
+        )
+
+        self.assertEqual(results["nodes"]["node-a"]["bios"], "A1")
+        self.assertEqual(results["nodes"]["node-a"]["gpu_pcie"]["card0"], "32GT/s \u00b7 x16")
+
+    def test_records_gpu_firmware(self):
+        results = {}
+        record_gpu_firmware(
+            results,
+            {
+                "node-a": [
+                    {
+                        "gpu": 0,
+                        "fw_list": [
+                            {"fw_id": "CP_MEC1", "fw_version": "32945"},
+                            {"fw_id": "RLC", "fw_version": "65"},
+                        ],
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(results["firmware"]["node-a"]["0"]["CP_MEC1"], "32945")
+        self.assertEqual(collected_fact_keys(results), ["firmware"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/profiles/hooks/host_configs_run_card.py
+++ b/cvs/lib/report/profiles/hooks/host_configs_run_card.py
@@ -1,0 +1,27 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Run-card fields for the host configuration inventory deck.
+'''
+
+from cvs.lib.platform.host_inventory import FACT_LABELS, collected_fact_keys
+from cvs.lib.report.rundeck.config_builder import provenance_link_rows
+
+
+def host_configs_run_card_display(results, provenance):
+    results = results or {}
+    nodes = set((results.get("nodes") or {}).keys())
+    nodes.update((results.get("firmware") or {}).keys())
+    fact_keys = collected_fact_keys(results)
+    fact_labels = [FACT_LABELS.get(key, key.replace("_", " ").title()) for key in fact_keys]
+    rows = [
+        ("Nodes sampled", str(len(nodes)), False),
+        ("Fact categories", str(len(fact_keys)), False),
+        ("Facts collected", ", ".join(fact_labels) or "\u2014", False),
+    ]
+    rows.extend(provenance_link_rows(provenance))
+    return rows
+
+
+__all__ = ["host_configs_run_card_display"]

--- a/cvs/lib/report/profiles/hooks/unittests/test_host_configs_run_card.py
+++ b/cvs/lib/report/profiles/hooks/unittests/test_host_configs_run_card.py
@@ -1,0 +1,25 @@
+'''Unit tests for the host configuration Run Deck run-card hook.'''
+
+import unittest
+
+from cvs.lib.report.profiles.hooks.host_configs_run_card import host_configs_run_card_display
+
+
+class TestHostConfigsRunCard(unittest.TestCase):
+    def test_rows_count_nodes_and_collected_facts(self):
+        rows = host_configs_run_card_display(
+            {
+                "nodes": {"n0": {"bios": "A1", "kernel": "k1"}, "n1": {"bios": "A1"}},
+                "firmware": {},
+            },
+            {},
+        )
+        values = {label: value for label, value, _link in rows}
+        self.assertEqual(values["Nodes sampled"], "2")
+        self.assertEqual(values["Fact categories"], "2")
+        self.assertIn("BIOS", values["Facts collected"])
+        self.assertNotIn("GPU firmware", values["Facts collected"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/profiles/host_configs_cvs.json
+++ b/cvs/lib/report/profiles/host_configs_cvs.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "profile_id": "host_configs_cvs_rundeck",
+  "suite_id": "host_configs",
+  "report_basename": "host_configs_run_deck",
+  "title": "Host Configuration Run Deck",
+  "subtitle": "Cross-node configuration inventory and drift",
+  "footer": "CVS host_configs_cvs · inventory-only · does not affect gates",
+  "link_name": "Host Configuration Run Deck",
+  "dataset_builder": "host_inventory",
+  "interactive_viewer": false,
+  "sources": {
+    "results": "cvs_results_dict",
+    "variant": "host_inventory_metadata"
+  },
+  "hooks": {
+    "run_card_display": "cvs.lib.report.profiles.hooks.host_configs_run_card:host_configs_run_card_display"
+  },
+  "host_inventory": {
+    "inventory_columns": [
+      ["os_release", "OS release"],
+      ["kernel", "Kernel"],
+      ["bios", "BIOS"],
+      ["rocm", "ROCm"],
+      ["gpu_count", "GPU count"],
+      ["online_memory", "Online memory"]
+    ]
+  },
+  "cards": [
+    {
+      "type": "run_card",
+      "id": "run-card",
+      "title": "Run card",
+      "bind": "run_card_display"
+    },
+    {
+      "type": "drift_matrix",
+      "id": "drift",
+      "title": "Cross-node drift matrix",
+      "bind": "datasets.host_inventory.drift_matrix"
+    },
+    {
+      "type": "table",
+      "id": "inventory",
+      "title": "Per-node inventory",
+      "bind": "datasets.host_inventory.inventory_table"
+    },
+    {
+      "type": "table",
+      "id": "firmware",
+      "title": "GPU firmware inventory",
+      "bind": "datasets.host_inventory.firmware_table",
+      "when_empty": "hide"
+    }
+  ]
+}

--- a/cvs/lib/report/profiles/schema.json
+++ b/cvs/lib/report/profiles/schema.json
@@ -23,7 +23,7 @@
     "footer": { "type": "string" },
     "link_name": { "type": "string" },
     "extends": { "type": "string", "description": "Stem of another profile JSON to merge before this one (child wins)." },
-    "dataset_builder": { "enum": ["sweep", "series", "matrix"] },
+    "dataset_builder": { "enum": ["sweep", "series", "matrix", "host_inventory"] },
     "interactive_viewer": { "type": "boolean" },
     "viewer_cell_threshold": { "type": "integer", "minimum": 1 },
     "sources": {
@@ -92,6 +92,7 @@
     },
     "series": { "type": "object" },
     "matrix": { "type": "object" },
+    "host_inventory": { "type": "object" },
     "lifecycle": { "type": "object" },
     "behavior": { "type": "object" }
   }

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -81,7 +81,11 @@ class ProfileConfigResolver:
     def from_profile_dict(cls, profile: dict[str, Any]) -> InferenceReportConfig:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
-        if builder in ("series", "matrix"):
+        hooks = profile.get("hooks") or {}
+        if builder != "sweep":
+            run_card_builder = None
+            if hooks.get("run_card_display"):
+                run_card_builder = cls.import_callable(hooks["run_card_display"])
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",
@@ -93,9 +97,9 @@ class ProfileConfigResolver:
                 metric_units={"bus_bw": "GB/s", "alg_bw": "GB/s"},
                 tier_metric_specs=lambda _c, _t: {},
                 interactive_viewer=bool(profile.get("interactive_viewer", False)),
+                run_card_display_builder=run_card_builder,
             )
 
-        hooks = profile.get("hooks") or {}
         sweep = profile.get("sweep") or {}
 
         tier_metric_specs = (

--- a/cvs/lib/report/rundeck/dataset_builders/__init__.py
+++ b/cvs/lib/report/rundeck/dataset_builders/__init__.py
@@ -1,3 +1,3 @@
 '''Normalize session data into ``datasets.*`` structures (no HTML).'''
 
-from cvs.lib.report.rundeck.dataset_builders import matrix, series, sweep  # noqa: F401
+from cvs.lib.report.rundeck.dataset_builders import host_inventory, matrix, series, sweep  # noqa: F401

--- a/cvs/lib/report/rundeck/dataset_builders/host_inventory.py
+++ b/cvs/lib/report/rundeck/dataset_builders/host_inventory.py
@@ -1,0 +1,135 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Dataset builder for host configuration inventory and cross-node drift.
+'''
+
+from cvs.lib.platform.host_inventory import FACT_LABELS
+from cvs.lib.report.rundeck.dataset_builders.registry import register_dataset_builder
+
+
+def _profile_config(profile):
+    return profile.get("host_inventory") or {}
+
+
+def _node_names(results):
+    nodes = set((results.get("nodes") or {}).keys())
+    nodes.update((results.get("firmware") or {}).keys())
+    return sorted(str(node) for node in nodes)
+
+
+def _fact_specs(profile):
+    configured = _profile_config(profile).get("inventory_columns") or [
+        "os_release",
+        "kernel",
+        "bios",
+        "rocm",
+        "gpu_count",
+        "online_memory",
+    ]
+    specs = []
+    for entry in configured:
+        if isinstance(entry, (list, tuple)) and len(entry) == 2:
+            specs.append((str(entry[0]), str(entry[1])))
+        else:
+            key = str(entry)
+            specs.append((key, FACT_LABELS.get(key, key.replace("_", " ").title())))
+    return specs
+
+
+def _inventory_table(results, profile, nodes):
+    specs = _fact_specs(profile)
+    headers = ["Node"] + [label for _key, label in specs]
+    rows = []
+    node_facts = results.get("nodes") or {}
+    for node in nodes:
+        facts = node_facts.get(node) or {}
+        rows.append([node] + [facts.get(key, "\u2014") for key, _label in specs])
+    return {"headers": headers, "rows": rows}
+
+
+def _flatten_value(rows, key, value, node):
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            _flatten_value(rows, f"{key}.{child_key}", child_value, node)
+        return
+    rows.setdefault(key, {})[node] = value
+
+
+def _flatten_node_facts(results):
+    rows = {}
+    for node, facts in (results.get("nodes") or {}).items():
+        if not isinstance(facts, dict):
+            continue
+        for key, value in facts.items():
+            _flatten_value(rows, str(key), value, str(node))
+
+    for node, gpu_entries in (results.get("firmware") or {}).items():
+        if not isinstance(gpu_entries, dict):
+            continue
+        for gpu, firmware in gpu_entries.items():
+            if not isinstance(firmware, dict):
+                continue
+            for firmware_id, version in firmware.items():
+                rows.setdefault(f"firmware.{gpu}.{firmware_id}", {})[str(node)] = version
+    return rows
+
+
+def _fact_label(key):
+    parts = key.split(".")
+    if parts[0] == "firmware" and len(parts) >= 3:
+        return f"GPU {parts[1]} firmware {'.'.join(parts[2:])}"
+    if parts[0] in ("gpu_pcie", "nic_pcie") and len(parts) >= 2:
+        return f"{FACT_LABELS[parts[0]]} card {'.'.join(parts[1:])}"
+    return FACT_LABELS.get(key, key.replace("_", " ").title())
+
+
+def _drift_matrix(results, nodes):
+    flattened = _flatten_node_facts(results)
+    rows = []
+    for key in sorted(flattened, key=lambda item: (_fact_label(item).lower(), item)):
+        by_node = flattened[key]
+        values = [by_node.get(node, "\u2014") for node in nodes]
+        mismatch = len({str(value) for value in values}) > 1
+        rows.append(
+            {
+                "key": key,
+                "label": _fact_label(key),
+                "values": values,
+                "mismatch": mismatch,
+            }
+        )
+    return {
+        "headers": ["Configuration"] + nodes + ["Drift"],
+        "rows": rows,
+        "mismatch_count": sum(1 for row in rows if row["mismatch"]),
+    }
+
+
+def _firmware_table(results):
+    rows = []
+    for node, gpu_entries in sorted((results.get("firmware") or {}).items()):
+        if not isinstance(gpu_entries, dict):
+            continue
+        for gpu, firmware in sorted(gpu_entries.items()):
+            if not isinstance(firmware, dict):
+                continue
+            for firmware_id, version in sorted(firmware.items()):
+                rows.append([node, gpu, firmware_id, version])
+    return {
+        "headers": ["Node", "GPU", "Firmware", "Version"],
+        "rows": rows,
+    }
+
+
+@register_dataset_builder("host_inventory")
+def build_host_inventory_datasets(sources, profile):
+    results = sources.get("results") or sources.get("cvs_results_dict") or {}
+    nodes = _node_names(results)
+    return {
+        "inventory_table": _inventory_table(results, profile, nodes),
+        "drift_matrix": _drift_matrix(results, nodes),
+        "firmware_table": _firmware_table(results),
+        "node_count": len(nodes),
+    }

--- a/cvs/lib/report/rundeck/dataset_builders/host_inventory.py
+++ b/cvs/lib/report/rundeck/dataset_builders/host_inventory.py
@@ -5,6 +5,8 @@ All rights reserved.
 Dataset builder for host configuration inventory and cross-node drift.
 '''
 
+import re
+
 from cvs.lib.platform.host_inventory import FACT_LABELS
 from cvs.lib.report.rundeck.dataset_builders.registry import register_dataset_builder
 
@@ -76,6 +78,10 @@ def _flatten_node_facts(results):
     return rows
 
 
+def _natural_key(label):
+    return [int(part) if part.isdigit() else part.lower() for part in re.split(r"(\d+)", str(label))]
+
+
 def _fact_label(key):
     parts = key.split(".")
     if parts[0] == "firmware" and len(parts) >= 3:
@@ -88,7 +94,7 @@ def _fact_label(key):
 def _drift_matrix(results, nodes):
     flattened = _flatten_node_facts(results)
     rows = []
-    for key in sorted(flattened, key=lambda item: (_fact_label(item).lower(), item)):
+    for key in sorted(flattened, key=lambda item: (_natural_key(_fact_label(item)), item)):
         by_node = flattened[key]
         values = [by_node.get(node, "\u2014") for node in nodes]
         mismatch = len({str(value) for value in values}) > 1
@@ -117,6 +123,8 @@ def _firmware_table(results):
                 continue
             for firmware_id, version in sorted(firmware.items()):
                 rows.append([node, gpu, firmware_id, version])
+    if not rows:
+        return {}
     return {
         "headers": ["Node", "GPU", "Firmware", "Version"],
         "rows": rows,

--- a/cvs/lib/report/rundeck/dataset_builders/registry.py
+++ b/cvs/lib/report/rundeck/dataset_builders/registry.py
@@ -2,7 +2,7 @@
 Copyright 2025 Advanced Micro Devices, Inc.
 All rights reserved.
 
-Registry for Run Deck dataset builders (``sweep``, ``series``, ``matrix``).
+Registry for Run Deck dataset builders.
 
 Builders are the Python extension point for new data shapes. Card types consume
 builder output; they are not builders themselves.

--- a/cvs/lib/report/rundeck/generate_rundeck.py
+++ b/cvs/lib/report/rundeck/generate_rundeck.py
@@ -104,7 +104,10 @@ class RundeckPublisher:
         )
 
         viewer_path = self._write_viewer(profile, config, out_dir, payload)
-        summary_path = write_inference_ci_summary(payload, config, out_dir)
+        builder_id = profile.get("dataset_builder", "sweep") if isinstance(profile, dict) else "sweep"
+        summary_path = None
+        if builder_id == "sweep":
+            summary_path = write_inference_ci_summary(payload, config, out_dir)
         artifacts = {
             "html": html_path_written,
             "json": json_path,
@@ -152,7 +155,8 @@ class RundeckPublisher:
             return
         self.report_manager.add_html_to_report(artifacts["html"], link_name=config.link_name)
         self.report_manager.add_html_to_report(artifacts["json"], link_name=f"{config.link_name} JSON")
-        self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
+        if artifacts.get("summary") is not None:
+            self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
         viewer = artifacts.get("viewer")
         if viewer is not None:
             self.report_manager.add_html_to_report(viewer, link_name=f"{config.link_name} viewer")

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -182,10 +182,7 @@ class DeckCardRenderer:
 
         mismatch_count = matrix.get("mismatch_count", 0)
         summary = f"<p class='drift-summary'>{mismatch_count} configuration row(s) differ across nodes.</p>"
-        return (
-            f"{summary}<table class='results-table drift-matrix'><tr>{header_html}</tr>"
-            f"{''.join(body)}</table>"
-        )
+        return f"{summary}<table class='results-table drift-matrix'><tr>{header_html}</tr>{''.join(body)}</table>"
 
     @staticmethod
     def render_launch(_payload: dict, _card: dict, data: Any) -> str:

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -8,6 +8,7 @@ Profile-driven card renderers for Run Deck static HTML.
 from __future__ import annotations
 
 import html
+from collections import Counter
 from typing import Any
 
 from cvs.lib.report.formatting import fmt_num, link_or_text_html
@@ -168,10 +169,15 @@ class DeckCardRenderer:
         body = []
         for row in rows:
             mismatch = bool(row.get("mismatch"))
-            value_class = "drift-cell-mismatch" if mismatch else "drift-cell-match"
-            values = "".join(
-                f"<td class='{value_class}'>{html.escape(str(value))}</td>" for value in row.get("values", [])
-            )
+            values_list = list(row.get("values", []))
+            counts = Counter(str(value) for value in values_list)
+            modal = counts.most_common(1)[0][0] if counts else ""
+            cells = []
+            for value in values_list:
+                outlier = mismatch and str(value) != modal
+                value_class = "drift-cell-mismatch" if outlier else "drift-cell-match"
+                cells.append(f"<td class='{value_class}'>{html.escape(str(value))}</td>")
+            values = "".join(cells)
             status = "Mismatch" if mismatch else "Consistent"
             status_class = "drift-status-mismatch" if mismatch else "drift-status-match"
             body.append(

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -157,6 +157,37 @@ class DeckCardRenderer:
         )
 
     @staticmethod
+    def render_drift_matrix(_payload, _card, data):
+        matrix = data if isinstance(data, dict) else {}
+        rows = matrix.get("rows") or []
+        if not rows:
+            return "<p class='muted'>No configuration facts recorded.</p>"
+
+        headers = matrix.get("headers") or []
+        header_html = "".join(f"<th>{html.escape(str(header))}</th>" for header in headers)
+        body = []
+        for row in rows:
+            mismatch = bool(row.get("mismatch"))
+            value_class = "drift-cell-mismatch" if mismatch else "drift-cell-match"
+            values = "".join(
+                f"<td class='{value_class}'>{html.escape(str(value))}</td>" for value in row.get("values", [])
+            )
+            status = "Mismatch" if mismatch else "Consistent"
+            status_class = "drift-status-mismatch" if mismatch else "drift-status-match"
+            body.append(
+                "<tr>"
+                f"<td>{html.escape(str(row.get('label', row.get('key', ''))))}</td>"
+                f"{values}<td class='{status_class}'>{status}</td></tr>"
+            )
+
+        mismatch_count = matrix.get("mismatch_count", 0)
+        summary = f"<p class='drift-summary'>{mismatch_count} configuration row(s) differ across nodes.</p>"
+        return (
+            f"{summary}<table class='results-table drift-matrix'><tr>{header_html}</tr>"
+            f"{''.join(body)}</table>"
+        )
+
+    @staticmethod
     def render_launch(_payload: dict, _card: dict, data: Any) -> str:
         return render_launch_panel_html(data or {})
 
@@ -211,6 +242,7 @@ class DeckCardRenderer:
             "gate_heatmap": self.render_gate_heatmap,
             "sweep_cell_cards": self.render_cell_cards,
             "table": self.render_table,
+            "drift_matrix": self.render_drift_matrix,
             "launch_panel": self.render_launch,
             "line_chart": self.render_line_chart,
             "heatmap": self.render_heatmap,
@@ -247,8 +279,8 @@ class DeckCardRenderer:
         if card_type == "gate_matrix":
             wrapped += f"<div class='matrix-wrap'>{html_body}"
             return section_id, wrapped, True
-        if card_type in ("table", "sweep_cell_cards"):
-            wrap_class = "results-wrap" if card_type == "table" else ""
+        if card_type in ("table", "drift_matrix", "sweep_cell_cards"):
+            wrap_class = "results-wrap" if card_type in ("table", "drift_matrix") else ""
             inner = f"<div class='{wrap_class}'>{html_body}</div>" if wrap_class else html_body
             return section_id, f"{wrapped}{inner}</section>", True
         if card_type == "lifecycle_timeline":

--- a/cvs/lib/report/rundeck/runtime/theme.py
+++ b/cvs/lib/report/rundeck/runtime/theme.py
@@ -101,6 +101,14 @@ h1 { font-size: 1.75rem; font-weight: 600; margin: 0 0 0.25rem; letter-spacing: 
 .bar-track { height: 4px; background: var(--border); border-radius: 2px; margin-top: 0.35rem; overflow: hidden; }
 .bar-fill { height: 100%; border-radius: 2px; }
 .bar-pass { background: var(--pass); } .bar-fail { background: var(--fail); } .bar-record { background: var(--record); }
+.results-wrap { overflow-x: auto; }
+.drift-summary { color: var(--muted); font-size: 0.8rem; margin: 0 0 0.75rem; }
+.drift-matrix td { white-space: nowrap; }
+.drift-cell-mismatch, .drift-status-mismatch {
+  color: var(--fail); background: rgba(255, 92, 106, 0.12);
+}
+.drift-status-mismatch, .drift-status-match { font-weight: 600; }
+.drift-status-match { color: var(--pass); }
 .target { font-size: 0.7rem; color: var(--muted); margin-left: 0.25rem; }
 .margin { font-size: 0.7rem; color: var(--pass); display: block; margin-top: 0.15rem; }
 .margin-fail { color: var(--fail); }

--- a/cvs/lib/report/rundeck/unittests/test_host_inventory_payload.py
+++ b/cvs/lib/report/rundeck/unittests/test_host_inventory_payload.py
@@ -74,6 +74,43 @@ class TestHostInventoryPayload(unittest.TestCase):
         self.assertNotIn("Sweep analytics", doc)
         self.assertNotIn("tok/s", doc)
 
+    def test_empty_firmware_card_is_hidden_and_outliers_are_marked(self):
+        results = {
+            "nodes": {
+                "node-a": {"bios": "A1", "kernel": "k1"},
+                "node-b": {"bios": "A1", "kernel": "k1"},
+                "node-c": {"bios": "B9", "kernel": "k1"},
+            }
+        }
+        payload = build_rundeck_payload(
+            profile=self.profile,
+            store={"cvs_results_dict": results, "variant_config": results},
+            cvs_version="1.0.0",
+        )
+        self.assertEqual(payload["datasets"]["host_inventory"]["firmware_table"], {})
+        doc = render_rundeck_html(payload)
+        self.assertNotIn("GPU firmware inventory", doc)
+        self.assertIn("class='drift-cell-mismatch'>B9</td>", doc)
+        self.assertNotIn("class='drift-cell-mismatch'>A1</td>", doc)
+        self.assertIn("B9", doc)
+
+    def test_hostile_host_facts_are_escaped(self):
+        results = {
+            "nodes": {
+                "node-a": {"bios": "<script>alert(1)</script>"},
+                "node-b": {"bios": "<script>alert(1)</script>"},
+            }
+        }
+        doc = render_rundeck_html(
+            build_rundeck_payload(
+                profile=self.profile,
+                store={"cvs_results_dict": results, "variant_config": results},
+                cvs_version="1.0.0",
+            )
+        )
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", doc)
+        self.assertNotIn("<script>alert(1)</script>", doc)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/lib/report/rundeck/unittests/test_host_inventory_payload.py
+++ b/cvs/lib/report/rundeck/unittests/test_host_inventory_payload.py
@@ -1,0 +1,79 @@
+'''Unit tests for the host configuration Run Deck.'''
+
+import unittest
+
+from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.dataset_builders.registry import build_datasets
+from cvs.lib.report.rundeck.payload import build_rundeck_payload
+from cvs.lib.report.rundeck.render import render_rundeck_html
+
+
+def sample_results():
+    return {
+        "nodes": {
+            "node-a": {
+                "os_release": "Ubuntu 24.04.1 LTS",
+                "kernel": "6.8.0-60-generic",
+                "bios": "A1",
+                "rocm": "7.0.2",
+                "gpu_count": "8",
+                "online_memory": "1.3T",
+                "gpu_pcie": {"card0": "32GT/s \u00b7 x16"},
+            },
+            "node-b": {
+                "os_release": "Ubuntu 24.04.1 LTS",
+                "kernel": "6.8.0-61-generic",
+                "bios": "A1",
+                "rocm": "7.0.2",
+                "gpu_count": "8",
+                "online_memory": "1.3T",
+                "gpu_pcie": {"card0": "32GT/s \u00b7 x16"},
+            },
+        },
+        "firmware": {
+            "node-a": {"0": {"CP_MEC1": "32945"}},
+            "node-b": {"0": {"CP_MEC1": "32946"}},
+        },
+    }
+
+
+class TestHostInventoryPayload(unittest.TestCase):
+    def setUp(self):
+        self.profile = load_json_profile("host_configs_cvs")
+
+    def test_profile_builds_inventory_and_drift_tables(self):
+        datasets = build_datasets("host_inventory", {"results": sample_results()}, self.profile)
+
+        self.assertEqual(datasets["node_count"], 2)
+        self.assertEqual(datasets["inventory_table"]["headers"][0], "Node")
+        self.assertEqual(len(datasets["inventory_table"]["rows"]), 2)
+
+        rows = {row["key"]: row for row in datasets["drift_matrix"]["rows"]}
+        self.assertTrue(rows["kernel"]["mismatch"])
+        self.assertFalse(rows["bios"]["mismatch"])
+        self.assertTrue(rows["firmware.0.CP_MEC1"]["mismatch"])
+        self.assertEqual(datasets["drift_matrix"]["mismatch_count"], 2)
+        self.assertEqual(len(datasets["firmware_table"]["rows"]), 2)
+
+    def test_payload_renders_inventory_without_performance_charts_or_viewer(self):
+        results = sample_results()
+        payload = build_rundeck_payload(
+            profile=self.profile,
+            store={"cvs_results_dict": results, "variant_config": results},
+            cvs_version="1.0.0",
+        )
+        doc = render_rundeck_html(payload)
+
+        self.assertEqual(payload["overall_status"], "record")
+        self.assertNotIn("viewer_config", payload)
+        self.assertIn("Nodes sampled", doc)
+        self.assertIn("Cross-node drift matrix", doc)
+        self.assertIn("drift-cell-mismatch", doc)
+        self.assertIn("Per-node inventory", doc)
+        self.assertIn("GPU firmware inventory", doc)
+        self.assertNotIn("Sweep analytics", doc)
+        self.assertNotIn("tok/s", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/tests/platform/host_configs_cvs.py
+++ b/cvs/tests/platform/host_configs_cvs.py
@@ -14,6 +14,22 @@ from cvs.lib.utils_lib import *
 from cvs.lib.verify_lib import *
 from cvs.lib.rocm_plib import *
 from cvs.lib import globals, linux_utils
+from cvs.lib.platform.host_inventory import (
+    normalize_output,
+    parse_gpu_count,
+    parse_iommu,
+    parse_kernel_version,
+    parse_numa_balancing,
+    parse_online_memory,
+    parse_os_release,
+    parse_pci_acs,
+    parse_pci_realloc,
+    parse_pcie_link,
+    parse_rocm_version,
+    record_gpu_firmware,
+    record_indexed_node_facts,
+    record_node_facts,
+)
 
 log = globals.log
 
@@ -85,12 +101,23 @@ def config_dict(config_file, cluster_dict):
     return config_dict
 
 
+@pytest.fixture(scope="session")
+def cvs_results_dict():
+    return {"nodes": {}, "firmware": {}}
+
+
+@pytest.fixture(scope="session")
+def host_inventory_metadata(cvs_results_dict):
+    return cvs_results_dict
+
+
 # Main Test cases start from here ..
 
 
 def test_check_os_release(
     orch,
     config_dict,
+    cvs_results_dict,
 ):
     """
     Validate that each node's OS release matches the expected version.
@@ -116,6 +143,7 @@ def test_check_os_release(
     log.info('Testcase check OS Version')
     os_version = config_dict['os_version']  # Expected version substring/pattern
     out_dict = orch.all.exec('cat /etc/os-release')
+    record_node_facts(cvs_results_dict, "os_release", out_dict, parse_os_release)
     for node in out_dict.keys():
         # If expected version is not present, extract the actual version and fail
         if not re.search(f'{os_version}', out_dict[node], re.I):
@@ -126,7 +154,7 @@ def test_check_os_release(
     update_test_result()
 
 
-def test_check_kernel_version(orch, config_dict):
+def test_check_kernel_version(orch, config_dict, cvs_results_dict):
     """
     Validate that each node's kernel version matches the expected version.
 
@@ -151,6 +179,7 @@ def test_check_kernel_version(orch, config_dict):
     log.info('Testcase check Kernel Version')
     kernel_version = config_dict['kernel_version']
     out_dict = orch.all.exec('uname -a')
+    record_node_facts(cvs_results_dict, "kernel", out_dict, parse_kernel_version)
     for node in out_dict.keys():
         # If expected version is not present, extract the actual version and fail
         if not re.search(f'{kernel_version}', out_dict[node], re.I):
@@ -163,7 +192,7 @@ def test_check_kernel_version(orch, config_dict):
     update_test_result()
 
 
-def test_check_bios_version(orch, config_dict):
+def test_check_bios_version(orch, config_dict, cvs_results_dict):
     """
     Verify that each node's BIOS/firmware version matches the expected value.
 
@@ -186,6 +215,7 @@ def test_check_bios_version(orch, config_dict):
     log.info('Testcase check BIOS Version')
     bios_version = config_dict['bios_version']
     out_dict = orch.all.exec('sudo dmidecode -s bios-version')
+    record_node_facts(cvs_results_dict, "bios", out_dict, normalize_output)
     for node in out_dict.keys():
         if not re.search(f'{bios_version}', out_dict[node], re.I):
             match = re.search('([a-z0-9\_\.\-]+)', out_dict[node], re.I)
@@ -196,7 +226,7 @@ def test_check_bios_version(orch, config_dict):
     update_test_result()
 
 
-def test_check_rocm_version(orch, config_dict):
+def test_check_rocm_version(orch, config_dict, cvs_results_dict):
     """
     Verify that each node's ROCm version matches the expected value.
 
@@ -222,6 +252,7 @@ def test_check_rocm_version(orch, config_dict):
     log.info('Testcase check rocm version')
     rocm_version = config_dict['rocm_version']
     out_dict = orch.all.exec('amd-smi version')
+    record_node_facts(cvs_results_dict, "rocm", out_dict, parse_rocm_version)
     for node in out_dict.keys():
         if not re.search(f'{rocm_version}', out_dict[node], re.I):
             match = re.search('ROCm version:\s+([0-9\.]+)', out_dict[node], re.I)
@@ -232,7 +263,7 @@ def test_check_rocm_version(orch, config_dict):
     update_test_result()
 
 
-def test_check_gpu_fw_version(orch, config_dict):
+def test_check_gpu_fw_version(orch, config_dict, cvs_results_dict):
     """
     Validate GPU firmware versions on each node against expected versions.
 
@@ -270,6 +301,7 @@ def test_check_gpu_fw_version(orch, config_dict):
     log.info('Testcase check GPU Firmware versions')
     fw_dict = config_dict['fw_dict']
     out_dict = get_amd_smi_fw_dict(orch.all)
+    record_gpu_firmware(cvs_results_dict, out_dict)
     for node in out_dict.keys():
         for gpu_dict in out_dict[node]:
             gpu_no = gpu_dict['gpu']
@@ -282,7 +314,7 @@ def test_check_gpu_fw_version(orch, config_dict):
     update_test_result()
 
 
-def test_check_pci_realloc(orch, config_dict):
+def test_check_pci_realloc(orch, config_dict, cvs_results_dict):
     """
     Verify that the kernel command line contains the expected PCI realloc flag.
 
@@ -304,13 +336,14 @@ def test_check_pci_realloc(orch, config_dict):
     log.info('Testcase check pci realloc')
     pci_realloc = config_dict['pci_realloc']
     out_dict = orch.all.exec('cat /proc/cmdline')
+    record_node_facts(cvs_results_dict, "pci_realloc", out_dict, parse_pci_realloc)
     for node in out_dict.keys():
         if not re.search(f'pci=realloc={pci_realloc}', out_dict[node], re.I):
             fail_test(f'PCI realloc flag not set to {pci_realloc} on node {node}')
     update_test_result()
 
 
-def test_check_iommu_pt(orch, config_dict):
+def test_check_iommu_pt(orch, config_dict, cvs_results_dict):
     """
     Verify that IOMMU is configured in pass-through mode (iommu=pt) on all nodes.
 
@@ -330,13 +363,14 @@ def test_check_iommu_pt(orch, config_dict):
     globals.error_list = []
     log.info('Testcase check IOMMU PT')
     out_dict = orch.all.exec('cat /proc/cmdline')
+    record_node_facts(cvs_results_dict, "iommu", out_dict, parse_iommu)
     for node in out_dict.keys():
         if not re.search('iommu=pt', out_dict[node], re.I):
             fail_test(f'IOMMU not set to pt on node {node}')
     update_test_result()
 
 
-def test_check_numa_balancing(orch, config_dict):
+def test_check_numa_balancing(orch, config_dict, cvs_results_dict):
     """
     Verify that automatic NUMA balancing is disabled across all nodes.
 
@@ -357,13 +391,14 @@ def test_check_numa_balancing(orch, config_dict):
     globals.error_list = []
     log.info('Testcase check NUMA balancing')
     out_dict = orch.all.exec('sudo sysctl kernel.numa_balancing')
+    record_node_facts(cvs_results_dict, "numa_balancing", out_dict, parse_numa_balancing)
     for node in out_dict.keys():
         if not re.search('=0|= 0', out_dict[node], re.I):
             fail_test(f'NUMA balancing not disabled on node {node}')
     update_test_result()
 
 
-def test_check_online_memory(orch, config_dict):
+def test_check_online_memory(orch, config_dict, cvs_results_dict):
     """
     Validate that the total online memory matches the expected value on each node.
 
@@ -387,6 +422,7 @@ def test_check_online_memory(orch, config_dict):
     log.info('Testcase check online memory')
     online_mem = config_dict['online_memory']
     out_dict = orch.all.exec('lsmem')
+    record_node_facts(cvs_results_dict, "online_memory", out_dict, parse_online_memory)
     for node in out_dict.keys():
         if not re.search(f'Total online memory:\s+{online_mem}', out_dict[node], re.I):
             match = re.search('Total online memory:\s+([0-9\.A-Za-z]+)', out_dict[node])
@@ -395,7 +431,7 @@ def test_check_online_memory(orch, config_dict):
     update_test_result()
 
 
-def test_check_pci_accelerators(orch, config_dict):
+def test_check_pci_accelerators(orch, config_dict, cvs_results_dict):
     """
     Confirm that the expected number of GPUs (accelerators) are enumerated on PCIe.
 
@@ -420,6 +456,7 @@ def test_check_pci_accelerators(orch, config_dict):
     log.info('Testcase check online GPUs in pcie')
     gpu_count = config_dict['gpu_count']
     out_dict = orch.all.exec('lspci | grep "accelerators" --color=never')
+    record_node_facts(cvs_results_dict, "gpu_count", out_dict, parse_gpu_count)
     for node in out_dict.keys():
         match_list = re.findall('accelerators:\s+Advanced', out_dict[node], re.I)
         actual_gpu_count = len(match_list)
@@ -430,7 +467,7 @@ def test_check_pci_accelerators(orch, config_dict):
     update_test_result()
 
 
-def test_check_gpu_pcie_speed_width(orch, config_dict):
+def test_check_gpu_pcie_speed_width(orch, config_dict, cvs_results_dict):
     """
     Verify PCIe link speed and width for each GPU on all nodes.
 
@@ -480,6 +517,7 @@ def test_check_gpu_pcie_speed_width(orch, config_dict):
             bus_no = out_dict[node][card_no]['PCI Bus']
             cmd_list.append(f'sudo lspci -vvv -s {bus_no} | grep "LnkSta:" --color=never')
         pci_dict = orch.all.exec_cmd_list(cmd_list)
+        record_indexed_node_facts(cvs_results_dict, "gpu_pcie", card_no, pci_dict, parse_pcie_link)
         for p_node in pci_dict.keys():
             bus_no = out_dict[p_node][card_no]['PCI Bus']
             if not re.search(f'Speed {gpu_pcie_speed}GT', pci_dict[p_node]):
@@ -495,7 +533,7 @@ def test_check_gpu_pcie_speed_width(orch, config_dict):
     update_test_result()
 
 
-def test_check_be_nic_pcie_speed_width(orch, config_dict):
+def test_check_be_nic_pcie_speed_width(orch, config_dict, cvs_results_dict):
     """
     Verify PCIe link speed and width for each Backend NIC on all nodes.
 
@@ -526,6 +564,7 @@ def test_check_be_nic_pcie_speed_width(orch, config_dict):
             nic_bdf = out_dict[node][card_no]['nic_bdf']
             cmd_list.append(f'sudo lspci -vvv -s {nic_bdf} | grep "LnkSta:" --color=never')
         pci_dict = orch.all.exec_cmd_list(cmd_list)
+        record_indexed_node_facts(cvs_results_dict, "nic_pcie", card_no, pci_dict, parse_pcie_link)
         for p_node in pci_dict:
             output = pci_dict[p_node]
             nic_bdf = out_dict[p_node][card_no]['nic_bdf']
@@ -543,7 +582,7 @@ def test_check_be_nic_pcie_speed_width(orch, config_dict):
     update_test_result()
 
 
-def test_check_pci_acs(orch, config_dict):
+def test_check_pci_acs(orch, config_dict, cvs_results_dict):
     """
     Verify PCIe ACS is disabled on all nodes.
 
@@ -563,6 +602,7 @@ def test_check_pci_acs(orch, config_dict):
 
     globals.error_list = []
     out_dict = orch.all.exec('sudo lspci -vv | grep ACSCtl | grep SrcValid+ --color=never')
+    record_node_facts(cvs_results_dict, "pci_acs", out_dict, parse_pci_acs)
     for node in out_dict.keys():
         if re.search('ACSCtl:', out_dict[node], re.I):
             fail_test(f'PCIe ACS not disabled on node {node}')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a render-only Run Deck for `cvs run host_configs_cvs`.

## Plan / code surfaces
- Profile `profiles/host_configs_cvs.json` with a `host_inventory` dataset builder
- Inventory parse helpers in `cvs/lib/platform/host_inventory.py`
- Session results wired from existing host-config collection (gates unchanged)
- New `drift_matrix` card for key × node mismatches

## Panels
- Run card (nodes sampled, facts collected)
- Cross-node drift matrix (the operator view)
- Per-node inventory table (OS, kernel, BIOS, ROCm, GPU count, memory)
- GPU firmware table when present
- Inference interactive viewer off

## Review follow-up (`edfe7a90`)
- Drift cells: only values that differ from the row majority are marked
- Empty GPU firmware tables are omitted; failed firmware collection is not listed as a collected fact
- Unparseable remote output maps to `unavailable`
- Inference CI summary sidecar is skipped for this non-sweep deck

A shared `config_adapter` landing (non-sweep hook threading) is still needed before merging the suite PR fleet.

## Quality
`make fmt-check` / `make lint` clean; targeted unittests pass. Hardware not run. Draft — do not merge yet.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bd374b-7c5a-4d24-be58-368133af2219?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bd374b-7c5a-4d24-be58-368133af2219&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

