### PR TITLE
chore(cloud-agent): add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "CVS (Cluster Validation Suite)",
+  "user": "ubuntu",
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Cloud Agent bootstrap for the Cluster Validation Suite (CVS).
+#
+# CVS is a head-node Python CLI. This script prepares a ready-to-use checkout:
+# it installs the `cvs` CLI into .cvs_venv (the README quickstart layout) and
+# pre-creates the lint/format toolchain so quality gates run without a
+# first-use delay. It is idempotent and safe to re-run.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# The base image ships Python 3 and build tools but not the venv/ensurepip
+# package that `python -m venv` needs to bootstrap pip. Install it only when
+# missing so re-runs and build snapshots stay fast.
+if ! python3 -c 'import ensurepip' >/dev/null 2>&1; then
+    if command -v sudo >/dev/null 2>&1; then
+        py_minor="$(python3 -c 'import sys; print(sys.version_info.minor)')"
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq "python3.${py_minor}-venv" \
+            || sudo apt-get install -y -qq python3-venv
+    else
+        echo "ERROR: python3 venv/ensurepip is unavailable and sudo is not present to install it." >&2
+        exit 1
+    fi
+fi
+
+# Build the source distribution and install the `cvs` CLI into .cvs_venv.
+# `make install` recreates .cvs_venv each run, so this converges cleanly.
+make install
+
+# Pre-build the ruff/pylint venv so `make lint` and `make fmt-check` are ready.
+make ruff-venv
+
+echo
+echo "CVS environment ready. Activate the CLI with: source .cvs_venv/bin/activate"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent development environment for CVS so future Cloud Agents boot into a ready-to-use checkout. A committed `.cursor/environment.json` is the highest-precedence environment source and follows branches/PRs.

### What's included
- `.cursor/environment.json` — default base image, runs as `ubuntu`, `install` points at the bootstrap script.
- `.cursor/install.sh` — idempotent bootstrap that:
  - installs the `python3.<minor>-venv` package only when `ensurepip` is missing (the base image ships Python 3 + build tools but not the venv package),
  - runs `make install` to build the sdist and install the `cvs` CLI into `.cvs_venv` (matches the README quickstart),
  - pre-creates the ruff/pylint venv so `make lint` / `make fmt-check` run without a first-use delay.

No custom Dockerfile is needed: the default image already provides `gcc`/`build-essential`, `libffi-dev`, and OpenSSL, and every Python dependency installs from wheels. The existing repo `Dockerfile` is the runtime distribution image and is intentionally left untouched. No `start`/`terminals` services are required — CVS is a head-node CLI.

## Validation (on a fresh VM)

| Check | Result |
| --- | --- |
| `cvs --version` / `cvs list` | `cvs: 0.2.0`; all suites enumerated |
| `cvs generate cluster_json` (real action) | Expanded `10.0.0.1-4` into a valid 4-node cluster JSON |
| Unit tests (`run_all_unittests.py`) | 1970 passed, OK (skipped=1) |
| `test_cli.sh` (CLI suite) | All CVS CLI tests passed |
| `make fmt-check` | 566 files already formatted |
| `make lint` (ruff + pylint) | 10.00/10 |
| Install idempotence | `./.cursor/install.sh` run twice from a clean shell, both succeeded |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b75edc2-2b7b-43a3-8c91-549a3c9d56f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b75edc2-2b7b-43a3-8c91-549a3c9d56f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

