### PR TITLE
feat(transferbench): enable Run Deck for transferbench_cvs

### DIFF
--- a/cvs/lib/report/profiles/hooks/transferbench_run_card.py
+++ b/cvs/lib/report/profiles/hooks/transferbench_run_card.py
@@ -1,0 +1,22 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+'''
+
+from cvs.lib.report.rundeck.config_builder import provenance_link_rows
+
+
+def transferbench_run_card_display(variant, provenance):
+    variant = variant or {}
+    tests = variant.get('tests_enabled') or []
+    duration = float(variant.get('duration_seconds') or 0.0)
+    rows = [
+        ('ROCm path', variant.get('rocm_path') or '—', False),
+        ('Tests enabled', ', '.join(tests) if tests else '—', False),
+        ('Duration', f'{duration:.1f} s', False),
+    ]
+    rows.extend(provenance_link_rows(provenance))
+    return rows
+
+
+__all__ = ['transferbench_run_card_display']

--- a/cvs/lib/report/profiles/transferbench_cvs.json
+++ b/cvs/lib/report/profiles/transferbench_cvs.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "profile_id": "transferbench_cvs_rundeck",
+  "suite_id": "transferbench_cvs",
+  "metric_contract": {"id": "transferbench-health", "version": 1},
+  "report_basename": "transferbench_cvs_run_deck",
+  "title": "TransferBench Run Deck",
+  "subtitle": "TransferBench health and bandwidth summary",
+  "footer": "CVS TransferBench · render-only · does not affect qualification gates",
+  "link_name": "TransferBench Run Deck",
+  "dataset_builder": "series",
+  "interactive_viewer": false,
+  "sources": {
+    "results": "cvs_results_dict",
+    "variant": "variant_config"
+  },
+  "hooks": {
+    "run_card_display": "cvs.lib.report.profiles.hooks.transferbench_run_card:transferbench_run_card_display"
+  },
+  "series": {
+    "x_field": "GPU, bytes, or CU count",
+    "y_fields": ["a2a_bw", "p2p_bw", "a2asweep_bw", "scaling_bw", "schmoo_bw"],
+    "table_columns": [
+      {"label": "Test", "field": "test"},
+      {"label": "Node", "field": "node"},
+      {"label": "Metric", "field": "metric"},
+      {"label": "GPU / bytes / CUs", "field": "$x"},
+      {"label": "Value", "field": "value"},
+      {"label": "Unit", "field": "unit"},
+      {"label": "Status", "field": "status"},
+      {"label": "Duration (s)", "field": "duration_s"}
+    ]
+  },
+  "cards": [
+    {"type": "run_card", "id": "run-card", "title": "Run card", "bind": "run_card_display"},
+    {
+      "type": "line_chart",
+      "id": "a2a-bandwidth",
+      "title": "A2A receive bandwidth by GPU",
+      "bind": "datasets.series",
+      "when_empty": "hide",
+      "series": {"y_field": "a2a_bw", "unit": "GB/s"}
+    },
+    {
+      "type": "line_chart",
+      "id": "p2p-bandwidth",
+      "title": "P2P bandwidth by GPU pair",
+      "bind": "datasets.series",
+      "when_empty": "hide",
+      "series": {"y_field": "p2p_bw", "unit": "GB/s"}
+    },
+    {
+      "type": "line_chart",
+      "id": "a2a-sweep",
+      "title": "A2A sweep bandwidth by CU count",
+      "bind": "datasets.series",
+      "when_empty": "hide",
+      "series": {"y_field": "a2asweep_bw", "unit": "GB/s"}
+    },
+    {
+      "type": "line_chart",
+      "id": "scaling",
+      "title": "Scaling bandwidth by CU count",
+      "bind": "datasets.series",
+      "when_empty": "hide",
+      "series": {"y_field": "scaling_bw", "unit": "GB/s"}
+    },
+    {
+      "type": "line_chart",
+      "id": "schmoo",
+      "title": "Schmoo bandwidth by CU count",
+      "bind": "datasets.series",
+      "when_empty": "hide",
+      "series": {"y_field": "schmoo_bw", "unit": "GB/s"}
+    },
+    {"type": "table", "id": "results", "title": "TransferBench results", "bind": "results_table"}
+  ]
+}

--- a/cvs/lib/report/profiles/transferbench_cvs.json
+++ b/cvs/lib/report/profiles/transferbench_cvs.json
@@ -39,7 +39,7 @@
       "title": "A2A receive bandwidth by GPU",
       "bind": "datasets.series",
       "when_empty": "hide",
-      "series": {"y_field": "a2a_bw", "unit": "GB/s"}
+      "series": {"y_field": "a2a_bw", "unit": "GB/s", "x_label": "GPU {x}"}
     },
     {
       "type": "line_chart",
@@ -47,7 +47,7 @@
       "title": "P2P bandwidth by GPU pair",
       "bind": "datasets.series",
       "when_empty": "hide",
-      "series": {"y_field": "p2p_bw", "unit": "GB/s"}
+      "series": {"y_field": "p2p_bw", "unit": "GB/s", "x_label": "\u2192GPU {x}"}
     },
     {
       "type": "line_chart",
@@ -55,7 +55,7 @@
       "title": "A2A sweep bandwidth by CU count",
       "bind": "datasets.series",
       "when_empty": "hide",
-      "series": {"y_field": "a2asweep_bw", "unit": "GB/s"}
+      "series": {"y_field": "a2asweep_bw", "unit": "GB/s", "x_label": "{x} CUs"}
     },
     {
       "type": "line_chart",
@@ -63,7 +63,7 @@
       "title": "Scaling bandwidth by CU count",
       "bind": "datasets.series",
       "when_empty": "hide",
-      "series": {"y_field": "scaling_bw", "unit": "GB/s"}
+      "series": {"y_field": "scaling_bw", "unit": "GB/s", "x_label": "{x} CUs"}
     },
     {
       "type": "line_chart",
@@ -71,7 +71,7 @@
       "title": "Schmoo bandwidth by CU count",
       "bind": "datasets.series",
       "when_empty": "hide",
-      "series": {"y_field": "schmoo_bw", "unit": "GB/s"}
+      "series": {"y_field": "schmoo_bw", "unit": "GB/s", "x_label": "{x} CUs"}
     },
     {"type": "table", "id": "results", "title": "TransferBench results", "bind": "results_table"}
   ]

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -82,10 +82,14 @@ class ProfileConfigResolver:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
         hooks = profile.get("hooks") or {}
-        if builder in ("series", "matrix"):
-            run_card_builder = None
+        if builder != "sweep":
+            extra = {}
             if hooks.get("run_card_display"):
-                run_card_builder = cls.import_callable(hooks["run_card_display"])
+                extra["run_card_display_builder"] = cls.import_callable(hooks["run_card_display"])
+            if hooks.get("launch_provenance"):
+                extra["launch_provenance_builder"] = cls.import_callable(hooks["launch_provenance"])
+            if profile.get("metric_contract"):
+                extra["metric_contract"] = profile["metric_contract"]
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",
@@ -97,7 +101,7 @@ class ProfileConfigResolver:
                 metric_units={"bus_bw": "GB/s", "alg_bw": "GB/s"},
                 tier_metric_specs=lambda _c, _t: {},
                 interactive_viewer=bool(profile.get("interactive_viewer", False)),
-                run_card_display_builder=run_card_builder,
+                **extra,
             )
 
         sweep = profile.get("sweep") or {}

--- a/cvs/lib/report/rundeck/config_adapter.py
+++ b/cvs/lib/report/rundeck/config_adapter.py
@@ -81,7 +81,11 @@ class ProfileConfigResolver:
     def from_profile_dict(cls, profile: dict[str, Any]) -> InferenceReportConfig:
         """Materialize ``InferenceReportConfig`` from a JSON deck profile."""
         builder = profile.get("dataset_builder", "sweep")
+        hooks = profile.get("hooks") or {}
         if builder in ("series", "matrix"):
+            run_card_builder = None
+            if hooks.get("run_card_display"):
+                run_card_builder = cls.import_callable(hooks["run_card_display"])
             return make_inference_report_config(
                 suite_id=profile.get("suite_id") or profile.get("profile_id", "suite"),
                 report_basename=profile.get("report_basename") or f"{profile.get('suite_id', 'suite')}_run_deck",
@@ -93,9 +97,9 @@ class ProfileConfigResolver:
                 metric_units={"bus_bw": "GB/s", "alg_bw": "GB/s"},
                 tier_metric_specs=lambda _c, _t: {},
                 interactive_viewer=bool(profile.get("interactive_viewer", False)),
+                run_card_display_builder=run_card_builder,
             )
 
-        hooks = profile.get("hooks") or {}
         sweep = profile.get("sweep") or {}
 
         tier_metric_specs = (

--- a/cvs/lib/report/rundeck/dataset_builders/series.py
+++ b/cvs/lib/report/rundeck/dataset_builders/series.py
@@ -35,6 +35,33 @@ def _graph_to_series(graph_dict: dict, *, y_field: str = "bus_bw") -> dict[str, 
     return series_by_name
 
 
+def _table_columns(series_cfg):
+    raw = series_cfg.get("table_columns") or []
+    columns = []
+    for item in raw:
+        if isinstance(item, dict) and item.get("label") and item.get("field"):
+            columns.append((item["label"], item["field"]))
+        elif isinstance(item, (list, tuple)) and len(item) == 2:
+            columns.append((item[0], item[1]))
+    if columns:
+        return columns
+    return [
+        ("Collective", "$series"),
+        ("Message size", "$x"),
+        ("Bus BW (GB/s)", "bus_bw"),
+        ("Alg BW (GB/s)", "alg_bw"),
+        ("Time (us)", "time"),
+    ]
+
+
+def _table_value(field, series_name, x_value, entry):
+    if field == "$series":
+        return series_name
+    if field == "$x":
+        return x_value
+    return entry.get(field, "—")
+
+
 @register_dataset_builder("series")
 def build_series_datasets(sources: dict[str, Any], profile: dict[str, Any]) -> dict[str, Any]:
     results = sources.get("results") or sources.get("cvs_results_dict") or {}
@@ -48,7 +75,8 @@ def build_series_datasets(sources: dict[str, Any], profile: dict[str, Any]) -> d
         charts[y_field] = _graph_to_series(results, y_field=y_field)
 
     table_rows = []
-    headers = ["Collective", "Message size", "Bus BW (GB/s)", "Alg BW (GB/s)", "Time (us)"]
+    table_columns = _table_columns(series_cfg)
+    headers = [label for label, _field in table_columns]
     for collective, sizes in sorted((results or {}).items()):
         if not isinstance(sizes, dict):
             continue
@@ -56,15 +84,7 @@ def build_series_datasets(sources: dict[str, Any], profile: dict[str, Any]) -> d
             entry = sizes[size_key]
             if not isinstance(entry, dict):
                 continue
-            table_rows.append(
-                [
-                    collective,
-                    size_key,
-                    entry.get("bus_bw", "—"),
-                    entry.get("alg_bw", "—"),
-                    entry.get("time", "—"),
-                ]
-            )
+            table_rows.append([_table_value(field, collective, size_key, entry) for _label, field in table_columns])
 
     return {
         "charts": charts,

--- a/cvs/lib/report/rundeck/generate_rundeck.py
+++ b/cvs/lib/report/rundeck/generate_rundeck.py
@@ -104,7 +104,10 @@ class RundeckPublisher:
         )
 
         viewer_path = self._write_viewer(profile, config, out_dir, payload)
-        summary_path = write_inference_ci_summary(payload, config, out_dir)
+        builder_id = profile.get("dataset_builder", "sweep") if isinstance(profile, dict) else "sweep"
+        summary_path = None
+        if builder_id == "sweep":
+            summary_path = write_inference_ci_summary(payload, config, out_dir)
         artifacts = {
             "html": html_path_written,
             "json": json_path,
@@ -152,7 +155,8 @@ class RundeckPublisher:
             return
         self.report_manager.add_html_to_report(artifacts["html"], link_name=config.link_name)
         self.report_manager.add_html_to_report(artifacts["json"], link_name=f"{config.link_name} JSON")
-        self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
+        if artifacts.get("summary") is not None:
+            self.report_manager.add_html_to_report(artifacts["summary"], link_name=f"{config.link_name} summary")
         viewer = artifacts.get("viewer")
         if viewer is not None:
             self.report_manager.add_html_to_report(viewer, link_name=f"{config.link_name} viewer")

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -23,6 +23,14 @@ from cvs.lib.report.types import DEFAULT_SESSION_LIFECYCLE_LABELS
 SESSION_FALLBACK = DEFAULT_SESSION_LIFECYCLE_LABELS
 
 
+def _chart_x_label(series_cfg):
+    if series_cfg.get("x_label"):
+        return series_cfg["x_label"]
+    if "x_label_prefix" in series_cfg:
+        return f"{series_cfg.get('x_label_prefix') or ''}{{x}}"
+    return "C={x}"
+
+
 class DeckCardRenderer:
     """Profile-driven card renderers for Run Deck static HTML sections."""
 
@@ -175,7 +183,7 @@ class DeckCardRenderer:
         elif isinstance(raw, list):
             entries = raw
         if not entries:
-            return "<p class='muted'>No series data.</p>"
+            return ""
         parts = []
         title = card.get("title") or y_field
         for entry in entries:
@@ -183,10 +191,15 @@ class DeckCardRenderer:
                 continue
             points = entry.get("points") or []
             label = entry.get("label") or title
-            part = self._charts.render_series_chart(str(label), points, series_cfg.get("unit") or "GB/s")
+            part = self._charts.render_series_chart(
+                str(label),
+                points,
+                series_cfg.get("unit") or "GB/s",
+                x_label=_chart_x_label(series_cfg),
+            )
             if part:
                 parts.append(part)
-        return f"<div class='chart-grid'>{''.join(parts)}</div>" if parts else "<p class='muted'>No series data.</p>"
+        return f"<div class='chart-grid'>{''.join(parts)}</div>" if parts else ""
 
     @staticmethod
     def render_heatmap(_payload: dict, card: dict, data: Any) -> str:

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -149,9 +149,7 @@ class SweepChartRenderer:
         for p in points:
             if isinstance(p, (list, tuple)) and len(p) >= 2:
                 normalized.append((p[0], p[1]))
-        return self.render_bar_chart(
-            title, normalized, unit, accent="accent2", x_label=x_label, min_points=1
-        )
+        return self.render_bar_chart(title, normalized, unit, accent="accent2", x_label=x_label, min_points=1)
 
 
 _DEFAULT_RENDERER = SweepChartRenderer()

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -64,8 +64,10 @@ class SweepChartRenderer:
         unit: str,
         *,
         accent: str = "accent",
+        x_label="C={x}",
+        min_points=2,
     ) -> str:
-        if len(points) < 2:
+        if len(points) < min_points:
             return ""
         values = [p[1] for p in points]
         max_val = max(values) or 1.0
@@ -84,13 +86,17 @@ class SweepChartRenderer:
         x_labels = []
         for conc, val in points:
             h = self._bar_height_pct(val, min_val, max_val)
-            tip = html.escape(f"C={conc}: {fmt_num(val)} {unit}".strip())
+            try:
+                xlabel = x_label.format(x=conc)
+            except (KeyError, IndexError, ValueError):
+                xlabel = str(conc)
+            tip = html.escape(f"{xlabel}: {fmt_num(val)} {unit}".strip())
             bars.append(
                 f"<div class='chart-col'>"
                 f"<div class='chart-bar chart-bar-{accent} chart-has-tip' style='height:{h:.1f}%' "
                 f"data-tip='{tip}' tabindex='0' role='img' aria-label='{tip}'></div></div>"
             )
-            x_labels.append(f"<span class='chart-xlbl'>C={conc}</span>")
+            x_labels.append(f"<span class='chart-xlbl'>{html.escape(str(xlabel))}</span>")
         return (
             f"<div class='chart-panel'><h3>{html.escape(title)}</h3>"
             f"<div class='chart-viz'>"
@@ -138,12 +144,14 @@ class SweepChartRenderer:
             else "<p class='muted'>Concurrency charts need two or more points per sweep shape.</p>"
         )
 
-    def render_series_chart(self, title: str, points: list, unit: str) -> str:
+    def render_series_chart(self, title: str, points: list, unit: str, x_label="{x}"):
         normalized = []
         for p in points:
             if isinstance(p, (list, tuple)) and len(p) >= 2:
                 normalized.append((p[0], p[1]))
-        return self.render_bar_chart(title, normalized, unit, accent="accent2")
+        return self.render_bar_chart(
+            title, normalized, unit, accent="accent2", x_label=x_label, min_points=1
+        )
 
 
 _DEFAULT_RENDERER = SweepChartRenderer()

--- a/cvs/lib/unittests/test_transferbench_health.py
+++ b/cvs/lib/unittests/test_transferbench_health.py
@@ -154,6 +154,7 @@ class TestTransferBenchReportMetrics(unittest.TestCase):
 
         self.assertEqual(a2a['a2a RTotal · nodeA']['0']['a2a_bw'], 320.0)
         self.assertEqual(p2p['p2p UniDir GPU 0 · nodeA']['1']['p2p_bw'], 48.0)
+        self.assertNotIn('0', p2p['p2p UniDir GPU 0 · nodeA'])
         self.assertEqual(sweep['a2asweep B256 U2 Min · nodeA']['8']['a2asweep_bw'], 314.99)
         self.assertEqual(scaling['scaling GPU00 · nodeA']['32']['scaling_bw'], 493.17)
         self.assertEqual(schmoo['schmoo Local Read · nodeA']['32']['schmoo_bw'], 1700.0)

--- a/cvs/lib/unittests/test_transferbench_health.py
+++ b/cvs/lib/unittests/test_transferbench_health.py
@@ -213,11 +213,82 @@ class TestTransferBenchReportMetrics(unittest.TestCase):
             payload['results_table']['headers'],
             ['Test', 'Node', 'Metric', 'GPU / bytes / CUs', 'Value', 'Unit', 'Status', 'Duration (s)'],
         )
+        self.assertEqual(
+            (payload.get('metric_contract') or {}).get('id'),
+            'transferbench-health',
+        )
         self.assertIn('a2asweep_bw', payload['datasets']['series']['charts'])
         self.assertIn('TransferBench Run Deck', document)
         self.assertIn('/opt/rocm/core-7.2', document)
         self.assertIn('A2A sweep bandwidth by CU count', document)
         self.assertIn('healthcheck', document)
+        self.assertNotIn('C=0', document)
+        self.assertNotIn('C=7', document)
+        self.assertIn('GPU 0', document)
+        self.assertIn('→GPU 1', document)
+        self.assertIn('4 CUs', document)
+        self.assertGreater(document.count('chart-bar'), 10)
+        self.assertGreater(document.count('chart-panel'), 4)
+
+    def test_empty_chart_cards_hidden_when_preset_missing(self):
+        results = {}
+        variant = {
+            'rocm_path': '/opt/rocm',
+            'tests_enabled': ['a2a'],
+            'duration_seconds': 1.0,
+        }
+        tb.globals.error_list = []
+        tb.record_transferbench_results(results, variant, 'a2a', {'nodeA': A2A_OUTPUT}, 1.0)
+
+        payload = build_rundeck_payload(
+            profile=load_json_profile('transferbench_cvs'),
+            store={'cvs_results_dict': results, 'variant_config': variant},
+            cvs_version='1.0.0',
+        )
+        document = render_rundeck_html(payload)
+        self.assertIn('A2A receive bandwidth by GPU', document)
+        self.assertNotIn('P2P bandwidth by GPU pair', document)
+        self.assertNotIn('A2A sweep bandwidth by CU count', document)
+        self.assertNotIn('Scaling bandwidth by CU count', document)
+        self.assertNotIn('Schmoo bandwidth by CU count', document)
+        self.assertNotIn('No series data.', document)
+        self.assertIn('TransferBench results', document)
+
+    def test_extractors_read_pipe_separated_tables(self):
+        schmoo = tb.extract_tb_schmoo_metrics(
+            {
+                'nodeA': (
+                    'TransferBench v1.65.00\n'
+                    '#CUs | Local | Write | Copy | RRead | RWrite | RCopy |\n'
+                    '  | 32 |  12.5 |  11.0 |  10.0 |  9.0 |  8.0 |  7.0 |\n'
+                    '  | 64 |  22.5 |  21.0 |  20.0 | 18.0 | 17.0 | 16.0 |\n'
+                )
+            }
+        )
+        scaling = tb.extract_tb_scaling_metrics(
+            {
+                'nodeA': (
+                    'TransferBench v1.65.00\n'
+                    'NumCUs | CPU00 | GPU00 |\n'
+                    '  | 32 |  40.0 |  80.0 |\n'
+                    '  | 64 |  50.0 | 160.0 |\n'
+                )
+            }
+        )
+        sweep = tb.extract_tb_a2asweep_metrics(
+            {
+                'nodeA': (
+                    'TransferBench v1.65.00\n'
+                    'Blocksize: 256\n'
+                    '#CUs\\Unroll 1(Min) 2(Min)\n'
+                    '  | 32 |  50.0 |  48.0 |\n'
+                    '  | 64 | 100.0 |  96.0 |\n'
+                )
+            }
+        )
+        self.assertEqual(schmoo['schmoo Local Read · nodeA']['32']['schmoo_bw'], 12.5)
+        self.assertEqual(scaling['scaling GPU00 · nodeA']['32']['scaling_bw'], 80.0)
+        self.assertEqual(sweep['a2asweep B256 U1 Min · nodeA']['32']['a2asweep_bw'], 50.0)
 
 
 class TestScanTestResultsNumaAbort(unittest.TestCase):

--- a/cvs/lib/unittests/test_transferbench_health.py
+++ b/cvs/lib/unittests/test_transferbench_health.py
@@ -5,6 +5,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.payload import build_rundeck_payload
+from cvs.lib.report.rundeck.render import render_rundeck_html
+
 
 _TB_PATH = Path(__file__).resolve().parents[2] / 'tests' / 'health' / 'transferbench_cvs.py'
 _SPEC = importlib.util.spec_from_file_location('transferbench_cvs_under_test', _TB_PATH)
@@ -26,6 +30,43 @@ P2P_EXPECT = {
     'avg_gpu_to_gpu_p2p_unidir_bw': '33.9',
     'avg_gpu_to_gpu_p2p_bidir_bw': '43.9',
 }
+
+A2A_OUTPUT = """\
+RTotal 320.0 321.0 322.0 323.0 324.0 325.0 326.0 327.0
+"""
+
+P2P_MATRIX_OUTPUT = """\
+NUM_CPU_DEVICES = 2 : Using 2 CPUs
+Bytes Per Direction 268435456
+Unidirectional copy peak bandwidth GB/s
+GPU 00 -> 55.0 55.0 1600.0 48.0
+GPU 01 -> 55.0 55.0 49.0 1700.0
+Averages (During UniDir): 37.0 34.0 55.0 48.5
+Bidirectional copy peak bandwidth GB/s
+GPU 00 <-> 80.0 80.0 N/A 92.0
+GPU 01 <-> 80.0 80.0 93.0 N/A
+Averages (During BiDir): 70.0 70.0 80.0 92.5
+"""
+
+A2A_SWEEP_OUTPUT = """\
+Blocksize: 256
+#CUs\\Unroll 1(Min) 2(Min)
+4 120.38 209.89
+8 229.32 314.99
+"""
+
+SCALING_OUTPUT = """\
+NumCUs CPU00 CPU01 GPU00 GPU01
+1 20.22 20.41 18.68 25.91
+32 57.15 56.35 493.17 49.23
+Best 57.15( 32) 56.35( 32) 493.17( 32) 49.23( 32)
+"""
+
+SCHMOO_OUTPUT = """\
+#CUs |G00->G00->N00|N00->G00->G00|G00->G00->G00|G01->G00->N00|N00->G00->G01|G00->G00->G01|
+1 51.0 53.0 54.0 23.0 46.0 26.0
+32 1700.0 1300.0 1300.0 49.0 49.0 49.0
+"""
 
 
 class TestCpuDeviceCount(unittest.TestCase):
@@ -101,6 +142,81 @@ class TestParseTbP2pBw(unittest.TestCase):
         with patch.object(tb, 'fail_test') as fail_test:
             tb.parse_tb_p2p_bw({'nodeA': HELIOS_R_P2P_SUCCESS}, P2P_EXPECT)
         fail_test.assert_not_called()
+
+
+class TestTransferBenchReportMetrics(unittest.TestCase):
+    def test_extracts_supported_bandwidth_shapes(self):
+        a2a = tb.extract_tb_a2a_metrics({'nodeA': A2A_OUTPUT})
+        p2p = tb.extract_tb_p2p_metrics({'nodeA': P2P_MATRIX_OUTPUT})
+        sweep = tb.extract_tb_a2asweep_metrics({'nodeA': A2A_SWEEP_OUTPUT})
+        scaling = tb.extract_tb_scaling_metrics({'nodeA': SCALING_OUTPUT})
+        schmoo = tb.extract_tb_schmoo_metrics({'nodeA': SCHMOO_OUTPUT})
+
+        self.assertEqual(a2a['a2a RTotal · nodeA']['0']['a2a_bw'], 320.0)
+        self.assertEqual(p2p['p2p UniDir GPU 0 · nodeA']['1']['p2p_bw'], 48.0)
+        self.assertEqual(sweep['a2asweep B256 U2 Min · nodeA']['8']['a2asweep_bw'], 314.99)
+        self.assertEqual(scaling['scaling GPU00 · nodeA']['32']['scaling_bw'], 493.17)
+        self.assertEqual(schmoo['schmoo Local Read · nodeA']['32']['schmoo_bw'], 1700.0)
+
+    def test_a2a_test_populates_session_results_with_mocked_orch(self):
+        orch = MagicMock()
+        orch.exec.side_effect = [
+            {'nodeA': '/opt/rocm/lib/libamdhip64.so.7'},
+            {'nodeA': A2A_OUTPUT},
+        ]
+        config = {
+            'path': '/opt/TransferBench',
+            'rocm_path': '/opt/rocm',
+            'num_cpu_devices': 2,
+            'results': {'gpu_to_gpu_a2a_rtotal': '300.0'},
+        }
+        results = {}
+        variant = {
+            'rocm_path': '—',
+            'tests_enabled': ['a2a'],
+            'duration_seconds': 0.0,
+        }
+
+        tb.test_transfer_bench_a2a(orch, config, results, variant)
+
+        self.assertIn('a2a RTotal · nodeA', results)
+        self.assertEqual(variant['rocm_path'], '/opt/rocm')
+        self.assertGreaterEqual(variant['duration_seconds'], 0.0)
+        self.assertEqual(orch.exec.call_count, 2)
+
+    def test_real_profile_builder_payload_and_render(self):
+        results = {}
+        variant = {
+            'rocm_path': '/opt/rocm/core-7.2',
+            'tests_enabled': list(tb._TB_TEST_NAMES),
+            'duration_seconds': 12.25,
+        }
+        tb.globals.error_list = []
+        tb.record_transferbench_results(results, variant, 'a2a', {'nodeA': A2A_OUTPUT}, 1.0)
+        tb.record_transferbench_results(results, variant, 'p2p', {'nodeA': P2P_MATRIX_OUTPUT}, 2.0)
+        tb.record_transferbench_results(results, variant, 'healthcheck', {'nodeA': 'PASS'}, 3.0)
+        tb.record_transferbench_results(results, variant, 'a2asweep', {'nodeA': A2A_SWEEP_OUTPUT}, 4.0)
+        tb.record_transferbench_results(results, variant, 'scaling', {'nodeA': SCALING_OUTPUT}, 5.0)
+        tb.record_transferbench_results(results, variant, 'schmoo', {'nodeA': SCHMOO_OUTPUT}, 6.0)
+
+        profile = load_json_profile('transferbench_cvs')
+        payload = build_rundeck_payload(
+            profile=profile,
+            store={'cvs_results_dict': results, 'variant_config': variant},
+            cvs_version='1.0.0',
+        )
+        document = render_rundeck_html(payload)
+
+        self.assertFalse(profile['interactive_viewer'])
+        self.assertEqual(
+            payload['results_table']['headers'],
+            ['Test', 'Node', 'Metric', 'GPU / bytes / CUs', 'Value', 'Unit', 'Status', 'Duration (s)'],
+        )
+        self.assertIn('a2asweep_bw', payload['datasets']['series']['charts'])
+        self.assertIn('TransferBench Run Deck', document)
+        self.assertIn('/opt/rocm/core-7.2', document)
+        self.assertIn('A2A sweep bandwidth by CU count', document)
+        self.assertIn('healthcheck', document)
 
 
 class TestScanTestResultsNumaAbort(unittest.TestCase):

--- a/cvs/tests/health/transferbench_cvs.py
+++ b/cvs/tests/health/transferbench_cvs.py
@@ -10,6 +10,7 @@ import pytest
 import json
 import re
 import shlex
+import time
 
 from cvs.lib.env_lib import build_env_prefix
 from cvs.lib.utils_lib import *
@@ -34,6 +35,8 @@ _TB_NUMA_ABORT_HINT = (
     "transferbench.num_cpu_devices or transferbench.env.NUM_CPU_DEVICES to the "
     "populated CPU NUMA count (Helios-R / Venice: 2)."
 )
+_TB_NUMBER = r'[0-9]+(?:\.[0-9]+)?'
+_TB_TEST_NAMES = ('a2a', 'p2p', 'healthcheck', 'a2asweep', 'scaling', 'schmoo')
 
 
 def count_linux_id_list(spec):
@@ -145,16 +148,247 @@ def build_transferbench_command(path, rocm_path, preset, extra_env=None):
     return f'sudo bash -c {shlex.quote(inner)}'
 
 
-def run_transferbench(orch, config_dict, preset, timeout, extra_env=None):
+def run_transferbench(orch, config_dict, preset, timeout, extra_env=None, report_context=None):
     """Resolve ROCm/env and execute one TransferBench preset on all orch hosts."""
     path = config_dict['path']
     rocm_path = detect_rocm_path(orch, config_dict.get('rocm_path', ''))
+    if report_context is not None:
+        report_context['rocm_path'] = rocm_path
     env = resolve_runtime_tb_env(orch, config_dict)
     if extra_env:
         env.update(extra_env)
     cmd = build_transferbench_command(path, rocm_path, preset, env)
     log.info('TransferBench command: %s', cmd)
     return orch.exec(cmd, timeout=timeout)
+
+
+def _metric_entry(test_name, node, metric, value, unit='GB/s'):
+    return {
+        'test': test_name,
+        'node': node,
+        'metric': metric,
+        'value': value,
+        'unit': unit,
+    }
+
+
+def extract_tb_a2a_metrics(out_dict):
+    metrics = {}
+    for node, output in out_dict.items():
+        match = re.search(r'(?m)^[ \t│|]*RTotal[ \t│|]+(.+)$', output)
+        if not match:
+            continue
+        values = re.findall(_TB_NUMBER, match.group(1))
+        if not values:
+            continue
+        series = metrics.setdefault(f'a2a RTotal · {node}', {})
+        for gpu, value in enumerate(values):
+            entry = _metric_entry('a2a', node, f'GPU {gpu} receive total', float(value))
+            entry['a2a_bw'] = float(value)
+            series[str(gpu)] = entry
+    return metrics
+
+
+def extract_tb_p2p_metrics(out_dict):
+    metrics = {}
+    for node, output in out_dict.items():
+        cpu_match = re.search(r'NUM_CPU_DEVICES\s*=\s*(\d+)', output)
+        cpu_count = int(cpu_match.group(1)) if cpu_match else 0
+        bytes_match = re.search(r'Bytes (?:Per Direction|to transfer:)\s*(\d+)', output, re.I)
+        transfer_bytes = bytes_match.group(1) if bytes_match else '1'
+        direction = None
+        found_rows = False
+        for raw_line in output.splitlines():
+            line = raw_line.strip()
+            if line.startswith('Unidirectional copy'):
+                direction = 'UniDir'
+                continue
+            if line.startswith('Bidirectional copy'):
+                direction = 'BiDir'
+                continue
+            if direction == 'UniDir':
+                match = re.match(r'GPU\s+(\d+)\s+->\s+(.+)$', line)
+            elif direction == 'BiDir':
+                match = re.match(r'GPU\s+(\d+)\s+<->\s+(.+)$', line)
+            else:
+                match = None
+            if not match:
+                continue
+            values = match.group(2).split()[cpu_count:]
+            src_gpu = int(match.group(1))
+            series = metrics.setdefault(f'p2p {direction} GPU {src_gpu} · {node}', {})
+            for dst_gpu, value in enumerate(values):
+                if not re.fullmatch(_TB_NUMBER, value):
+                    continue
+                bw = float(value)
+                entry = _metric_entry('p2p', node, f'{direction} GPU {src_gpu}→{dst_gpu}', bw)
+                entry['p2p_bw'] = bw
+                series[str(dst_gpu)] = entry
+                found_rows = True
+        if found_rows:
+            continue
+        for label, pattern in (
+            ('UniDir', r'Averages\s+\(During\s+UniDir\):\s+(?:[0-9\.]+\s+){3}([0-9\.]+)'),
+            ('BiDir', r'Averages\s+\(During\s+BiDir\):\s+(?:[0-9\.]+\s+){3}([0-9\.]+)'),
+        ):
+            match = re.search(pattern, output, re.I)
+            if not match:
+                continue
+            bw = float(match.group(1))
+            entry = _metric_entry('p2p', node, f'{label} GPU average', bw)
+            entry['p2p_bw'] = bw
+            metrics[f'p2p {label} average · {node}'] = {transfer_bytes: entry}
+    return metrics
+
+
+def extract_tb_a2asweep_metrics(out_dict):
+    metrics = {}
+    for node, output in out_dict.items():
+        blocksize = None
+        columns = []
+        for raw_line in output.splitlines():
+            line = raw_line.strip().strip('│|').strip()
+            match = re.match(r'Blocksize:\s*(\d+)', line, re.I)
+            if match:
+                blocksize = match.group(1)
+                columns = []
+                continue
+            if line.startswith('#CUs\\Unroll'):
+                columns = re.findall(r'(\d+)\((Min|Max)\)', line, re.I)
+                continue
+            if blocksize is None or not columns:
+                continue
+            match = re.fullmatch(rf'(\d+)\s+((?:{_TB_NUMBER}\s*)+)', line)
+            if not match:
+                continue
+            cu_count = match.group(1)
+            values = re.findall(_TB_NUMBER, match.group(2))
+            if len(values) != len(columns):
+                continue
+            for (unroll, result_kind), value in zip(columns, values):
+                bw = float(value)
+                label = f'a2asweep B{blocksize} U{unroll} {result_kind.title()} · {node}'
+                entry = _metric_entry(
+                    'a2asweep',
+                    node,
+                    f'block {blocksize}, unroll {unroll}, {result_kind.lower()}',
+                    bw,
+                )
+                entry['a2asweep_bw'] = bw
+                metrics.setdefault(label, {})[cu_count] = entry
+    return metrics
+
+
+def extract_tb_scaling_metrics(out_dict):
+    metrics = {}
+    for node, output in out_dict.items():
+        devices = []
+        for raw_line in output.splitlines():
+            line = raw_line.strip()
+            if line.startswith('NumCUs '):
+                devices = re.findall(r'(?:CPU|GPU)\d+', line)
+                continue
+            if not devices:
+                continue
+            match = re.fullmatch(rf'(\d+)\s+((?:{_TB_NUMBER}\s*)+)', line)
+            if not match:
+                continue
+            cu_count = match.group(1)
+            values = re.findall(_TB_NUMBER, match.group(2))
+            if len(values) != len(devices):
+                continue
+            for device, value in zip(devices, values):
+                bw = float(value)
+                entry = _metric_entry('scaling', node, f'{device} bandwidth', bw)
+                entry['scaling_bw'] = bw
+                metrics.setdefault(f'scaling {device} · {node}', {})[cu_count] = entry
+    return metrics
+
+
+def extract_tb_schmoo_metrics(out_dict):
+    operations = (
+        'Local Read',
+        'Local Write',
+        'Local Copy',
+        'Remote Read',
+        'Remote Write',
+        'Remote Copy',
+    )
+    metrics = {}
+    for node, output in out_dict.items():
+        in_table = False
+        for raw_line in output.splitlines():
+            line = raw_line.strip().strip('│|').strip()
+            if line.startswith('#CUs'):
+                in_table = True
+                continue
+            if not in_table:
+                continue
+            match = re.fullmatch(rf'(\d+)\s+((?:{_TB_NUMBER}\s*)+)', line)
+            if not match:
+                continue
+            cu_count = match.group(1)
+            values = re.findall(_TB_NUMBER, match.group(2))
+            if len(values) != len(operations):
+                continue
+            for operation, value in zip(operations, values):
+                bw = float(value)
+                entry = _metric_entry('schmoo', node, operation, bw)
+                entry['schmoo_bw'] = bw
+                metrics.setdefault(f'schmoo {operation} · {node}', {})[cu_count] = entry
+    return metrics
+
+
+_TB_METRIC_EXTRACTORS = {
+    'a2a': extract_tb_a2a_metrics,
+    'p2p': extract_tb_p2p_metrics,
+    'a2asweep': extract_tb_a2asweep_metrics,
+    'scaling': extract_tb_scaling_metrics,
+    'schmoo': extract_tb_schmoo_metrics,
+}
+
+
+def record_transferbench_results(cvs_results_dict, variant_config, test_name, out_dict, duration_s):
+    status = 'pass' if not globals.error_list else 'fail'
+    extracted = _TB_METRIC_EXTRACTORS.get(test_name, lambda _outputs: {})(out_dict)
+    for series in extracted.values():
+        for entry in series.values():
+            entry['status'] = status
+            entry['duration_s'] = round(duration_s, 3)
+    if not extracted:
+        for node in out_dict:
+            extracted[f'{test_name} status · {node}'] = {
+                '0': {
+                    'test': test_name,
+                    'node': node,
+                    'metric': 'test status',
+                    'value': status,
+                    'unit': '',
+                    'status': status,
+                    'duration_s': round(duration_s, 3),
+                }
+            }
+    cvs_results_dict.update(extracted)
+    variant_config['duration_seconds'] += duration_s
+
+
+@pytest.fixture(scope='session')
+def cvs_results_dict():
+    return {}
+
+
+@pytest.fixture(scope='session')
+def variant_config(request):
+    selected = []
+    collected_names = {item.name for item in request.session.items}
+    for test_name in _TB_TEST_NAMES:
+        if f'test_transfer_bench_{test_name}' in collected_names:
+            selected.append(test_name)
+    return {
+        'rocm_path': '—',
+        'tests_enabled': selected,
+        'duration_seconds': 0.0,
+    }
 
 
 def _tb_output_excerpt(out, tail=6000):
@@ -379,93 +613,179 @@ def parse_tb_schmoo_bw(out_dict, exp_dict):
 def test_transfer_bench_a2a(
     orch,
     config_dict,
+    cvs_results_dict,
+    variant_config,
 ):
     globals.error_list = []
     log.info('Testcase Run Transferbench a2a')
     preset = config_dict.get('a2a_preset') or 'a2a'
-    out_dict = run_transferbench(orch, config_dict, preset, timeout=(60 * 5))
+    started = time.monotonic()
+    out_dict = run_transferbench(
+        orch,
+        config_dict,
+        preset,
+        timeout=(60 * 5),
+        report_context=variant_config,
+    )
     print_test_output(log, out_dict)
     scan_test_results(out_dict)
     parse_tb_a2a_bw(out_dict, config_dict['results'])
     scan_test_results(out_dict)
+    record_transferbench_results(
+        cvs_results_dict,
+        variant_config,
+        'a2a',
+        out_dict,
+        time.monotonic() - started,
+    )
     update_test_result()
 
 
 def test_transfer_bench_p2p(
     orch,
     config_dict,
+    cvs_results_dict,
+    variant_config,
 ):
     globals.error_list = []
     log.info('Testcase Run Transferbench p2p')
     preset = config_dict.get('p2p_preset') or 'p2p'
-    out_dict = run_transferbench(orch, config_dict, preset, timeout=(60 * 5))
+    started = time.monotonic()
+    out_dict = run_transferbench(
+        orch,
+        config_dict,
+        preset,
+        timeout=(60 * 5),
+        report_context=variant_config,
+    )
     print_test_output(log, out_dict)
     parse_tb_p2p_bw(out_dict, config_dict['results'])
     scan_test_results(out_dict)
+    record_transferbench_results(
+        cvs_results_dict,
+        variant_config,
+        'p2p',
+        out_dict,
+        time.monotonic() - started,
+    )
     update_test_result()
 
 
 def test_transfer_bench_healthcheck(
     orch,
     config_dict,
+    cvs_results_dict,
+    variant_config,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench healthcheck')
     preset = config_dict.get('healthcheck_preset') or 'healthcheck'
-    out_dict = run_transferbench(orch, config_dict, preset, timeout=(60 * 3))
+    started = time.monotonic()
+    out_dict = run_transferbench(
+        orch,
+        config_dict,
+        preset,
+        timeout=(60 * 3),
+        report_context=variant_config,
+    )
     print_test_output(log, out_dict)
     scan_test_results(out_dict)
+    record_transferbench_results(
+        cvs_results_dict,
+        variant_config,
+        'healthcheck',
+        out_dict,
+        time.monotonic() - started,
+    )
     update_test_result()
 
 
 def test_transfer_bench_a2asweep(
     orch,
     config_dict,
+    cvs_results_dict,
+    variant_config,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench a2asweep')
     preset = config_dict.get('a2asweep_preset') or 'a2asweep'
-    out_dict = run_transferbench(orch, config_dict, preset, timeout=(60 * 10))
+    started = time.monotonic()
+    out_dict = run_transferbench(
+        orch,
+        config_dict,
+        preset,
+        timeout=(60 * 10),
+        report_context=variant_config,
+    )
     print_test_output(log, out_dict)
     scan_test_results(out_dict)
+    record_transferbench_results(
+        cvs_results_dict,
+        variant_config,
+        'a2asweep',
+        out_dict,
+        time.monotonic() - started,
+    )
     update_test_result()
 
 
 def test_transfer_bench_scaling(
     orch,
     config_dict,
+    cvs_results_dict,
+    variant_config,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench scaling')
     preset = config_dict.get('scaling_preset') or 'scaling'
+    started = time.monotonic()
     out_dict = run_transferbench(
         orch,
         config_dict,
         preset,
         timeout=(60 * 10),
         extra_env={'GFX_TEMPORAL': '3', 'GFX_UNROLL': '32'},
+        report_context=variant_config,
     )
     print_test_output(log, out_dict)
     parse_tb_scaling_bw(out_dict, config_dict['results'])
     scan_test_results(out_dict)
+    record_transferbench_results(
+        cvs_results_dict,
+        variant_config,
+        'scaling',
+        out_dict,
+        time.monotonic() - started,
+    )
     update_test_result()
 
 
 def test_transfer_bench_schmoo(
     orch,
     config_dict,
+    cvs_results_dict,
+    variant_config,
 ):
     globals.error_list = []
     log.info('Testcase Run TransferBench schmoo')
     preset = config_dict.get('schmoo_preset') or 'schmoo'
+    started = time.monotonic()
     out_dict = run_transferbench(
         orch,
         config_dict,
         preset,
         timeout=(60 * 5),
         extra_env={'GFX_UNROLL': '32', 'SWEEP_MIN': '32'},
+        report_context=variant_config,
     )
     print_test_output(log, out_dict)
     scan_test_results(out_dict)
     parse_tb_schmoo_bw(out_dict, config_dict['results'])
+    record_transferbench_results(
+        cvs_results_dict,
+        variant_config,
+        'schmoo',
+        out_dict,
+        time.monotonic() - started,
+    )
     update_test_result()

--- a/cvs/tests/health/transferbench_cvs.py
+++ b/cvs/tests/health/transferbench_cvs.py
@@ -172,6 +172,12 @@ def _metric_entry(test_name, node, metric, value, unit='GB/s'):
     }
 
 
+def _numeric_table_row(line):
+    cleaned = re.sub(r'[|│]', ' ', str(line or '').strip())
+    cleaned = re.sub(r'\s+', ' ', cleaned).strip()
+    return re.fullmatch(rf'(\d+)\s+((?:{_TB_NUMBER}\s*)+)', cleaned)
+
+
 def extract_tb_a2a_metrics(out_dict):
     metrics = {}
     for node, output in out_dict.items():
@@ -258,7 +264,7 @@ def extract_tb_a2asweep_metrics(out_dict):
                 continue
             if blocksize is None or not columns:
                 continue
-            match = re.fullmatch(rf'(\d+)\s+((?:{_TB_NUMBER}\s*)+)', line)
+            match = _numeric_table_row(line)
             if not match:
                 continue
             cu_count = match.group(1)
@@ -284,13 +290,13 @@ def extract_tb_scaling_metrics(out_dict):
     for node, output in out_dict.items():
         devices = []
         for raw_line in output.splitlines():
-            line = raw_line.strip()
-            if line.startswith('NumCUs '):
+            line = raw_line.strip().strip('│|').strip()
+            if line.startswith('NumCUs'):
                 devices = re.findall(r'(?:CPU|GPU)\d+', line)
                 continue
             if not devices:
                 continue
-            match = re.fullmatch(rf'(\d+)\s+((?:{_TB_NUMBER}\s*)+)', line)
+            match = _numeric_table_row(line)
             if not match:
                 continue
             cu_count = match.group(1)
@@ -324,7 +330,7 @@ def extract_tb_schmoo_metrics(out_dict):
                 continue
             if not in_table:
                 continue
-            match = re.fullmatch(rf'(\d+)\s+((?:{_TB_NUMBER}\s*)+)', line)
+            match = _numeric_table_row(line)
             if not match:
                 continue
             cu_count = match.group(1)
@@ -350,7 +356,11 @@ _TB_METRIC_EXTRACTORS = {
 
 def record_transferbench_results(cvs_results_dict, variant_config, test_name, out_dict, duration_s):
     status = 'pass' if not globals.error_list else 'fail'
-    extracted = _TB_METRIC_EXTRACTORS.get(test_name, lambda _outputs: {})(out_dict)
+    extractor = _TB_METRIC_EXTRACTORS.get(test_name)
+    try:
+        extracted = extractor(out_dict) if extractor else {}
+    except (TypeError, ValueError, KeyError, IndexError, AttributeError):
+        extracted = {}
     for series in extracted.values():
         for entry in series.values():
             entry['status'] = status

--- a/cvs/tests/health/transferbench_cvs.py
+++ b/cvs/tests/health/transferbench_cvs.py
@@ -218,7 +218,7 @@ def extract_tb_p2p_metrics(out_dict):
             src_gpu = int(match.group(1))
             series = metrics.setdefault(f'p2p {direction} GPU {src_gpu} · {node}', {})
             for dst_gpu, value in enumerate(values):
-                if not re.fullmatch(_TB_NUMBER, value):
+                if dst_gpu == src_gpu or not re.fullmatch(_TB_NUMBER, value):
                     continue
                 bw = float(value)
                 entry = _metric_entry('p2p', node, f'{direction} GPU {src_gpu}→{dst_gpu}', bw)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a render-only series Run Deck for `cvs run transferbench_cvs`.

## Plan / code surfaces
- Profile `profiles/transferbench_cvs.json` using the existing `series` builder (extended for TransferBench metric fields / table columns)
- Session fixtures in `transferbench_cvs.py` for all six tests (a2a, p2p, healthcheck, a2asweep, scaling, schmoo)
- Qualification gates unchanged

## Graphs / tables
- A2A receive BW by GPU (`GPU {x}` ticks)
- P2P BW by GPU pair (self-copy excluded; `→GPU {x}` ticks)
- A2A sweep / scaling / schmoo BW by CU count (`{x} CUs`)
- Combined results table (node, metric, status, duration)
- Run card metadata; inference viewer off
- Empty preset chart cards are hidden instead of showing “No series data.”

## Review follow-up
- Non-sweep `config_adapter` path uses `builder != "sweep"` and forwards `metric_contract`
- Skip inference CI summary sidecar for series decks
- Pipe-drawn schmoo/scaling/sweep tables parse the same shapes the gate parsers accept
- Recorder extract failures cannot fail qualification

## Quality
`make fmt-check`, `make lint`, `make ut` (1975 tests). Hardware not run. Residual: cluster-scale HTML size and p2p matrix shape still need a real 8-GPU capture.

Draft only — do not merge until the shared engine hunks land and this branch is rebased.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bd374b-7c5a-4d24-be58-368133af2219?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bd374b-7c5a-4d24-be58-368133af2219&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

