### PR TITLE
feat(megatron): enable Run Deck for training sweeps

### DIFF
--- a/cvs/lib/report/profile.py
+++ b/cvs/lib/report/profile.py
@@ -21,6 +21,12 @@ _PROFILES_DIR = Path(__file__).resolve().parent / "profiles"
 
 # Multiple ``cvs run`` stems may share one deck profile (same sweep/report layout).
 PROFILE_STEM_ALIASES: dict[str, str] = {
+    "megatron_single": "megatron",
+    "megatron_distributed": "megatron",
+    "megatron_llama3_1_8b_single": "megatron",
+    "megatron_llama3_1_8b_distributed": "megatron",
+    "megatron_llama3_1_70b_single": "megatron",
+    "megatron_llama3_1_70b_distributed": "megatron",
     "sglang_single": "sglang",
     "sglang_distributed": "sglang",
     "sglang_disagg_distributed": "sglang",

--- a/cvs/lib/report/profiles/hooks/megatron_run_card.py
+++ b/cvs/lib/report/profiles/hooks/megatron_run_card.py
@@ -5,6 +5,8 @@ All rights reserved.
 Megatron Run Deck hooks.
 '''
 
+from types import SimpleNamespace
+
 from cvs.lib.report.rundeck.config_builder import provenance_link_rows, thresholds_run_card_row
 from cvs.lib.utils.verdict import _check_one
 
@@ -39,7 +41,43 @@ def megatron_metric_verdict(metric, actual, spec):
     return ("fail", error) if error else ("pass", "")
 
 
+def build_legacy_rundeck_variant(raw, stem, training_dict, model_params, gpu_type, variant_config):
+    """Map a legacy Llama JSON config onto the named-cell variant, or None on mismatch."""
+    if not isinstance(raw, dict) or "config" not in raw:
+        return variant_config
+    try:
+        distributed = str(stem or "").endswith("_distributed")
+        model_name = "llama3_1_70b" if "70b" in str(stem or "") else "llama3_1_8b"
+        topology = "multi_node" if distributed else "single_node"
+        params = dict(model_params[topology][model_name][gpu_type])
+        cell_id = f"MBS={params['micro_batch_size']},GBS={params['batch_size']},PRECISION={params['precision']}"
+        threshold_specs = {
+            f"training.{metric}": {"kind": "min", "value": value}
+            for metric, value in (params.get("result_dict") or {}).items()
+            if not str(metric).startswith("_")
+        }
+        params["model_name"] = model_name
+        params["nnodes"] = str((training_dict or {}).get("nnodes") or 1)
+        combo = SimpleNamespace(
+            micro_batch_size=str(params["micro_batch_size"]),
+            global_batch_size=str(params["batch_size"]),
+            precision=str(params["precision"]),
+        )
+        return SimpleNamespace(
+            train_params=params,
+            gpu_arch=str(gpu_type).upper(),
+            enforce_thresholds=True,
+            thresholds={cell_id: threshold_specs},
+            sweep=SimpleNamespace(combinations={cell_id: combo}, runs=[cell_id]),
+            container=SimpleNamespace(env={"NNODES": params["nnodes"]}),
+        )
+    except (KeyError, TypeError, AttributeError):
+        return None
+
+
 def megatron_run_card_display(variant, provenance):
+    if variant is None:
+        variant = SimpleNamespace()
     train_params = getattr(variant, "train_params", {}) or {}
     env = getattr(getattr(variant, "container", None), "env", {}) or {}
     parallelism = ", ".join(
@@ -62,6 +100,7 @@ def megatron_run_card_display(variant, provenance):
 
 __all__ = [
     "MEGATRON_METRIC_UNITS",
+    "build_legacy_rundeck_variant",
     "megatron_metric_verdict",
     "megatron_run_card_display",
     "megatron_tier_metric_specs",

--- a/cvs/lib/report/profiles/hooks/megatron_run_card.py
+++ b/cvs/lib/report/profiles/hooks/megatron_run_card.py
@@ -1,0 +1,68 @@
+'''
+Copyright 2025 Advanced Micro Devices, Inc.
+All rights reserved.
+
+Megatron Run Deck hooks.
+'''
+
+from cvs.lib.report.rundeck.config_builder import provenance_link_rows, thresholds_run_card_row
+from cvs.lib.utils.verdict import _check_one
+
+
+MEGATRON_METRIC_UNITS = {
+    "throughput_per_gpu": "TFLOP/s/GPU",
+    "tokens_per_gpu": "tok/s/GPU",
+    "elapsed_time_per_iteration": "ms",
+    "mem_usage": "",
+    "scaling_efficiency_pct": "%",
+    "lm_loss": "",
+    "grad_norm": "",
+    "hip_mem_usage_ratio": "%",
+    "rocm_mem_usage_ratio": "%",
+    "steps_to_target": "steps",
+    "time_to_target_seconds": "s",
+}
+
+
+def megatron_tier_metric_specs(thresholds_cell, tier):
+    if tier == "thresholds":
+        return dict(thresholds_cell or {})
+    return {}
+
+
+def megatron_metric_verdict(metric, actual, spec):
+    if actual is None:
+        if spec.get("optional"):
+            return "pass", f"{metric} is optional and was not reported"
+        return "fail", f"{metric} was not reported"
+    error = _check_one(metric, actual, spec)
+    return ("fail", error) if error else ("pass", "")
+
+
+def megatron_run_card_display(variant, provenance):
+    train_params = getattr(variant, "train_params", {}) or {}
+    env = getattr(getattr(variant, "container", None), "env", {}) or {}
+    parallelism = ", ".join(
+        (
+            f"TP={train_params.get('tensor_parallelism', '—')}",
+            f"PP={train_params.get('pipeline_parallelism', '—')}",
+            f"FSDP={train_params.get('fsdp', '—')}",
+        )
+    )
+    rows = [
+        ("Model", train_params.get("model_name") or train_params.get("model") or "—", False),
+        ("GPU", getattr(variant, "gpu_arch", "—"), False),
+        ("Nodes", str(env.get("NNODES") or train_params.get("nnodes") or "—"), False),
+        ("Parallelism", parallelism, False),
+        thresholds_run_card_row(variant),
+    ]
+    rows.extend(provenance_link_rows(provenance))
+    return rows
+
+
+__all__ = [
+    "MEGATRON_METRIC_UNITS",
+    "megatron_metric_verdict",
+    "megatron_run_card_display",
+    "megatron_tier_metric_specs",
+]

--- a/cvs/lib/report/profiles/megatron.json
+++ b/cvs/lib/report/profiles/megatron.json
@@ -23,6 +23,13 @@
   "sweep": {
     "layout": "named_cells",
     "metric_prefix": "training.",
+    "dimension_keys": ["micro_batch_size", "global_batch_size", "precision"],
+    "label_parts": ["micro_batch_size", "global_batch_size", "precision"],
+    "label_aliases": {
+      "micro_batch_size": "MBS",
+      "global_batch_size": "GBS",
+      "precision": "PRECISION"
+    },
     "tier_order": ["thresholds", "record"],
     "throughput_metric": "training.throughput_per_gpu",
     "headline_metric": "training.throughput_per_gpu",
@@ -88,14 +95,14 @@
       "id": "throughput",
       "title": "Throughput vs cells",
       "bind": "datasets.sweep",
-      "series": {"y_field": "throughput_per_gpu", "unit": "TFLOP/s/GPU", "x_label_prefix": ""}
+      "series": {"y_field": "throughput_per_gpu", "unit": "TFLOP/s/GPU", "x_label": "{x}"}
     },
     {
       "type": "line_chart",
       "id": "token-throughput",
       "title": "Token throughput vs cells",
       "bind": "datasets.sweep",
-      "series": {"y_field": "tokens_per_gpu", "unit": "tok/s/GPU", "x_label_prefix": ""}
+      "series": {"y_field": "tokens_per_gpu", "unit": "tok/s/GPU", "x_label": "{x}"}
     },
     {"type": "gate_matrix", "id": "gates", "title": "Gate matrix", "bind": "gate_matrix"},
     {"type": "table", "id": "results", "title": "Full results", "bind": "results_table"}

--- a/cvs/lib/report/profiles/megatron.json
+++ b/cvs/lib/report/profiles/megatron.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": 1,
+  "profile_id": "megatron_rundeck",
+  "suite_id": "megatron",
+  "report_basename": "megatron_run_deck",
+  "title": "Megatron Training Run Deck",
+  "subtitle": "Megatron · training sweep performance summary",
+  "footer": "CVS Megatron · render-only · does not affect gates",
+  "link_name": "Megatron Training Run Deck",
+  "dataset_builder": "sweep",
+  "interactive_viewer": false,
+  "sources": {
+    "results": "train_res_dict",
+    "variant": "rundeck_variant",
+    "lifecycle": "lifecycle"
+  },
+  "hooks": {
+    "tier_metric_specs": "cvs.lib.report.profiles.hooks.megatron_run_card:megatron_tier_metric_specs",
+    "metric_units": "cvs.lib.report.profiles.hooks.megatron_run_card:MEGATRON_METRIC_UNITS",
+    "metric_verdict": "cvs.lib.report.profiles.hooks.megatron_run_card:megatron_metric_verdict",
+    "run_card_display": "cvs.lib.report.profiles.hooks.megatron_run_card:megatron_run_card_display"
+  },
+  "sweep": {
+    "layout": "named_cells",
+    "metric_prefix": "training.",
+    "tier_order": ["thresholds", "record"],
+    "throughput_metric": "training.throughput_per_gpu",
+    "headline_metric": "training.throughput_per_gpu",
+    "results_table_columns": [
+      ["Cell", null],
+      ["Model", "model"],
+      ["GPU", "gpu"],
+      ["Nodes", "nnodes"],
+      ["MBS", "micro_batch_size"],
+      ["GBS", "global_batch_size"],
+      ["Precision", "precision"],
+      ["Throughput/GPU", "training.throughput_per_gpu"],
+      ["Tokens/GPU/s", "training.tokens_per_gpu"],
+      ["Iteration time", "training.elapsed_time_per_iteration"],
+      ["Memory usage", "training.mem_usage"],
+      ["Scaling efficiency", "training.scaling_efficiency_pct"],
+      ["LM loss", "training.lm_loss"],
+      ["Gradient norm", "training.grad_norm"],
+      ["HIP memory ratio", "training.hip_mem_usage_ratio"],
+      ["ROCm memory ratio", "training.rocm_mem_usage_ratio"],
+      ["Steps to target", "training.steps_to_target"],
+      ["Time to target", "training.time_to_target_seconds"]
+    ],
+    "cell_highlights": [
+      ["throughput_per_gpu", "Throughput/GPU"],
+      ["tokens_per_gpu", "Tokens/GPU/s"],
+      ["elapsed_time_per_iteration", "Iteration time"],
+      ["scaling_efficiency_pct", "Scaling efficiency"]
+    ],
+    "chart_series": [
+      {
+        "metric_suffix": "throughput_per_gpu",
+        "title": "Throughput per GPU",
+        "unit": "TFLOP/s/GPU",
+        "invert": false
+      },
+      {
+        "metric_suffix": "tokens_per_gpu",
+        "title": "Token throughput per GPU",
+        "unit": "tok/s/GPU",
+        "invert": false
+      }
+    ]
+  },
+  "lifecycle": {
+    "session_labels": ["container_launch", "tokenizer_download", "smoke", "training", "teardown"],
+    "cell_labels": []
+  },
+  "behavior": {
+    "inference_test_substring": "test_training",
+    "row_card_extras": false,
+    "row_card_test_names": []
+  },
+  "viewer": {
+    "interactivity": {
+      "enabled": false
+    }
+  },
+  "cards": [
+    {"type": "run_card", "id": "run-card", "title": "Run card", "bind": "run_card_display"},
+    {
+      "type": "line_chart",
+      "id": "throughput",
+      "title": "Throughput vs cells",
+      "bind": "datasets.sweep",
+      "series": {"y_field": "throughput_per_gpu", "unit": "TFLOP/s/GPU", "x_label_prefix": ""}
+    },
+    {
+      "type": "line_chart",
+      "id": "token-throughput",
+      "title": "Token throughput vs cells",
+      "bind": "datasets.sweep",
+      "series": {"y_field": "tokens_per_gpu", "unit": "tok/s/GPU", "x_label_prefix": ""}
+    },
+    {"type": "gate_matrix", "id": "gates", "title": "Gate matrix", "bind": "gate_matrix"},
+    {"type": "table", "id": "results", "title": "Full results", "bind": "results_table"}
+  ]
+}

--- a/cvs/lib/report/render/gate_matrix.py
+++ b/cvs/lib/report/render/gate_matrix.py
@@ -22,6 +22,8 @@ class GateMatrixRenderer:
 
     @staticmethod
     def cell_label(cell: Mapping[str, object]) -> str:
+        if cell.get("display_label"):
+            return str(cell["display_label"])
         base = f"{cell['policy']} \u00b7 C={cell['concurrency']}"
         if cell.get("show_host_in_label"):
             return f"{base} \u00b7 {cell['host']}"
@@ -32,7 +34,7 @@ class GateMatrixRenderer:
             {
                 "label": self.cell_label(cell),
                 "cell_id": cell["cell_id"],
-                "concurrency": cell["concurrency"],
+                "concurrency": cell.get("concurrency"),
                 "tiers": cell["tiers"],
             }
             for cell in cells

--- a/cvs/lib/report/rundeck/dataset_builders/sweep.py
+++ b/cvs/lib/report/rundeck/dataset_builders/sweep.py
@@ -7,6 +7,7 @@ Sweep dataset builder — lifts inference payload assembly into ``datasets.sweep
 
 from __future__ import annotations
 
+import math
 from typing import Any, Mapping
 
 from cvs.lib.report.cell_build import (
@@ -35,38 +36,83 @@ def _results_dict(sources: Mapping[str, Any]) -> Mapping:
     return sources.get("results") or sources.get("cvs_results_dict") or sources.get("inf_res_dict") or {}
 
 
-def _last_value(value):
-    while isinstance(value, (list, tuple)):
-        if not value:
-            return None
-        value = value[-1]
-    if value is None:
+def _sweep_layout_cfg(profile):
+    if isinstance(profile, dict):
+        return profile.get("sweep") or {}
+    return {}
+
+
+def _metric_samples(value):
+    items = list(value) if isinstance(value, (list, tuple)) else [value]
+    samples = []
+    for item in items:
+        if item is None or item == "":
+            continue
+        try:
+            samples.append(float(item))
+        except (TypeError, ValueError):
+            continue
+    return samples
+
+
+def _reduce_actual(value, spec):
+    samples = _metric_samples(value)
+    if not samples:
+        while isinstance(value, (list, tuple)):
+            if not value:
+                return None
+            value = value[-1]
+        return value
+    kind = str((spec or {}).get("kind") or "")
+    if kind.startswith("min"):
+        return min(samples)
+    if kind.startswith("max"):
+        return max(samples)
+    return samples[-1]
+
+
+def _safe_bar_pct(config, actual, spec):
+    if spec is None or actual is None or "value" not in spec:
+        return None
+    if config.metric_verdict is not None and not (type(actual) in (int, float) and math.isfinite(actual)):
         return None
     try:
-        return float(value)
-    except (TypeError, ValueError):
-        return value
+        return bar_pct(float(actual), spec)
+    except (TypeError, ValueError, KeyError):
+        return None
 
 
-def _named_cell_dimensions(cell_id, variant_config):
+def _named_cell_dimensions(cell_id, variant_config, sweep_cfg):
+    dimension_keys = list(sweep_cfg.get("dimension_keys") or [])
+    aliases = sweep_cfg.get("label_aliases") or {}
+    alias_to_key = {str(key).lower(): key for key in dimension_keys}
+    alias_to_key.update({str(alias).lower(): key for key, alias in aliases.items()})
+
     dimensions = {}
     if cell_id != "default":
         for part in str(cell_id).split(","):
-            if "=" in part:
-                name, value = part.split("=", 1)
-                dimensions[name.strip().lower()] = value.strip()
+            if "=" not in part:
+                continue
+            name, value = part.split("=", 1)
+            key = alias_to_key.get(name.strip().lower(), name.strip().lower())
+            dimensions[key] = value.strip()
 
     combinations = getattr(getattr(variant_config, "sweep", None), "combinations", {}) or {}
     combo = combinations.get(cell_id)
-    for name in ("micro_batch_size", "global_batch_size", "precision"):
+    for name in dimension_keys:
         value = getattr(combo, name, None)
         if value is not None:
             dimensions.setdefault(name, str(value))
-
-    dimensions.setdefault("micro_batch_size", dimensions.pop("mbs", "—"))
-    dimensions.setdefault("global_batch_size", dimensions.pop("gbs", "—"))
-    dimensions.setdefault("precision", "—")
+        dimensions.setdefault(name, "—")
     return dimensions
+
+
+def _display_label(cell_id, dimensions, sweep_cfg):
+    keys = list(sweep_cfg.get("label_parts") or sweep_cfg.get("dimension_keys") or [])
+    if not keys:
+        return str(cell_id)
+    aliases = sweep_cfg.get("label_aliases") or {}
+    return " · ".join(f"{aliases.get(key, key)}={dimensions.get(key, '—')}" for key in keys)
 
 
 def _variant_metadata(variant_config):
@@ -95,20 +141,27 @@ def _named_cell_metrics(config, actuals, thresholds_cell, enforce):
                 "unit": config.metric_units.get(short, ""),
                 "spec": spec,
                 "status": status,
-                "bar_pct": bar_pct(float(actual), spec) if spec and actual is not None else None,
+                "bar_pct": _safe_bar_pct(config, actual, spec),
                 "margin": margin_text(actual, spec) if spec else None,
             }
         )
     return metrics
 
 
+def _extra_metric_label(config, metric):
+    prefix = config.metric_prefix or ""
+    bare = metric[len(prefix) :] if prefix and str(metric).startswith(prefix) else str(metric)
+    return bare.replace("_", " ").title()
+
+
 def _named_results_table(config, cells):
     columns = list(config.results_columns)
     known = {key for _label, key in columns if key}
+    id_label = next((label for label, key in columns if key is None), "Cell")
     for cell in cells:
         for metric in cell["actuals"]:
             if metric not in known:
-                columns.append((metric.replace("training.", "").replace("_", " ").title(), metric))
+                columns.append((_extra_metric_label(config, metric), metric))
                 known.add(metric)
 
     headers = [label for label, _key in columns]
@@ -118,7 +171,7 @@ def _named_results_table(config, cells):
         dimensions = cell["dimensions"]
         for label, key in columns:
             if key is None:
-                value = cell["cell_id"] if label == "Cell" else "—"
+                value = cell["cell_id"] if label == id_label else "—"
             elif key in cell:
                 value = cell[key]
             elif key in dimensions:
@@ -151,44 +204,43 @@ def _named_charts(config, cells):
     return charts, chart_series
 
 
-def _build_named_cell_datasets(sources, config):
+def _build_named_cell_datasets(sources, config, profile):
+    sweep_cfg = _sweep_layout_cfg(profile)
     variant_config = sources.get("variant")
     results = _results_dict(sources)
-    enforce = bool(getattr(variant_config, "enforce_thresholds", False))
-    thresholds = getattr(variant_config, "thresholds", {}) or {}
+    enforce = bool(getattr(variant_config, "enforce_thresholds", False)) if variant_config is not None else False
+    thresholds = getattr(variant_config, "thresholds", {}) or {} if variant_config is not None else {}
     metadata = _variant_metadata(variant_config)
     tier_builder = CellRecordBuilder(config)
     cells = []
 
     for cell_id, raw_metrics in results.items():
-        if not isinstance(raw_metrics, dict):
+        crashed = raw_metrics is None
+        if crashed:
+            raw_metrics = {}
+        elif not isinstance(raw_metrics, dict):
             continue
+        thresholds_cell = thresholds.get(cell_id) or {}
         actuals = {}
         for metric, value in raw_metrics.items():
             if str(metric).startswith("_"):
                 continue
             full = str(metric) if "." in str(metric) else config.full_metric(str(metric))
-            actuals[full] = _last_value(value)
-        dimensions = _named_cell_dimensions(cell_id, variant_config)
-        thresholds_cell = thresholds.get(cell_id) or {}
+            actuals[full] = _reduce_actual(value, thresholds_cell.get(full))
+        dimensions = _named_cell_dimensions(cell_id, variant_config, sweep_cfg)
+        tiers = {
+            tier: "na" if crashed else tier_builder.tier_status(actuals, thresholds_cell, tier, enforce)
+            for tier in config.metric_tier_order
+        }
         cells.append(
             {
                 **metadata,
                 **dimensions,
                 "cell_id": str(cell_id),
-                "display_label": " · ".join(
-                    (
-                        f"MBS={dimensions['micro_batch_size']}",
-                        f"GBS={dimensions['global_batch_size']}",
-                        f"PRECISION={dimensions['precision']}",
-                    )
-                ),
+                "display_label": _display_label(cell_id, dimensions, sweep_cfg),
                 "dimensions": dimensions,
                 "metrics": _named_cell_metrics(config, actuals, thresholds_cell, enforce),
-                "tiers": {
-                    tier: tier_builder.tier_status(actuals, thresholds_cell, tier, enforce)
-                    for tier in config.metric_tier_order
-                },
+                "tiers": tiers,
                 "actuals": actuals,
                 "cell_lifecycle": {},
                 "pytest_inference_nodeid": "",
@@ -231,7 +283,7 @@ def _build_named_cell_datasets(sources, config):
 def build_sweep_datasets(sources: dict[str, Any], profile: DeckProfile) -> dict[str, Any]:
     config = resolve_report_config(profile)
     if isinstance(profile, dict) and (profile.get("sweep") or {}).get("layout") == "named_cells":
-        return _build_named_cell_datasets(sources, config)
+        return _build_named_cell_datasets(sources, config, profile)
 
     variant_config = sources.get("variant")
     lifecycle_report = sources.get("lifecycle_report") or {}

--- a/cvs/lib/report/rundeck/dataset_builders/sweep.py
+++ b/cvs/lib/report/rundeck/dataset_builders/sweep.py
@@ -9,7 +9,14 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from cvs.lib.report.cell_build import build_all_cells, select_summary_cells
+from cvs.lib.report.cell_build import (
+    CellRecordBuilder,
+    bar_pct,
+    build_all_cells,
+    margin_text,
+    metric_pass,
+    select_summary_cells,
+)
 from cvs.lib.report.inference_payload import (
     build_chart_series,
     build_results_table,
@@ -28,9 +35,204 @@ def _results_dict(sources: Mapping[str, Any]) -> Mapping:
     return sources.get("results") or sources.get("cvs_results_dict") or sources.get("inf_res_dict") or {}
 
 
+def _last_value(value):
+    while isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        value = value[-1]
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _named_cell_dimensions(cell_id, variant_config):
+    dimensions = {}
+    if cell_id != "default":
+        for part in str(cell_id).split(","):
+            if "=" in part:
+                name, value = part.split("=", 1)
+                dimensions[name.strip().lower()] = value.strip()
+
+    combinations = getattr(getattr(variant_config, "sweep", None), "combinations", {}) or {}
+    combo = combinations.get(cell_id)
+    for name in ("micro_batch_size", "global_batch_size", "precision"):
+        value = getattr(combo, name, None)
+        if value is not None:
+            dimensions.setdefault(name, str(value))
+
+    dimensions.setdefault("micro_batch_size", dimensions.pop("mbs", "—"))
+    dimensions.setdefault("global_batch_size", dimensions.pop("gbs", "—"))
+    dimensions.setdefault("precision", "—")
+    return dimensions
+
+
+def _variant_metadata(variant_config):
+    train_params = getattr(variant_config, "train_params", {}) or {}
+    container = getattr(variant_config, "container", None)
+    env = getattr(container, "env", {}) or {}
+    return {
+        "model": train_params.get("model_name") or train_params.get("model") or "—",
+        "gpu": getattr(variant_config, "gpu_arch", "—"),
+        "nnodes": str(env.get("NNODES") or train_params.get("nnodes") or "—"),
+    }
+
+
+def _named_cell_metrics(config, actuals, thresholds_cell, enforce):
+    metrics = []
+    for short, label in config.cell_highlights:
+        full = config.full_metric(short)
+        actual = actuals.get(full)
+        spec = thresholds_cell.get(full)
+        status = metric_pass(full, actual, spec, evaluator=config.metric_verdict) if enforce and spec else "record"
+        metrics.append(
+            {
+                "label": label,
+                "metric": full,
+                "actual": actual,
+                "unit": config.metric_units.get(short, ""),
+                "spec": spec,
+                "status": status,
+                "bar_pct": bar_pct(float(actual), spec) if spec and actual is not None else None,
+                "margin": margin_text(actual, spec) if spec else None,
+            }
+        )
+    return metrics
+
+
+def _named_results_table(config, cells):
+    columns = list(config.results_columns)
+    known = {key for _label, key in columns if key}
+    for cell in cells:
+        for metric in cell["actuals"]:
+            if metric not in known:
+                columns.append((metric.replace("training.", "").replace("_", " ").title(), metric))
+                known.add(metric)
+
+    headers = [label for label, _key in columns]
+    rows = []
+    for cell in cells:
+        row = []
+        dimensions = cell["dimensions"]
+        for label, key in columns:
+            if key is None:
+                value = cell["cell_id"] if label == "Cell" else "—"
+            elif key in cell:
+                value = cell[key]
+            elif key in dimensions:
+                value = dimensions[key]
+            else:
+                value = cell["actuals"].get(key, "—")
+            row.append("—" if value is None else value)
+        rows.append(row)
+    return {"headers": headers, "rows": rows}
+
+
+def _named_charts(config, cells):
+    charts = {}
+    chart_series = {}
+    for chart in config.chart_series:
+        full = config.full_metric(chart.metric_suffix)
+        points = []
+        for cell in cells:
+            value = cell["actuals"].get(full)
+            if value is None:
+                continue
+            try:
+                points.append((cell["display_label"], float(value)))
+            except (TypeError, ValueError):
+                continue
+        if points:
+            entry = {"label": f"{chart.title} vs cells", "points": points}
+            charts[chart.metric_suffix] = {"cells": [entry]}
+            chart_series[chart.metric_suffix] = [entry]
+    return charts, chart_series
+
+
+def _build_named_cell_datasets(sources, config):
+    variant_config = sources.get("variant")
+    results = _results_dict(sources)
+    enforce = bool(getattr(variant_config, "enforce_thresholds", False))
+    thresholds = getattr(variant_config, "thresholds", {}) or {}
+    metadata = _variant_metadata(variant_config)
+    tier_builder = CellRecordBuilder(config)
+    cells = []
+
+    for cell_id, raw_metrics in results.items():
+        if not isinstance(raw_metrics, dict):
+            continue
+        actuals = {}
+        for metric, value in raw_metrics.items():
+            if str(metric).startswith("_"):
+                continue
+            full = str(metric) if "." in str(metric) else config.full_metric(str(metric))
+            actuals[full] = _last_value(value)
+        dimensions = _named_cell_dimensions(cell_id, variant_config)
+        thresholds_cell = thresholds.get(cell_id) or {}
+        cells.append(
+            {
+                **metadata,
+                **dimensions,
+                "cell_id": str(cell_id),
+                "display_label": " · ".join(
+                    (
+                        f"MBS={dimensions['micro_batch_size']}",
+                        f"GBS={dimensions['global_batch_size']}",
+                        f"PRECISION={dimensions['precision']}",
+                    )
+                ),
+                "dimensions": dimensions,
+                "metrics": _named_cell_metrics(config, actuals, thresholds_cell, enforce),
+                "tiers": {
+                    tier: tier_builder.tier_status(actuals, thresholds_cell, tier, enforce)
+                    for tier in config.metric_tier_order
+                },
+                "actuals": actuals,
+                "cell_lifecycle": {},
+                "pytest_inference_nodeid": "",
+                "pytest_metrics_nodeid": "",
+            }
+        )
+
+    charts, chart_series = _named_charts(config, cells)
+    chart_config = [
+        {
+            "suffix": chart.metric_suffix,
+            "title": chart.title,
+            "unit": chart.unit,
+            "metric": config.full_metric(chart.metric_suffix),
+            "invert": chart.invert,
+        }
+        for chart in config.chart_series
+    ]
+    return {
+        "cells": cells,
+        "all_cells": cells,
+        "charts": charts,
+        "chart_series": chart_series,
+        "chart_config": chart_config,
+        "sweep_summaries": [],
+        "gate_matrix": build_gate_matrix_rows(cells),
+        "results_table": _named_results_table(config, cells),
+        "multi_shape_comparison": False,
+        "overall_status": overall_status(config, cells, enforce),
+        "metric_tier_order": config.metric_tier_order,
+        "headline_metric": config.headline_metric,
+        "session_lifecycle_labels": config.session_lifecycle_labels,
+        "cell_lifecycle_labels": config.cell_lifecycle_labels,
+        "enforce": enforce,
+        "config": config,
+    }
+
+
 @register_dataset_builder("sweep")
 def build_sweep_datasets(sources: dict[str, Any], profile: DeckProfile) -> dict[str, Any]:
     config = resolve_report_config(profile)
+    if isinstance(profile, dict) and (profile.get("sweep") or {}).get("layout") == "named_cells":
+        return _build_named_cell_datasets(sources, config)
+
     variant_config = sources.get("variant")
     lifecycle_report = sources.get("lifecycle_report") or {}
     if hasattr(sources.get("lifecycle"), "report"):

--- a/cvs/lib/report/rundeck/generate_rundeck.py
+++ b/cvs/lib/report/rundeck/generate_rundeck.py
@@ -52,8 +52,7 @@ class RundeckPublisher:
         variant_config = store.get("variant_config")
         builder_id = profile.get("dataset_builder") if isinstance(profile, dict) else "sweep"
         if variant_config is None and builder_id == "sweep":
-            log.warning("Skipping Run Deck generation: variant_config not in session store")
-            return None
+            log.warning("Run Deck variant_config missing; publishing without variant metadata")
 
         config = resolve_report_config(profile)
         htmlpath = getattr(self.config.option, "htmlpath", None)

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -183,7 +183,12 @@ class DeckCardRenderer:
                 continue
             points = entry.get("points") or []
             label = entry.get("label") or title
-            part = self._charts.render_series_chart(str(label), points, series_cfg.get("unit") or "GB/s")
+            part = self._charts.render_series_chart(
+                str(label),
+                points,
+                series_cfg.get("unit") or "GB/s",
+                x_label_prefix=series_cfg.get("x_label_prefix", "C="),
+            )
             if part:
                 parts.append(part)
         return f"<div class='chart-grid'>{''.join(parts)}</div>" if parts else "<p class='muted'>No series data.</p>"

--- a/cvs/lib/report/rundeck/runtime/cards.py
+++ b/cvs/lib/report/rundeck/runtime/cards.py
@@ -23,6 +23,14 @@ from cvs.lib.report.types import DEFAULT_SESSION_LIFECYCLE_LABELS
 SESSION_FALLBACK = DEFAULT_SESSION_LIFECYCLE_LABELS
 
 
+def _chart_x_label(series_cfg):
+    if series_cfg.get("x_label"):
+        return series_cfg["x_label"]
+    if "x_label_prefix" in series_cfg:
+        return f"{series_cfg.get('x_label_prefix') or ''}{{x}}"
+    return "C={x}"
+
+
 class DeckCardRenderer:
     """Profile-driven card renderers for Run Deck static HTML sections."""
 
@@ -187,7 +195,7 @@ class DeckCardRenderer:
                 str(label),
                 points,
                 series_cfg.get("unit") or "GB/s",
-                x_label_prefix=series_cfg.get("x_label_prefix", "C="),
+                x_label=_chart_x_label(series_cfg),
             )
             if part:
                 parts.append(part)

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -64,6 +64,7 @@ class SweepChartRenderer:
         unit: str,
         *,
         accent: str = "accent",
+        x_label_prefix="C=",
     ) -> str:
         if len(points) < 2:
             return ""
@@ -82,15 +83,16 @@ class SweepChartRenderer:
         )
         bars = []
         x_labels = []
-        for conc, val in points:
+        for x_value, val in points:
             h = self._bar_height_pct(val, min_val, max_val)
-            tip = html.escape(f"C={conc}: {fmt_num(val)} {unit}".strip())
+            x_label = f"{x_label_prefix}{x_value}"
+            tip = html.escape(f"{x_label}: {fmt_num(val)} {unit}".strip())
             bars.append(
                 f"<div class='chart-col'>"
                 f"<div class='chart-bar chart-bar-{accent} chart-has-tip' style='height:{h:.1f}%' "
                 f"data-tip='{tip}' tabindex='0' role='img' aria-label='{tip}'></div></div>"
             )
-            x_labels.append(f"<span class='chart-xlbl'>C={conc}</span>")
+            x_labels.append(f"<span class='chart-xlbl'>{html.escape(str(x_label))}</span>")
         return (
             f"<div class='chart-panel'><h3>{html.escape(title)}</h3>"
             f"<div class='chart-viz'>"
@@ -138,12 +140,18 @@ class SweepChartRenderer:
             else "<p class='muted'>Concurrency charts need two or more points per sweep shape.</p>"
         )
 
-    def render_series_chart(self, title: str, points: list, unit: str) -> str:
+    def render_series_chart(self, title: str, points: list, unit: str, x_label_prefix="C=") -> str:
         normalized = []
         for p in points:
             if isinstance(p, (list, tuple)) and len(p) >= 2:
                 normalized.append((p[0], p[1]))
-        return self.render_bar_chart(title, normalized, unit, accent="accent2")
+        return self.render_bar_chart(
+            title,
+            normalized,
+            unit,
+            accent="accent2",
+            x_label_prefix=x_label_prefix,
+        )
 
 
 _DEFAULT_RENDERER = SweepChartRenderer()

--- a/cvs/lib/report/rundeck/runtime/sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/sweep_charts.py
@@ -64,9 +64,10 @@ class SweepChartRenderer:
         unit: str,
         *,
         accent: str = "accent",
-        x_label_prefix="C=",
+        x_label="C={x}",
+        min_points=2,
     ) -> str:
-        if len(points) < 2:
+        if len(points) < min_points:
             return ""
         values = [p[1] for p in points]
         max_val = max(values) or 1.0
@@ -85,14 +86,17 @@ class SweepChartRenderer:
         x_labels = []
         for x_value, val in points:
             h = self._bar_height_pct(val, min_val, max_val)
-            x_label = f"{x_label_prefix}{x_value}"
-            tip = html.escape(f"{x_label}: {fmt_num(val)} {unit}".strip())
+            try:
+                xlabel = x_label.format(x=x_value)
+            except (KeyError, IndexError, ValueError):
+                xlabel = str(x_value)
+            tip = html.escape(f"{xlabel}: {fmt_num(val)} {unit}".strip())
             bars.append(
                 f"<div class='chart-col'>"
                 f"<div class='chart-bar chart-bar-{accent} chart-has-tip' style='height:{h:.1f}%' "
                 f"data-tip='{tip}' tabindex='0' role='img' aria-label='{tip}'></div></div>"
             )
-            x_labels.append(f"<span class='chart-xlbl'>{html.escape(str(x_label))}</span>")
+            x_labels.append(f"<span class='chart-xlbl'>{html.escape(str(xlabel))}</span>")
         return (
             f"<div class='chart-panel'><h3>{html.escape(title)}</h3>"
             f"<div class='chart-viz'>"
@@ -140,18 +144,12 @@ class SweepChartRenderer:
             else "<p class='muted'>Concurrency charts need two or more points per sweep shape.</p>"
         )
 
-    def render_series_chart(self, title: str, points: list, unit: str, x_label_prefix="C=") -> str:
+    def render_series_chart(self, title: str, points: list, unit: str, x_label="{x}"):
         normalized = []
         for p in points:
             if isinstance(p, (list, tuple)) and len(p) >= 2:
                 normalized.append((p[0], p[1]))
-        return self.render_bar_chart(
-            title,
-            normalized,
-            unit,
-            accent="accent2",
-            x_label_prefix=x_label_prefix,
-        )
+        return self.render_bar_chart(title, normalized, unit, accent="accent2", x_label=x_label, min_points=1)
 
 
 _DEFAULT_RENDERER = SweepChartRenderer()

--- a/cvs/lib/report/rundeck/runtime/unittests/test_sweep_charts.py
+++ b/cvs/lib/report/rundeck/runtime/unittests/test_sweep_charts.py
@@ -1,0 +1,21 @@
+'''Unit tests for Run Deck bar-chart x labels and point floors.'''
+
+import unittest
+
+from cvs.lib.report.rundeck.runtime.sweep_charts import SweepChartRenderer
+
+
+class TestSweepCharts(unittest.TestCase):
+    def test_inference_floor_stays_two_points(self):
+        html = SweepChartRenderer().render_bar_chart("tput", [(1, 10.0)], "tok/s")
+        self.assertEqual(html, "")
+
+    def test_series_allows_single_point_without_c_prefix(self):
+        html = SweepChartRenderer().render_series_chart("tput", [("MBS=4", 12.0)], "TFLOP/s", x_label="{x}")
+        self.assertIn("MBS=4", html)
+        self.assertNotIn("C=", html)
+        self.assertIn("chart-bar", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/rundeck/unittests/test_megatron_profile.py
+++ b/cvs/lib/report/rundeck/unittests/test_megatron_profile.py
@@ -1,0 +1,127 @@
+'''Unit tests for the Megatron named-cell Run Deck profile.'''
+
+import unittest
+from types import SimpleNamespace
+
+from cvs.lib.report.profile import load_json_profile
+from cvs.lib.report.rundeck.dataset_builders.sweep import build_sweep_datasets
+from cvs.lib.report.rundeck.payload import build_rundeck_payload
+from cvs.lib.report.rundeck.render import render_rundeck_html
+
+
+def _variant():
+    cells = (
+        "MBS=4,GBS=128,PRECISION=FP8",
+        "MBS=4,GBS=128,PRECISION=BF16",
+    )
+    combinations = {
+        cell: SimpleNamespace(micro_batch_size="4", global_batch_size="128", precision=cell.rsplit("=", 1)[-1])
+        for cell in cells
+    }
+    thresholds = {
+        cell: {
+            "training.throughput_per_gpu": {"kind": "min", "value": 100},
+            "training.tokens_per_gpu": {"kind": "min", "value": 1000},
+            "training.mem_usage": {"kind": "max", "value": 0.85, "optional": True},
+        }
+        for cell in cells
+    }
+    return SimpleNamespace(
+        train_params={
+            "model_name": "llama3.1_8B",
+            "tensor_parallelism": "1",
+            "pipeline_parallelism": "2",
+            "fsdp": "0",
+        },
+        gpu_arch="MI300X",
+        enforce_thresholds=True,
+        thresholds=thresholds,
+        sweep=SimpleNamespace(combinations=combinations, runs=list(cells)),
+        container=SimpleNamespace(env={"NNODES": "2"}),
+    )
+
+
+def _results():
+    return {
+        "MBS=4,GBS=128,PRECISION=FP8": {
+            "throughput_per_gpu": ["120.5"],
+            "tokens_per_gpu": ["1400"],
+            "mem_usage": [],
+        },
+        "MBS=4,GBS=128,PRECISION=BF16": {
+            "throughput_per_gpu": ["90"],
+            "tokens_per_gpu": ["1100"],
+            "mem_usage": [],
+        },
+    }
+
+
+class TestMegatronProfile(unittest.TestCase):
+    def test_all_megatron_stems_share_profile(self):
+        stems = (
+            "megatron_single",
+            "megatron_distributed",
+            "megatron_llama3_1_8b_single",
+            "megatron_llama3_1_8b_distributed",
+            "megatron_llama3_1_70b_single",
+            "megatron_llama3_1_70b_distributed",
+        )
+        for stem in stems:
+            with self.subTest(stem=stem):
+                profile = load_json_profile(stem)
+                self.assertEqual(profile["suite_id"], "megatron")
+                self.assertEqual(profile["dataset_builder"], "sweep")
+
+    def test_named_sweep_preserves_training_dimensions_and_gates(self):
+        profile = load_json_profile("megatron")
+        datasets = build_sweep_datasets(
+            {"results": _results(), "variant": _variant(), "lifecycle_report": {}},
+            profile,
+        )
+
+        self.assertEqual(len(datasets["cells"]), 2)
+        self.assertNotIn("isl", datasets["cells"][0])
+        self.assertNotIn("osl", datasets["cells"][0])
+        self.assertEqual(datasets["cells"][0]["micro_batch_size"], "4")
+        self.assertEqual(datasets["cells"][0]["global_batch_size"], "128")
+        self.assertEqual(
+            [cell["tiers"]["thresholds"] for cell in datasets["cells"]],
+            ["pass", "fail"],
+        )
+        self.assertEqual(datasets["overall_status"], "fail")
+        self.assertIn("MBS", datasets["results_table"]["headers"])
+        self.assertIn("Throughput/GPU", datasets["results_table"]["headers"])
+
+        points = datasets["charts"]["throughput_per_gpu"]["cells"][0]["points"]
+        self.assertEqual(points[0][0], "MBS=4 · GBS=128 · PRECISION=FP8")
+        self.assertEqual(points[0][1], 120.5)
+
+    def test_payload_renders_training_graphs_and_run_card(self):
+        profile = load_json_profile("megatron")
+        payload = build_rundeck_payload(
+            profile=profile,
+            store={
+                "cvs_results_dict": _results(),
+                "variant_config": _variant(),
+                "lifecycle_report": {},
+            },
+            cvs_version="test",
+        )
+        run_card = {label: value for label, value, _link in payload["run_card_display"]}
+        self.assertEqual(run_card["Model"], "llama3.1_8B")
+        self.assertEqual(run_card["GPU"], "MI300X")
+        self.assertEqual(run_card["Nodes"], "2")
+        self.assertEqual(run_card["Parallelism"], "TP=1, PP=2, FSDP=0")
+        self.assertFalse(payload["viewer_config"]["interactivity"]["enabled"])
+
+        document = render_rundeck_html(payload)
+        self.assertIn("Throughput per GPU vs cells", document)
+        self.assertIn("Token throughput per GPU vs cells", document)
+        self.assertIn("Gate matrix", document)
+        self.assertIn("Full results", document)
+        self.assertNotIn("ISL=", document)
+        self.assertNotIn("OSL=", document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cvs/lib/report/rundeck/unittests/test_megatron_profile.py
+++ b/cvs/lib/report/rundeck/unittests/test_megatron_profile.py
@@ -122,6 +122,69 @@ class TestMegatronProfile(unittest.TestCase):
         self.assertNotIn("ISL=", document)
         self.assertNotIn("OSL=", document)
 
+    def test_legacy_lookup_mismatch_returns_none(self):
+        from cvs.lib.report.profiles.hooks.megatron_run_card import build_legacy_rundeck_variant
+
+        self.assertIsNone(
+            build_legacy_rundeck_variant(
+                {"config": {}},
+                "megatron_llama3_1_8b_single",
+                {},
+                {"single_node": {"llama3_1_8b": {"mi300x": {}}}},
+                "mi355",
+                object(),
+            )
+        )
+        self.assertIs(
+            build_legacy_rundeck_variant({"pydantic": True}, "megatron_single", {}, {}, None, "keep"),
+            "keep",
+        )
+
+    def test_crashed_combo_and_non_numeric_spec_do_not_raise(self):
+        profile = load_json_profile("megatron")
+        variant = _variant()
+        cell = "MBS=4,GBS=128,PRECISION=FP8"
+        variant.thresholds[cell]["training.throughput_per_gpu"] = {"kind": "info"}
+        datasets = build_sweep_datasets(
+            {
+                "results": {
+                    cell: {"throughput_per_gpu": "n/a", "tokens_per_gpu": ["1400"]},
+                    "MBS=4,GBS=128,PRECISION=BF16": None,
+                },
+                "variant": variant,
+            },
+            profile,
+        )
+        self.assertEqual(len(datasets["cells"]), 2)
+        self.assertEqual(datasets["cells"][1]["tiers"]["thresholds"], "na")
+        thru = next(m for m in datasets["cells"][0]["metrics"] if m["metric"].endswith("throughput_per_gpu"))
+        self.assertIsNone(thru["bar_pct"])
+
+    def test_min_gate_uses_worst_sample(self):
+        profile = load_json_profile("megatron")
+        results = {
+            "MBS=4,GBS=128,PRECISION=FP8": {"throughput_per_gpu": ["200", "90"], "tokens_per_gpu": ["1400"]},
+            "MBS=4,GBS=128,PRECISION=BF16": {"throughput_per_gpu": ["120"], "tokens_per_gpu": ["1100"]},
+        }
+        datasets = build_sweep_datasets({"results": results, "variant": _variant()}, profile)
+        self.assertEqual(datasets["cells"][0]["actuals"]["training.throughput_per_gpu"], 90.0)
+        self.assertEqual(datasets["cells"][0]["tiers"]["thresholds"], "fail")
+
+    def test_single_cell_renders_chart(self):
+        profile = load_json_profile("megatron")
+        cell = "MBS=4,GBS=128,PRECISION=FP8"
+        payload = build_rundeck_payload(
+            profile=profile,
+            store={
+                "cvs_results_dict": {cell: {"throughput_per_gpu": ["120.5"], "tokens_per_gpu": ["1400"]}},
+                "variant_config": _variant(),
+            },
+            cvs_version="test",
+        )
+        document = render_rundeck_html(payload)
+        self.assertIn("chart-bar", document)
+        self.assertNotIn("No series data.", document)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cvs/tests/training/megatron/conftest.py
+++ b/cvs/tests/training/megatron/conftest.py
@@ -7,6 +7,7 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 
 import json
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -126,6 +127,45 @@ def train_res_dict():
 
 
 @pytest.fixture(scope="module")
+def rundeck_variant(request):
+    config_file = request.config.getoption("config_file")
+    with open(config_file) as fp:
+        raw = json.load(fp)
+    if "config" not in raw:
+        return request.getfixturevalue("variant_config")
+
+    stem = getattr(request.config, "_suite_name", "")
+    distributed = stem.endswith("_distributed")
+    model_name = "llama3_1_70b" if "70b" in stem else "llama3_1_8b"
+    training_dict = request.getfixturevalue("training_dict")
+    model_params = request.getfixturevalue("model_params_dict")
+    gpu_type = request.getfixturevalue("gpu_type")
+    topology = "multi_node" if distributed else "single_node"
+    params = dict(model_params[topology][model_name][gpu_type])
+    cell_id = f"MBS={params['micro_batch_size']},GBS={params['batch_size']},PRECISION={params['precision']}"
+    threshold_specs = {
+        f"training.{metric}": {"kind": "min", "value": value}
+        for metric, value in (params.get("result_dict") or {}).items()
+        if not metric.startswith("_")
+    }
+    params["model_name"] = model_name
+    params["nnodes"] = str(training_dict.get("nnodes") or 1)
+    combo = SimpleNamespace(
+        micro_batch_size=str(params["micro_batch_size"]),
+        global_batch_size=str(params["batch_size"]),
+        precision=str(params["precision"]),
+    )
+    return SimpleNamespace(
+        train_params=params,
+        gpu_arch=str(gpu_type).upper(),
+        enforce_thresholds=True,
+        thresholds={cell_id: threshold_specs},
+        sweep=SimpleNamespace(combinations={cell_id: combo}, runs=[cell_id]),
+        container=SimpleNamespace(env={"NNODES": params["nnodes"]}),
+    )
+
+
+@pytest.fixture(scope="module")
 def orch(cluster_dict, variant_config, lifecycle):
     """Construct a ContainerOrchestrator and own a final teardown safety net.
 
@@ -139,6 +179,7 @@ def orch(cluster_dict, variant_config, lifecycle):
     env = dict(container_block.get("env") or {})
     node_dict = cluster_dict.get("node_dict") or {}
     env["NNODES"] = str(len(node_dict))
+    variant_config.container.env["NNODES"] = env["NNODES"]
     container_block["env"] = env
     testsuite_config = {"orchestrator": "container", "container": container_block}
     cfg = OrchestratorConfig.from_configs(cluster_dict, testsuite_config)

--- a/cvs/tests/training/megatron/conftest.py
+++ b/cvs/tests/training/megatron/conftest.py
@@ -7,12 +7,11 @@ All code contained here is Property of Advanced Micro Devices, Inc.
 
 import json
 import os
-from types import SimpleNamespace
-
 import pytest
 
 from cvs.core.orchestrators.factory import OrchestratorConfig, OrchestratorFactory
 from cvs.lib import globals
+from cvs.lib.report.profiles.hooks.megatron_run_card import build_legacy_rundeck_variant
 from cvs.lib.utils_lib import resolve_cluster_config_placeholders
 from cvs.lib.training.megatron.utils.training_config_loader import load_training_variant
 
@@ -129,40 +128,23 @@ def train_res_dict():
 @pytest.fixture(scope="module")
 def rundeck_variant(request):
     config_file = request.config.getoption("config_file")
-    with open(config_file) as fp:
-        raw = json.load(fp)
-    if "config" not in raw:
-        return request.getfixturevalue("variant_config")
-
-    stem = getattr(request.config, "_suite_name", "")
-    distributed = stem.endswith("_distributed")
-    model_name = "llama3_1_70b" if "70b" in stem else "llama3_1_8b"
-    training_dict = request.getfixturevalue("training_dict")
-    model_params = request.getfixturevalue("model_params_dict")
-    gpu_type = request.getfixturevalue("gpu_type")
-    topology = "multi_node" if distributed else "single_node"
-    params = dict(model_params[topology][model_name][gpu_type])
-    cell_id = f"MBS={params['micro_batch_size']},GBS={params['batch_size']},PRECISION={params['precision']}"
-    threshold_specs = {
-        f"training.{metric}": {"kind": "min", "value": value}
-        for metric, value in (params.get("result_dict") or {}).items()
-        if not metric.startswith("_")
-    }
-    params["model_name"] = model_name
-    params["nnodes"] = str(training_dict.get("nnodes") or 1)
-    combo = SimpleNamespace(
-        micro_batch_size=str(params["micro_batch_size"]),
-        global_batch_size=str(params["batch_size"]),
-        precision=str(params["precision"]),
-    )
-    return SimpleNamespace(
-        train_params=params,
-        gpu_arch=str(gpu_type).upper(),
-        enforce_thresholds=True,
-        thresholds={cell_id: threshold_specs},
-        sweep=SimpleNamespace(combinations={cell_id: combo}, runs=[cell_id]),
-        container=SimpleNamespace(env={"NNODES": params["nnodes"]}),
-    )
+    try:
+        with open(config_file) as fp:
+            raw = json.load(fp)
+        variant_config = request.getfixturevalue("variant_config")
+        if not isinstance(raw, dict) or "config" not in raw:
+            return variant_config
+        return build_legacy_rundeck_variant(
+            raw,
+            getattr(request.config, "_suite_name", ""),
+            request.getfixturevalue("training_dict"),
+            request.getfixturevalue("model_params_dict"),
+            request.getfixturevalue("gpu_type"),
+            variant_config,
+        )
+    except Exception:
+        log.warning("rundeck_variant unavailable; Run Deck will omit variant metadata", exc_info=True)
+        return None
 
 
 @pytest.fixture(scope="module")

--- a/cvs/tests/training/megatron/megatron_llama3_1_70b_distributed.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_70b_distributed.py
@@ -289,7 +289,15 @@ def test_launch_megatron_containers(phdl, training_dict):
     update_test_result()
 
 
-def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_dict, hf_token):
+def test_llama_3_1_fp8_single_node(
+    phdl,
+    gpu_type,
+    training_dict,
+    model_params_dict,
+    hf_token,
+    train_res_dict,
+    rundeck_variant,
+):
     """
     Pytest: Single-node Megatron Llama 3.1 FP8 training lifecycle test.
 
@@ -325,4 +333,5 @@ def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_d
     mt_obj.start_training_job()
     mt_obj.poll_for_training_completion()
     mt_obj.verify_training_results()
+    train_res_dict[rundeck_variant.sweep.runs[0]] = mt_obj.training_results_dict
     update_test_result()

--- a/cvs/tests/training/megatron/megatron_llama3_1_70b_single.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_70b_single.py
@@ -272,7 +272,15 @@ def test_launch_megatron_containers(phdl, training_dict):
     update_test_result()
 
 
-def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_dict, hf_token):
+def test_llama_3_1_fp8_single_node(
+    phdl,
+    gpu_type,
+    training_dict,
+    model_params_dict,
+    hf_token,
+    train_res_dict,
+    rundeck_variant,
+):
     """
     Pytest: Single-node Megatron Llama 3.1 training lifecycle test.
 
@@ -308,4 +316,5 @@ def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_d
     mt_obj.start_training_job()
     mt_obj.poll_for_training_completion()
     mt_obj.verify_training_results()
+    train_res_dict[rundeck_variant.sweep.runs[0]] = mt_obj.training_results_dict
     update_test_result()

--- a/cvs/tests/training/megatron/megatron_llama3_1_8b_distributed.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_8b_distributed.py
@@ -288,7 +288,15 @@ def test_launch_megatron_containers(phdl, training_dict):
     update_test_result()
 
 
-def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_dict, hf_token):
+def test_llama_3_1_fp8_single_node(
+    phdl,
+    gpu_type,
+    training_dict,
+    model_params_dict,
+    hf_token,
+    train_res_dict,
+    rundeck_variant,
+):
     """
     Pytest: Single-node Megatron Llama 3.1 FP8 training lifecycle test.
 
@@ -324,4 +332,5 @@ def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_d
     mt_obj.start_training_job()
     mt_obj.poll_for_training_completion()
     mt_obj.verify_training_results()
+    train_res_dict[rundeck_variant.sweep.runs[0]] = mt_obj.training_results_dict
     update_test_result()

--- a/cvs/tests/training/megatron/megatron_llama3_1_8b_single.py
+++ b/cvs/tests/training/megatron/megatron_llama3_1_8b_single.py
@@ -273,7 +273,15 @@ def test_launch_megatron_containers(phdl, training_dict):
     update_test_result()
 
 
-def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_dict, hf_token):
+def test_llama_3_1_fp8_single_node(
+    phdl,
+    gpu_type,
+    training_dict,
+    model_params_dict,
+    hf_token,
+    train_res_dict,
+    rundeck_variant,
+):
     """
     Pytest: Single-node Megatron Llama 3.1 FP8 training lifecycle test.
 
@@ -309,4 +317,5 @@ def test_llama_3_1_fp8_single_node(phdl, gpu_type, training_dict, model_params_d
     mt_obj.start_training_job()
     mt_obj.poll_for_training_completion()
     mt_obj.verify_training_results()
+    train_res_dict[rundeck_variant.sweep.runs[0]] = mt_obj.training_results_dict
     update_test_result()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a render-only sweep Run Deck for Megatron training stems (`megatron_single`, `megatron_distributed`, and the Llama 8B/70B variants via profile aliases).

## Plan / code surfaces
- Profile `profiles/megatron.json` with `dataset_builder: sweep` and `layout: named_cells`
- Session fixtures (`train_res_dict`, `rundeck_variant`) in megatron conftest plus the four legacy Llama suite files
- Sweep builder/renderer extended for named training cells (not ISL/OSL inference shapes)
- Training gates unchanged; token-interactivity viewer off

## Graphs / tables
- TFLOP/s per GPU and tokens/s per GPU vs named cells
- Threshold gate matrix
- Full results table
- Run card: model, GPU, nodes, parallelism

## Review follow-up (`379e43a6`)
- Legacy `rundeck_variant` GPU/topology mismatches return None instead of erroring the module
- Sweep decks still publish without variant metadata
- `bar_pct` uses the same numeric/`value` guard as cell records
- Single-cell charts render; x labels use `{x}` (compatible with the RCCL deck)
- Display labels and extra-metric names come from profile `dimension_keys` / `metric_prefix`
- Min gates use the worst sample; crashed combos appear as `na` rows

## Quality
`make fmt-check` / `make lint` clean; report unittests 123 OK. Hardware not run. Draft — do not merge yet.

Note: this PR still touches shared sweep chart/gate-matrix code; review that path against vLLM/SGLang decks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bd374b-7c5a-4d24-be58-368133af2219?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bd374b-7c5a-4d24-be58-368133af2219&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

